### PR TITLE
bazel_skylib: Register unittest toolchains

### DIFF
--- a/modules/bazel_skylib/1.0.3/MODULE.bazel
+++ b/modules/bazel_skylib/1.0.3/MODULE.bazel
@@ -2,4 +2,8 @@ module(
     name = "bazel_skylib",
     version = "1.0.3",
     compatibility_level = 1,
+    toolchains_to_register = [
+        "@bazel_skylib//toolchains/unittest:cmd_toolchain",
+        "@bazel_skylib//toolchains/unittest:bash_toolchain",
+    ],
 )


### PR DESCRIPTION
The module definition of `bazel_skylib` lacks the equivalent of the
`bazel_skylib_workspace()` macro, which registers the unittest
toolchains.