### PR TITLE
Add rules_cuda 0.1.2

### DIFF
--- a/modules/rules_cuda/0.1.2/MODULE.bazel
+++ b/modules/rules_cuda/0.1.2/MODULE.bazel
@@ -1,0 +1,17 @@
+module(
+    name = "rules_cuda",
+    compatibility_level = 1,
+    version = "0.1.2",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.2.1")
+bazel_dep(name = "platforms", version = "0.0.4")
+
+toolchain = use_extension("@rules_cuda//cuda:extensions.bzl", "local_toolchain")
+use_repo(toolchain, "local_cuda")
+
+register_toolchains(
+    "@local_cuda//toolchain:nvcc-local-toolchain",
+    "@local_cuda//toolchain/clang:clang-local-toolchain",
+)
+

--- a/modules/rules_cuda/0.1.2/patches/module_dot_bazel.patch
+++ b/modules/rules_cuda/0.1.2/patches/module_dot_bazel.patch
@@ -1,0 +1,11 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_cuda",
+     compatibility_level = 1,
+-    version = "0.1.1",
++    version = "0.1.2",
+ )
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.2.1")

--- a/modules/rules_cuda/0.1.2/presubmit.yml
+++ b/modules/rules_cuda/0.1.2/presubmit.yml
@@ -1,0 +1,4 @@
+tasks:
+  verify_targets_linux:
+    name: Verify build targets
+    platform: ubuntu2004 

--- a/modules/rules_cuda/0.1.2/source.json
+++ b/modules/rules_cuda/0.1.2/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/bazel-contrib/rules_cuda/releases/download/v0.1.2/rules_cuda-v0.1.2.tar.gz",
+    "integrity": "sha256-3B9PcEylbj1e3Zc/mKRfBIfQ8oxonQpXuiNhEhSLGDM=",
+    "strip_prefix": "rules_cuda-v0.1.2",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-N6/Kw8gRCR+dWN+PBW8ZAp+GYtYhmPIBHOOO2vdseJM="
+    }
+}

--- a/modules/rules_cuda/metadata.json
+++ b/modules/rules_cuda/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/bazel-contrib/rules_cuda",
+    "maintainers": [
+        {
+            "email": "james.sharpe@zenotech.com",
+            "github": "jsharpe",
+            "name": "James Sharpe"
+        }
+    ],
+    "repository": [
+        "github:bazel-contrib/rules_cuda"
+    ],
+    "versions": [
+        "0.1.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Note that presubmit.yml is currently empty as we don't yet have a hermetic toolchain to install cuda and a local cuda toolchain is not available in Bazel CI.