### PR TITLE
bcr_validation.py: Validate MODULE.bazel

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -173,14 +173,14 @@ def verify_presubmit_yml_change(registry, module_name, version):
 def apply_patch(work_dir, patch_strip, patch_file):
   # Requries patch to be installed
   subprocess.run(
-      ["patch", "-p%d" % patch_strip, "-i", patch_file], shell=False, check=True, env=os.environ, cwd=work_dir
+      ["patch", "-p%d" % patch_strip, "-l", "-i", patch_file], shell=False, check=True, env=os.environ, cwd=work_dir
   )
 
 def remove_trailing_empty_lines(lines):
   pos = len(lines)
   while pos > 0 and not lines[pos - 1].strip():
     pos = pos - 1
-  return lines[0:pos]
+  return [line.rstrip() + "\n" for line in lines[0:pos]]
 
 def verify_module_dot_bazel(registry, module_name, version):
   validation_results = []

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -143,9 +143,9 @@ class BcrValidator:
     # Verify source archive URL is stable.
     if verify_stable_archive(source_url) == UrlStability.UNSTABLE:
       self.report(BcrValidationResult.FAILED,
-                          f"{module_name}@{version} is using an unstable source url: `{source_url}`.\n"
-                          + "The source url should follow the format of `https://github.com/<ORGANIZATION>/<REPO>/archive/refs/tags/<TAG>.tar.gz` to retrieve a source archive that is guaranteed by GitHub to be stable over time.\n"
-                          + "See https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1029861300 for more context.")
+                  f"{module_name}@{version} is using an unstable source url: `{source_url}`.\n"
+                  + "The source url should follow the format of `https://github.com/<ORGANIZATION>/<REPO>/archive/refs/tags/<TAG>.tar.gz` to retrieve a source archive that is guaranteed by GitHub to be stable over time.\n"
+                  + "See https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1029861300 for more context.")
     else:
       self.report(BcrValidationResult.GOOD, "The source URL doesn't look unstable.")
 
@@ -177,8 +177,8 @@ class BcrValidator:
       diff = list(unified_diff(previous_presubmit_content, current_presubmit_content, fromfile=str(previous_presubmit_yml), tofile = str(current_presubmit_yml)))
       if diff:
         self.report(BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW,
-                            f"The presubmit.yml file of {module_name}@{version} doesn't match its previous version {module_name}@{pre_version}, the following presubmit.yml file change should be reviewed by a BCR maintainer.\n"
-                            + "    " + "    ".join(diff))
+                    f"The presubmit.yml file of {module_name}@{version} doesn't match its previous version {module_name}@{pre_version}, the following presubmit.yml file change should be reviewed by a BCR maintainer.\n"
+                    + "    " + "    ".join(diff))
       else:
         self.report(BcrValidationResult.GOOD, "The presubmit.yml file matches the previous version.")
 
@@ -228,9 +228,9 @@ class BcrValidator:
 
     if diff:
       self.report(BcrValidationResult.FAILED,
-                                "Checked in MODULE.bazel file doesn't match the one in the extracted and patched sources.\n"
-                                + f"Please fix the MODULE.bazel file or you can add the following patch to {module_name}@{version}:\n"
-                                + "    " + "    ".join(diff))
+                  "Checked in MODULE.bazel file doesn't match the one in the extracted and patched sources.\n"
+                  + f"Please fix the MODULE.bazel file or you can add the following patch to {module_name}@{version}:\n"
+                  + "    " + "    ".join(diff))
       if self.should_fix:
         self.add_module_dot_bazel_patch(diff, module_name, version)
     else:

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -83,164 +83,159 @@ def parse_module_versions(registry, check_all, inputs):
       result.extend(registry.get_module_versions(s))
   return result
 
-def print_validation_result(result):
-  for code, message in result:
-    color = COLOR[code]
-    print(f"{color}{code}{RESET}: {message}\n")
+def apply_patch(work_dir, patch_strip, patch_file):
+  # Requires patch to be installed
+  subprocess.run(
+      ["patch", "-p%d" % patch_strip, "-l", "-i", patch_file], shell=False, check=True, env=os.environ, cwd=work_dir
+  )
+
+def fix_line_endings(lines):
+  return [line.rstrip() + "\n" for line in lines]
 
 class BcrValidationException(Exception):
   """
   Raised whenever we should stop the validation immediately.
   """
 
