### PR TITLE
Set up workflow trigger for bcr-ui rebuild

### DIFF
--- a/.github/workflows/trigger_bcr_ui_rebuild.yml
+++ b/.github/workflows/trigger_bcr_ui_rebuild.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - main
+jobs:
+  trigger_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger build of BCR UI
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          repository: bazel-contrib/bcr-ui
+          # Fine-grained PAT (https://github.com/settings/personal-access-tokens/new), which needs
+          # to be exchanged once a year.
+          # Scoped to the `bazel-contrib/bcr-ui` repository.
+          # Requires "Read and write" permissions for "Contents" to be able to do the workflow dispatch.
+          token: ${{ secrets.BCR_UI_REPO_ACCESS_TOKEN }}
+          event-type: on-bcr-trigger
+          client-payload: '{"bcrCommitHash": "${{ github.sha }}"}'


### PR DESCRIPTION
Addresses https://github.com/bazel-contrib/bcr-ui/issues/20

For this to work a `BCR_UI_REPO_ACCESS_TOKEN` secret needs to be set by one of the repo maintainers.
I've included a comment describing what kind of access token needs to be generated (and the newly released fine-grained PATs seem great for it, but need to be enabled on the `bazel-contrib` org first).