### PR TITLE
Yank rules_testing 0.0.5 because it's mostly broken.

### DIFF
--- a/modules/rules_testing/metadata.json
+++ b/modules/rules_testing/metadata.json
@@ -15,5 +15,7 @@
         "0.0.4",
         "0.0.5"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+      "0.0.5": "Mostly broken: https://github.com/bazelbuild/rules_testing/issues/33"
+    }
 }


### PR DESCRIPTION
The rules_testing 0.0.5 release is mostly broken because it requires users to register a specific repo name. A new release is being made that doesn't have this problem.

See https://github.com/bazelbuild/rules_testing/issues/33 for details.