### PR TITLE
Change archive mirror location for the BCR

### DIFF
--- a/bazel_registry.json
+++ b/bazel_registry.json
@@ -1,3 +1,3 @@
 {
-    "mirrors": ["https://bcr.bazel.build/test-mirror"]
+    "mirrors": ["https://bcr.bazel.build/mirror"]
 }


### PR DESCRIPTION
Previously we were using https://bcr.bazel.build/test-mirror as the mirror location in case something goes wrong, it turns out the setup is reliable enough, now we can switch to https://bcr.bazel.build/mirror