### PR TITLE
Update gazelle 0.27.0 in place

### DIFF
--- a/modules/gazelle/0.27.0/MODULE.bazel
+++ b/modules/gazelle/0.27.0/MODULE.bazel
@@ -1,11 +1,13 @@
 module(
     name = "gazelle",
     version = "0.27.0",
+    repo_name = "bazel_gazelle",
 )
 
 print("WARNING: The bazel_gazelle Bazel module is still highly experimental and subject to change at any time. Only use it to try out bzlmod for now.")
 
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
+bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_go", version = "0.33.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_proto", version = "4.0.0")
 

--- a/modules/gazelle/0.27.0/source.json
+++ b/modules/gazelle/0.27.0/source.json
@@ -1,5 +1,5 @@
 {
-    "integrity": "sha256-BTrvZ/k/8JzPtj6s17g5XS0Grr21UlqO0ebOX2Mzacc=",
-    "strip_prefix": "bazel-gazelle-bcr-commit-36eba6548c755c3cb1db9e4170447dceabbd5cb9",
-    "url": "https://github.com/bazelbuild/bazel-gazelle/archive/refs/tags/bcr-commit-36eba6548c755c3cb1db9e4170447dceabbd5cb9.tar.gz"
+    "integrity": "sha256-nrLINXLASaT2ESZnhFde2BV3nh0BEbnIdeHdpZeM5SY=",
+    "strip_prefix": "bazel-gazelle-bcr-commit-234130f0d9ee7cbd1560115d57dd440ee570b772",
+    "url": "https://github.com/bazelbuild/bazel-gazelle/archive/refs/tags/bcr-commit-234130f0d9ee7cbd1560115d57dd440ee570b772.tar.gz"
 }


### PR DESCRIPTION
Allows rules_go to support custom `go_proto_library` compilers.