### PR TITLE
Add protobuf v21.7

### DIFF
--- a/modules/protobuf/21.7/MODULE.bazel
+++ b/modules/protobuf/21.7/MODULE.bazel
@@ -15,7 +15,6 @@ bazel_dep(name = "zlib", version = "1.2.11")
 bazel_dep(name = "upb", version = "0.0.0-20220923-a547704")
 
 # TODO: Add missing rules_kotlin
-#bazel_dep(name = "rules_kotlin", repo_name = "io_bazel_rules_kotlin", dev_dependency = True)
 
 # Maven dependencies
 bazel_dep(name = "rules_jvm_external", version = "4.4.2")

--- a/modules/protobuf/21.7/MODULE.bazel
+++ b/modules/protobuf/21.7/MODULE.bazel
@@ -1,0 +1,43 @@
+module(
+    name = "protobuf",
+    compatibility_level = 1,
+    version = "21.7",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.0.3")
+bazel_dep(name = "rules_python", version = "0.10.2")
+bazel_dep(name = "rules_cc", version = "0.0.1")
+bazel_dep(name = "rules_proto", version = "4.0.0")
+bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_pkg", version = "0.7.0")
+bazel_dep(name = "abseil-cpp", repo_name = "com_google_abseil", version = "20211102.0")
+bazel_dep(name = "zlib", version = "1.2.11")
+bazel_dep(name = "upb", version = "0.0.0-20220923-a547704")
+
+# TODO: Add missing rules_kotlin
+#bazel_dep(name = "rules_kotlin", repo_name = "io_bazel_rules_kotlin", dev_dependency = True)
+
+# Maven dependencies
+bazel_dep(name = "rules_jvm_external", version = "4.4.2")
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+
+maven.install(
+    name = "maven",
+    artifacts = [
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.code.gson:gson:2.8.9",
+        "com.google.errorprone:error_prone_annotations:2.3.2",
+        "com.google.j2objc:j2objc-annotations:1.3",
+        "com.google.guava:guava:31.1-jre",
+        "com.google.guava:guava-testlib:31.1-jre",
+        "com.google.truth:truth:1.1.2",
+        "junit:junit:4.13.2",
+        "org.mockito:mockito-core:4.3.1",
+    ],
+)
+
+use_repo(maven, "maven")
+
+# Dependencies needed in tests
+bazel_dep(name = "googletest", repo_name = "com_google_googletest", version = "1.11.0")

--- a/modules/protobuf/21.7/patches/add_missing_files.patch
+++ b/modules/protobuf/21.7/patches/add_missing_files.patch
@@ -1,0 +1,204 @@
+commit d1565d42a7c3bbeee13b9ea74563144937c341c6
+Author: Ivo List <ilist@google.com>
+Date:   Fri Dec 23 15:03:53 2022 +0100
+
+    Add missing files
+
+diff --git a/conformance/conformance_test_runner.sh b/conformance/conformance_test_runner.sh
+new file mode 100755
+index 0000000..3149f82
+--- /dev/null
++++ b/conformance/conformance_test_runner.sh
+@@ -0,0 +1,57 @@
++#!/bin/bash
++
++set -x
++echo $@
++
++set -euo pipefail
++# --- begin runfiles.bash initialization ---
++if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
++    if [[ -f "$0.runfiles_manifest" ]]; then
++      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
++    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
++      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
++    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
++      export RUNFILES_DIR="$0.runfiles"
++    fi
++fi
++if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
++  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
++elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
++  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
++            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
++else
++  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
++  exit 1
++fi
++# --- end runfiles.bash initialization ---
++
++TESTEE=unset
++FAILURE_LIST=unset
++TEXT_FORMAT_FAILURE_LIST=unset
++
++while [[ -n "$@" ]]; do
++  arg="$1"; shift
++  val="$1"; shift
++  case "$arg" in
++    "--testee") TESTEE="$val" ;;
++    "--failure_list") FAILURE_LIST="$val" ;;
++    "--text_format_failure_list") TEXT_FORMAT_FAILURE_LIST="$val" ;;
++    *) echo "Flag $arg is not recognized." && exit 1 ;;
++  esac
++done
++
++conformance_test_runner=$(rlocation com_google_protobuf/conformance/conformance_test_runner)
++conformance_testee=$(rlocation $TESTEE)
++args=(--enforce_recommended)
++
++failure_list=$(rlocation $FAILURE_LIST)
++if [ "$failure_list" != "1" ] ; then
++  args+=(--failure_list $failure_list)
++fi
++
++text_format_failure_list=$(rlocation $TEXT_FORMAT_FAILURE_LIST)
++if [ "$text_format_failure_list" != "1" ]; then
++  args+=(--text_format_failure_list $text_format_failure_list)
++fi
++
++$conformance_test_runner "${args[@]}" $conformance_testee
+diff --git a/conformance/failure_list_java.txt b/conformance/failure_list_java.txt
+index a41fc28..808e230 100644
+--- a/conformance/failure_list_java.txt
++++ b/conformance/failure_list_java.txt
+@@ -1,44 +1,44 @@
+-# This is the list of conformance tests that are known to fail for the Java
+-# implementation right now.  These should be fixed.
+-#
+-# By listing them here we can keep tabs on which ones are failing and be sure
+-# that we don't introduce regressions in other tests.
+-
+-Recommended.FieldMaskNumbersDontRoundTrip.JsonOutput
+-Recommended.FieldMaskPathsDontRoundTrip.JsonOutput
+-Recommended.FieldMaskTooManyUnderscore.JsonOutput
+-Recommended.Proto3.JsonInput.BoolFieldAllCapitalFalse
+-Recommended.Proto3.JsonInput.BoolFieldAllCapitalTrue
+-Recommended.Proto3.JsonInput.BoolFieldCamelCaseFalse
+-Recommended.Proto3.JsonInput.BoolFieldCamelCaseTrue
+-Recommended.Proto3.JsonInput.BoolFieldDoubleQuotedFalse
+-Recommended.Proto3.JsonInput.BoolFieldDoubleQuotedTrue
+-Recommended.Proto3.JsonInput.BoolMapFieldKeyNotQuoted
+-Recommended.Proto3.JsonInput.DoubleFieldInfinityNotQuoted
+-Recommended.Proto3.JsonInput.DoubleFieldNanNotQuoted
+-Recommended.Proto3.JsonInput.DoubleFieldNegativeInfinityNotQuoted
+-Recommended.Proto3.JsonInput.FieldMaskInvalidCharacter
+-Recommended.Proto3.JsonInput.FieldNameDuplicate
+-Recommended.Proto3.JsonInput.FieldNameNotQuoted
+-Recommended.Proto3.JsonInput.FloatFieldInfinityNotQuoted
+-Recommended.Proto3.JsonInput.FloatFieldNanNotQuoted
+-Recommended.Proto3.JsonInput.FloatFieldNegativeInfinityNotQuoted
+-Recommended.Proto3.JsonInput.Int32MapFieldKeyNotQuoted
+-Recommended.Proto3.JsonInput.Int64MapFieldKeyNotQuoted
+-Recommended.Proto3.JsonInput.JsonWithComments
+-Recommended.Proto3.JsonInput.StringFieldSingleQuoteBoth
+-Recommended.Proto3.JsonInput.StringFieldSingleQuoteKey
+-Recommended.Proto3.JsonInput.StringFieldSingleQuoteValue
+-Recommended.Proto3.JsonInput.StringFieldSurrogateInWrongOrder
+-Recommended.Proto3.JsonInput.StringFieldUnpairedHighSurrogate
+-Recommended.Proto3.JsonInput.StringFieldUnpairedLowSurrogate
+-Recommended.Proto3.JsonInput.Uint32MapFieldKeyNotQuoted
+-Recommended.Proto3.JsonInput.Uint64MapFieldKeyNotQuoted
+-Recommended.Proto2.JsonInput.FieldNameExtension.Validator
+-Required.Proto3.JsonInput.EnumFieldNotQuoted
+-Required.Proto3.JsonInput.Int32FieldLeadingZero
+-Required.Proto3.JsonInput.Int32FieldNegativeWithLeadingZero
+-Required.Proto3.JsonInput.Int32FieldPlusSign
+-Required.Proto3.JsonInput.RepeatedFieldWrongElementTypeExpectingStringsGotBool
+-Required.Proto3.JsonInput.RepeatedFieldWrongElementTypeExpectingStringsGotInt
+-Required.Proto3.JsonInput.StringFieldNotAString
++# This is the list of conformance tests that are known to fail for the Java
++# implementation right now.  These should be fixed.
++#
++# By listing them here we can keep tabs on which ones are failing and be sure
++# that we don't introduce regressions in other tests.
++
++Recommended.FieldMaskNumbersDontRoundTrip.JsonOutput
++Recommended.FieldMaskPathsDontRoundTrip.JsonOutput
++Recommended.FieldMaskTooManyUnderscore.JsonOutput
++Recommended.Proto3.JsonInput.BoolFieldAllCapitalFalse
++Recommended.Proto3.JsonInput.BoolFieldAllCapitalTrue
++Recommended.Proto3.JsonInput.BoolFieldCamelCaseFalse
++Recommended.Proto3.JsonInput.BoolFieldCamelCaseTrue
++Recommended.Proto3.JsonInput.BoolFieldDoubleQuotedFalse
++Recommended.Proto3.JsonInput.BoolFieldDoubleQuotedTrue
++Recommended.Proto3.JsonInput.BoolMapFieldKeyNotQuoted
++Recommended.Proto3.JsonInput.DoubleFieldInfinityNotQuoted
++Recommended.Proto3.JsonInput.DoubleFieldNanNotQuoted
++Recommended.Proto3.JsonInput.DoubleFieldNegativeInfinityNotQuoted
++Recommended.Proto3.JsonInput.FieldMaskInvalidCharacter
++Recommended.Proto3.JsonInput.FieldNameDuplicate
++Recommended.Proto3.JsonInput.FieldNameNotQuoted
++Recommended.Proto3.JsonInput.FloatFieldInfinityNotQuoted
++Recommended.Proto3.JsonInput.FloatFieldNanNotQuoted
++Recommended.Proto3.JsonInput.FloatFieldNegativeInfinityNotQuoted
++Recommended.Proto3.JsonInput.Int32MapFieldKeyNotQuoted
++Recommended.Proto3.JsonInput.Int64MapFieldKeyNotQuoted
++Recommended.Proto3.JsonInput.JsonWithComments
++Recommended.Proto3.JsonInput.StringFieldSingleQuoteBoth
++Recommended.Proto3.JsonInput.StringFieldSingleQuoteKey
++Recommended.Proto3.JsonInput.StringFieldSingleQuoteValue
++Recommended.Proto3.JsonInput.StringFieldSurrogateInWrongOrder
++Recommended.Proto3.JsonInput.StringFieldUnpairedHighSurrogate
++Recommended.Proto3.JsonInput.StringFieldUnpairedLowSurrogate
++Recommended.Proto3.JsonInput.Uint32MapFieldKeyNotQuoted
++Recommended.Proto3.JsonInput.Uint64MapFieldKeyNotQuoted
++Recommended.Proto2.JsonInput.FieldNameExtension.Validator
++Required.Proto3.JsonInput.EnumFieldNotQuoted
++Required.Proto3.JsonInput.Int32FieldLeadingZero
++Required.Proto3.JsonInput.Int32FieldNegativeWithLeadingZero
++Required.Proto3.JsonInput.Int32FieldPlusSign
++Required.Proto3.JsonInput.RepeatedFieldWrongElementTypeExpectingStringsGotBool
++Required.Proto3.JsonInput.RepeatedFieldWrongElementTypeExpectingStringsGotInt
++Required.Proto3.JsonInput.StringFieldNotAString
+diff --git a/conformance/failure_list_java_lite.txt b/conformance/failure_list_java_lite.txt
+new file mode 100644
+index 0000000..57a082e
+--- /dev/null
++++ b/conformance/failure_list_java_lite.txt
+@@ -0,0 +1,10 @@
++# This is the list of conformance tests that are known to fail for the Java
++# implementation right now. These should be fixed.
++#
++# By listing them here we can keep tabs on which ones are failing and be sure
++# that we don't introduce regressions in other tests.
++
++Required.Proto3.ProtobufInput.PrematureEofInDelimitedDataForKnownNonRepeatedValue.MESSAGE
++Required.Proto3.ProtobufInput.PrematureEofInDelimitedDataForKnownRepeatedValue.MESSAGE
++Required.Proto2.ProtobufInput.PrematureEofInDelimitedDataForKnownNonRepeatedValue.MESSAGE
++Required.Proto2.ProtobufInput.PrematureEofInDelimitedDataForKnownRepeatedValue.MESSAGE
+diff --git a/conformance/text_format_failure_list_java.txt b/conformance/text_format_failure_list_java.txt
+new file mode 100644
+index 0000000..793aae1
+--- /dev/null
++++ b/conformance/text_format_failure_list_java.txt
+@@ -0,0 +1,9 @@
++Recommended.Proto3.ProtobufInput.GroupUnknownFields_Drop.TextFormatOutput
++Recommended.Proto3.ProtobufInput.MessageUnknownFields_Drop.TextFormatOutput
++Recommended.Proto3.ProtobufInput.RepeatedUnknownFields_Drop.TextFormatOutput
++Recommended.Proto3.ProtobufInput.ScalarUnknownFields_Drop.TextFormatOutput
++Required.Proto3.TextFormatInput.AnyField.ProtobufOutput
++Required.Proto3.TextFormatInput.AnyField.TextFormatOutput
++
++Required.Proto3.TextFormatInput.StringFieldBadUTF8Hex
++Required.Proto3.TextFormatInput.StringFieldBadUTF8Octal
+diff --git a/conformance/text_format_failure_list_java_lite.txt b/conformance/text_format_failure_list_java_lite.txt
+new file mode 100644
+index 0000000..61f1a96
+--- /dev/null
++++ b/conformance/text_format_failure_list_java_lite.txt
+@@ -0,0 +1,5 @@
++# This is the list of conformance tests that are known to fail for the Java
++# Lite TextFormat implementation right now. These should be fixed.
++#
++# By listing them here we can keep tabs on which ones are failing and be sure
++# that we don't introduce regressions in other tests.

