### PR TITLE
Improve presubmit.yml generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,13 @@ Currently, the Bazel team is the registry maintainer, who are responsible for:
 
 ## presubmit.yml
 
-We require every module version to have a presubmit.yml file. With this file, you can specify a list of build and test targets for supported platforms. Those could be the targets you want to expose to the downstream users and a few integration tests that have good coverage over your APIs.
+We require every module version to have a `presubmit.yml` file for configuring the presubmit tests to verify the integrity of the module.
 
-**Note that**, it's NOT recommended to specify your entire test suite in this presubmit.yml file. Because running the entire test suite could be expensive and the result could be flaky. It's best to specify a list of test targets that are heavily used, well maintained and have a history of providing good signal and high-quality test results.
+In the `presubmit.yml` file:
+
+  - You should specify the list of build targets that you want to expose to downstream users.
+  - It's highly recommended to have a [test module](https://github.com/bazelbuild/continuous-integration/issues/1302) in your source archive.
+  - In general, you should NOT specify unit tests or test suites foucing on implementation details in this file.
 
 The presubmit.yml file will be used for:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In the `presubmit.yml` file:
 
   - You should specify the list of build targets that you want to expose to downstream users.
   - It's highly recommended to have a [test module](https://github.com/bazelbuild/continuous-integration/issues/1302) in your source archive.
-  - In general, you should NOT specify unit tests or test suites foucing on implementation details in this file.
+  - In general, you should NOT specify unit tests or test suites focusing on implementation details in this file.
 
 The presubmit.yml file will be used for:
 

--- a/tools/add_module.py
+++ b/tools/add_module.py
@@ -106,25 +106,39 @@ def from_user_input():
         name, version = dep.split("@")
         module.add_dep(name, version)
 
-  if yes_or_no("Do you want to specify a presubmit.yml file?", False):
+  presubmit_url = "https://github.com/bazelbuild/bazel-central-registry/tree/main#presubmityml"
+  if yes_or_no(f"Do you want to specify an existing presubmit.yml file? (See {presubmit_url})", False):
     path = ask_input("Please enter the presubmit.yml file path: ").strip()
     module.set_presubmit_yml(path)
   else:
     first = True
-    while not (module.build_targets or module.test_targets):
+    while not module.build_targets:
       if not first:
-        print("Build targets and test targets cannot both be empty, please re-enter!")
+        print("Build targets cannot be empty, please re-enter!")
       first = False
       build_targets = ask_input(
-          "Please enter a list of build targets for this module, separated by `,`: ")
+          "Please enter a list of build targets you want to expose to downstream users, separated by `,`: ")
       for target in build_targets.strip().split(","):
         if target:
           module.add_build_target(target)