-def verify_module_existence(registry, module_name, version):
-  """Verify the directory exists and the version is recorded in metadata.json."""
-  validation_results = []
-  if not registry.contains(module_name, version):
-    validation_results.append((BcrValidationResult.FAILED, f"{module_name}@{version} doesn't exist."))
-    print_validation_result(validation_results)
-    raise BcrValidationException("The module to be validated doesn't exist!")
-  versions = registry.get_metadata(module_name)["versions"]
-  if version not in versions:
-    validation_results.append((BcrValidationResult.FAILED, f"Version {version} is not recorded in {module_name}'s metadata.json file."))
-  else:
-    validation_results.append((BcrValidationResult.GOOD, "The module exists and is recorded in metadata.json."))
-  return validation_results
+class BcrValidator:
 
-def verify_source_archive_url(registry, module_name, version):
-  # Verify the source archive URL matches the github repo. For now, we only support github repositories check.
   validation_results = []
-  source_url = registry.get_source(module_name, version)["url"]
-  source_repositories = registry.get_metadata(module_name).get("repository", [])
-  matched = not source_repositories
-  for source_repository in source_repositories:
-    if matched:
-      break
-    repo_type, repo_path = source_repository.split(":")
-    if repo_type == "github":
-      parts = urlparse(source_url)
-      matched = parts.scheme == "https" and parts.netloc == "github.com" and os.path.abspath(parts.path).startswith(f"/{repo_path}/")
-  if not matched:
-    validation_results.append((BcrValidationResult.FAILED, f"The source URL of {module_name}@{version} ({source_url}) doesn't match any of the module's source repositories {source_repositories}."))
-  else:
-    validation_results.append((BcrValidationResult.GOOD, "The source URL matches one of the source repositories."))
 
-  # Verify source archive URL is stable.
-  if verify_stable_archive(source_url) == UrlStability.UNSTABLE:
-    validation_results.append((BcrValidationResult.FAILED,
-                        f"{module_name}@{version} is using an unstable source url: `{source_url}`.\n"
-                        + "The source url should follow the format of `https://github.com/<ORGANIZATION>/<REPO>/archive/refs/tags/<TAG>.tar.gz` to retrieve a source archive that is guaranteed by GitHub to be stable over time.\n"
-                        + "See https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1029861300 for more context."))
-  else:
-    validation_results.append((BcrValidationResult.GOOD, "The source URL doesn't look unstable."))
-  return validation_results
+  def report(self, type, message):
+    color = COLOR[type]
+    print(f"{color}{type}{RESET}: {message}\n")
+    self.validation_results.append(type, message)
 
-def verify_source_archive_integrity(registry, module_name, version):
-  """Verify the integrity value of the URL is correct."""
-  validation_results = []
-  source_url = registry.get_source(module_name, version)["url"]
-  expected_integrity = registry.get_source(module_name, version)["integrity"]
-  real_integrity = integrity(download(source_url))
-  if real_integrity != expected_integrity:
-    validation_results.append((BcrValidationResult.FAILED, f"{module_name}@{version}'s source archive `{source_url}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{real_integrity}`!"))
-  else:
-    validation_results.append((BcrValidationResult.GOOD, "The source archive's integrity value matches."))
-  return validation_results
-
-def verify_presubmit_yml_change(registry, module_name, version):
-  """Verify if the presubmit.yml is the same as the previous version."""
-  validation_results = []
-  versions = registry.get_metadata(module_name)["versions"]
-  versions.sort(key=Version)
-  index = versions.index(version)
-  if index == 0:
-    validation_results.append((BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW, f"Module version {module_name}@{version} is new, the presubmit.yml file should be reviewed by a BCR maintainer."))
-  elif index > 0:
-    pre_version = versions[index - 1]
-    previous_presubmit_yml = registry.get_presubmit_yml_path(module_name, pre_version)
-    previous_presubmit_content = open(previous_presubmit_yml, "r").readlines()
-    current_presubmit_yml = registry.get_presubmit_yml_path(module_name, version)
-    current_presubmit_content = open(current_presubmit_yml, "r").readlines()
-    diff = list(unified_diff(previous_presubmit_content, current_presubmit_content, fromfile=str(previous_presubmit_yml), tofile=str(current_presubmit_yml)))
-    if diff:
-      validation_results.append((BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW,
-                          f"The presubmit.yml file of {module_name}@{version} doesn't match its previous version {module_name}@{pre_version}, the following presubmit.yml file change should be reviewed by a BCR maintainer.\n"
-                          + "    " + "    ".join(diff)))
+  def verify_module_existence(self, registry, module_name, version):
+    """Verify the directory exists and the version is recorded in metadata.json."""
+    if not registry.contains(module_name, version):
+      self.report(BcrValidationResult.FAILED, f"{module_name}@{version} doesn't exist.")
+      raise BcrValidationException("The module to be validated doesn't exist!")
+    versions = registry.get_metadata(module_name)["versions"]
+    if version not in versions:
+      self.report(BcrValidationResult.FAILED, f"Version {version} is not recorded in {module_name}'s metadata.json file.")
     else:
