### PR TITLE
Yank rules_python 0.14.0

### DIFF
--- a/modules/rules_python/metadata.json
+++ b/modules/rules_python/metadata.json
@@ -23,5 +23,7 @@
         "0.15.0",
         "0.15.1"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "0.14.0", "rules_python 0.14.0 is broken due to https://github.com/bazelbuild/bazel-central-registry/issues/287, please upgrade to version >= 0.15.0"
+    }
 }


### PR DESCRIPTION
This module version is broken and no one can use it, yanking it will provide better error message for users. 

Closes https://github.com/bazelbuild/bazel-central-registry/issues/287