### PR TITLE
Add abseil.py 1.4.0

### DIFF
--- a/modules/abseil-py/1.4.0/MODULE.bazel
+++ b/modules/abseil-py/1.4.0/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "abseil-py",
+    version = "1.4.0",
+    compatibility_level = 1,
+)

--- a/modules/abseil-py/1.4.0/patches/module_dot_bazel.patch
+++ b/modules/abseil-py/1.4.0/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "abseil-py",
++    version = "1.4.0",
++    compatibility_level = 1,
++)

--- a/modules/abseil-py/1.4.0/presubmit.yml
+++ b/modules/abseil-py/1.4.0/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@abseil-py//absl:app'

--- a/modules/abseil-py/1.4.0/source.json
+++ b/modules/abseil-py/1.4.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-D7OkkWoVfrSBJO8wkjHOzf3Zb/VK3xZgs5wNSpeQosA=",
+    "strip_prefix": "abseil-py-1.4.0",
+    "url": "https://github.com/abseil/abseil-py/archive/refs/tags/v1.4.0.tar.gz",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-UQ1CIg0RJnam6b/g27lXS+lO9hgJCYjSMvyh8PgYFtA="
+    }
+}

--- a/modules/abseil-py/metadata.json
+++ b/modules/abseil-py/metadata.json
@@ -1,0 +1,9 @@
+{
+    "homepage": "https://github.com/abseil/abseil-py",
+    "maintainers": [],
+    "repository": [
+        "github:abseil/abseil-py"
+    ],
+    "versions": ["1.4.0"],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add abseil.py as a module to the BCR.

This is required to migrate android_rules to bzlmod.