### PR TITLE
Add rules_swift 1.2.0

### DIFF
--- a/modules/rules_swift/1.2.0/MODULE.bazel
+++ b/modules/rules_swift/1.2.0/MODULE.bazel
@@ -1,0 +1,31 @@
+module(
+    name = "rules_swift",
+    compatibility_level = 1,
+    repo_name = "build_bazel_rules_swift",
+    version = "1.2.0",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.1.1")
+bazel_dep(name = "apple_support", repo_name = "build_bazel_apple_support", version = "1.3.1")
+bazel_dep(name = "rules_cc", version = "0.0.2")
+bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "3.19.2")  # To be removed once rules_proto is bzlmod-ready.
+
+non_module_deps = use_extension("//swift:extensions.bzl", "non_module_deps")
+
+use_repo(
+    non_module_deps,
+    "build_bazel_rules_swift_local_config",
+    "com_github_apple_swift_protobuf",
+    "com_github_grpc_grpc_swift",
+    "com_github_apple_swift_nio",
+    "com_github_apple_swift_nio_http2",
+    "com_github_apple_swift_nio_transport_services",
+    "com_github_apple_swift_nio_extras",
+    "com_github_apple_swift_log",
+    "com_github_nlohmann_json",
+    "rules_proto",
+    "build_bazel_rules_swift_index_import",
+)
+
+# Dev dependencies
+bazel_dep(name = "stardoc", dev_dependency = True, repo_name = "io_bazel_skydoc", version = "0.5.3")

