### PR TITLE
seh/rules@cue@v0.2.1

### DIFF
--- a/modules/rules_cue/0.2.1/MODULE.bazel
+++ b/modules/rules_cue/0.2.1/MODULE.bazel
@@ -1,0 +1,21 @@
+module(
+    name = "rules_cue",
+    version = "0.2.1",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "platforms", version = "0.0.6")
+bazel_dep(name = "rules_go", version = "0.38.1")
+
+cue = use_extension("//cue:extensions.bzl", "cue")
+use_repo(
+    cue,
+    "cue_tool_toolchains",
+)
+
+register_toolchains("@cue_tool_toolchains//:all")
+
+bazel_dep(name = "gazelle", version = "0.29.0")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")

--- a/modules/rules_cue/0.2.1/presubmit.yml
+++ b/modules/rules_cue/0.2.1/presubmit.yml
@@ -1,0 +1,30 @@
+matrix: &matrix
+  platform:
+  - centos7
+  - debian10
+  - macos
+  - ubuntu2004
+  # Some valid invocations of the "cue" tool can't succeed (e.g. use
+  # of the "path" and "expression" rules attributes) until we resolve
+  # or find a reliable workaround for the following issue:
+  #
+  #   https://github.com/bazelbuild/bazel/issues/17487
+  #
+  # Until then, withdraw promised support for using this module on
+  # Windows.
+  #- windows
+tasks:
+  verify_targets:
+    name: Verify that all tests succeed
+    platform: ${{ platform }}
+    test_targets:
+    - '@rules_cue//test:all'
+bcr_test_module:
+  module_path: examples/bzlmod
+  matrix: *matrix
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      build_targets:
+      - //root

--- a/modules/rules_cue/0.2.1/source.json
+++ b/modules/rules_cue/0.2.1/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-YE5OghdPrTVy6r4UgLOfMuH0iRYPM/YnOHZwF6QpO64=",
+    "strip_prefix": "rules_cue-0.2.1",
+    "url": "https://github.com/seh/rules_cue/archive/refs/tags/v0.2.1.tar.gz"
+}

--- a/modules/rules_cue/metadata.json
+++ b/modules/rules_cue/metadata.json
@@ -11,7 +11,8 @@
         "github:seh/rules_cue"
     ],
     "versions": [
-        "0.2.0"
+        "0.2.0",
+        "0.2.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release author: @seh.

Note that I failed to install the [Publish to BCR](https://github.com/apps/publish-to-bcr) app into the the _seh/rules_cue_ GitHub repository before issuing [this release](https://github.com/seh/rules_cue/releases/tag/v0.2.1).