### PR TITLE
Add source repositories for all modules from github

### DIFF
--- a/modules/abseil-cpp/metadata.json
+++ b/modules/abseil-cpp/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/abseil/abseil-cpp",
     "maintainers": [],
+    "repository": [
+        "github:abseil/abseil-cpp"
+    ],
     "versions": [
         "20210324.2",
         "20211102.0"

--- a/modules/apple_rules_lint/metadata.json
+++ b/modules/apple_rules_lint/metadata.json
@@ -7,6 +7,9 @@
             "name": "Simon Stewart"
         }
     ],
+    "repository": [
+        "github:apple/apple_rules_lint"
+    ],
     "versions": [
         "0.2.0"
     ],

--- a/modules/apple_support/metadata.json
+++ b/modules/apple_support/metadata.json
@@ -12,6 +12,9 @@
             "name": "Patrick Balestra"
         }
     ],
+    "repository": [
+        "github:bazelbuild/apple_support"
+    ],
     "versions": [
         "0.11.0",
         "0.13.0",

--- a/modules/asio/metadata.json
+++ b/modules/asio/metadata.json
@@ -7,6 +7,9 @@
             "name": "Lukasz Tekieli"
         }
     ],
+    "repository": [
+        "github:chriskohlhoff/asio"
+    ],
     "versions": [
         "1.21.0"
     ],

--- a/modules/aspect_bazel_lib/metadata.json
+++ b/modules/aspect_bazel_lib/metadata.json
@@ -7,6 +7,9 @@
             "name": "Aspect team"
         }
     ],
+    "repository": [
+        "github:aspect-build/bazel-lib"
+    ],
     "versions": [
         "0.11.0",
         "0.11.4",

--- a/modules/aspect_rules_js/metadata.json
+++ b/modules/aspect_rules_js/metadata.json
@@ -7,6 +7,9 @@
             "name": "Aspect team"
         }
     ],
+    "repository": [
+        "github:aspect-build/rules_js"
+    ],
     "versions": [
         "0.3.2",
         "0.11.1",

--- a/modules/aspect_rules_swc/metadata.json
+++ b/modules/aspect_rules_swc/metadata.json
@@ -7,6 +7,9 @@
             "name": "Aspect team"
         }
     ],
+    "repository": [
+        "github:aspect-build/rules_swc"
+    ],
     "versions": [
         "0.3.0"
     ],

--- a/modules/bazel_skylib/metadata.json
+++ b/modules/bazel_skylib/metadata.json
@@ -6,6 +6,9 @@
             "name": "The Bazel Team"
         }
     ],
+    "repository": [
+        "github:bazelbuild/bazel-skylib"
+    ],
     "versions": [
         "1.0.3",
         "1.1.1",

--- a/modules/boringssl/metadata.json
+++ b/modules/boringssl/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/google/boringssl",
     "maintainers": [],
+    "repository": [
+        "github:google/boringssl"
+    ],
     "versions": [
         "0.0.0-20211025-d4f1ab9"
     ],

--- a/modules/c-ares/metadata.json
+++ b/modules/c-ares/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/c-ares/c-ares",
     "maintainers": [],
+    "repository": [
+        "github:c-ares/c-ares"
+    ],
     "versions": [
         "1.15.0",
         "1.16.1"

--- a/modules/fmt/metadata.json
+++ b/modules/fmt/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/fmtlib/fmt",
     "maintainers": [],
+    "repository": [
+        "github:fmtlib/fmt"
+    ],
     "versions": [
         "8.1.1"
     ],

--- a/modules/gazelle/metadata.json
+++ b/modules/gazelle/metadata.json
@@ -7,6 +7,9 @@
             "name": "Fabian Meumertzheim"
         }
     ],
