### PR TITLE
Update protobuf to have better test config

### DIFF
--- a/modules/protobuf/3.19.0/patches/add_module_dot_bazel_for_examples.patch
+++ b/modules/protobuf/3.19.0/patches/add_module_dot_bazel_for_examples.patch
@@ -1,0 +1,55 @@
+commit 8798cdb6a94dcddd97af2d6267b62c80a1608240
+Author: Yun Peng <pcloudy@google.com>
+Date:   Wed Jan 5 17:48:13 2022 +0100
+
+    Add MODULE.bazel for examples and clear the WORKSPACE file
+
+diff --git a/examples/MODULE.bazel b/examples/MODULE.bazel
+new file mode 100644
+index 000000000..20dbae8cc
+--- /dev/null
++++ b/examples/MODULE.bazel
+@@ -0,0 +1,7 @@
++bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "")
++
++local_path_override(
++  module_name = "protobuf",
++  path = "..",
++)
++
+diff --git a/examples/WORKSPACE b/examples/WORKSPACE
+index fb36639ae..9fb7e4dc9 100644
+--- a/examples/WORKSPACE
++++ b/examples/WORKSPACE
+@@ -1,31 +1,2 @@
+ workspace(name = "com_google_protobuf_examples")
+ 
+-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+-
+-# This com_google_protobuf repository is required for proto_library rule.
+-# It provides the protocol compiler binary (i.e., protoc).
+-#
+-# We declare it as local_repository so we can test changes
+-# before they get merged. You'll want to use the following instead:
+-#
+-# http_archive(
+-#     name = "com_google_protobuf",
+-#     strip_prefix = "protobuf-master",
+-#     urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+-# )
+-local_repository(
+-    name = "com_google_protobuf",
+-    path = "..",
+-)
+-
+-# Similar to com_google_protobuf but for Java lite. If you are building
+-# for Android, the lite version should be preferred because it has a much
+-# smaller code size.
+-local_repository(
+-    name = "com_google_protobuf_javalite",
+-    path = "..",
+-)
+-
+-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+-
+-protobuf_deps()

--- a/modules/protobuf/3.19.0/presubmit.yml
+++ b/modules/protobuf/3.19.0/presubmit.yml
@@ -1,17 +1,23 @@
-build_targets: &build_targets
-- '@protobuf//:protobuf'
-- '@protobuf//:protobuf_lite'
-- '@protobuf//:protoc'
-- '@protobuf//:test_messages_proto2_proto_cc'
+matrix:
+  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
 
-platforms:
-  centos7:
-    build_targets: *build_targets
-  debian10:
-    build_targets: *build_targets
-  macos:
-    build_targets: *build_targets
-  ubuntu2004:
-    build_targets: *build_targets
-  windows:
-    build_targets: *build_targets
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    build_targets:
+    - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_lite'
+    - '@protobuf//:protoc'
+    - '@protobuf//:test_messages_proto2_proto_cc'
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      build_targets:
+      - "//..."

--- a/modules/protobuf/3.19.0/source.json
+++ b/modules/protobuf/3.19.0/source.json
@@ -3,7 +3,8 @@
     "patch_strip": 1,
     "patches": {
         "relative_repo_names.patch": "sha256-w/5gw/zGv8NFId+669hcdw1Uus2lxgYpulATHIwIByI=",
-        "remove_dependency_on_rules_jvm_external.patch": "sha256-J8u5VCpDBSRMnq8mjUiI0UM+kpZDc9jV0UMF4KtU9VM="
+        "remove_dependency_on_rules_jvm_external.patch": "sha256-J8u5VCpDBSRMnq8mjUiI0UM+kpZDc9jV0UMF4KtU9VM=",
+        "add_module_dot_bazel_for_examples.patch": "sha256-s/b1gi3baK3LsXefI2rQilhmkb2R5jVJdnT6zEcdfHY="
     },
     "strip_prefix": "protobuf-3.19.0",
     "url": "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.0.zip"

