### PR TITLE
Add rules_apple 2.0.0-rc1

### DIFF
--- a/modules/rules_apple/2.0.0-rc1/MODULE.bazel
+++ b/modules/rules_apple/2.0.0-rc1/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "rules_apple",
+    compatibility_level = 1,
+    repo_name = "build_bazel_rules_apple",
+    version = "2.0.0-rc1",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.1.1")
+bazel_dep(name = "apple_support", repo_name = "build_bazel_apple_support", version = "1.3.2")
+bazel_dep(name = "rules_swift", repo_name = "build_bazel_rules_swift", version = "1.2.0")

--- a/modules/rules_apple/2.0.0-rc1/MODULE.bazel
+++ b/modules/rules_apple/2.0.0-rc1/MODULE.bazel
@@ -8,3 +8,11 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.1.1")
 bazel_dep(name = "apple_support", repo_name = "build_bazel_apple_support", version = "1.3.2")
 bazel_dep(name = "rules_swift", repo_name = "build_bazel_rules_swift", version = "1.2.0")
+
+non_module_deps = use_extension("//apple:extensions.bzl", "non_module_deps")
+
+use_repo(
+	non_module_deps,
+	"subpar",
+	"xctestrunner",
+)

--- a/modules/rules_apple/2.0.0-rc1/MODULE.bazel
+++ b/modules/rules_apple/2.0.0-rc1/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "rules_swift", repo_name = "build_bazel_rules_swift", version =
 non_module_deps = use_extension("//apple:extensions.bzl", "non_module_deps")
 
 use_repo(
-	non_module_deps,
-	"subpar",
-	"xctestrunner",
+    non_module_deps,
+    "subpar",
+    "xctestrunner",
 )

--- a/modules/rules_apple/2.0.0-rc1/patches/add-non-module-deps-via-bzlmod-module-extension.patch
+++ b/modules/rules_apple/2.0.0-rc1/patches/add-non-module-deps-via-bzlmod-module-extension.patch
@@ -22,9 +22,9 @@ index 22f034f0..599546d8 100644
 +non_module_deps = use_extension("//apple:extensions.bzl", "non_module_deps")
 +
 +use_repo(
-+	non_module_deps,
-+	"subpar",
-+	"xctestrunner",
++    non_module_deps,
++    "subpar",
++    "xctestrunner",
 +)
 diff --git a/apple/extensions.bzl b/apple/extensions.bzl
 new file mode 100644