+    "repository": [
+        "github:bazelbuild/bazel-gazelle"
+    ],
     "versions": [
         "0.26.0",
         "0.27.0"

--- a/modules/gflags/metadata.json
+++ b/modules/gflags/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://gflags.github.io/gflags/",
     "maintainers": [],
+    "repository": [
+        "github:gflags/gflags"
+    ],
     "versions": [
         "2.2.2"
     ],

--- a/modules/glog/metadata.json
+++ b/modules/glog/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/google/glog",
     "maintainers": [],
+    "repository": [
+        "github:google/glog"
+    ],
     "versions": [
         "0.5.0"
     ],

--- a/modules/googletest/metadata.json
+++ b/modules/googletest/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://google.github.io/googletest/",
     "maintainers": [],
+    "repository": [
+        "github:google/googletest"
+    ],
     "versions": [
         "1.11.0"
     ],

--- a/modules/grpc/metadata.json
+++ b/modules/grpc/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/grpc/grpc",
     "maintainers": [],
+    "repository": [
+        "github:grpc/grpc"
+    ],
     "versions": [
         "1.41.0",
         "1.47.0"

--- a/modules/platforms/metadata.json
+++ b/modules/platforms/metadata.json
@@ -6,6 +6,9 @@
             "name": "The Bazel Team"
         }
     ],
+    "repository": [
+        "github:bazelbuild/platforms"
+    ],
     "versions": [
         "0.0.4",
         "0.0.5"

--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/protocolbuffers/protobuf",
     "maintainers": [],
+    "repository": [
+        "github:protocolbuffers/protobuf"
+    ],
     "versions": [
         "3.19.0",
         "3.19.2",

--- a/modules/re2/metadata.json
+++ b/modules/re2/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/google/re2",
     "maintainers": [],
+    "repository": [
+        "github:google/re2"
+    ],
     "versions": [
         "2021-09-01"
     ],

--- a/modules/rules_android/metadata.json
+++ b/modules/rules_android/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/bazelbuild/rules_android",
     "maintainers": [],
+    "repository": [
+        "github:bazelbuild/rules_android"
+    ],
     "versions": [
         "0.1.1"
     ],

--- a/modules/rules_cc/metadata.json
+++ b/modules/rules_cc/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/bazelbuild/rules_cc",
     "maintainers": [],
+    "repository": [
+        "github:bazelbuild/rules_cc"
+    ],
     "versions": [
         "0.0.1",
         "0.0.2"

--- a/modules/rules_erlang/metadata.json
+++ b/modules/rules_erlang/metadata.json
@@ -7,6 +7,9 @@
             "name": "Rin Kuryloski"
         }
     ],
+    "repository": [
+        "github:rabbitmq/rules_erlang"
+    ],
     "versions": [
         "2.4.0",
         "2.5.2",

--- a/modules/rules_foreign_cc/metadata.json
+++ b/modules/rules_foreign_cc/metadata.json
@@ -6,6 +6,9 @@
             "name": "James Sharpe"
         }
     ],
+    "repository": [
+        "github:bazelbuild/rules_foreign_cc"
+    ],
     "versions": [
         "0.8.0",
         "0.9.0"

--- a/modules/rules_go/metadata.json
+++ b/modules/rules_go/metadata.json
@@ -7,6 +7,9 @@
             "name": "Fabian Meumertzheim"
         }
     ],
+    "repository": [
+        "github:bazelbuild/rules_go"
+    ],
     "versions": [
         "0.33.0",
         "0.34.0",

--- a/modules/rules_java/metadata.json
+++ b/modules/rules_java/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/bazelbuild/rules_java",
     "maintainers": [],
+    "repository": [
+        "github:bazelbuild/rules_java"
+    ],
     "versions": [
         "4.0.0",
         "5.0.0",

--- a/modules/rules_jni/metadata.json
+++ b/modules/rules_jni/metadata.json
@@ -7,6 +7,9 @@
             "name": "Fabian Meumertzheim"
         }
     ],
+    "repository": [
+        "github:fmeum/rules_jni"
+    ],
     "versions": [
         "0.3.1",
         "0.4.0",

--- a/modules/rules_jvm_external/metadata.json
+++ b/modules/rules_jvm_external/metadata.json
@@ -17,6 +17,9 @@
             "name": "Chris Heisterkamp"
         }
     ],
+    "repository": [
+        "github:bazelbuild/rules_jvm_external"
+    ],
     "versions": [
         "4.4.2"
     ],

--- a/modules/rules_license/metadata.json
+++ b/modules/rules_license/metadata.json
@@ -7,6 +7,9 @@
             "name": "Tony Aiuto"
         }
     ],
+    "repository": [
+        "github:bazelbuild/rules_license"
+    ],
     "versions": [
         "0.0.2",
         "0.0.3"

--- a/modules/rules_nodejs/metadata.json
+++ b/modules/rules_nodejs/metadata.json
@@ -7,6 +7,9 @@
             "name": "Aspect team"
         }
     ],
