### PR TITLE
add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tools/__pycache__


### PR DESCRIPTION
Ignore the tools/__pycache__/registry.cpython-38.pyc file that gets created when running the ./tools/add_module.py script