### PR TITLE
Update file list for c-ares 1.16.1

### DIFF
--- a/modules/c-ares/1.16.1/patches/add_build_file.patch
+++ b/modules/c-ares/1.16.1/patches/add_build_file.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ BUILD.bazel
-@@ -0,0 +1,170 @@
+@@ -0,0 +1,173 @@
 +load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 +
 +config_setting(
@@ -67,7 +67,10 @@
 +    srcs = [
 +        "ares__close_sockets.c",
 +        "ares__get_hostent.c",
++        "ares__parse_into_addrinfo.c",
 +        "ares__read_line.c",
++        "ares__readaddrinfo.c",
++        "ares__sortaddrinfo.c",
 +        "ares__timeval.c",
 +        "ares_android.c",
 +        "ares_cancel.c",
@@ -79,11 +82,12 @@
 +        "ares_fds.c",
 +        "ares_free_hostent.c",
 +        "ares_free_string.c",
++        "ares_freeaddrinfo.c",
++        "ares_getaddrinfo.c",
 +        "ares_getenv.c",
 +        "ares_gethostbyaddr.c",
 +        "ares_gethostbyname.c",
 +        "ares_getnameinfo.c",
-+        "ares_getopt.c",
 +        "ares_getsock.c",
 +        "ares_init.c",
 +        "ares_library_init.c",
@@ -125,7 +129,6 @@
 +        "ares_data.h",
 +        "ares_dns.h",
 +        "ares_getenv.h",
-+        "ares_getopt.h",
 +        "ares_inet_net_pton.h",
 +        "ares_iphlpapi.h",
 +        "ares_ipv6.h",

--- a/modules/c-ares/1.16.1/source.json
+++ b/modules/c-ares/1.16.1/source.json
@@ -2,7 +2,7 @@
     "integrity": "sha256-0IMS0OzDvUju4KTMDSE3yfGU4KKN4gKJKMD2yuhfhs4=",
     "patch_strip": 0,
     "patches": {
-        "add_build_file.patch": "sha256-+SUCFxBIkR0GE9FRFPps/e6AnA9cQIGANBHK14UAKwQ="
+        "add_build_file.patch": "sha256-BfqAaVGKiHH4Cg0dPisG+ycnHKlogIgO1znwG8tNIVY="
     },
     "strip_prefix": "c-ares-1.16.1",
     "url": "https://github.com/c-ares/c-ares/releases/download/cares-1_16_1/c-ares-1.16.1.tar.gz"


### PR DESCRIPTION
The file list of c-ares 1.15.0 is used for 1.16.1 since the following files are
the same:
1. modules/c-ares/1.16.1/patches/add_build_file.patch
2. modules/c-ares/1.15.0/patches/add_build_file.patch

And add_build_file.patch is adapted from
https://github.com/grpc/grpc/tree/master/third_party/cares. I have tried to find
c-ares version 1.16.1 in grpc project. A search of grpc project commit log shows
that the most relevant thing is commit bdb3f860649bb4c136ba36bad3d9363fccbd29fa
which mentions '-DgRPC_CARES_PROVIDER=package with c-ares 1.16.0 overrides'. My
guess is that grpc has upgraded c-ares from 1.15.0 to 1.17.2 directly.

I built c-ares 1.16.1 with `buildconf` on macOS. The resulted Makefile has
the following two file list:
1. CSOURCES: C++ source files.
2. HHEADERS: C++ header files.

A comparison of CSOURCES with cc_library srcs attribute shows that some source
files are missing. ares_getopt.c is unneeded ares_getopt is not include in
CSOURCES. It is included in SAMPLESOURCES. So this commit deletes it. This
commit also adds the missing C++ source files.

A comparison of HHEADERS with cc_library hdrs attribute shows that hdrs has
three extra files:
1. ares_config.h
2. config-win32.h
3. ares_getopt.h

ares_getopt.h will be deleted together with ares_getopt.c. Since I am not sure of
the reason why the other two files exist, they are kept untouched.

Fix #77