--- a/modules/rules_swift/1.2.0/patches/add-initial-bzlmod-support.patch
+++ b/modules/rules_swift/1.2.0/patches/add-initial-bzlmod-support.patch
@@ -1,0 +1,167 @@
+From 218a8babe872169174be860db14c321fc6eb8379 Mon Sep 17 00:00:00 2001
+From: Patrick Balestra <me@patrickbalestra.com>
+Date: Wed, 12 Oct 2022 15:29:12 +0200
+Subject: [PATCH] Add initial bzlmod support
+
+---
+ MODULE.bazel           | 31 ++++++++++++++++++++++++++++++
+ doc/setup.md           |  9 ++++++++-
+ swift/extensions.bzl   | 22 +++++++++++++++++++++
+ swift/repositories.bzl | 43 +++++++++++++++++++++++-------------------
+ 4 files changed, 85 insertions(+), 20 deletions(-)
+ create mode 100644 MODULE.bazel
+ create mode 100644 swift/extensions.bzl
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..e394f48
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,31 @@
++module(
++    name = "rules_swift",
++    compatibility_level = 1,
++    repo_name = "build_bazel_rules_swift",
++    version = "1.2.0",
++)
++
++bazel_dep(name = "bazel_skylib", version = "1.1.1")
++bazel_dep(name = "apple_support", repo_name = "build_bazel_apple_support", version = "1.3.1")
++bazel_dep(name = "rules_cc", version = "0.0.2")
++bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "3.19.2")  # To be removed once rules_proto is bzlmod-ready.
++
++non_module_deps = use_extension("//swift:extensions.bzl", "non_module_deps")
++
++use_repo(
++    non_module_deps,
++    "build_bazel_rules_swift_local_config",
++    "com_github_apple_swift_protobuf",
++    "com_github_grpc_grpc_swift",
++    "com_github_apple_swift_nio",
++    "com_github_apple_swift_nio_http2",
++    "com_github_apple_swift_nio_transport_services",
++    "com_github_apple_swift_nio_extras",
++    "com_github_apple_swift_log",
++    "com_github_nlohmann_json",
++    "rules_proto",
++    "build_bazel_rules_swift_index_import",
++)
++
++# Dev dependencies
++bazel_dep(name = "stardoc", dev_dependency = True, repo_name = "io_bazel_skydoc", version = "0.5.3")
+diff --git a/doc/setup.md b/doc/setup.md
+index 38e3e0f..5a52217 100644
+--- a/doc/setup.md
++++ b/doc/setup.md
+@@ -5,7 +5,7 @@
+ ## swift_rules_dependencies
+ 
+ <pre>
+-swift_rules_dependencies()
++swift_rules_dependencies(<a href="#swift_rules_dependencies-include_bzlmod_ready_dependencies">include_bzlmod_ready_dependencies</a>)
+ </pre>
+ 
+ Fetches repositories that are dependencies of `rules_swift`.
+@@ -15,4 +15,11 @@ dependencies of the Swift rules are downloaded and that they are isolated
+ from changes to those dependencies.
+ 
+ 
++**PARAMETERS**
++
++
++| Name  | Description | Default Value |
++| :------------- | :------------- | :------------- |
++| <a id="swift_rules_dependencies-include_bzlmod_ready_dependencies"></a>include_bzlmod_ready_dependencies |  Whether or not bzlmod-ready dependencies should be included.   |  <code>True</code> |
++
+ 
+diff --git a/swift/extensions.bzl b/swift/extensions.bzl
+new file mode 100644
+index 0000000..dc2a7ff
+--- /dev/null
++++ b/swift/extensions.bzl
+@@ -0,0 +1,22 @@
++# Copyright 2022 The Bazel Authors. All rights reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#    http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++"""Definitions for bzlmod module extensions."""
++
++load("//swift:repositories.bzl", "swift_rules_dependencies")
++
++def _non_module_deps_impl(_):
++    swift_rules_dependencies(include_bzlmod_ready_dependencies = False)
++
++non_module_deps = module_extension(implementation = _non_module_deps_impl)
+diff --git a/swift/repositories.bzl b/swift/repositories.bzl
+index 2b85185..60d662a 100644
+--- a/swift/repositories.bzl
++++ b/swift/repositories.bzl
+@@ -31,31 +31,36 @@ def _maybe(repo_rule, name, **kwargs):
+     if not native.existing_rule(name):
+         repo_rule(name = name, **kwargs)
+ 
+-def swift_rules_dependencies():
++def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
+     """Fetches repositories that are dependencies of `rules_swift`.
+ 
+     Users should call this macro in their `WORKSPACE` to ensure that all of the
+     dependencies of the Swift rules are downloaded and that they are isolated
+     from changes to those dependencies.
+-    """
+-    _maybe(
+-        http_archive,
+-        name = "bazel_skylib",
+-        urls = [
+-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+-        ],
+-        sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
+-    )
+ 
+-    _maybe(
+-        http_archive,
+-        name = "build_bazel_apple_support",
+-        urls = [
+-            "https://github.com/bazelbuild/apple_support/releases/download/1.3.1/apple_support.1.3.1.tar.gz",
+-        ],
+-        sha256 = "f4fdf5c9b42b92ea12f229b265d74bb8cedb8208ca7a445b383c9f866cf53392",
+-    )
++    Args:
++        include_bzlmod_ready_dependencies: Whether or not bzlmod-ready
++            dependencies should be included.
++    """
++    if include_bzlmod_ready_dependencies:
++        _maybe(
++            http_archive,
++            name = "bazel_skylib",
++            urls = [
++                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
++                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
++            ],
++            sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
++        )
++
++        _maybe(
++            http_archive,
++            name = "build_bazel_apple_support",
++            urls = [
++                "https://github.com/bazelbuild/apple_support/releases/download/1.3.1/apple_support.1.3.1.tar.gz",
++            ],
++            sha256 = "f4fdf5c9b42b92ea12f229b265d74bb8cedb8208ca7a445b383c9f866cf53392",
++        )
+ 
+     _maybe(
+         http_archive,
+-- 
+2.37.0 (Apple Git-136)
+

--- a/modules/rules_swift/1.2.0/presubmit.yml
+++ b/modules/rules_swift/1.2.0/presubmit.yml
@@ -1,15 +1,23 @@
+shell_commands: &shell_commands
+- "echo --- Downloading and extracting Swift $SWIFT_VERSION to $SWIFT_HOME"
+- "mkdir $SWIFT_HOME"
+- "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
+
 matrix:
   platform:
-  - centos7
-  - debian10
   - ubuntu2004
-  - windows
 tasks:
   verify_targets:
     name: Verify build targets
     platform: ${{ platform }}
     environment:
       CC: "clang"
+      SWIFT_VERSION: "5.5.3"
+      SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
+      PATH: "$PATH:$SWIFT_HOME/usr/bin"
+    shell_commands: *shell_commands
+    build_flags:
+    - "--action_env=PATH"
     build_targets:
     - "@rules_swift//examples/xplatform/..."
   verify_targets_macos:

--- a/modules/rules_swift/1.2.0/presubmit.yml
+++ b/modules/rules_swift/1.2.0/presubmit.yml
@@ -8,6 +8,8 @@ tasks:
   verify_targets:
     name: Verify build targets
     platform: ${{ platform }}
+    environment:
+      CC: "clang"
     build_targets:
     - "@rules_swift//examples/xplatform/..."
   verify_targets_macos:

--- a/modules/rules_swift/1.2.0/presubmit.yml
+++ b/modules/rules_swift/1.2.0/presubmit.yml
@@ -20,6 +20,7 @@ tasks:
     - "--action_env=PATH"
     build_targets:
     - "@rules_swift//examples/xplatform/..."
+    - "-@rules_swift//examples/xplatform/grpc/..." # TODO: Fix grpc on Linux
   verify_targets_macos:
     name: Verify build targets
     platform: macos

--- a/modules/rules_swift/1.2.0/presubmit.yml
+++ b/modules/rules_swift/1.2.0/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - "//examples/xplatform/..."
+  verify_targets_macos:
+    name: Verify build targets
+    platform: macos
+    build_targets:
+    - "//examples/apple/..."

--- a/modules/rules_swift/1.2.0/presubmit.yml
+++ b/modules/rules_swift/1.2.0/presubmit.yml
@@ -9,9 +9,9 @@ tasks:
     name: Verify build targets
     platform: ${{ platform }}
     build_targets:
-    - "//examples/xplatform/..."
+    - "@rules_swift//examples/xplatform/..."
   verify_targets_macos:
     name: Verify build targets
     platform: macos
     build_targets:
-    - "//examples/apple/..."
+    - "@rules_swift//examples/apple/..."

--- a/modules/rules_swift/1.2.0/source.json
+++ b/modules/rules_swift/1.2.0/source.json
@@ -1,4 +1,8 @@
 {
     "integrity": "sha256-Ue/a+F4E5RF03nbvVj8lVFHVpc0kxhrZAv7q2vxwRtk=",
+    "patch_strip": 1,
+    "patches": {
+        "add-initial-bzlmod-support.patch": "sha256-vvJmXqGJVvASBe1l6/cm/Hv4RF2u/cchcbs7mF3f+tU="
+    },
     "url": "https://github.com/bazelbuild/rules_swift/releases/download/1.2.0/rules_swift.1.2.0.tar.gz"
 }

--- a/modules/rules_swift/1.2.0/source.json
+++ b/modules/rules_swift/1.2.0/source.json
@@ -1,5 +1,4 @@
 {
     "integrity": "sha256-Ue/a+F4E5RF03nbvVj8lVFHVpc0kxhrZAv7q2vxwRtk=",
-    "strip_prefix": "rules_swift.1.2.0",
     "url": "https://github.com/bazelbuild/rules_swift/releases/download/1.2.0/rules_swift.1.2.0.tar.gz"
 }

--- a/modules/rules_swift/1.2.0/source.json
+++ b/modules/rules_swift/1.2.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-Ue/a+F4E5RF03nbvVj8lVFHVpc0kxhrZAv7q2vxwRtk=",
+    "strip_prefix": "rules_swift.1.2.0",
+    "url": "https://github.com/bazelbuild/rules_swift/releases/download/1.2.0/rules_swift.1.2.0.tar.gz"
+}

--- a/modules/rules_swift/metadata.json
+++ b/modules/rules_swift/metadata.json
@@ -12,6 +12,9 @@
             "name": "Keith Smiley"
         }
     ],
+    "repository": [
+        "github:bazelbuild/rules_swift"
+    ],
     "versions": [
         "1.2.0"
     ],

--- a/modules/rules_swift/metadata.json
+++ b/modules/rules_swift/metadata.json
@@ -1,0 +1,19 @@
+{
+    "homepage": "https://github.com/bazelbuild/rules_swift",
+    "maintainers": [
+        {
+            "email": "me@patrickbalestra.com",
+            "github": "BalestraPatrick",
+            "name": "Patrick Balestra"
+        },
+        {
+            "email": "keithbsmiley@gmail.com",
+            "github": "keith",
+            "name": "Keith Smiley"
+        }
+    ],
+    "versions": [
+        "1.2.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This PR adds the current release of `rules_swift` to the central registry. The patch will be useless in the next version that we'll hopefully cut soon.