### PR TITLE
Patch glog to work with canonical label literals

### DIFF
--- a/modules/glog/0.5.0/patches/remove_only_the_first_leading_at.patch
+++ b/modules/glog/0.5.0/patches/remove_only_the_first_leading_at.patch
@@ -1,0 +1,13 @@
+diff --git a/bazel/glog.bzl b/bazel/glog.bzl
+index 40833b4..bcbdc8a 100644
+--- a/bazel/glog.bzl
++++ b/bazel/glog.bzl
+@@ -33,7 +33,7 @@ def dict_union(x, y):
+ 
+ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
+     if native.repository_name() != "@":
+-        repo_name = native.repository_name().lstrip("@")
++        repo_name = native.repository_name()[1:] # Strip the first leading @
+         gendir = "$(GENDIR)/external/" + repo_name
+         src_windows = "external/%s/src/windows" % repo_name
+     else:

--- a/modules/glog/0.5.0/source.json
+++ b/modules/glog/0.5.0/source.json
@@ -1,5 +1,9 @@
 {
     "integrity": "sha256-7t5x8oNxvzmqabRd4jsynTchQBbiBVJps7Xnz9QLWfU=",
+    "patch_strip": 1,
+    "patches": {
+        "remove_only_the_first_leading_at.patch": "sha256-ieceuBwB5MiGzs1ES3FKKLTCuHwxxERo2clZn5h8S3g="
+    },
     "strip_prefix": "glog-0.5.0",
     "url": "https://github.com/google/glog/archive/refs/tags/v0.5.0.tar.gz"
 }


### PR DESCRIPTION
Upstream PR: https://github.com/google/glog/pull/832