-      validation_results.append((BcrValidationResult.GOOD, "The presubmit.yml file matches the previous version."))
-  return validation_results
+      self.report(BcrValidationResult.GOOD, "The module exists and is recorded in metadata.json.")
 
-def apply_patch(work_dir, patch_strip, patch_file):
-  # Requries patch to be installed
-  subprocess.run(
-      ["patch", "-p%d" % patch_strip, "-l", "-i", patch_file], shell=False, check=True, env=os.environ, cwd=work_dir
-  )
 
-def remove_trailing_empty_lines(lines):
-  pos = len(lines)
-  while pos > 0 and not lines[pos - 1].strip():
-    pos = pos - 1
-  # Also fix the line endings
-  return [line.rstrip() + "\n" for line in lines[0:pos]]
+  def verify_source_archive_url(self, registry, module_name, version):
+    # Verify the source archive URL matches the github repo. For now, we only support github repositories check.
+    source_url = registry.get_source(module_name, version)["url"]
+    source_repositories = registry.get_metadata(module_name).get("repository", [])
+    matched = not source_repositories
+    for source_repository in source_repositories:
+      if matched:
+        break
+      repo_type, repo_path = source_repository.split(":")
+      if repo_type == "github":
+        parts = urlparse(source_url)
+        matched = parts.scheme == "https" and parts.netloc == "github.com" and os.path.abspath(parts.path).startswith(f"/{repo_path}/")
+    if not matched:
+      self.report(BcrValidationResult.FAILED, f"The source URL of {module_name}@{version} ({source_url}) doesn't match any of the module's source repositories {source_repositories}.")
+    else:
+      self.report(BcrValidationResult.GOOD, "The source URL matches one of the source repositories.")
 
-def verify_module_dot_bazel(registry, module_name, version):
-  validation_results = []
-  source = registry.get_source(module_name, version)
-  source_url = source["url"]
-  tmp_dir = Path(tempfile.mkdtemp())
-  archive_file = tmp_dir.joinpath(source_url.split("/")[-1])
-  output_dir = tmp_dir.joinpath("source_root")
-  download_file(source_url, archive_file)
-  shutil.unpack_archive(str(archive_file), output_dir)
+    # Verify source archive URL is stable.
+    if verify_stable_archive(source_url) == UrlStability.UNSTABLE:
+      self.report(BcrValidationResult.FAILED,
+                          f"{module_name}@{version} is using an unstable source url: `{source_url}`.\n"
+                          + "The source url should follow the format of `https://github.com/<ORGANIZATION>/<REPO>/archive/refs/tags/<TAG>.tar.gz` to retrieve a source archive that is guaranteed by GitHub to be stable over time.\n"
+                          + "See https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1029861300 for more context.")
+    else:
+      self.report(BcrValidationResult.GOOD, "The source URL doesn't look unstable.")
 