-      test_targets = ask_input(
-          "Please enter a list of test targets for this module, separated by `,`: ")
-      for target in test_targets.strip().split(","):
-        if target:
-          module.add_test_targets(target)
+
+    if yes_or_no("Do you have a test module in your source archive?", True):
+      module.test_module_path = ask_input("Please enter the test module path in your source archive: ")
+      first = True
+      while not (module.test_module_build_targets or module.test_module_test_targets):
+        if not first:
+          print("Build targets and test targets cannot both be empty, please re-enter!")
+        first = False
+        build_targets = ask_input(
+            "Please enter a list of build targets for the test module, separated by `,`: ")
+        for target in build_targets.strip().split(","):
+          if target:
+            module.add_test_module_build_target(target)
+        test_targets = ask_input(
+            "Please enter a list of test targets for the test module, separated by `,`: ")
+        for target in test_targets.strip().split(","):
+          if target:
+            module.add_test_module_test_target(target)
   return module
 
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -269,11 +269,11 @@ module(
       shutil.copy(module.presubmit_yml, presubmit_yml)
     else:
       PLATFORMS = ["centos7", "debian10", "ubuntu2004", "macos", "windows"]
-      presubmit = {}
-      presubmit["matrix"] = {}
+      presubmit = dict()
+      presubmit["matrix"] = dict()
       presubmit["matrix"]["platform"] = PLATFORMS.copy()
-      presubmit["tasks"] = {}
-      task = {}
+      presubmit["tasks"] = dict()
+      task = dict()
       task["name"] = "Verify build targets"
       task["platform"] = "${{ platform }}"
       if module.build_targets:
@@ -281,12 +281,12 @@ module(
       presubmit["tasks"]["verify_targets"] = task
 
       if module.test_module_path:
-        presubmit["bcr_test_module"] = {}
+        presubmit["bcr_test_module"] = dict()
         presubmit["bcr_test_module"]["module_path"] = module.test_module_path
-        presubmit["bcr_test_module"]["matrix"] = {}
+        presubmit["bcr_test_module"]["matrix"] = dict()
         presubmit["bcr_test_module"]["matrix"]["platform"] = PLATFORMS.copy()
-        presubmit["bcr_test_module"]["tasks"] = {}
-        task = {}
+        presubmit["bcr_test_module"]["tasks"] = dict()
+        task = dict()
         task["name"] = "Run test module"
         task["platform"] = "${{ platform }}"
         if module.test_module_build_targets:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -72,7 +72,9 @@ class Module:
     self.build_file = None
     self.presubmit_yml = None
     self.build_targets = []
-    self.test_targets = []
+    self.test_module_path = None
+    self.test_module_build_targets = []
+    self.test_module_test_targets = []
 
   def add_dep(self, module_name, version):
     self.deps.append((module_name, version))
@@ -109,10 +111,12 @@ class Module:
     self.build_targets.append(target)
     return self
 
-  def add_test_targets(self, target):
-    if not target.startswith("@" + self.name):
-      target = "@" + self.name + target
-    self.test_targets.append(target)
+  def add_test_module_build_target(self, target):
+    self.test_module_build_targets.append(target)
+    return self
+
+  def add_test_module_test_target(self, target):
+    self.test_module_test_targets.append(target)
     return self
 
   def dump(self, file):
@@ -264,20 +268,35 @@ module(
     if module.presubmit_yml:
       shutil.copy(module.presubmit_yml, presubmit_yml)
     else:
-      platforms = {
-          "centos7": {},
-          "debian10": {},
-          "ubuntu2004": {},
-          "macos": {},
-          "windows": {},
-      }
-      for _, config in platforms.items():
-        if module.build_targets:
-          config["build_targets"] = module.build_targets.copy()
-        if module.test_targets:
-          config["test_targets"] = module.test_targets.copy()
+      PLATFORMS = ["centos7", "debian10", "ubuntu2004", "macos", "windows"]
+      presubmit = {}
+      presubmit["matrix"] = {}
+      presubmit["matrix"]["platform"] = PLATFORMS.copy()
+      presubmit["tasks"] = {}
+      task = {}
+      task["name"] = "Verify build targets"
+      task["platform"] = "${{ platform }}"
+      if module.build_targets:
+        task["build_targets"] = module.build_targets.copy()
+      presubmit["tasks"]["verify_targets"] = task
+
+      if module.test_module_path:
+        presubmit["bcr_test_module"] = {}
+        presubmit["bcr_test_module"]["module_path"] = module.test_module_path
+        presubmit["bcr_test_module"]["matrix"] = {}
+        presubmit["bcr_test_module"]["matrix"]["platform"] = PLATFORMS.copy()
+        presubmit["bcr_test_module"]["tasks"] = {}
+        task = {}
+        task["name"] = "Run test module"
+        task["platform"] = "${{ platform }}"
+        if module.test_module_build_targets:
+          task["build_targets"] = module.test_module_build_targets.copy()
+        if module.test_module_test_targets:
+          task["test_targets"] = module.test_module_test_targets.copy()
+        presubmit["bcr_test_module"]["tasks"]["run_test_module"] = task
+
       with presubmit_yml.open("w") as f:
-        yaml.dump({"platforms": platforms}, f)
+        yaml.dump(presubmit, f, sort_keys=False)
 
     # Add new version to metadata.json
     metadata_path = self.root.joinpath("modules", module.name,


### PR DESCRIPTION
With https://github.com/bazelbuild/continuous-integration/issues/1302, we now encourage module maintainer to check in a test module instead of the entire test suite of the project.

Also generating presubmit.yml in the new matrix testing format.