### PR TITLE
Add apple_support 1.0.0

### DIFF
--- a/modules/apple_support/1.0.0/MODULE.bazel
+++ b/modules/apple_support/1.0.0/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "apple_support",
+    version = "1.0.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.1.1")
+bazel_dep(name = "platforms", version = "0.0.4")
+bazel_dep(name = "stardoc", version = "0.5.0", repo_name = "io_bazel_stardoc", dev_dependency = True)

--- a/modules/apple_support/1.0.0/presubmit.yml
+++ b/modules/apple_support/1.0.0/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+
+tasks:
+  verify_targets:
+    name: "Build targets under //lib"
+    platform: ${{ platform }}
+    build_targets:
+    - '@apple_support//lib/...'
+  run_tests:
+    name: "Run test targets"
+    platform: "macos"
+    test_targets:
+    - '@apple_support//test/...'

--- a/modules/apple_support/1.0.0/source.json
+++ b/modules/apple_support/1.0.0/source.json
@@ -1,0 +1,4 @@
+{
+    "integrity": "sha256-3zF0c7WJTdjrQyJA0gknHryDx2uzDFVIE3Szbd8eT9E=",
+    "url": "https://github.com/bazelbuild/apple_support/releases/download/1.0.0/apple_support.1.0.0.tar.gz"
+}


### PR DESCRIPTION
Adds the new 1.0.0 release: https://github.com/bazelbuild/apple_support/releases/tag/1.0.0

One question: we forgot to bump our checked-in `MODULE.bazel` version number before cutting the release in `apple_support`: https://github.com/bazelbuild/apple_support/releases/tag/1.0.0

Will this cause issues and is it something that we need to fix before merging this PR, or can it be postponed until the next release? Also, why does it matter if the `MODULE.bazel` is already checked-in here?