### PR TITLE
Add rules_xcodeproj 0.12.0

### DIFF
--- a/modules/rules_xcodeproj/0.12.0/MODULE.bazel
+++ b/modules/rules_xcodeproj/0.12.0/MODULE.bazel
@@ -1,0 +1,22 @@
+module(
+    name = "rules_xcodeproj",
+    version = "0.12.0",
+    repo_name = "com_github_buildbuddy_io_rules_xcodeproj",
+    compatibility_level = 1,
+)
+bazel_dep(name = "bazel_skylib", version = "1.3.0")
+bazel_dep(name = "rules_swift", version = "1.5.1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_apple", version = "2.0.0", repo_name = "build_bazel_rules_apple")
+
+non_module_deps = use_extension("//xcodeproj:extensions.bzl", "non_module_deps")
+use_repo(
+    non_module_deps,
+    "rules_xcodeproj_index_import",
+    "com_github_kylef_pathkit",
+    "com_github_tadija_aexml",
+    "com_github_michaeleisel_jjliso8601dateformatter",
+    "com_github_michaeleisel_zippyjsoncfamily",
+    "com_github_michaeleisel_zippyjson",
+    "com_github_tuist_xcodeproj",
+    "com_github_apple_swift_collections",
+)

--- a/modules/rules_xcodeproj/0.12.0/patches/add_module.patch
+++ b/modules/rules_xcodeproj/0.12.0/patches/add_module.patch
@@ -1,0 +1,28 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 00000000..f14b8395
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,22 @@
++module(
++    name = "rules_xcodeproj",
++    version = "0.12.0",
++    repo_name = "com_github_buildbuddy_io_rules_xcodeproj",
++    compatibility_level = 1,
++)
++bazel_dep(name = "bazel_skylib", version = "1.3.0")
++bazel_dep(name = "rules_swift", version = "1.5.1", repo_name = "build_bazel_rules_swift")
++bazel_dep(name = "rules_apple", version = "2.0.0", repo_name = "build_bazel_rules_apple")
++
++non_module_deps = use_extension("//xcodeproj:extensions.bzl", "non_module_deps")
++use_repo(
++    non_module_deps,
++    "rules_xcodeproj_index_import",
++    "com_github_kylef_pathkit",
++    "com_github_tadija_aexml",
++    "com_github_michaeleisel_jjliso8601dateformatter",
++    "com_github_michaeleisel_zippyjsoncfamily",
++    "com_github_michaeleisel_zippyjson",
++    "com_github_tuist_xcodeproj",
++    "com_github_apple_swift_collections",
++)

--- a/modules/rules_xcodeproj/0.12.0/presubmit.yml
+++ b/modules/rules_xcodeproj/0.12.0/presubmit.yml
@@ -1,0 +1,6 @@
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: macos
+    build_targets:
+    - '@rules_xcodeproj//tools/generator:xcodeproj'

--- a/modules/rules_xcodeproj/0.12.0/source.json
+++ b/modules/rules_xcodeproj/0.12.0/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.12.0/release.tar.gz",
+    "integrity": "sha256-Yw40NLSegHg0MO9HDA6afxyLTmSPeJuf4yT803reihk=",
+    "patch_strip": 1,
+    "patches": {
+        "add_module.patch": "sha256-0oh0WAavYS/RT8EYw2zINy+fWW1WCu9ZjLbKNUswMCc="
+    }
+}

--- a/modules/rules_xcodeproj/metadata.json
+++ b/modules/rules_xcodeproj/metadata.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "https://github.com/buildbuddy-io/rules_xcodeproj",
+    "maintainers": [
+        {
+            "email": "github@brentleyjones.com",
+            "github": "brentleyjones",
+            "name": "Jones Brentley"
+        },
+        {
+            "email": "me@patrickbalestra.com",
+            "github": "BalestraPatrick",
+            "name": "Patrick Balestra"
+        },
+        {
+            "email": "t@thi.im",
+            "github": "thii",
+            "name": "Thi Doãn"
+        }
+    ],
+    "repository": [
+        "github:buildbuddy-io/rules_xcodeproj"
+    ],
+    "versions": [
+        "0.12.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
First release [rules_xcodeproj](https://github.com/buildbuddy-io/rules_xcodeproj) that supports bzlmod. After this we'll be switching to automatic releases once https://github.com/buildbuddy-io/rules_xcodeproj/pull/1585 is merged.