--- a/modules/protobuf/21.7/patches/add_module_dot_bazel.patch
+++ b/modules/protobuf/21.7/patches/add_module_dot_bazel.patch
@@ -1,0 +1,58 @@
+commit 4e4b7efc584b4c7ca607168b67a09f5cf2b2d5f8
+Author: Ivo List <ilist@google.com>
+Date:   Fri Dec 23 14:34:15 2022 +0100
+
+    MODULE.bazel
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..ea23fe2
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,43 @@
++module(
++    name = "protobuf",
++    compatibility_level = 1,
++    version = "21.7",
++)
++
++bazel_dep(name = "bazel_skylib", version = "1.0.3")
++bazel_dep(name = "rules_python", version = "0.10.2")
++bazel_dep(name = "rules_cc", version = "0.0.1")
++bazel_dep(name = "rules_proto", version = "4.0.0")
++bazel_dep(name = "rules_java", version = "4.0.0")
++bazel_dep(name = "rules_pkg", version = "0.7.0")
++bazel_dep(name = "abseil-cpp", repo_name = "com_google_abseil", version = "20211102.0")
++bazel_dep(name = "zlib", version = "1.2.11")
++bazel_dep(name = "upb", version = "0.0.0-20220923-a547704")
++
++# TODO: Add missing rules_kotlin
++#bazel_dep(name = "rules_kotlin", repo_name = "io_bazel_rules_kotlin", dev_dependency = True)
++
++# Maven dependencies
++bazel_dep(name = "rules_jvm_external", version = "4.4.2")
++
++maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
++
++maven.install(
++    name = "maven",
++    artifacts = [
++        "com.google.code.findbugs:jsr305:3.0.2",
++        "com.google.code.gson:gson:2.8.9",
++        "com.google.errorprone:error_prone_annotations:2.3.2",
++        "com.google.j2objc:j2objc-annotations:1.3",
++        "com.google.guava:guava:31.1-jre",
++        "com.google.guava:guava-testlib:31.1-jre",
++        "com.google.truth:truth:1.1.2",
++        "junit:junit:4.13.2",
++        "org.mockito:mockito-core:4.3.1",
++    ],
++)
++
++use_repo(maven, "maven")
++
++# Dependencies needed in tests
++bazel_dep(name = "googletest", repo_name = "com_google_googletest", version = "1.11.0")
+diff --git a/WORKSPACE.bzlmod b/WORKSPACE.bzlmod
+new file mode 100644
+index 0000000..e69de29

