### PR TITLE
Remove toolchain registration from rules_cc

### DIFF
--- a/modules/rules_cc/0.0.1/patches/add_module_extension.patch
+++ b/modules/rules_cc/0.0.1/patches/add_module_extension.patch
@@ -9,19 +9,15 @@ new file mode 100644
 index 0000000..be5b13d
 --- /dev/null
 +++ b/MODULE.bazel
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,8 @@
 +module(
 +    name = "rules_cc",
 +    version = "0.0.1",
 +    compatibility_level = 1,
-+    toolchains_to_register = ["@local_config_cc_toolchains//:all"],
 +)
 +
 +bazel_dep(name = "bazel_skylib", version = "1.0.3")
 +bazel_dep(name = "platforms", version = "0.0.4")
-+
-+cc_configure = use_extension("@rules_cc//bzlmod:extensions.bzl", "cc_configure")
-+use_repo(cc_configure, "local_config_cc_toolchains")
 diff --git a/bzlmod/BUILD b/bzlmod/BUILD
 new file mode 100644
 index 0000000..8b13789

--- a/modules/rules_cc/0.0.1/source.json
+++ b/modules/rules_cc/0.0.1/source.json
@@ -2,7 +2,7 @@
     "integrity": "sha256-Tcy/0iwN7xZMj0dFi9UODHFI89kgAs20WcKpamhJgkE=",
     "patch_strip": 1,
     "patches": {
-        "add_module_extension.patch": "sha256-Q5mKDRxtJmASGYfBc6HAP/RK6WgFVzTk4ISIXSXrLYo="
+        "add_module_extension.patch": "sha256-g3+zmGs0YT2HKOVevZpN0Jet89Ylw90Cp9XsIAY8QqU="
     },
     "url": "https://github.com/bazelbuild/rules_cc/releases/download/0.0.1/rules_cc-0.0.1.tar.gz"
 }


### PR DESCRIPTION
This is because Bazel currently uses the built-in cc toolchain configuring mechanism (in `@bazel_tools`), and *not* the one in rules_cc. In order to prevent the local cc toolchain from being discovered twice, this commit removes the automatic toolchain registration from rules_cc. In the rare case where someone wants to specifically use the toolchain from rules_cc, they can call `use_extension` on this extension themselves and add the relevant toolchain in their own MODULE.bazel file.

NB: We're directly updating the current version instead of creating a new version because the BCR is not officially launched yet.