### PR TITLE
Add spdlog 1.11.0

### DIFF
--- a/modules/spdlog/1.11.0/MODULE.bazel
+++ b/modules/spdlog/1.11.0/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "spdlog",
+    compatibility_level = 1,
+    version = "1.11.0",
+)
+
+bazel_dep(name = "fmt", version = "9.1.0")
+bazel_dep(name = "rules_cc", version = "0.0.1")

--- a/modules/spdlog/1.11.0/patches/add_build_file.patch
+++ b/modules/spdlog/1.11.0/patches/add_build_file.patch
@@ -1,0 +1,21 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,18 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++licenses(["notice"])  # Apache 2
++
++package(
++    default_visibility = ["//visibility:public"],
++)
++
++cc_library(
++    name = "spdlog",
++    hdrs = glob([
++        "include/**/*.cc",
++        "include/**/*.h",
++    ]),
++    defines = ["SPDLOG_FMT_EXTERNAL"],
++    includes = ["include"],
++    deps = ["@fmt"],
++)

--- a/modules/spdlog/1.11.0/patches/module_dot_bazel.patch
+++ b/modules/spdlog/1.11.0/patches/module_dot_bazel.patch
@@ -1,0 +1,11 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,8 @@
++module(
++    name = "spdlog",
++    compatibility_level = 1,
++    version = "1.11.0",
++)
++
++bazel_dep(name = "fmt", version = "9.1.0")
++bazel_dep(name = "rules_cc", version = "0.0.1")

--- a/modules/spdlog/1.11.0/presubmit.yml
+++ b/modules/spdlog/1.11.0/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@spdlog//:spdlog'

--- a/modules/spdlog/1.11.0/source.json
+++ b/modules/spdlog/1.11.0/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-ylyujWysFdrg7GOyHWrTUwBwZQ9oB286SoYsopOoWLs=",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-G4/iVL0sDRRdcC8X+DCRN2l6oDVNE2TxJ6Vj8IaNct4=",
+        "module_dot_bazel.patch": "sha256-I2IS/xHAmpQmE3Imurb6lHqZg/X3bul9P59NN7FSJn0="
+    },
+    "strip_prefix": "spdlog-1.11.0",
+    "url": "https://github.com/gabime/spdlog/archive/refs/tags/v1.11.0.tar.gz"
+}

--- a/modules/spdlog/metadata.json
+++ b/modules/spdlog/metadata.json
@@ -5,7 +5,8 @@
         "github:gabime/spdlog"
     ],
     "versions": [
-        "1.10.0"
+        "1.10.0",
+	"1.11.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Just copied across the existing module definition and bumped the version of fmt as required by the newer version of spdlog.