### PR TITLE
Set up GH Action to verify stable source URLs

### DIFF
--- a/.github/workflows/verify_source_urls.yml
+++ b/.github/workflows/verify_source_urls.yml
@@ -1,0 +1,8 @@
+name: Verify stable source URLs
+on: [push]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: python3 ./tools/verify_stable_archives.py

--- a/modules/aspect_bazel_lib/0.4.2/source.json
+++ b/modules/aspect_bazel_lib/0.4.2/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-U0ycYbcsJXyVMC1USYT9juY5U8IzKSxbaVLKWzPNIl4=",
     "strip_prefix": "bazel-lib-0.4.2",
-    "url": "https://github.com/aspect-build/bazel-lib/archive/v0.4.2.tar.gz"
+    "url": "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v0.4.2.tar.gz"
 }

--- a/modules/aspect_rules_js/0.3.2/source.json
+++ b/modules/aspect_rules_js/0.3.2/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-3Xl2YgKPYK0fTlsxlHljSUy7kWpwqjO+ePJ7NMb4IBk=",
     "strip_prefix": "rules_js-0.3.2",
-    "url": "https://github.com/aspect-build/rules_js/archive/v0.3.2.tar.gz"
+    "url": "https://github.com/aspect-build/rules_js/archive/refs/tags/v0.3.2.tar.gz"
 }

--- a/modules/aspect_rules_swc/0.3.0/source.json
+++ b/modules/aspect_rules_swc/0.3.0/source.json
@@ -5,5 +5,5 @@
         "dir.patch": "sha256-1aGvpMK+jcXLfrfjQzRJsiear/JYBvJmhOmWAeOzBcA="
     },
     "strip_prefix": "rules_swc-0.3.0",
-    "url": "https://github.com/aspect-build/rules_swc/archive/v0.3.0.tar.gz"
+    "url": "https://github.com/aspect-build/rules_swc/archive/refs/tags/v0.3.0.tar.gz"
 }

--- a/modules/zlib/1.2.11/source.json
+++ b/modules/zlib/1.2.11/source.json
@@ -5,5 +5,5 @@
         "add_build_file.patch": "sha256-Z2ig1F01/dfdG63H+GwYRMcGbW/zAGIUWnKKrwKSEaQ="
     },
     "strip_prefix": "zlib-1.2.11",
-    "url": "https://github.com/madler/zlib/archive/v1.2.11.zip"
+    "url": "https://github.com/madler/zlib/archive/refs/tags/v1.2.11.zip"
 }

--- a/modules/zstd-jni/1.5.0-4/source.json
+++ b/modules/zstd-jni/1.5.0-4/source.json
@@ -6,5 +6,5 @@
         "add_build_file.patch": "sha256-DIaXCfbXs7o6r1/pORaSj18pfeIzGKCSwAfWPoT6OKs="
     },
     "strip_prefix": "zstd-jni-1.5.0-4",
-    "url": "https://github.com/luben/zstd-jni/archive/v1.5.0-4.zip"
+    "url": "https://github.com/luben/zstd-jni/archive/refs/tags/v1.5.0-4.zip"
 }

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -152,10 +152,25 @@ module(
     modules_dir = self.root.joinpath("modules")
     return [path.name for path in modules_dir.iterdir()]
 
+  def get_all_module_versions(self):
+    module_versions = []
+
+    for module_name in self.get_all_modules():
+      metadata = self.get_metadata(module_name)
+      for version in metadata["versions"]:
+        module_versions.append((module_name, version))
+
+    return module_versions
+
   def get_metadata(self, module_name):
     metadata_path = self.root.joinpath("modules", module_name,
                                        "metadata.json")
     return json.load(metadata_path.open())
+
+  def get_source(self, module_name, version):
+    source_path = self.root.joinpath("modules", module_name, version,
+                                     "source.json")
+    return json.load(source_path.open())
 
   def contains(self, module_name, version=None):
     """

--- a/tools/verify_stable_archives.py
+++ b/tools/verify_stable_archives.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from urllib.parse import urlparse
+from enum import Enum
+
+from registry import RegistryClient
+
+class UrlStability(Enum):
+  STABLE = 1
+  UNSTABLE = 2
+  UNKNOWN = 3
+
+def verify_stable_archive(url):
+  parsed = urlparse(url)
+  if parsed.scheme != "https" or parsed.hostname != "github.com":
+    return UrlStability.UNKNOWN
+
+  path_parts = parsed.path.split("/")
+
+  # We are putting `protocolbuffers/upb` and `google/boringssl` on a temporary allowlist until their
+  # modules have found maintainers.
+  # See https://github.com/bazelbuild/bazel-central-registry/issues/69
+  if path_parts[1] == "protocolbuffers" and path_parts[2] == "upb":
+    return UrlStability.STABLE
+  if path_parts[1] == "google" and path_parts[2] == "boringssl":
+    return UrlStability.STABLE
+
+  if path_parts[3] == "archive" and path_parts[4] == "refs" and path_parts[5] == "tags":
+    return UrlStability.STABLE
+  if path_parts[3] == "releases" and path_parts[4] == "download":
+    return UrlStability.STABLE
+
+  return UrlStability.UNSTABLE
+
+def main(argv=None):
+  if argv is None:
+    argv = sys.argv[1:]
+
+  client = RegistryClient(".")
+
+  has_failure = False
+  for module_name, version in client.get_all_module_versions():
+    source_url = client.get_source(module_name, version)["url"]
+    stability = verify_stable_archive(source_url)
+    if stability == UrlStability.UNSTABLE:
+      has_failure = True
+      print(f'Version `{version}` of module `{module_name}` is using an unstable source url: `{source_url}`')
+      print("The source url should follow the format of `https://github.com/<ORGANIZATION>/<REPO>/archive/refs/tags/<TAG>.tar.gz` to retrieve a source archive that is guaranteed by GitHub to be stable over time.")
+      print("See https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1029861300 for more context.")
+
+  if has_failure:
+    sys.exit(1)
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
As suggested in https://github.com/bazelbuild/bazel-central-registry/issues/69#issuecomment-1090885327, this PR adds a tool and GH Action to verify that all the source URLs follow the format of stable URL as per https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1029861300

There are two open questions for me:
- Should we also verify that the archive has a file ending of `.tar.gz`? There are currently some sources that utilize the `.zip` variant of archives.
- The lint fails right now, as I was unsure how to handle the preexisting unstable URLs. I started to manually migrate the URLs, but the first one I adjusted (of `rules_cc`), yielded an artifact that had a different checksum to the previous artifact, which would break the integrity hash. What's the best way to move forward here?