### PR TITLE
Add fmt-9.1.0 module

### DIFF
--- a/modules/fmt/9.1.0/MODULE.bazel
+++ b/modules/fmt/9.1.0/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "fmt",
+    version = "9.1.0",
+    compatibility_level = 9,
+)

--- a/modules/fmt/9.1.0/patches/add_build_file.patch
+++ b/modules/fmt/9.1.0/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++package(default_visibility = ["//visibility:public"])
++
++licenses(["notice"])
++
++cc_library(
++    name = "fmt",
++    srcs = [
++        "src/format.cc",
++        "src/os.cc",
++    ],
++    hdrs = glob([
++        "include/fmt/*.h",
++    ]),
++    includes = ["include"],
++)

--- a/modules/fmt/9.1.0/patches/module_dot_bazel.patch
+++ b/modules/fmt/9.1.0/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "fmt",
++    version = "9.1.0",
++    compatibility_level = 9,
++)

--- a/modules/fmt/9.1.0/presubmit.yml
+++ b/modules/fmt/9.1.0/presubmit.yml
@@ -1,0 +1,12 @@
+build_targets: &build_targets
+- '@fmt//:fmt'
+
+platforms:
+  debian10:
+    build_targets: *build_targets
+  macos:
+    build_targets: *build_targets
+  ubuntu2004:
+    build_targets: *build_targets
+  windows:
+    build_targets: *build_targets

--- a/modules/fmt/9.1.0/source.json
+++ b/modules/fmt/9.1.0/source.json
@@ -2,6 +2,7 @@
     "integrity": "sha256-XepI0fzdw+xXHOIFjhORCg1Ka6tMwJqAnYsd0ciK5vI=",
     "patch_strip": 0,
     "patches": {
+        "add_build_file.patch": "sha256-bUYJz9G64DPC99/aSnVNx3JD1nStIA4zXK89OvIDmfY=",
         "module_dot_bazel.patch": "sha256-EViB7Mee2g44y9GWjM2Ems1s58noqTsc5o/UjoJDKIs="
     },
     "strip_prefix": "fmt-9.1.0",

--- a/modules/fmt/9.1.0/source.json
+++ b/modules/fmt/9.1.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-XepI0fzdw+xXHOIFjhORCg1Ka6tMwJqAnYsd0ciK5vI=",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-EViB7Mee2g44y9GWjM2Ems1s58noqTsc5o/UjoJDKIs="
+    },
+    "strip_prefix": "fmt-9.1.0",
+    "url": "https://github.com/fmtlib/fmt/archive/refs/tags/9.1.0.tar.gz"
+}

--- a/modules/fmt/metadata.json
+++ b/modules/fmt/metadata.json
@@ -5,7 +5,8 @@
         "github:fmtlib/fmt"
     ],
     "versions": [
-        "8.1.1"
+        "8.1.1",
+        "9.1.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
I'm testing BCR on a separate project and wanted to work with [fmt-9.1.0](https://github.com/fmtlib/fmt/releases/tag/9.1.0).

Signed-off-by: Mihai Maruseac <mihaimaruseac@google.com>