### PR TITLE
Update BUILD file for zlib

### DIFF
--- a/modules/zlib/1.2.11/patches/add_build_file.patch
+++ b/modules/zlib/1.2.11/patches/add_build_file.patch
@@ -1,17 +1,46 @@
 --- /dev/null
-+++ BUILD
-@@ -0,0 +1,14 @@
-+licenses(["notice"])  #  BSD/MIT-like license
++++ BUILD.bazel
+@@ -0,0 +1,43 @@
++package(default_visibility = ["//visibility:public"])
++
++licenses(["notice"])  # BSD/MIT-like license (for zlib)
 +
 +cc_library(
 +    name = "zlib",
-+    srcs = glob(["*.c"]),
-+    hdrs = glob(["*.h"]),
-+    # Use -Dverbose=-1 to turn off zlib's trace logging. (#3280)
-+    copts = [
-+        "-w",
-+        "-Dverbose=-1",
++    srcs = [
++        "adler32.c",
++        "compress.c",
++        "crc32.c",
++        "crc32.h",
++        "deflate.c",
++        "deflate.h",
++        "gzclose.c",
++        "gzguts.h",
++        "gzlib.c",
++        "gzread.c",
++        "gzwrite.c",
++        "infback.c",
++        "inffast.c",
++        "inffast.h",
++        "inffixed.h",
++        "inflate.c",
++        "inflate.h",
++        "inftrees.c",
++        "inftrees.h",
++        "trees.c",
++        "trees.h",
++        "uncompr.c",
++        "zconf.h",
++        "zutil.c",
++        "zutil.h",
 +    ],
++    hdrs = ["zlib.h"],
++    copts = select({
++        "@bazel_tools//src/conditions:windows": [],
++        "//conditions:default": [
++            "-Wno-shift-negative-value",
++            "-DZ_HAVE_UNISTD_H",
++        ],
++    }),
 +    includes = ["."],
-+    visibility = ["//visibility:public"],
 +)

--- a/modules/zlib/1.2.11/presubmit.yml
+++ b/modules/zlib/1.2.11/presubmit.yml
@@ -1,16 +1,13 @@
-platforms:
-  centos7:
-    build_targets:
-    - '@zlib//:zlib'
-  debian10:
-    build_targets:
-    - '@zlib//:zlib'
-  macos:
-    build_targets:
-    - '@zlib//:zlib'
-  ubuntu2004:
-    build_targets:
-    - '@zlib//:zlib'
-  windows:
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
     build_targets:
     - '@zlib//:zlib'

--- a/modules/zlib/1.2.11/source.json
+++ b/modules/zlib/1.2.11/source.json
@@ -2,7 +2,7 @@
     "integrity": "sha256-9cxKuRDbmbK9u6Oeu9wiX/wqoEtAV7woF/G5S2l4z8M=",
     "patch_strip": 0,
     "patches": {
-        "add_build_file.patch": "sha256-Pha0vKfp2QE7e/YKfFg4284U1BQxxhrxJAfIDCQFOBI="
+        "add_build_file.patch": "sha256-Z2ig1F01/dfdG63H+GwYRMcGbW/zAGIUWnKKrwKSEaQ="
     },
     "strip_prefix": "zlib-1.2.11",
     "url": "https://github.com/madler/zlib/archive/v1.2.11.zip"


### PR DESCRIPTION
Use [the BUILD file](https://github.com/tensorflow/tensorflow/blob/80d2c8dfe24003804bb1921632bc0974be1569af/third_party/zlib.BUILD#L1) from TensorFlow, which makes `@zlib//:zlib.h` public.