### PR TITLE
Update verify_source_urls.yml

### DIFF
--- a/.github/workflows/verify_source_urls.yml
+++ b/.github/workflows/verify_source_urls.yml
@@ -5,4 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: 'main'
       - run: python3 ./tools/verify_stable_archives.py


### PR DESCRIPTION
Pin the repo fetched to the main branch, otherwise someone can modify `verify_stable_archives.py` in a PR to bypass the check.