### PR TITLE
Remove verify_source_urls.yml

### DIFF
--- a/.github/workflows/verify_source_urls.yml
+++ b/.github/workflows/verify_source_urls.yml
@@ -1,8 +1,0 @@
-name: Verify stable source URLs
-on: [pull_request]
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: python3 ./tools/verify_stable_archives.py


### PR DESCRIPTION
Verifying the source url step is moved the bcr_validation.py and is integrated in the BCR presubmit on BuildKite, therefore we no longer need this.