### PR TITLE
protobuf: Remove dependency on rules_jvm_external (for now)

### DIFF
--- a/modules/com_google_protobuf/3.19.0/patches/remove_dependency_on_rules_jvm_external.patch
+++ b/modules/com_google_protobuf/3.19.0/patches/remove_dependency_on_rules_jvm_external.patch
@@ -1,0 +1,94 @@
+diff --git a/java/core/BUILD b/java/core/BUILD
+index c65f10a4e..541b46bb4 100644
+--- a/java/core/BUILD
++++ b/java/core/BUILD
+@@ -1,6 +1,6 @@
+ load("@bazel_skylib//rules:build_test.bzl", "build_test")
+ load("@rules_java//java:defs.bzl", "java_library", "java_proto_library", "java_lite_proto_library")
+-load("@rules_jvm_external//:defs.bzl", "java_export")
++# load("@rules_jvm_external//:defs.bzl", "java_export")
+ load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
+ load("//:internal.bzl", "conformance_test")
+ load("//:protobuf_version.bzl", "PROTOBUF_VERSION")
+@@ -111,15 +111,15 @@ java_library(
+ )
+ 
+ # Bazel users, don't depend on this target, use //java/lite.
+-java_export(
+-    name = "lite_mvn",
+-    maven_coordinates = "com.google.protobuf:protobuf-javalite:%s" % PROTOBUF_VERSION,
+-    pom_template = "//java/lite:pom_template.xml",
+-    runtime_deps = [":lite"],
+-    resources = [
+-        "//:lite_well_known_protos",
+-    ],
+-)
++# java_export(
++#     name = "lite_mvn",
++#     maven_coordinates = "com.google.protobuf:protobuf-javalite:%s" % PROTOBUF_VERSION,
++#     pom_template = "//java/lite:pom_template.xml",
++#     runtime_deps = [":lite"],
++#     resources = [
++#         "//:lite_well_known_protos",
++#     ],
++# )
+ 
+ java_library(
+     name = "lite_runtime_only",
+@@ -146,15 +146,15 @@ java_library(
+ )
+ 
+ # Bazel users, don't depend on this target, use :core.
+-java_export(
+-    name = "core_mvn",
+-    maven_coordinates = "com.google.protobuf:protobuf-java:%s" % PROTOBUF_VERSION,
+-    pom_template = "pom_template.xml",
+-    runtime_deps = [":core"],
+-    resources = [
+-        "//:well_known_protos",
+-    ],
+-)
++# java_export(
++#     name = "core_mvn",
++#     maven_coordinates = "com.google.protobuf:protobuf-java:%s" % PROTOBUF_VERSION,
++#     pom_template = "pom_template.xml",
++#     runtime_deps = [":core"],
++#     resources = [
++#         "//:well_known_protos",
++#     ],
++# )
+ 
+ filegroup(
+     name = "release",
+diff --git a/java/util/BUILD b/java/util/BUILD
+index 3855da96f..0036526ae 100644
+--- a/java/util/BUILD
++++ b/java/util/BUILD
+@@ -1,5 +1,5 @@
+ load("@rules_java//java:defs.bzl", "java_proto_library")
+-load("@rules_jvm_external//:defs.bzl", "java_export")
++# load("@rules_jvm_external//:defs.bzl", "java_export")
+ load("@rules_proto//proto:defs.bzl", "proto_library")
+ load("//:protobuf_version.bzl", "PROTOBUF_VERSION")
+ load("//java/internal:testing.bzl", "junit_tests")
+@@ -21,13 +21,13 @@ java_library(
+     ],
+ )
+ # Bazel users, don't depend on this target, use :util.
+-java_export(
+-    name = "util_mvn",
+-    maven_coordinates = "com.google.protobuf:protobuf-java-util:%s" % PROTOBUF_VERSION,
+-    pom_template = "pom_template.xml",
+-    runtime_deps = [":util"],
+-    visibility = ["//java:__pkg__"],
+-)
++# java_export(
++#     name = "util_mvn",
++#     maven_coordinates = "com.google.protobuf:protobuf-java-util:%s" % PROTOBUF_VERSION,
++#     pom_template = "pom_template.xml",
++#     runtime_deps = [":util"],
++#     visibility = ["//java:__pkg__"],
++# )
+ 
+ filegroup(
+     name = "release",

--- a/modules/com_google_protobuf/3.19.0/source.json
+++ b/modules/com_google_protobuf/3.19.0/source.json
@@ -1,5 +1,9 @@
 {
     "integrity": "sha256-xWcVcOxfvgZRtzWyaHlkmslWHrSTNd2lqq++YntPz6U=",
+    "patch_strip": 1,
+    "patches": {
+        "remove_dependency_on_rules_jvm_external.patch": "sha256-J8u5VCpDBSRMnq8mjUiI0UM+kpZDc9jV0UMF4KtU9VM="
+    },
     "strip_prefix": "protobuf-3.19.0",
     "url": "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.0.zip"
 }


### PR DESCRIPTION
In protobuf 3.19.0, some packages load the rules_jvm_external repo , but `rules_jvm_external` hasn't adopted Bzlmod yet, so we avoid loading it for now to not break the integrity of the BUILD file.

