### PR TITLE
Add protobuf 3.19.2

### DIFF
--- a/modules/protobuf/3.19.2/MODULE.bazel
+++ b/modules/protobuf/3.19.2/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "protobuf",
+    version = "3.19.2",
+    compatibility_level = 1,
+)
+bazel_dep(name = "bazel_skylib", version = "1.0.3")
+bazel_dep(name = "zlib", version = "1.2.11")
+bazel_dep(name = "rules_python", version = "0.4.0")
+bazel_dep(name = "rules_cc", version = "0.0.1")
+bazel_dep(name = "rules_proto", version = "4.0.0")
+bazel_dep(name = "rules_java", version = "4.0.0")

--- a/modules/protobuf/3.19.2/patches/relative_repo_names.patch
+++ b/modules/protobuf/3.19.2/patches/relative_repo_names.patch
@@ -1,0 +1,49 @@
+diff --git a/protobuf.bzl b/protobuf.bzl
+index 971612812..26b662532 100644
+--- a/protobuf.bzl
++++ b/protobuf.bzl
+@@ -259,9 +259,9 @@ def cc_proto_library(
+         deps = [],
+         cc_libs = [],
+         include = None,
+-        protoc = "@com_google_protobuf//:protoc",
++        protoc = Label("//:protoc"),
+         use_grpc_plugin = False,
+-        default_runtime = "@com_google_protobuf//:protobuf",
++        default_runtime = Label("//:protobuf"),
+         **kargs):
+     """Bazel rule to create a C++ protobuf library from proto source files
+ 
+@@ -379,7 +379,7 @@ internal_gen_well_known_protos_java = rule(
+         "_protoc": attr.label(
+             executable = True,
+             cfg = "exec",
+-            default = "@com_google_protobuf//:protoc",
++            default = "//:protoc",
+         ),
+     },
+ )
+@@ -422,8 +422,8 @@ def py_proto_library(
+         py_libs = [],
+         py_extra_srcs = [],
+         include = None,
+-        default_runtime = "@com_google_protobuf//:protobuf_python",
+-        protoc = "@com_google_protobuf//:protoc",
++        default_runtime = Label("//:protobuf_python"),
++        protoc = Label("//:protoc"),
+         use_grpc_plugin = False,
+         **kargs):
+     """Bazel rule to create a Python protobuf library from proto source files
+diff --git a/protobuf_deps.bzl b/protobuf_deps.bzl
+index 32f38ebb6..f2d545901 100644
+--- a/protobuf_deps.bzl
++++ b/protobuf_deps.bzl
+@@ -29,7 +29,7 @@ def protobuf_deps():
+     if not native.existing_rule("zlib"):
+         http_archive(
+             name = "zlib",
+-            build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
++            build_file = "//:third_party/zlib.BUILD",
+             sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
+             strip_prefix = "zlib-1.2.11",
+             urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],

