### PR TITLE
Add catch2 v3.3.0

### DIFF
--- a/modules/catch2/3.3.0/MODULE.bazel
+++ b/modules/catch2/3.3.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "catch2",
+    version = "3.3.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.3.0")

--- a/modules/catch2/3.3.0/patches/module_dot_bazel.patch
+++ b/modules/catch2/3.3.0/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "catch2",
++    version = "3.3.0",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "bazel_skylib", version = "1.3.0")

--- a/modules/catch2/3.3.0/presubmit.yml
+++ b/modules/catch2/3.3.0/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_flags:
+    - --cxxopt=-std=c++14
+    build_targets:
+    - '@catch2//:catch2'
+    - '@catch2//:catch2_main'

--- a/modules/catch2/3.3.0/source.json
+++ b/modules/catch2/3.3.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/catchorg/Catch2/archive/refs/tags/v3.3.0.tar.gz",
+    "integrity": "sha256-/i8ppUyndcLdBLuX/7edOY5iEOPKoXQ0i1zTt+TKiH0=",
+    "strip_prefix": "Catch2-3.3.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-0ZKA9VjsNb7SM6kYVsfPs+XBKKFVGTYgnHFpohIOkXA="
+    }
+}

--- a/modules/catch2/3.3.0/source.json
+++ b/modules/catch2/3.3.0/source.json
@@ -4,6 +4,6 @@
     "strip_prefix": "Catch2-3.3.0",
     "patch_strip": 0,
     "patches": {
-        "module_dot_bazel.patch": "sha256-0ZKA9VjsNb7SM6kYVsfPs+XBKKFVGTYgnHFpohIOkXA="
+        "module_dot_bazel.patch": "sha256-Ssp5WC3aSXutLRpglAFDmlxvtV3B9SDP1rKpI0tAfvE="
     }
 }

--- a/modules/catch2/metadata.json
+++ b/modules/catch2/metadata.json
@@ -11,6 +11,7 @@
         "github:catchorg/Catch2"
     ],
     "versions": [
+        "3.3.0",
         "3.2.1"
     ],
     "yanked_versions": {}

--- a/modules/catch2/metadata.json
+++ b/modules/catch2/metadata.json
@@ -11,8 +11,8 @@
         "github:catchorg/Catch2"
     ],
     "versions": [
-        "3.3.0",
-        "3.2.1"
+        "3.2.1",
+        "3.3.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Simply add the newest catch2 version available right now.