### PR TITLE
gazelle: Update 0.26.0 to more recent commit

### DIFF
--- a/modules/gazelle/0.26.0/source.json
+++ b/modules/gazelle/0.26.0/source.json
@@ -1,5 +1,5 @@
 {
-    "integrity": "sha256-IIoS3P9bmYXwHzPUPjvLpi0IBOc593mIgGuOpMXEvww=",
-    "strip_prefix": "bazel-gazelle-bcr-commit-a648a15f9f9e9ffe1bdfb5fb3d92f8ef9a727126",
-    "url": "https://github.com/bazelbuild/bazel-gazelle/archive/refs/tags/bcr-commit-a648a15f9f9e9ffe1bdfb5fb3d92f8ef9a727126.tar.gz"
+    "integrity": "sha256-ACSc6MQtGR1gd3/aBFQyM4Vu2IkJQSSt8Y8/bHg3aE8=",
+    "strip_prefix": "bazel-gazelle-bcr-commit-55ba8e3f2aaad0f43d82d02eba90ccf7a7fe9c73",
+    "url": "https://github.com/bazelbuild/bazel-gazelle/archive/refs/tags/bcr-commit-55ba8e3f2aaad0f43d82d02eba90ccf7a7fe9c73.tar.gz"
 }


### PR DESCRIPTION
Mutates an existing version as the BCR isn't immutable yet.

Lays the groundwork for `go_proto_library` support.