### PR TITLE
Add rules_sh 0.2.0

### DIFF
--- a/modules/rules_sh/0.2.0/MODULE.bazel
+++ b/modules/rules_sh/0.2.0/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "rules_sh",
+    version = "0.2.0",
+    compatibility_level = 0,
+    toolchains_to_register = ["@local_posix_config//:local_posix_toolchain"],
+)
+bazel_dep(name = "bazel_skylib", version = "1.0.3")
+bazel_dep(name = "platforms", version = "0.0.4")
+
+sh_configure = use_extension("@rules_sh//bzlmod:extensions.bzl", "sh_configure")
+use_repo(sh_configure, "local_posix_config")

--- a/modules/rules_sh/0.2.0/patches/add_module_extension.patch
+++ b/modules/rules_sh/0.2.0/patches/add_module_extension.patch
@@ -1,0 +1,82 @@
+diff --git a/.bazelci/presubmit.yml b/.bazelci/presubmit.yml
+new file mode 100644
+index 0000000..8b8cbda
+--- /dev/null
++++ b/.bazelci/presubmit.yml
+@@ -0,0 +1,16 @@
++platforms:
++  centos7:
++    build_targets:
++    - '@rules_sh//...'
++  debian10:
++    build_targets:
++    - '@rules_sh//...'
++  macos:
++    build_targets:
++    - '@rules_sh//...'
++  ubuntu2004:
++    build_targets:
++    - '@rules_sh//...'
++  windows:
++    build_targets:
++    - '@rules_sh//...'
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..1610bed
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,11 @@
++module(
++    name = "rules_sh",
++    version = "0.2.0",
++    compatibility_level = 0,
++    toolchains_to_register = ["@local_posix_config//:local_posix_toolchain"],
++)
++bazel_dep(name = "bazel_skylib", version = "1.0.3")
++bazel_dep(name = "platforms", version = "0.0.4")
++
++sh_configure = use_extension("@rules_sh//bzlmod:extensions.bzl", "sh_configure")
++use_repo(sh_configure, "local_posix_config")
+diff --git a/bzlmod/BUILD.bazel b/bzlmod/BUILD.bazel
+new file mode 100644
+index 0000000..1bb8bf6
+--- /dev/null
++++ b/bzlmod/BUILD.bazel
+@@ -0,0 +1 @@
++# empty
+diff --git a/bzlmod/extensions.bzl b/bzlmod/extensions.bzl
+new file mode 100644
+index 0000000..5dd6441
+--- /dev/null
++++ b/bzlmod/extensions.bzl
+@@ -0,0 +1,7 @@
++load("//sh:posix.bzl", "sh_posix_configure")
++
++
++def _sh_configure_impl(ctx):
++    sh_posix_configure(register = False)
++
++sh_configure = module_extension(implementation = _sh_configure_impl)
+diff --git a/sh/posix.bzl b/sh/posix.bzl
+index 4662883..62ef40d 100644
+--- a/sh/posix.bzl
++++ b/sh/posix.bzl
+@@ -339,7 +339,7 @@ _sh_posix_config = repository_rule(
+     implementation = _sh_posix_config_impl,
+ )
+ 
+-def sh_posix_configure(name = "local_posix_config"):
++def sh_posix_configure(name = "local_posix_config", register = True):
+     """Autodetect local Unix commands.
+ 
+     Scans the environment (`$PATH`) for standard shell commands, generates a
+@@ -350,7 +350,8 @@ def sh_posix_configure(name = "local_posix_config"):
+     `POSIX_MAKE=/usr/bin/gmake` will override the make command.
+     """
+     _sh_posix_config(name = name)
+-    native.register_toolchains("@{}//:local_posix_toolchain".format(name))
++    if register:
++        native.register_toolchains("@{}//:local_posix_toolchain".format(name))
+ 
+ posix = struct(
+     commands = _commands,

--- a/modules/rules_sh/0.2.0/presubmit.yml
+++ b/modules/rules_sh/0.2.0/presubmit.yml
@@ -1,0 +1,16 @@
+platforms:
+  centos7:
+    build_targets:
+    - '@rules_sh//...'
+  debian10:
+    build_targets:
+    - '@rules_sh//...'
+  macos:
+    build_targets:
+    - '@rules_sh//...'
+  ubuntu2004:
+    build_targets:
+    - '@rules_sh//...'
+  windows:
+    build_targets:
+    - '@rules_sh//...'

--- a/modules/rules_sh/0.2.0/source.json
+++ b/modules/rules_sh/0.2.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-g6BlumRpE1o1eG63QeF9UPNgypKrKJeFdHWrF8DSmTE=",
+    "patch_strip": 1,
+    "patches": {
+        "add_module_extension.patch": "sha256-49ltsUGEbDnDx/BjXR1ouWG6e3IyVro1I1kW2Y4aHxg="
+    },
+    "strip_prefix": "rules_sh-0.2.0",
+    "url": "https://github.com/tweag/rules_sh/archive/refs/tags/v0.2.0.tar.gz"
+}

--- a/modules/rules_sh/metadata.json
+++ b/modules/rules_sh/metadata.json
@@ -1,0 +1,14 @@
+{
+    "homepage": "https://github.com/tweag/rules_sh#readme",
+    "maintainers": [
+        {
+            "email": "andreas.herrmann@tweag.io",
+            "github": "aherrmann",
+            "name": "Andreas Herrmann"
+        }
+    ],
+    "versions": [
+        "0.2.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
[rules_sh](https://github.com/tweag/rules_sh) provides a Bazel toolchain for standard shell tools. It is a dependency of rules_haskell and rules_nixpkgs.