### PR TITLE
Remove the default source archive mirror

### DIFF
--- a/bazel_registry.json
+++ b/bazel_registry.json
@@ -1,3 +1,3 @@
 {
-    "mirrors": ["https://bcr.bazel.build/mirror"]
+    "mirrors": []
 }


### PR DESCRIPTION
Per legal review, we can't easily host a source archive mirror without triggering license issues. Given the reasonable reliability of GitHub CDN, this isn't really worth pursuing (and enterprise users can still use their own mirros if necessary).