+    "repository": [
+        "github:bazelbuild/rules_nodejs"
+    ],
     "versions": [
         "4.5.0",
         "4.5.1",

--- a/modules/rules_pkg/metadata.json
+++ b/modules/rules_pkg/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/bazelbuild/rules_pkg.git",
     "maintainers": [],
+    "repository": [
+        "github:bazelbuild/rules_pkg"
+    ],
     "versions": [
         "0.5.1",
         "0.7.0"

--- a/modules/rules_proto/metadata.json
+++ b/modules/rules_proto/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/bazelbuild/rules_proto",
     "maintainers": [],
+    "repository": [
+        "github:bazelbuild/rules_proto"
+    ],
     "versions": [
         "4.0.0"
     ],

--- a/modules/rules_python/metadata.json
+++ b/modules/rules_python/metadata.json
@@ -7,6 +7,9 @@
             "name": "Aspect team"
         }
     ],
+    "repository": [
+        "github:bazelbuild/rules_python"
+    ],
     "versions": [
         "0.4.0",
         "0.10.2",

--- a/modules/rules_sh/metadata.json
+++ b/modules/rules_sh/metadata.json
@@ -7,6 +7,9 @@
             "name": "Andreas Herrmann"
         }
     ],
+    "repository": [
+        "github:tweag/rules_sh"
+    ],
     "versions": [
         "0.2.0"
     ],

--- a/modules/spdlog/metadata.json
+++ b/modules/spdlog/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/gabime/spdlog",
     "maintainers": [],
+    "repository": [
+        "github:gabime/spdlog"
+    ],
     "versions": [
         "1.10.0"
     ],

--- a/modules/stardoc/metadata.json
+++ b/modules/stardoc/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/bazelbuild/stardoc",
     "maintainers": [],
+    "repository": [
+        "github:bazelbuild/stardoc"
+    ],
     "versions": [
         "0.5.0",
         "0.5.1",

--- a/modules/upb/metadata.json
+++ b/modules/upb/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/protocolbuffers/upb",
     "maintainers": [],
+    "repository": [
+        "github:protocolbuffers/upb"
+    ],
     "versions": [
         "0.0.0-20211020-160625a",
         "0.0.0-20220602-e5f2601"

--- a/modules/zlib/metadata.json
+++ b/modules/zlib/metadata.json
@@ -6,6 +6,9 @@
             "name": "The Bazel Team"
         }
     ],
+    "repository": [
+        "github:madler/zlib"
+    ],
     "versions": [
         "1.2.11",
         "1.2.12",

--- a/modules/zstd-jni/metadata.json
+++ b/modules/zstd-jni/metadata.json
@@ -1,6 +1,9 @@
 {
     "homepage": "https://github.com/luben/zstd-jni",
     "maintainers": [],
+    "repository": [
+        "github:luben/zstd-jni"
+    ],
     "versions": [
         "1.5.0-4",
         "1.5.2-3"

--- a/tools/add_module.py
+++ b/tools/add_module.py
@@ -197,7 +197,11 @@ def main(argv=None):
     homepage = ask_input(
         "Please enter the homepage url for this module: ").strip()
     maintainers = get_maintainers_from_input()
-    client.init_module(module.name, maintainers, homepage)
+    source_repository = ""
+    if module.url.startswith("https://github.com/"):
+      parts = module.url.split("/")
+      source_repository = "github:" + parts[3] + "/" + parts[4]
+    client.init_module(module.name, maintainers, homepage, source_repository)
 
   client.add(module, override=True)
   log(f"{module.name} {module.version} is added into the registry.")

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -194,7 +194,7 @@ module(
       dir_path = dir_path.joinpath(version)
     return dir_path.is_dir()
 
-  def init_module(self, module_name, maintainers, homepage):
+  def init_module(self, module_name, maintainers, homepage, source_repository = ""):
     """
     Initialize a module, create the directory and metadata.json file.
 
@@ -217,6 +217,7 @@ module(
     metadata = {
         "maintainers": maintainers,
         "homepage": homepage,
+        "repository": [source_repository] if source_repository else [],
         "versions": [],
         "yanked_versions": {},
     }


### PR DESCRIPTION
The only outliner that's not from github is https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/bzip2/metadata.json

We use a similar format as: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository

This information will be used to check if the source url matches the source repository.

Fixing https://github.com/bazelbuild/bazel-central-registry/issues/118