### PR TITLE
Expose missing repos for rules_python 0.10.2

### DIFF
--- a/modules/rules_python/0.10.2/MODULE.bazel
+++ b/modules/rules_python/0.10.2/MODULE.bazel
@@ -9,8 +9,12 @@ pip_install = use_extension("//python:extensions.bzl", "pip_install")
 
 use_repo(pip_install,
   "pypi__click",
+  "pypi__colorama",
+  "pypi__installer",
+  "pypi__pep517",
   "pypi__pip",
   "pypi__pip_tools",
   "pypi__setuptools",
+  "pypi__tomli",
   "pypi__wheel",
 )


### PR DESCRIPTION
These are needed when invoking `pip_repository`.