### PR TITLE
Publish oxidase/rules_poetry@v0.1.0

### DIFF
--- a/modules/rules_poetry/0.1.0/MODULE.bazel
+++ b/modules/rules_poetry/0.1.0/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "rules_poetry",
+    version = "0.1.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "platforms", version = "0.0.6")
+
+internal_deps = use_extension("@rules_poetry//python:extensions.bzl", "internal_deps")
+internal_deps.install()
+use_repo(internal_deps, "rules_poetry_deps", "rules_poetry_pip")

--- a/modules/rules_poetry/0.1.0/presubmit.yml
+++ b/modules/rules_poetry/0.1.0/presubmit.yml
@@ -1,0 +1,23 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - macos
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@rules_poetry//python/...'
+    - '@rules_poetry//lib/...'
+bcr_test_module:
+  module_path: "examples/simple"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2004"]
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      test_targets:
+      - //...

--- a/modules/rules_poetry/0.1.0/source.json
+++ b/modules/rules_poetry/0.1.0/source.json
@@ -1,0 +1,7 @@
+{
+    "url": "https://github.com/oxidase/rules_poetry/archive/refs/tags/v0.1.0.tar.gz",
+    "integrity": "sha256-+Z92GTqaFl3dXEoGW3LXrdoP/gWjsF10QXpyJTalGiQ=",
+    "strip_prefix": "rules_poetry-0.1.0",
+    "patch_strip": 0,
+    "patches": {}
+}

--- a/modules/rules_poetry/metadata.json
+++ b/modules/rules_poetry/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/oxidase/rules_poetry",
+    "maintainers": [
+        {
+            "email": "michael.krasnyk@gmail.com",
+            "github": "oxidase",
+            "name": "Michael Krasnyk"
+        }
+    ],
+    "repository": [
+        "github:oxidase/rules_poetry"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
The PR publishes the initial version of rules_poetry module that can use poetry.lock files to set up Python dependencies.

