### PR TITLE
Toolchain registration improvement for rules_cc and rules_python

### DIFF
--- a/modules/rules_cc/0.0.1/patches/add_module_extension.patch
+++ b/modules/rules_cc/0.0.1/patches/add_module_extension.patch
@@ -34,7 +34,7 @@ new file mode 100644
 index 0000000..3fdbe87
 --- /dev/null
 +++ b/bzlmod/extensions.bzl
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,24 @@
 +# Copyright 2018 The Bazel Authors. All rights reserved.
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,9 +51,11 @@ index 0000000..3fdbe87
 +"""Module extension for cc auto configuration."""
 +
 +load("//cc/private/toolchain:cc_configure.bzl", "cc_autoconf_toolchains", "cc_autoconf")
++load("@bazel_tools//tools/osx:xcode_configure.bzl", "xcode_configure")
 +
 +def _cc_configure_impl(ctx):
 +  cc_autoconf_toolchains(name = "local_config_cc_toolchains")
 +  cc_autoconf(name = "local_config_cc")
++  xcode_configure("@bazel_tools//tools/osx:xcode_locator.m")
 +
 +cc_configure = module_extension(implementation = _cc_configure_impl)

--- a/modules/rules_cc/0.0.1/source.json
+++ b/modules/rules_cc/0.0.1/source.json
@@ -2,7 +2,7 @@
     "integrity": "sha256-Tcy/0iwN7xZMj0dFi9UODHFI89kgAs20WcKpamhJgkE=",
     "patch_strip": 1,
     "patches": {
-        "add_module_extension.patch": "sha256-ees694Rs4ca6Ogle8ZY93xLl3Hfhggojy9KyJG706Xo="
+        "add_module_extension.patch": "sha256-Q5mKDRxtJmASGYfBc6HAP/RK6WgFVzTk4ISIXSXrLYo="
     },
     "url": "https://github.com/bazelbuild/rules_cc/releases/download/0.0.1/rules_cc-0.0.1.tar.gz"
 }

--- a/modules/rules_python/0.4.0/MODULE.bazel
+++ b/modules/rules_python/0.4.0/MODULE.bazel
@@ -2,6 +2,7 @@ module(
   name = "rules_python",
   version = "0.4.0",
   compatibility_level = 1,
+  toolchains_to_register = ["@bazel_tools//tools/python:autodetecting_toolchain"],
 )
 
 pip_install = use_extension("@rules_python//bzlmod:extensions.bzl", "pip_install")


### PR DESCRIPTION
- rules_cc now also includes xcode_configure in the cc_configure module extension, which allows us to not appending xcode_configure.WORKSPACE.
- rules_python now registers default python toolchains, which allows us to not appending python.WORKSPACE.