### PR TITLE
Yank protobuf versions affected by security issue

### DIFF
--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -6,5 +6,8 @@
         "3.19.2",
         "3.19.6"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "3.19.0": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)",
+        "3.19.2": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)"
+    }
 }


### PR DESCRIPTION
Context: https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-h4h5-3hr4-j3g2