### PR TITLE
Update README.md and fix add_modules.py about module maintainer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,50 @@
 **Status:** This repository is still in alpha test phase, the content may not be accurate and can change without any notice.
 
 ## Goal
-A registry of Bazel modules for the Bzlmod external dependency system. It is the recommended place to publish your Bazel open source projects for downstream users.
+A registry of Bazel modules for the Bzlmod external dependency system. It is the recommended Bazel registry to publish your Bazel open source projects for downstream users.
 
 For more information, see the [Bazel Central Registry Policies and Procedures](https://docs.google.com/document/d/1ReuBBp4EHnsuvcpfXM6ITDmP2lrOu8DGlePMUKvDnXM/edit?usp=sharing).
 
-## Add a new module
+## Roles
 
-You can start with the interactive helper script
+### Module Contributor
+
+A person who contributes a Bazel module entry to this registry is a module contributor.
+
+To contribute a Bazel module, you can start with the interactive helper script:
 ```
 python3 ./tools/add_module.py
 ```
+
+### Module Maintainer
+
+A person who maintains a speicify module entry in this registry is a module maintainer. The name and contact information of the module maintainers are recorded in the metadata.json file for each module.
+
+**Note that**, a module maintainer doesn't have to be the project owner. Ideally, we prefer the project owner to maintain the module entry, as they know the project the best. But if the project owner is not maintaining the entry, a Bazel user who is interested in making the project available in this registry could also take on the responsibility.
+
+Being a module maintainer means:
+
+  - You will be asked to review future changes of this module entry. For example, a PR for adding a new version for this module.
+  - You will be asked for help when a new version of the module is required by users.
+  - You should maintain [the compatibility](https://docs.google.com/document/d/1ReuBBp4EHnsuvcpfXM6ITDmP2lrOu8DGlePMUKvDnXM/edit#heading=h.d7dl8s7vxf63) for this module when necessary.
+
+To become a module maintainer, send a PR to add yourself as a maintainer in the metadata.json file of the module you want to maintain.
+
+### Registry Maintainer
+
+Currently, the Bazel team is the registry maintainer, who are repsonsible for:
+
+  - Review and merge PRs for this repository.
+  - Maintain testing and serving infrastructures for the Bazel Central Registry.
+
+## presubmit.yml
+
+We require every module version to have a presubmit.yml file. With this file, you can specify a list of build and test targets for supported platforms. Those could be the targets you want to expose to the downstream users and a few integration tests that have good coverage over your APIs.
+
+**Note that**, it's NOT recommended to specify your entire test suite in this presubmit.yml file. Because running the entire test suite could be expensive and the result could be flaky. It's best to specify a list of test targets that are heavily used, well maintained and have a history of providing good signal and high-quality test results.
+
+The presubmit.yml file will be used for:
+
+  - [Presubmit test](https://docs.google.com/document/d/1ReuBBp4EHnsuvcpfXM6ITDmP2lrOu8DGlePMUKvDnXM/edit#heading=h.1o9h5yrz477i) when checking in the module version
+  - [Downstream test](https://docs.google.com/document/d/1ReuBBp4EHnsuvcpfXM6ITDmP2lrOu8DGlePMUKvDnXM/edit#heading=h.c7d1a4rk6dvj) for dependencies of this module
+  - [Bazel compatiblity test](https://docs.google.com/document/d/1ReuBBp4EHnsuvcpfXM6ITDmP2lrOu8DGlePMUKvDnXM/edit#heading=h.vp6y2sd6hujz)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ python3 ./tools/add_module.py
 
 ### Module Maintainer
 
-A person who maintains a speicify module entry in this registry is a module maintainer. The name and contact information of the module maintainers are recorded in the metadata.json file for each module.
+A person who maintains a specific module entry in this registry is a module maintainer. The name and contact information of the module maintainers are recorded in the metadata.json file for each module.
 
 **Note that**, a module maintainer doesn't have to be the project owner. Ideally, we prefer the project owner to maintain the module entry, as they know the project the best. But if the project owner is not maintaining the entry, a Bazel user who is interested in making the project available in this registry could also take on the responsibility.
 
@@ -34,7 +34,7 @@ To become a module maintainer, send a PR to add yourself as a maintainer in the 
 
 ### Registry Maintainer
 
-Currently, the Bazel team is the registry maintainer, who are repsonsible for:
+Currently, the Bazel team is the registry maintainer, who are responsible for:
 
   - Review and merge PRs for this repository.
   - Maintain testing and serving infrastructures for the Bazel Central Registry.

--- a/tools/add_module.py
+++ b/tools/add_module.py
@@ -130,22 +130,21 @@ def from_user_input():
 
 def get_maintainers_from_input():
   maintainers = []
-  while True:
+  prefix = "a"
+  explain = " (See https://github.com/bazelbuild/bazel-central-registry/tree/main#module-maintainer)"
+  while yes_or_no(f"Do you want to add {prefix} maintainer for this module?{explain}", False):
     maintainer = {}
-    name = ask_input(
-        "Please enter maintainer name [default: The Bazel Team]: ") or "The Bazel Team"
+    name = ask_input("Please enter maintainer name: ")
     maintainer["name"] = name
-    email = ask_input(
-        "Please enter the maintainer's email address [default: bazel-dev@googlegroups.com]: ") \
-        or "bazel-dev@googlegroups.com"
+    email = ask_input("Please enter the maintainer's email address: ")
     maintainer["email"] = email
     username = ask_input(
         "(Optional) Please enter the maintainer's github username: ")
     if username:
       maintainer["github"] = username
     maintainers.append(maintainer)
-    if not yes_or_no("Do you want to add another maintainer?", False):
-      break
+    prefix = "another"
+    explain = ""
   return maintainers
 
 


### PR DESCRIPTION
The Bazel team should not be the default maintainer of a module, if not set, the field will just be empty in the generated json file.