### PR TITLE
Add missing compatibility_level in rules_pkg

### DIFF
--- a/modules/rules_pkg/0.8.1/MODULE.bazel
+++ b/modules/rules_pkg/0.8.1/MODULE.bazel
@@ -2,6 +2,7 @@ module(
     name = "rules_pkg",
     version = "0.8.1",  # Must sync with version.bzl.
     repo_name = "rules_pkg",
+    compatibility_level = 1,
 )
 
 # Do not update to newer versions until you need a specific new feature.


### PR DESCRIPTION
It cause build errors otherwise when multiple rules_pkg versions used.