### PR TITLE
Fix JSON formatting in rules_python metadata.json

### DIFF
--- a/modules/rules_python/metadata.json
+++ b/modules/rules_python/metadata.json
@@ -24,6 +24,6 @@
         "0.15.1"
     ],
     "yanked_versions": {
-        "0.14.0", "rules_python 0.14.0 is broken due to https://github.com/bazelbuild/bazel-central-registry/issues/287, please upgrade to version >= 0.15.0"
+        "0.14.0": "rules_python 0.14.0 is broken due to https://github.com/bazelbuild/bazel-central-registry/issues/287, please upgrade to version >= 0.15.0"
     }
 }


### PR DESCRIPTION
https://github.com/bazelbuild/bazel-central-registry/pull/305 contained some invalid JSON formatting