### PR TITLE
Patch rules_testing 0.0.5 to remove register_toolchains call

### DIFF
--- a/modules/rules_testing/0.0.5/MODULE.bazel
+++ b/modules/rules_testing/0.0.5/MODULE.bazel
@@ -31,9 +31,10 @@ python.toolchain(
 )
 use_repo(python, "python3_11_toolchains")
 
-register_toolchains(
-    "@python3_11_toolchains//:all",
-)
+# Dev only. Commented out by BCR publishing patch
+# register_toolchains(
+#     "@python3_11_toolchains//:all",
+# )
 
 pip = use_extension(
     "@rules_python//python:extensions.bzl",

--- a/modules/rules_testing/0.0.5/patches/remove_register_toolchains.patch
+++ b/modules/rules_testing/0.0.5/patches/remove_register_toolchains.patch
@@ -1,0 +1,18 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 046e33e..fc0dde5 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -31,9 +31,10 @@ python.toolchain(
+ )
+ use_repo(python, "python3_11_toolchains")
+ 
+-register_toolchains(
+-    "@python3_11_toolchains//:all",
+-)
++# Dev only. Commented out by BCR publishing patch
++# register_toolchains(
++#     "@python3_11_toolchains//:all",
++# )
+ 
+ pip = use_extension(
+     "@rules_python//python:extensions.bzl",

--- a/modules/rules_testing/0.0.5/source.json
+++ b/modules/rules_testing/0.0.5/source.json
@@ -3,7 +3,8 @@
     "strip_prefix": "rules_testing-0.0.5",
     "url": "https://github.com/bazelbuild/rules_testing/releases/download/v0.0.5/rules_testing-v0.0.5.tar.gz",
     "patches": {
-        "module_dot_bazel_version.patch": "sha256-7gJRcKlwwSZOt/kANYw2SQI65odnTEQ6CITUS4//1ZI="
+        "module_dot_bazel_version.patch": "sha256-7gJRcKlwwSZOt/kANYw2SQI65odnTEQ6CITUS4//1ZI=",
+        "remove_register_toolchains.patch": "sha256-TSdJKlMRNjqVEpPFjV3CItj8EKi5Zm6qabiIPVYtvnc="
     },
     "patch_strip": 0
 }


### PR DESCRIPTION
This is to make the release usable, otherwise every transitive user is required to create a toolchain of that given that.