### PR TITLE
Add rules_flex v0.2.1

### DIFF
--- a/modules/rules_flex/0.2.1/MODULE.bazel
+++ b/modules/rules_flex/0.2.1/MODULE.bazel
@@ -1,0 +1,45 @@
+module(
+    name = "rules_flex",
+    version = "0.2.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_m4", version = "0.2.3")
+
+bazel_dep(
+    name = "googletest",
+    version = "1.12.1",
+    dev_dependency = True,
+    repo_name = "com_google_googletest",
+)
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.2.1",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "stardoc",
+    version = "0.5.3",
+    dev_dependency = True,
+    repo_name = "io_bazel_stardoc",
+)
+
+default_toolchain = use_extension(
+    "//flex/internal:default_toolchain_ext.bzl",
+    "default_toolchain_ext",
+)
+use_repo(default_toolchain, "flex")
+
+register_toolchains("@flex//:toolchain")
+
+testutil = use_extension(
+    "//flex/internal:testutil_ext.bzl",
+    "rules_flex_testutil_ext",
+    dev_dependency = True,
+)
+use_repo(testutil, "rules_flex_testutil")
+
+register_toolchains(
+    "@rules_flex_testutil//toolchains:all",
+    dev_dependency = True,
+)

--- a/modules/rules_flex/0.2.1/presubmit.yml
+++ b/modules/rules_flex/0.2.1/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - macos
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@rules_flex//tests:hello_c'
+    - '@rules_flex//tests:genrule_flex_cc'

--- a/modules/rules_flex/0.2.1/source.json
+++ b/modules/rules_flex/0.2.1/source.json
@@ -1,0 +1,4 @@
+{
+    "url": "https://github.com/jmillikin/rules_flex/releases/download/v0.2.1/rules_flex-v0.2.1.tar.xz",
+    "integrity": "sha256-iSn+3ECQnRmktCVI0HhfeWx2d9zvi10WALQV5aSndJ8="
+}

--- a/modules/rules_flex/metadata.json
+++ b/modules/rules_flex/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/jmillikin/rules_flex",
+    "maintainers": [
+        {
+            "email": "john@john-millikin.com",
+            "github": "jmillikin",
+            "name": "John Millikin"
+        }
+    ],
+    "repository": [
+        "github:jmillikin/rules_flex"
+    ],
+    "versions": [
+        "0.2.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
As requested in https://github.com/bazelbuild/bazel-central-registry/issues/204

I edited the `presubmit.yml` to remove `windows`, because Flex does not build on that platform (https://github.com/westes/flex/issues/367).

cc @aaronmondal