### PR TITLE
Silence zlib 1.2.13 compile warnings

### DIFF
--- a/modules/zlib/1.2.13/patches/add_build_file.patch
+++ b/modules/zlib/1.2.13/patches/add_build_file.patch
@@ -38,6 +38,7 @@
 +    copts = select({
 +        "@bazel_tools//src/conditions:windows": [],
 +        "//conditions:default": [
++            "-Wno-deprecated-non-prototype",
 +            "-Wno-shift-negative-value",
 +            "-DZ_HAVE_UNISTD_H",
 +        ],

--- a/modules/zlib/1.2.13/source.json
+++ b/modules/zlib/1.2.13/source.json
@@ -2,7 +2,7 @@
     "integrity": "sha256-woVpUbvzDjCGGs43ZVldhroT8s8BJ52QH2xiJYxX9P8=",
     "patch_strip": 0,
     "patches": {
-        "add_build_file.patch": "sha256-Z2ig1F01/dfdG63H+GwYRMcGbW/zAGIUWnKKrwKSEaQ=",
+        "add_build_file.patch": "sha256-t4qbtzKyJVasJkdcIavMYZGNgX+l0tNeXtxBfBLDz0w=",
         "module_dot_bazel.patch": "sha256-Nc7xP02Dl6yHQvkiZWSQnlnw1T277yS4cJxxONWJ/Ic="
     },
     "strip_prefix": "zlib-1.2.13",


### PR DESCRIPTION
I'm using zlib 1.2.13 from bazel-central-registry and I get a lot of compile warnings like this (note, I'm using clang 15.0.7 as my cc toolchain):
```
INFO: From Compiling infback.c:
external/zlib~1.2.13/infback.c:28:13: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
int ZEXPORT inflateBackInit_(strm, windowBits, window, version, stream_size)
            ^
external/zlib~1.2.13/infback.c:83:12: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
local void fixedtables(state)
           ^
external/zlib~1.2.13/infback.c:83:12: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
external/zlib~1.2.13/infback.c:251:13: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
int ZEXPORT inflateBack(strm, in, in_desc, out, out_desc)
            ^
external/zlib~1.2.13/infback.c:635:13: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
int ZEXPORT inflateBackEnd(strm)
            ^
5 warnings generated.
INFO: From Compiling uncompr.c:
external/zlib~1.2.13/uncompr.c:27:13: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
int ZEXPORT uncompress2(dest, destLen, source, sourceLen)
            ^
external/zlib~1.2.13/uncompr.c:86:13: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
int ZEXPORT uncompress(dest, destLen, source, sourceLen)
            ^
2 warnings generated.
```

Fix this by using -Wno-deprecated-non-prototype