--- a/modules/protobuf/21.7/patches/add_module_dot_bazel.patch
+++ b/modules/protobuf/21.7/patches/add_module_dot_bazel.patch
@@ -1,15 +1,15 @@
-commit 4e4b7efc584b4c7ca607168b67a09f5cf2b2d5f8
+commit 598c4b8ae66a121c317db6c3fff04a3d7a9182bf
 Author: Ivo List <ilist@google.com>
-Date:   Fri Dec 23 14:34:15 2022 +0100
+Date:   Fri Dec 23 14:52:50 2022 +0100
 
-    MODULE.bazel
+    Add MODULE.bazel
 
 diff --git a/MODULE.bazel b/MODULE.bazel
 new file mode 100644
-index 0000000..ea23fe2
+index 0000000..140f322
 --- /dev/null
 +++ b/MODULE.bazel
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,42 @@
 +module(
 +    name = "protobuf",
 +    compatibility_level = 1,
@@ -27,7 +27,6 @@ index 0000000..ea23fe2
 +bazel_dep(name = "upb", version = "0.0.0-20220923-a547704")
 +
 +# TODO: Add missing rules_kotlin
-+#bazel_dep(name = "rules_kotlin", repo_name = "io_bazel_rules_kotlin", dev_dependency = True)
 +
 +# Maven dependencies
 +bazel_dep(name = "rules_jvm_external", version = "4.4.2")
@@ -53,6 +52,3 @@ index 0000000..ea23fe2
 +
 +# Dependencies needed in tests
 +bazel_dep(name = "googletest", repo_name = "com_google_googletest", version = "1.11.0")
-diff --git a/WORKSPACE.bzlmod b/WORKSPACE.bzlmod
-new file mode 100644
-index 0000000..e69de29

--- a/modules/protobuf/21.7/patches/add_module_dot_bazel_for_examples.patch
+++ b/modules/protobuf/21.7/patches/add_module_dot_bazel_for_examples.patch
@@ -1,0 +1,25 @@
+commit f45e980d861674f38e414a21f6724d3c1b5ab29e
+Author: Ivo List <ilist@google.com>
+Date:   Fri Dec 23 14:34:32 2022 +0100
+
+    Examples MODULE.bazel
+
+diff --git a/examples/MODULE.bazel b/examples/MODULE.bazel
+new file mode 100644
+index 0000000..7e7f44f
+--- /dev/null
++++ b/examples/MODULE.bazel
+@@ -0,0 +1,10 @@
++bazel_dep(name = "rules_cc", version = "0.0.1")
++bazel_dep(name = "rules_proto", version = "4.0.0")
++bazel_dep(name = "rules_java", version = "4.0.0")
++bazel_dep(name = "rules_pkg", version = "0.7.0")
++bazel_dep(name = "protobuf", repo_name = "com_google_protobuf")
++
++local_path_override(
++    module_name = "protobuf",
++    path = "..",
++)
+diff --git a/examples/WORKSPACE.bzlmod b/examples/WORKSPACE.bzlmod
+new file mode 100644
+index 0000000..e69de29

--- a/modules/protobuf/21.7/patches/add_module_dot_bazel_for_examples.patch
+++ b/modules/protobuf/21.7/patches/add_module_dot_bazel_for_examples.patch
@@ -1,4 +1,4 @@
-commit f45e980d861674f38e414a21f6724d3c1b5ab29e
+commit dc742061cfa30f2786ef9c3893e0ce73a1b7d829
 Author: Ivo List <ilist@google.com>
 Date:   Fri Dec 23 14:34:32 2022 +0100
 
@@ -20,6 +20,3 @@ index 0000000..7e7f44f
 +    module_name = "protobuf",
 +    path = "..",
 +)