--- a/modules/rules_apple/2.0.0-rc1/patches/add-non-module-deps-via-bzlmod-module-extension.patch
+++ b/modules/rules_apple/2.0.0-rc1/patches/add-non-module-deps-via-bzlmod-module-extension.patch
@@ -1,0 +1,143 @@
+From 09deb2e19c361d026a3ce0d7d839fe7116ca298e Mon Sep 17 00:00:00 2001
+From: Patrick Balestra <patrickb@spotify.com>
+Date: Tue, 8 Nov 2022 23:41:33 +0100
+Subject: [PATCH] Add non-module deps via bzlmod module extension
+
+---
+ MODULE.bazel           |  8 ++++++
+ apple/extensions.bzl   | 22 ++++++++++++++
+ apple/repositories.bzl | 65 ++++++++++++++++++++++--------------------
+ 3 files changed, 64 insertions(+), 31 deletions(-)
+ create mode 100644 apple/extensions.bzl
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 22f034f0..599546d8 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -8,3 +8,11 @@ module(
+ bazel_dep(name = "bazel_skylib", version = "1.1.1")
+ bazel_dep(name = "apple_support", repo_name = "build_bazel_apple_support", version = "1.3.2")
+ bazel_dep(name = "rules_swift", repo_name = "build_bazel_rules_swift", version = "1.2.0")
++
++non_module_deps = use_extension("//apple:extensions.bzl", "non_module_deps")
++
++use_repo(
++	non_module_deps,
++	"subpar",
++	"xctestrunner",
++)
+diff --git a/apple/extensions.bzl b/apple/extensions.bzl
+new file mode 100644
+index 00000000..7fdef2a3
+--- /dev/null
++++ b/apple/extensions.bzl
+@@ -0,0 +1,22 @@
++# Copyright 2022 The Bazel Authors. All rights reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#    http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++"""Definitions for bzlmod module extensions."""
++
++load("//apple:repositories.bzl", "apple_rules_dependencies")
++
++def _non_module_deps_impl(_):
++    apple_rules_dependencies(include_bzlmod_ready_dependencies = False)
++
++non_module_deps = module_extension(implementation = _non_module_deps_impl)
+diff --git a/apple/repositories.bzl b/apple/repositories.bzl
+index c6e99374..baf0d649 100644
+--- a/apple/repositories.bzl
++++ b/apple/repositories.bzl
+@@ -85,7 +85,7 @@ run into compatibility issues. To silence this warning, pass \
+ 
+     repo_rule(name = name, **kwargs)
+ 
+-def apple_rules_dependencies(ignore_version_differences = False):
++def apple_rules_dependencies(ignore_version_differences = False, include_bzlmod_ready_dependencies = True):
+     """Fetches repositories that are dependencies of the `rules_apple` workspace.
+ 
+     Users should call this macro in their `WORKSPACE` to ensure that all of the
+@@ -95,37 +95,40 @@ def apple_rules_dependencies(ignore_version_differences = False):
+     Args:
+       ignore_version_differences: If `True`, warnings about potentially
+           incompatible versions of depended-upon repositories will be silenced.
++      include_bzlmod_ready_dependencies: Whether or not bzlmod-ready
++             dependencies should be included.
+     """
+-    _maybe(
+-        http_archive,
+-        name = "bazel_skylib",
+-        urls = [
+-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+-        ],
+-        sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
+-        ignore_version_differences = ignore_version_differences,
+-    )
+-
+-    _maybe(
+-        http_archive,
+-        name = "build_bazel_apple_support",
+-        sha256 = "2e3dc4d0000e8c2f5782ea7bb53162f37c485b5d8dc62bb3d7d7fc7c276f0d00",
+-        urls = [
+-            "https://github.com/bazelbuild/apple_support/releases/download/1.3.2/apple_support.1.3.2.tar.gz",
+-        ],
+-        ignore_version_differences = ignore_version_differences,
+-    )
+-
+-    _maybe(
+-        http_archive,
+-        name = "build_bazel_rules_swift",
+-        urls = [
+-            "https://github.com/bazelbuild/rules_swift/releases/download/1.2.0/rules_swift.1.2.0.tar.gz",
+-        ],
+-        sha256 = "51efdaf85e04e51174de76ef563f255451d5a5cd24c61ad902feeadafc7046d9",
+-        ignore_version_differences = ignore_version_differences,
+-    )
++    if include_bzlmod_ready_dependencies:
++        _maybe(
++            http_archive,
++            name = "bazel_skylib",
++            urls = [
++                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
++                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
++            ],
++            sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
++            ignore_version_differences = ignore_version_differences,
++        )
++
++        _maybe(
++            http_archive,
++            name = "build_bazel_apple_support",
++            sha256 = "2e3dc4d0000e8c2f5782ea7bb53162f37c485b5d8dc62bb3d7d7fc7c276f0d00",
++            urls = [
++                "https://github.com/bazelbuild/apple_support/releases/download/1.3.2/apple_support.1.3.2.tar.gz",
++            ],
++            ignore_version_differences = ignore_version_differences,
++        )
++
++        _maybe(
++            http_archive,
++            name = "build_bazel_rules_swift",
++            urls = [
++                "https://github.com/bazelbuild/rules_swift/releases/download/1.2.0/rules_swift.1.2.0.tar.gz",
++            ],
++            sha256 = "51efdaf85e04e51174de76ef563f255451d5a5cd24c61ad902feeadafc7046d9",
++            ignore_version_differences = ignore_version_differences,
++        )
+ 
+     _maybe(
+         http_archive,
+-- 
+2.37.0 (Apple Git-136)
+

--- a/modules/rules_apple/2.0.0-rc1/presubmit.yml
+++ b/modules/rules_apple/2.0.0-rc1/presubmit.yml
@@ -4,3 +4,9 @@ tasks:
     platform: macos
     test_targets:
     - '@rules_apple//examples/...'
+    # TODO(balestrapatrick): Re-enable these tests as soon as xctestrunner is bzlmod-compatible.
+    - '-@rules_apple//examples/ios/Squarer:SquarerTests'
+    - '-@rules_apple//examples/ios/PrenotCalculator:PrenotCalculatorTests'
+    - '-@rules_apple//examples/multi_platform/Buttons:ButtonsUITests'
+    - '-@rules_apple//examples/multi_platform/Buttons:ButtonsTests'
+    - '-@rules_apple//examples/multi_platform/Buttons:ButtonsLogicTests'

--- a/modules/rules_apple/2.0.0-rc1/presubmit.yml
+++ b/modules/rules_apple/2.0.0-rc1/presubmit.yml
@@ -2,5 +2,5 @@ tasks:
   verify_targets:
     name: Verify build targets
     platform: macos
-    build_targets:
+    test_targets:
     - '@rules_apple//examples/...'

--- a/modules/rules_apple/2.0.0-rc1/presubmit.yml
+++ b/modules/rules_apple/2.0.0-rc1/presubmit.yml
@@ -1,0 +1,6 @@
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: macos
+    build_targets:
+    - '@rules_apple//examples/...'

--- a/modules/rules_apple/2.0.0-rc1/source.json
+++ b/modules/rules_apple/2.0.0-rc1/source.json
@@ -1,4 +1,8 @@
 {
     "url": "https://github.com/bazelbuild/rules_apple/releases/download/2.0.0-rc1/rules_apple.2.0.0-rc1.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "add-non-module-deps-via-bzlmod-module-extension.patch": "sha256-57T+W202/zATXtYqXrxBsmF0Cr2ndKg6mc5QtGANq+4="
+    },
     "integrity": "sha256-v0isxz5TbTa0lChXZHrCGVEtSYSspq4IOhH9P9VA+qA="
 }

--- a/modules/rules_apple/2.0.0-rc1/source.json
+++ b/modules/rules_apple/2.0.0-rc1/source.json
@@ -1,0 +1,4 @@
+{
+    "url": "https://github.com/bazelbuild/rules_apple/releases/download/2.0.0-rc1/rules_apple.2.0.0-rc1.tar.gz",
+    "integrity": "sha256-v0isxz5TbTa0lChXZHrCGVEtSYSspq4IOhH9P9VA+qA="
+}

--- a/modules/rules_apple/2.0.0-rc1/source.json
+++ b/modules/rules_apple/2.0.0-rc1/source.json
@@ -2,7 +2,7 @@
     "url": "https://github.com/bazelbuild/rules_apple/releases/download/2.0.0-rc1/rules_apple.2.0.0-rc1.tar.gz",
     "patch_strip": 1,
     "patches": {
-        "add-non-module-deps-via-bzlmod-module-extension.patch": "sha256-57T+W202/zATXtYqXrxBsmF0Cr2ndKg6mc5QtGANq+4="
+        "add-non-module-deps-via-bzlmod-module-extension.patch": "sha256-z7polvqcVSSfJVM9pQma/zizjlHnOpMRxVHe8NnqkFc="
     },
     "integrity": "sha256-v0isxz5TbTa0lChXZHrCGVEtSYSspq4IOhH9P9VA+qA="
 }

--- a/modules/rules_apple/metadata.json
+++ b/modules/rules_apple/metadata.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://github.com/bazelbuild/rules_apple",
+    "maintainers": [
+        {
+            "email": "me@patrickbalestra.com",
+            "github": "BalestraPatrick",
+            "name": "Patrick Balestra"
+        },
+        {
+            "email": "keithbsmiley@gmail.com",
+            "github": "keith",
+            "name": "Keith Smiley"
+        }
+    ],
+    "repository": [
+        "github:bazelbuild/rules_apple"
+    ],
+    "versions": [
+        "2.0.0-rc1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
We recently cut a new release of `rules_apple` that supports Bazel 6.0.0rc1, so this version should build in the BCR as well now.