### PR TITLE
Add rules_m4 v0.2.3

### DIFF
--- a/modules/rules_m4/0.2.3/MODULE.bazel
+++ b/modules/rules_m4/0.2.3/MODULE.bazel
@@ -1,0 +1,44 @@
+module(
+    name = "rules_m4",
+    version = "0.2.3",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "googletest",
+    version = "1.12.1",
+    dev_dependency = True,
+    repo_name = "com_google_googletest",
+)
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.2.1",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "stardoc",
+    version = "0.5.3",
+    dev_dependency = True,
+    repo_name = "io_bazel_stardoc",
+)
+
+# Register an m4 toolchain using the default version of GNU M4.
+default_toolchain = use_extension(
+    "//m4/internal:default_toolchain_ext.bzl",
+    "default_toolchain_ext",
+)
+use_repo(default_toolchain, "m4")
+
+register_toolchains("@m4//:toolchain")
+
+testutil = use_extension(
+    "//m4/internal:testutil_ext.bzl",
+    "rules_m4_testutil_ext",
+    dev_dependency = True,
+)
+use_repo(testutil, "rules_m4_testutil")
+
+register_toolchains(
+    "@rules_m4_testutil//toolchains:all",
+    dev_dependency = True,
+)

--- a/modules/rules_m4/0.2.3/presubmit.yml
+++ b/modules/rules_m4/0.2.3/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@rules_m4//tests:expansion_test'
+    - '@rules_m4//tests:genrule_test'

--- a/modules/rules_m4/0.2.3/source.json
+++ b/modules/rules_m4/0.2.3/source.json
@@ -1,0 +1,4 @@
+{
+    "url": "https://github.com/jmillikin/rules_m4/releases/download/v0.2.3/rules_m4-v0.2.3.tar.xz",
+    "integrity": "sha256-EM5B8VDM+/3cnSOU7mgOuYTcij3+phOv0BPPsi6nRFw="
+}

--- a/modules/rules_m4/metadata.json
+++ b/modules/rules_m4/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/jmillikin/rules_m4",
+    "maintainers": [
+        {
+            "email": "john@john-millikin.com",
+            "github": "jmillikin",
+            "name": "John Millikin"
+        }
+    ],
+    "repository": [
+        "github:jmillikin/rules_m4"
+    ],
+    "versions": [
+        "0.2.3"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
As requested in https://github.com/bazelbuild/bazel-central-registry/issues/204

I think I've assembled the modules stuff correctly. Once this is merged and all the tests seem happy, I plan to add `rules_flex` and `rules_bison` as well.

cc @aaronmondal