### PR TITLE
Fix wrong SHA on rules_nodejs artifact.

### DIFF
--- a/modules/rules_nodejs/4.5.0/source.json
+++ b/modules/rules_nodejs/4.5.0/source.json
@@ -1,4 +1,4 @@
 {
-    "integrity": "sha256-ByrmR+cdNUK23cVijpz6GSHh8pHfvSh/Bx4hjMT6J0Q=",
+    "integrity": "sha256-idnKJcTmPmkDPjevL8BOJh2nuZy/5dvxKsGzJgBq7Yw=",
     "url": "https://github.com/bazelbuild/rules_nodejs/releases/download/4.5.0/rules_nodejs-core-4.5.0.tar.gz"
 }


### PR DESCRIPTION
I made a mistake in yesterday's release and uploaded files that didn't match the release SHA.
As a result, usage of this module fails (the extensions.bzl file isn't
in that artifact).