-  # Apply patch files if there are any, also verify their integrity values
-  source_root = output_dir.joinpath(source["strip_prefix"] if "strip_prefix" in source else "")
-  if "patches" in source:
-      for patch_name, expected_integrity in source["patches"].items():
-          patch_file = registry.get_patch_file_path(module_name, version, patch_name)
-          actual_integrity = integrity(read(patch_file))
-          if actual_integrity != expected_integrity:
-            validation_results.append((BcrValidationResult.FAILED, f"The patch file `{patch_file}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{actual_integrity}`."))
-          apply_patch(source_root, source["patch_strip"], str(patch_file.resolve()))
 
-  source_module_dot_bazel = source_root.joinpath("MODULE.bazel")
-  if source_module_dot_bazel.exists():
-    source_module_dot_bazel_content = open(source_module_dot_bazel, "r").readlines()
-  else:
-    source_module_dot_bazel_content = []
-  bcr_module_dot_bazel_content = open(registry.get_module_dot_bazel_path(module_name, version), "r").readlines()
-  source_module_dot_bazel_content = remove_trailing_empty_lines(source_module_dot_bazel_content)
-  bcr_module_dot_bazel_content = remove_trailing_empty_lines(bcr_module_dot_bazel_content)
-  file_name = "a/" * int(source.get("patch_strip", 0)) + "MODULE.bazel"
-  diff = list(unified_diff(source_module_dot_bazel_content, bcr_module_dot_bazel_content, fromfile=file_name, tofile=file_name))
+  def verify_source_archive_integrity(self, registry, module_name, version):
+    """Verify the integrity value of the URL is correct."""
+    source_url = registry.get_source(module_name, version)["url"]
+    expected_integrity = registry.get_source(module_name, version)["integrity"]
+    real_integrity = integrity(download(source_url))
+    if real_integrity != expected_integrity:
+      self.report(BcrValidationResult.FAILED, f"{module_name}@{version}'s source archive `{source_url}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{real_integrity}`!")
+    else:
+      self.report(BcrValidationResult.GOOD, "The source archive's integrity value matches.")
 
-  if diff:
-    validation_results.append((BcrValidationResult.FAILED,
-                               "Checked in MODULE.bazel file doesn't match the one in the extracted and patched sources.\n"
-                               + f"Please fix the MODULE.bazel file or you can add the following patch to {module_name}@{version}:\n"
-                               + "    " + "    ".join(diff)))
-  else:
-    validation_results.append((BcrValidationResult.GOOD, "Checked in MODULE.bazel matches the sources."))
 
-  shutil.rmtree(tmp_dir)
+  def verify_presubmit_yml_change(self, registry, module_name, version):
+    """Verify if the presubmit.yml is the same as the previous version."""
+    versions = registry.get_metadata(module_name)["versions"]
+    versions.sort(key=Version)
+    index = versions.index(version)
+    if index == 0:
+      self.report(BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW, f"Module version {module_name}@{version} is new, the presubmit.yml file should be reviewed by a BCR maintainer.")
+    elif index > 0:
+      pre_version = versions[index - 1]
+      previous_presubmit_yml = registry.get_presubmit_yml_path(module_name, pre_version)
+      previous_presubmit_content = open(previous_presubmit_yml, "r").readlines()
+      current_presubmit_yml = registry.get_presubmit_yml_path(module_name, version)
+      current_presubmit_content = open(current_presubmit_yml, "r").readlines()
+      diff = list(unified_diff(previous_presubmit_content, current_presubmit_content, fromfile=str(previous_presubmit_yml), tofile = str(current_presubmit_yml)))
+      if diff:
+        self.report(BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW,
+                            f"The presubmit.yml file of {module_name}@{version} doesn't match its previous version {module_name}@{pre_version}, the following presubmit.yml file change should be reviewed by a BCR maintainer.\n"
+                            + "    " + "    ".join(diff))
+      else:
+        self.report(BcrValidationResult.GOOD, "The presubmit.yml file matches the previous version.")
 
-  return validation_results
+  def verify_module_dot_bazel(self, registry, module_name, version):
+    source = registry.get_source(module_name, version)
+    source_url = source["url"]
+    tmp_dir = Path(tempfile.mkdtemp())
+    archive_file = tmp_dir.joinpath(source_url.split("/")[-1])
+    output_dir = tmp_dir.joinpath("source_root")
+    download_file(source_url, archive_file)
+    shutil.unpack_archive(str(archive_file), output_dir)
 