--- a/modules/protobuf/3.19.2/patches/add_module_dot_bazel_for_examples.patch
+++ b/modules/protobuf/3.19.2/patches/add_module_dot_bazel_for_examples.patch
@@ -1,0 +1,55 @@
+commit 8798cdb6a94dcddd97af2d6267b62c80a1608240
+Author: Yun Peng <pcloudy@google.com>
+Date:   Wed Jan 5 17:48:13 2022 +0100
+
+    Add MODULE.bazel for examples and clear the WORKSPACE file
+
+diff --git a/examples/MODULE.bazel b/examples/MODULE.bazel
+new file mode 100644
+index 000000000..20dbae8cc
+--- /dev/null
++++ b/examples/MODULE.bazel
+@@ -0,0 +1,7 @@
++bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "")
++
++local_path_override(
++  module_name = "protobuf",
++  path = "..",
++)
++
+diff --git a/examples/WORKSPACE b/examples/WORKSPACE
+index fb36639ae..9fb7e4dc9 100644
+--- a/examples/WORKSPACE
++++ b/examples/WORKSPACE
+@@ -1,31 +1,2 @@
+ workspace(name = "com_google_protobuf_examples")
+ 
+-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+-
+-# This com_google_protobuf repository is required for proto_library rule.
+-# It provides the protocol compiler binary (i.e., protoc).
+-#
+-# We declare it as local_repository so we can test changes
+-# before they get merged. You'll want to use the following instead:
+-#
+-# http_archive(
+-#     name = "com_google_protobuf",
+-#     strip_prefix = "protobuf-master",
+-#     urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+-# )
+-local_repository(
+-    name = "com_google_protobuf",
+-    path = "..",
+-)
+-
+-# Similar to com_google_protobuf but for Java lite. If you are building
+-# for Android, the lite version should be preferred because it has a much
+-# smaller code size.
+-local_repository(
+-    name = "com_google_protobuf_javalite",
+-    path = "..",
+-)
+-
+-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+-
+-protobuf_deps()

--- a/modules/protobuf/3.19.2/presubmit.yml
+++ b/modules/protobuf/3.19.2/presubmit.yml
@@ -1,17 +1,23 @@
-build_targets: &build_targets
-- '@protobuf//:protobuf'
-- '@protobuf//:protobuf_lite'
-- '@protobuf//:protoc'
-- '@protobuf//:test_messages_proto2_proto_cc'
+matrix:
+  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
 
-platforms:
-  centos7:
-    build_targets: *build_targets
-  debian10:
-    build_targets: *build_targets
-  macos:
-    build_targets: *build_targets
-  ubuntu2004:
-    build_targets: *build_targets
-  windows:
-    build_targets: *build_targets
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    build_targets:
+    - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_lite'
+    - '@protobuf//:protoc'
+    - '@protobuf//:test_messages_proto2_proto_cc'
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      build_targets:
+      - "//..."

--- a/modules/protobuf/3.19.2/source.json
+++ b/modules/protobuf/3.19.2/source.json
@@ -3,7 +3,8 @@
     "patch_strip": 1,
     "patches": {
         "relative_repo_names.patch": "sha256-w/5gw/zGv8NFId+669hcdw1Uus2lxgYpulATHIwIByI=",
-        "remove_dependency_on_rules_jvm_external.patch": "sha256-THUTnVgEBmjA0W7fKzIyZOVG58DnW9HQTkr4D2zKUUc="
+        "remove_dependency_on_rules_jvm_external.patch": "sha256-THUTnVgEBmjA0W7fKzIyZOVG58DnW9HQTkr4D2zKUUc=",
+        "add_module_dot_bazel_for_examples.patch": "sha256-s/b1gi3baK3LsXefI2rQilhmkb2R5jVJdnT6zEcdfHY="
     },
     "strip_prefix": "protobuf-3.19.2",
     "url": "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.2.zip"


### PR DESCRIPTION
This PR updates the test config for protobuf to use the new matrix testing and bcr test module features.

This change adds more patch for already checked in modules, this should not happen when BCR officially launches, but it's fine for now because we're still in testing phase.