### PR TITLE
chore: introduce simple issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: File a bug report to help us improve
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+        
+        **Looking for help?** For support questions, please use [Bazel slack](https://slack.bazel.build).
+        This form should only be used when you suspect that there's a problem with the code or configurations in this repository.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: Please tell us about your environment
+      value: |
+        Development (host) and target OS/architectures:
+
+        Output of `bazel --version`:
+
+        Version of relevant rules from the `WORKSPACE` or `MODULE.bazel` file:
+
+        Language(s) and/or frameworks involved:
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      description: Your bug is more likely to be resolved if you provide the steps to reproduce, and if possible a minimal demo of the problem.
+      render: shell
+
+  - type: textarea
+    id: other
+    attributes:
+      label: Any other information?
+      description: |
+        (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, things you've tried, links for us to have context, eg. stackoverflow, gitter, etc)

--- a/.github/ISSUE_TEMPLATE/module_wanted.yaml
+++ b/.github/ISSUE_TEMPLATE/module_wanted.yaml
@@ -1,0 +1,39 @@
+name: Module Wanted
+description: Request that a module be added to the registry
+title: "wanted: [github path of the module, e.g. bazelbuild/rules_foo]"
+labels: ["module wanted"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The Central Registry is populated by community contributions.
+        You can file an issue to request that a volunteer add it to the registry.
+        There is no guarantee that anyone will volunteer.
+
+  - type: input
+    id: location
+    attributes:
+      label: Module location
+      description: Where can we find the source code for the module
+    validations:
+      required: true
+
+  - type: input
+    id: issue-link
+    attributes:
+      label: Link to bzlmod issue in the module's repository
+      description: In many cases, upstream work is needed, such as writing module extensions in a ruleset.
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Any other context to provide?
+      description: What do we need to know about the module?
+
+  - type: checkboxes
+    id: sponsor
+    attributes:
+      label: Fund our work
+      description: I'd like someone to add this module right away!
+      options:
+        - label: Sponsor our community's open source work by donating a [feature bounty](https://opencollective.com/bazel-rules-authors-sig/projects/bazel-central-registry)

--- a/.github/ISSUE_TEMPLATE/module_wanted.yaml
+++ b/.github/ISSUE_TEMPLATE/module_wanted.yaml
@@ -7,8 +7,9 @@ body:
     attributes:
       value: |
         The Central Registry is populated by community contributions.
-        You can file an issue to request that a volunteer add it to the registry.
-        There is no guarantee that anyone will volunteer.
+        You can file an issue to indicate that you depend on a module which isn't available here.
+        A volunteer may contribute that module, but there is no guarantee.
+        You may want to send a PR yourself, or consider sponsoring the work.
 
   - type: input
     id: location


### PR DESCRIPTION
The immediate goal is to ensure more uniformity of the module wanted requests, and to collect links to upstream issues. Hopefully this automates a bit of the maintenance work for this repo.