-def print_and_append_result(all_results, new_results):
-  print_validation_result(new_results)
-  all_results.extend(new_results)
+    # Apply patch files if there are any, also verify their integrity values
+    source_root = output_dir.joinpath(source["strip_prefix"] if "strip_prefix" in source else "")
+    if "patches" in source:
+        for patch_name, expected_integrity in source["patches"].items():
+            patch_file = registry.get_patch_file_path(module_name, version, patch_name)
+            actual_integrity = integrity(read(patch_file))
+            if actual_integrity != expected_integrity:
+              self.report(BcrValidationResult.FAILED, f"The patch file `{patch_file}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{actual_integrity}`.")
+            apply_patch(source_root, source["patch_strip"], str(patch_file.resolve()))
 
-def validate_module(registry, module_name, version):
-  print_expanded_group(f"Validating {module_name}@{version}")
+    source_module_dot_bazel = source_root.joinpath("MODULE.bazel")
+    if source_module_dot_bazel.exists():
+      source_module_dot_bazel_content = open(source_module_dot_bazel, "r").readlines()
+    else:
+      source_module_dot_bazel_content = []
+    bcr_module_dot_bazel_content = open(registry.get_module_dot_bazel_path(module_name, version), "r").readlines()
+    source_module_dot_bazel_content = fix_line_endings(source_module_dot_bazel_content)
+    bcr_module_dot_bazel_content = fix_line_endings(bcr_module_dot_bazel_content)
+    file_name = "a/" * int(source.get("patch_strip", 0)) + "MODULE.bazel"
+    diff = list(unified_diff(source_module_dot_bazel_content, bcr_module_dot_bazel_content, fromfile=file_name, tofile=file_name))
 
-  all_results = []
-  print_and_append_result(all_results, verify_module_existence(registry, module_name, version))
-  print_and_append_result(all_results, verify_source_archive_url(registry, module_name, version))
-  print_and_append_result(all_results, verify_source_archive_integrity(registry, module_name, version))
-  print_and_append_result(all_results, verify_presubmit_yml_change(registry, module_name, version))
-  print_and_append_result(all_results, verify_module_dot_bazel(registry, module_name, version))
+    if diff:
+      self.report(BcrValidationResult.FAILED,
+                                "Checked in MODULE.bazel file doesn't match the one in the extracted and patched sources.\n"
+                                + f"Please fix the MODULE.bazel file or you can add the following patch to {module_name}@{version}:\n"
+                                + "    " + "    ".join(diff))
+    else:
+      self.report(BcrValidationResult.GOOD, "Checked in MODULE.bazel matches the sources.")
 
-  return all_results
+    shutil.rmtree(tmp_dir)
+
+  def validate_module(self, registry, module_name, version):
+    print_expanded_group(f"Validating {module_name}@{version}")
+    self.verify_module_existence(registry, module_name, version)
+    self.verify_source_archive_url(registry, module_name, version)
+    self.verify_source_archive_integrity(registry, module_name, version)
+    self.verify_presubmit_yml_change(registry, module_name, version)
+
+  def getValidationReturnCode(self):
+    # Calculate the overall return code
+    # 0: All good
+    # 1: BCR validation failed
+    # 42: BCR validation passes, but some changes need BCR maintainer review before trigging follow up BCR presubmit jobs.
+    result_codes = [code for code, _ in self.validation_results]
+    if BcrValidationResult.FAILED in result_codes:
+      return 1
+    if BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW in result_codes:
+      # Use a special return code to avoid conflict with other error code
+      return 42
+    return 0
 
 def main(argv=None):
   if argv is None:
@@ -279,21 +274,10 @@ def main(argv=None):
     print(f"{name}@{version}")
 
   # Validate given module version.
-  validation_results = []
+  validator = BcrValidator()
   for name, version in module_versions:
-    validation_results.extend(validate_module(registry, name, version))
-
-  # Calculate the return code
-  # 0: All good
-  # 1: BCR validation failed
-  # 42: BCR validation passes, but some changes need BCR maintainer review before trigging follow up BCR presubmit jobs.
-  result_codes = [code for code, _ in validation_results]
-  if BcrValidationResult.FAILED in result_codes:
-    return 1
-  if BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW in result_codes:
-    # Use a special return code to avoid conflict with other error code
-    return 42
-  return 0
+    validator.validate_module(registry, name, version)
+  return validator.getValidationReturnCode()
 
 if __name__ == "__main__":
   sys.exit(main())

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -180,6 +180,7 @@ def remove_trailing_empty_lines(lines):
   pos = len(lines)
   while pos > 0 and not lines[pos - 1].strip():
     pos = pos - 1
+  # Also fix the line endings
   return [line.rstrip() + "\n" for line in lines[0:pos]]
 
 def verify_module_dot_bazel(registry, module_name, version):
@@ -215,7 +216,7 @@ def verify_module_dot_bazel(registry, module_name, version):
 
   if diff:
     validation_results.append((BcrValidationResult.FAILED,
-                               "Checked in MODULE.bazel file doesn't match the extracted and patched sources.\n"
+                               "Checked in MODULE.bazel file doesn't match the one in the extracted and patched sources.\n"
                                + f"Please fix the MODULE.bazel file or you can add the following patch to {module_name}@{version}:\n"
                                + "    " + "    ".join(diff)))
   else:

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -104,7 +104,7 @@ class BcrValidator:
   def report(self, type, message):
     color = COLOR[type]
     print(f"{color}{type}{RESET}: {message}\n")
-    self.validation_results.append(type, message)
+    self.validation_results.append((type, message))
 
   def verify_module_existence(self, registry, module_name, version):
     """Verify the directory exists and the version is recorded in metadata.json."""
@@ -116,7 +116,6 @@ class BcrValidator:
       self.report(BcrValidationResult.FAILED, f"Version {version} is not recorded in {module_name}'s metadata.json file.")
     else:
       self.report(BcrValidationResult.GOOD, "The module exists and is recorded in metadata.json.")
-
 
   def verify_source_archive_url(self, registry, module_name, version):
     # Verify the source archive URL matches the github repo. For now, we only support github repositories check.

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -24,6 +24,7 @@ Validations performed are:
   - Verify the source archive URL is stable
   - Verify if the presubmit.yml file matches the previous version
     - If not, we should require BCR maintainer review.
+  - Verify the checked in MODULE.bazel file matches the one in the extracted and patched source tree.
 """
 
 import argparse

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -57,6 +57,9 @@ def download(url):
   with urllib.request.urlopen(req) as response:
     return response.read()
 
+def download_file(url, file):
+  with open(file, "wb") as f:
+      f.write(download(url))
 
 def read(path):
   with open(path, "rb") as file:
@@ -243,6 +246,14 @@ module(
   def get_presubmit_yml_path(self, module_name, version):
     return self.root.joinpath("modules", module_name, version,
                               "presubmit.yml")
+
+  def get_patch_file_path(self, module_name, version, patch_name):
+    return self.root.joinpath("modules", module_name, version,
+                              "patches", patch_name)
+
+  def get_module_dot_bazel_path(self, module_name, version):
+    return self.root.joinpath("modules", module_name, version,
+                              "MODULE.bazel")
 
   def contains(self, module_name, version=None):
     """

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -243,6 +243,10 @@ module(
                                      "source.json")
     return json.load(source_path.open())
 
+  def get_source_path(self, module_name, version):
+    return self.root.joinpath("modules", module_name, version,
+                              "source.json")
+
   def get_presubmit_yml_path(self, module_name, version):
     return self.root.joinpath("modules", module_name, version,
                               "presubmit.yml")


### PR DESCRIPTION
This PR adds check for MODULE.bazel to make sure the checked in MODULE.bazel file is the same as the one in the extracted and patched source tree. Using `--fix` option to tell the script to fix the mismatch by applying a patch file for the MODULE.bazel file.

Also added check for patch files' integrity value.

Fixes https://github.com/bazelbuild/bazel-central-registry/issues/120