### PR TITLE
bazel_skylib: Add missing toolchain dependency

### DIFF
--- a/modules/bazel_skylib/1.0.3/MODULE.bazel
+++ b/modules/bazel_skylib/1.0.3/MODULE.bazel
@@ -7,3 +7,5 @@ module(
         "@bazel_skylib//toolchains/unittest:bash_toolchain",
     ],
 )
+
+bazel_dep(name = "platforms", version = "0.0.4")


### PR DESCRIPTION
The unittest toolchains offered by `bazel_skylib` use `@platforms`, which with `bzlmod` has to be declared as an explicit dependency.

Without this addition, I see failures such as:
```
ERROR: external/bazel_skylib.1.0.3/toolchains/unittest/BUILD:22:10: no such package '@platforms//os': The repository '@platforms' could not be resolved: Repository '@platforms' is not visible from repository '@bazel_skylib.1.0.3' and referenced by '@bazel_skylib.1.0.3//toolchains/unittest:cmd_toolchain'
```