### PR TITLE
BCR is now officially launched!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Bazel Central Registry
 
-**Status:** This repository is in beta test phase, feel free to submit your project as Bazel module. During the test phase, checked in modules may still change without any notice.
-
 ## Overview
 
 The default Bazel registry for the Bzlmod external dependency system of Bazel. It is the recommended place to find and publish your favorite Bazel projects. Visit https://registry.bazel.build to check what modules are already available!


### PR DESCRIPTION
After going through the internal launch review process, we have got the approval to officially launch the Bazel Central Registry.

Compared to the original design, the major difference is that we no longer have the default mirror for source archives due to legal concerns.

We should now fully respect the [BCR policies](https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/bcr-policies.md#bazel-central-registry-bcr-contribution-policies), especially the "add-only" policy to ensure reproducibility.
