### PR TITLE
Add bazel_registry.json file

### DIFF
--- a/bazel_registry.json
+++ b/bazel_registry.json
@@ -1,0 +1,3 @@
+{
+    "mirrors": ["https://bcr.bazel.build/test-mirror"]
+}


### PR DESCRIPTION
We can switch to `https://mirror.bazel.build` when we actually launch the BCR.