--- a/modules/protobuf/3.19.2/patches/remove_dependency_on_rules_jvm_external.patch
+++ b/modules/protobuf/3.19.2/patches/remove_dependency_on_rules_jvm_external.patch
@@ -1,0 +1,94 @@
+diff --git a/java/core/BUILD b/java/core/BUILD
+index 419eafb58..7ff4a3b5d 100644
+--- a/java/core/BUILD
++++ b/java/core/BUILD
+@@ -1,6 +1,6 @@
+ load("@bazel_skylib//rules:build_test.bzl", "build_test")
+ load("@rules_java//java:defs.bzl", "java_library", "java_lite_proto_library", "java_proto_library")
+-load("@rules_jvm_external//:defs.bzl", "java_export")
++# load("@rules_jvm_external//:defs.bzl", "java_export")
+ load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain", "proto_library")
+ load("//:internal.bzl", "conformance_test")
+ load("//:protobuf_version.bzl", "PROTOBUF_VERSION")
+@@ -111,15 +111,15 @@ java_library(
+ )
+ 
+ # Bazel users, don't depend on this target, use //java/lite.
+-java_export(
+-    name = "lite_mvn",
+-    maven_coordinates = "com.google.protobuf:protobuf-javalite:%s" % PROTOBUF_VERSION,
+-    pom_template = "//java/lite:pom_template.xml",
+-    resources = [
+-        "//:lite_well_known_protos",
+-    ],
+-    runtime_deps = [":lite"],
+-)
++# java_export(
++#     name = "lite_mvn",
++#     maven_coordinates = "com.google.protobuf:protobuf-javalite:%s" % PROTOBUF_VERSION,
++#     pom_template = "//java/lite:pom_template.xml",
++#     resources = [
++#         "//:lite_well_known_protos",
++#     ],
++#     runtime_deps = [":lite"],
++# )
+ 
+ java_library(
+     name = "lite_runtime_only",
+@@ -146,15 +146,15 @@ java_library(
+ )
+ 
+ # Bazel users, don't depend on this target, use :core.
+-java_export(
+-    name = "core_mvn",
+-    maven_coordinates = "com.google.protobuf:protobuf-java:%s" % PROTOBUF_VERSION,
+-    pom_template = "pom_template.xml",
+-    resources = [
+-        "//:well_known_protos",
+-    ],
+-    runtime_deps = [":core"],
+-)
++# java_export(
++#     name = "core_mvn",
++#     maven_coordinates = "com.google.protobuf:protobuf-java:%s" % PROTOBUF_VERSION,
++#     pom_template = "pom_template.xml",
++#     resources = [
++#         "//:well_known_protos",
++#     ],
++#     runtime_deps = [":core"],
++# )
+ 
+ filegroup(
+     name = "release",
+diff --git a/java/util/BUILD b/java/util/BUILD
+index ee6ddeaf1..e3796d2aa 100644
+--- a/java/util/BUILD
++++ b/java/util/BUILD
+@@ -1,5 +1,5 @@
+ load("@rules_java//java:defs.bzl", "java_proto_library")
+-load("@rules_jvm_external//:defs.bzl", "java_export")
++# load("@rules_jvm_external//:defs.bzl", "java_export")
+ load("@rules_proto//proto:defs.bzl", "proto_library")
+ load("//:protobuf_version.bzl", "PROTOBUF_VERSION")
+ load("//java/internal:testing.bzl", "junit_tests")
+@@ -22,13 +22,13 @@ java_library(
+ )
+ 
+ # Bazel users, don't depend on this target, use :util.
+-java_export(
+-    name = "util_mvn",
+-    maven_coordinates = "com.google.protobuf:protobuf-java-util:%s" % PROTOBUF_VERSION,
+-    pom_template = "pom_template.xml",
+-    visibility = ["//java:__pkg__"],
+-    runtime_deps = [":util"],
+-)
++# java_export(
++#     name = "util_mvn",
++#     maven_coordinates = "com.google.protobuf:protobuf-java-util:%s" % PROTOBUF_VERSION,
++#     pom_template = "pom_template.xml",
++#     visibility = ["//java:__pkg__"],
++#     runtime_deps = [":util"],
++# )
+ 
+ filegroup(
+     name = "release",

--- a/modules/protobuf/3.19.2/presubmit.yml
+++ b/modules/protobuf/3.19.2/presubmit.yml
@@ -1,0 +1,17 @@
+build_targets: &build_targets
+- '@protobuf//:protobuf'
+- '@protobuf//:protobuf_lite'
+- '@protobuf//:protoc'
+- '@protobuf//:test_messages_proto2_proto_cc'
+
+platforms:
+  centos7:
+    build_targets: *build_targets
+  debian10:
+    build_targets: *build_targets
+  macos:
+    build_targets: *build_targets
+  ubuntu2004:
+    build_targets: *build_targets
+  windows:
+    build_targets: *build_targets

--- a/modules/protobuf/3.19.2/source.json
+++ b/modules/protobuf/3.19.2/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-nO7w2vfovhbNmax1knHrCAIbU7HHtu3TmZU6djkCNM0=",
+    "patch_strip": 1,
+    "patches": {
+        "relative_repo_names.patch": "sha256-w/5gw/zGv8NFId+669hcdw1Uus2lxgYpulATHIwIByI=",
+        "remove_dependency_on_rules_jvm_external.patch": "sha256-THUTnVgEBmjA0W7fKzIyZOVG58DnW9HQTkr4D2zKUUc="
+    },
+    "strip_prefix": "protobuf-3.19.2",
+    "url": "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.2.zip"
+}

--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -2,7 +2,8 @@
     "homepage": "https://github.com/protocolbuffers/protobuf",
     "maintainers": [],
     "versions": [
-        "3.19.0"
+        "3.19.0",
+        "3.19.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Also adds the java_library targets used by Bazel to the presubmit config.