### PR TITLE
zstd-jni: add v1.5.2-3

### DIFF
--- a/modules/zstd-jni/1.5.2-3/MODULE.bazel
+++ b/modules/zstd-jni/1.5.2-3/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "zstd-jni",
+    version = "1.5.2-3",
+    compatibility_level = 1,
+)

--- a/modules/zstd-jni/1.5.2-3/patches/Native.java.patch
+++ b/modules/zstd-jni/1.5.2-3/patches/Native.java.patch
@@ -1,0 +1,11 @@
+--- a/src/main/java/com/github/luben/zstd/util/Native.java
++++ b/src/main/java/com/github/luben/zstd/util/Native.java
+@@ -59,7 +59,7 @@ public enum Native {
+         if (loaded) {
+             return;
+         }
+-        String resourceName = resourceName();
++        String resourceName = "/libzstd-jni.so";
+ 
+         String overridePath = System.getProperty(nativePathOverride);
+         if (overridePath != null) {

--- a/modules/zstd-jni/1.5.2-3/patches/add_build_file.patch
+++ b/modules/zstd-jni/1.5.2-3/patches/add_build_file.patch
@@ -1,0 +1,66 @@
+--- /dev/null
++++ a/BUILD.bazel
+@@ -0,0 +1,63 @@
++cc_binary(
++    name = "libzstd-jni.so",
++    srcs = glob([
++        "src/main/native/**/*.c",
++        "src/main/native/**/*.h",
++    ]) + select({
++        "@bazel_tools//src/conditions:windows": [
++            "src/windows/include/jni_md.h",
++            "jni/jni.h",
++        ],
++        "//conditions:default": [
++            "jni/jni_md.h",
++            "jni/jni.h",
++        ] + glob(["src/main/native/**/*.S"]),
++    }),
++    copts = select({
++        "@bazel_tools//src/conditions:windows": [],
++        "//conditions:default": [
++            "-std=c99",
++            "-Wno-unused-variable",
++            "-Wno-maybe-uninitialized",
++            "-Wno-sometimes-uninitialized",
++        ]
++    }),
++    linkshared = 1,
++    includes = select({
++        "@bazel_tools//src/conditions:windows": ["src/windows/include"],
++        "//conditions:default": [],
++    }) + [
++        "jni",
++        "src/main/native",
++        "src/main/native/common",
++    ],
++    local_defines = [
++        "ZSTD_LEGACY_SUPPORT=4",
++        "ZSTD_MULTITHREAD=1",
++    ] + select({
++        "@bazel_tools//src/conditions:windows": ["_JNI_IMPLEMENTATION_"],
++        "//conditions:default": [],
++    }),
++)
++
++
++genrule(
++    name = "version-java",
++    cmd_bash = 'echo "package com.github.luben.zstd.util;\n\npublic class ZstdVersion {\n\tpublic static final String VERSION = \\"$$(cat $<)\\";\n}" > $@',
++    cmd_ps = '$$PSDefaultParameterValues.Remove("*:Encoding"); $$version = (Get-Content $<) -join ""; Set-Content -NoNewline -Path $@ -Value "package com.github.luben.zstd.util;\n\npublic class ZstdVersion {\n\tpublic static final String VERSION = `"$${version}`";\n}\n"',
++    srcs = ["version"],
++    outs = ["ZstdVersion.java"],
++)
++
++java_library(
++    name = "zstd-jni",
++    srcs = glob([
++        "src/main/java/**/*.java",
++    ]) + [
++        ":version-java",
++    ],
++    resources = [":libzstd-jni.so"],
++    visibility = [
++        "//visibility:public",
++    ],
++)

--- a/modules/zstd-jni/1.5.2-3/presubmit.yml
+++ b/modules/zstd-jni/1.5.2-3/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@zstd-jni//...'

--- a/modules/zstd-jni/1.5.2-3/source.json
+++ b/modules/zstd-jni/1.5.2-3/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-NmAJpDz62jUBXkzECn78S38BfGuN9crD+H0keAJ7IFY=",
+    "patch_strip": 1,
+    "patches": {
+        "Native.java.patch": "sha256-HDzZr1BxNacyg+xWvojosR8VgfZdOQ2TDAPW2bCATDs=",
+        "add_build_file.patch": "sha256-FTICk5UVQHZRTkKtN0HwwD3j65zJmqxwePcGHozLfNw="
+    },
+    "strip_prefix": "zstd-jni-1.5.2-3",
+    "url": "https://github.com/luben/zstd-jni/archive/refs/tags/v1.5.2-3.zip"
+}

--- a/modules/zstd-jni/metadata.json
+++ b/modules/zstd-jni/metadata.json
@@ -2,7 +2,8 @@
     "homepage": "https://github.com/luben/zstd-jni",
     "maintainers": [],
     "versions": [
-        "1.5.0-4"
+        "1.5.0-4",
+        "1.5.2-3"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Included small addition of assembly files during non-windows builds. The rest is identical to 1.5.0-4.

Aimed to support https://github.com/bazelbuild/bazel/pull/16394