-diff --git a/examples/WORKSPACE.bzlmod b/examples/WORKSPACE.bzlmod
-new file mode 100644
-index 0000000..e69de29

--- a/modules/protobuf/21.7/patches/relative_repo_names.patch
+++ b/modules/protobuf/21.7/patches/relative_repo_names.patch
@@ -1,0 +1,122 @@
+commit aefde16741a6cc56e57e45ee40146de08ad6a8b8
+Author: Ivo List <ilist@google.com>
+Date:   Fri Dec 23 14:15:33 2022 +0100
+
+    Relative labels
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 0f6e41e..4fee7dd 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1061,18 +1061,18 @@ cc_library(
+ proto_lang_toolchain(
+     name = "cc_toolchain",
+     blacklisted_protos = [
+-        "@com_google_protobuf//:any_proto",
+-        "@com_google_protobuf//:api_proto",
+-        "@com_google_protobuf//:compiler_plugin_proto",
+-        "@com_google_protobuf//:descriptor_proto",
+-        "@com_google_protobuf//:duration_proto",
+-        "@com_google_protobuf//:empty_proto",
+-        "@com_google_protobuf//:field_mask_proto",
+-        "@com_google_protobuf//:source_context_proto",
+-        "@com_google_protobuf//:struct_proto",
+-        "@com_google_protobuf//:timestamp_proto",
+-        "@com_google_protobuf//:type_proto",
+-        "@com_google_protobuf//:wrappers_proto",
++        "//:any_proto",
++        "//:api_proto",
++        "//:compiler_plugin_proto",
++        "//:descriptor_proto",
++        "//:duration_proto",
++        "//:empty_proto",
++        "//:field_mask_proto",
++        "//:source_context_proto",
++        "//:struct_proto",
++        "//:timestamp_proto",
++        "//:type_proto",
++        "//:wrappers_proto",
+     ],
+     command_line = "--cpp_out=$(OUT)",
+     runtime = ":protobuf",
+diff --git a/protobuf.bzl b/protobuf.bzl
+index c5b8dab..27a29d0 100644
+--- a/protobuf.bzl
++++ b/protobuf.bzl
+@@ -389,7 +389,7 @@ internal_gen_well_known_protos_java = rule(
+         "_protoc": attr.label(
+             executable = True,
+             cfg = "exec",
+-            default = "@com_google_protobuf//:protoc",
++            default = "//:protoc",
+         ),
+     },
+ )
+@@ -457,7 +457,6 @@ internal_gen_kt_protos = rule(
+ )
+ 
+ 
+-
+ def internal_copied_filegroup(name, srcs, strip_prefix, dest, **kwargs):
+     """Macro to copy files to a different directory and then create a filegroup.
+ 
+@@ -491,6 +490,15 @@ def internal_copied_filegroup(name, srcs, strip_prefix, dest, **kwargs):
+         **kwargs
+     )
+ 
++# When canonical labels are in use, use additional "@" prefix
++_canonical_label_prefix = "@" if str(Label("//:protoc")).startswith("@@") else ""
++
++def _to_label(label_str):
++    """Converts a string to a label using the repository of the calling thread"""
++    if type(label_str) == type(Label("//:foo")):
++        return label_str
++    return Label(_canonical_label_prefix + native.repository_name() + "//" + native.package_name() + ":foo").relative(label_str)
++
+ def py_proto_library(
+         name,
+         srcs = [],
+@@ -498,8 +506,8 @@ def py_proto_library(
+         py_libs = [],
+         py_extra_srcs = [],
+         include = None,
+-        default_runtime = "@com_google_protobuf//:protobuf_python",
+-        protoc = "@com_google_protobuf//:protoc",
++        default_runtime = Label("//:protobuf_python"),
++        protoc = Label("//:protoc"),
+         use_grpc_plugin = False,
+         **kargs):
+     """Bazel rule to create a Python protobuf library from proto source files
+@@ -551,8 +559,12 @@ def py_proto_library(
+         plugin_language = "grpc",
+     )
+ 
+-    if default_runtime and not default_runtime in py_libs + deps:
+-        py_libs = py_libs + [default_runtime]
++    if default_runtime:
++        # Resolve non-local labels
++        labels = [_to_label(lib) for lib in py_libs + deps]
++        if not _to_label(default_runtime) in labels:
++            py_libs = py_libs + [default_runtime]
++
+     py_library(
+         name = name,
+         srcs = outs + py_extra_srcs,
+diff --git a/protobuf_deps.bzl b/protobuf_deps.bzl
+index afb1f1e..91432de 100644
+--- a/protobuf_deps.bzl
++++ b/protobuf_deps.bzl
+@@ -47,11 +47,11 @@ def protobuf_deps():
+     if not native.existing_rule("zlib"):
+         http_archive(
+             name = "zlib",
+-            build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
++            build_file = "//:third_party/zlib.BUILD",
+             sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
+             strip_prefix = "zlib-1.2.11",
+             urls = ["https://github.com/madler/zlib/archive/v1.2.11.tar.gz"],
+-        )
++       )
+ 
+     if not native.existing_rule("rules_cc"):
+         _github_archive(

--- a/modules/protobuf/21.7/presubmit.yml
+++ b/modules/protobuf/21.7/presubmit.yml
@@ -1,0 +1,24 @@
+matrix:
+  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    build_targets:
+    - '@protobuf//:all'
+    - '@protobuf//java/core/...'
+    - '@protobuf//java/lite/...'
+    - '-@protobuf//:common_dist_files'
+    - '-@protobuf//:proto_api'
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      build_targets:
+      - "//..."

--- a/modules/protobuf/21.7/presubmit.yml
+++ b/modules/protobuf/21.7/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["debian10", "macos", "ubuntu2004"]
 
 tasks:
   verify_targets:
@@ -15,7 +15,7 @@ tasks:
 bcr_test_module:
   module_path: "examples"
   matrix:
-    platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["centos7", "debian10", "macos", "ubuntu2004"]
   tasks:
     run_test_module:
       name: "Run test module"

--- a/modules/protobuf/21.7/source.json
+++ b/modules/protobuf/21.7/source.json
@@ -4,7 +4,8 @@
     "patches": {
         "add_module_dot_bazel.patch": "sha256-q3V2+eq0v2XF0z8z+V+QF4cynD6JvHI1y3kI/+rzl5s=",
         "add_module_dot_bazel_for_examples.patch": "sha256-O7YP6s3lo/1opUiO0jqXYORNHdZ/2q3hjz1QGy8QdIU=",
-        "relative_repo_names.patch": "sha256-RK9RjW8T5UJNG7flIrnFiNE9vKwWB+8uWWtJqXYT0w4="
+        "relative_repo_names.patch": "sha256-RK9RjW8T5UJNG7flIrnFiNE9vKwWB+8uWWtJqXYT0w4=",
+        "add_missing_files.patch": "sha256-Hyne4DG2u5bXcWHNxNMirA2QFAe/2Cl8oMm1XJdkQIY="
     },
     "strip_prefix": "protobuf-21.7",
     "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protobuf-all-21.7.zip"

--- a/modules/protobuf/21.7/source.json
+++ b/modules/protobuf/21.7/source.json
@@ -2,8 +2,8 @@
     "integrity": "sha256-VJOiH17T/FAuZv7GuUScBqVRztYwAvpIkDxA36jeeko=",
     "patch_strip": 1,
     "patches": {
-        "add_module_dot_bazel.patch": "sha256-Px4JMo48eFUcLx+w7NLGeIu6vXGbIqoGd0JvohieCc0=",
-        "add_module_dot_bazel_for_examples.patch": "sha256-AtxOqAx/tQqbnIjjUDkGqDtMo9qDZvjPZ9ocdDAd9eo=",
+        "add_module_dot_bazel.patch": "sha256-q3V2+eq0v2XF0z8z+V+QF4cynD6JvHI1y3kI/+rzl5s=",
+        "add_module_dot_bazel_for_examples.patch": "sha256-q3V2+eq0v2XF0z8z+V+QF4cynD6JvHI1y3kI/+rzl5s=",
         "relative_repo_names.patch": "sha256-RK9RjW8T5UJNG7flIrnFiNE9vKwWB+8uWWtJqXYT0w4="
     },
     "strip_prefix": "protobuf-21.7",

--- a/modules/protobuf/21.7/source.json
+++ b/modules/protobuf/21.7/source.json
@@ -3,7 +3,7 @@
     "patch_strip": 1,
     "patches": {
         "add_module_dot_bazel.patch": "sha256-q3V2+eq0v2XF0z8z+V+QF4cynD6JvHI1y3kI/+rzl5s=",
-        "add_module_dot_bazel_for_examples.patch": "sha256-q3V2+eq0v2XF0z8z+V+QF4cynD6JvHI1y3kI/+rzl5s=",
+        "add_module_dot_bazel_for_examples.patch": "sha256-O7YP6s3lo/1opUiO0jqXYORNHdZ/2q3hjz1QGy8QdIU=",
         "relative_repo_names.patch": "sha256-RK9RjW8T5UJNG7flIrnFiNE9vKwWB+8uWWtJqXYT0w4="
     },
     "strip_prefix": "protobuf-21.7",

--- a/modules/protobuf/21.7/source.json
+++ b/modules/protobuf/21.7/source.json
@@ -1,0 +1,11 @@
+{
+    "integrity": "sha256-VJOiH17T/FAuZv7GuUScBqVRztYwAvpIkDxA36jeeko=",
+    "patch_strip": 1,
+    "patches": {
+        "add_module_dot_bazel.patch": "sha256-Px4JMo48eFUcLx+w7NLGeIu6vXGbIqoGd0JvohieCc0=",
+        "add_module_dot_bazel_for_examples.patch": "sha256-AtxOqAx/tQqbnIjjUDkGqDtMo9qDZvjPZ9ocdDAd9eo=",
+        "relative_repo_names.patch": "sha256-RK9RjW8T5UJNG7flIrnFiNE9vKwWB+8uWWtJqXYT0w4="
+    },
+    "strip_prefix": "protobuf-21.7",
+    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.7/protobuf-all-21.7.zip"
+}

--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -7,7 +7,8 @@
     "versions": [
         "3.19.0",
         "3.19.2",
-        "3.19.6"
+        "3.19.6",
+	"21.7"
     ],
     "yanked_versions": {
         "3.19.0": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)",


### PR DESCRIPTION
All the deps are handled except for rules_kotlin, which is still missing on BCR.

Adding protobuf without Kotlin, to make it possible to release `rules_proto` and then also `py_proto_library` in `rules_python`.