### PR TITLE
Publish google/jsonnet@0.20.0

### DIFF
--- a/modules/jsonnet/0.20.0/MODULE.bazel
+++ b/modules/jsonnet/0.20.0/MODULE.bazel
@@ -1,5 +1,7 @@
 module(name = "jsonnet", version = "0.20.0")
 
+bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest")
+
 build_defs = use_extension("//tools/build_defs:extensions.bzl", "build_defs")
 use_repo(
     build_defs,
@@ -8,7 +10,3 @@ use_repo(
 )
 
 register_toolchains("//platform_defs:default_python3_toolchain")
-
-# Dev dependencies
-
-bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest", dev_dependency = True)

--- a/modules/jsonnet/0.20.0/MODULE.bazel
+++ b/modules/jsonnet/0.20.0/MODULE.bazel
@@ -1,0 +1,14 @@
+module(name = "jsonnet", version = "0.20.0")
+
+build_defs = use_extension("//tools/build_defs:extensions.bzl", "build_defs")
+use_repo(
+    build_defs,
+    "default_python3_headers",
+    "io_bazel_rules_jsonnet",
+)
+
+register_toolchains("//platform_defs:default_python3_toolchain")
+
+# Dev dependencies
+
+bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest", dev_dependency = True)

--- a/modules/jsonnet/0.20.0/patches/extensions_dot_bzl.patch
+++ b/modules/jsonnet/0.20.0/patches/extensions_dot_bzl.patch
@@ -1,0 +1,22 @@
+diff --git tools/build_defs/extensions.bzl tools/build_defs/extensions.bzl
+new file mode 100644
+index 0000000..0a5aa70
+--- /dev/null
++++ tools/build_defs/extensions.bzl
+@@ -0,0 +1,16 @@
++load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
++load(":python_repo.bzl", "python_headers")
++
++def _impl(repository_ctx):
++    git_repository(
++         name = "io_bazel_rules_jsonnet",
++         commit = "ad2b4204157ddcf7919e8bd210f607f8a801aa7f",
++         remote = "https://github.com/bazelbuild/rules_jsonnet.git",
++         shallow_since = "1556260764 +0200",
++    )
++
++    python_headers(name = "default_python3_headers")
++
++build_defs = module_extension(
++    implementation = _impl,
++)

--- a/modules/jsonnet/0.20.0/patches/module_dot_bazel.patch
+++ b/modules/jsonnet/0.20.0/patches/module_dot_bazel.patch
@@ -1,10 +1,12 @@
 diff --git MODULE.bazel MODULE.bazel
 new file mode 100644
-index 0000000..0fddb83
+index 0000000..94ac264
 --- /dev/null
 +++ MODULE.bazel
-@@ -0,0 +1,14 @@
-+module(name = "jsonnet", version = "0.20.0")
+@@ -0,0 +1,12 @@
++module(name = "jsonnet", version = "0.0.0")
++
++bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest")
 +
 +build_defs = use_extension("//tools/build_defs:extensions.bzl", "build_defs")
 +use_repo(
@@ -14,7 +16,3 @@ index 0000000..0fddb83
 +)
 +
 +register_toolchains("//platform_defs:default_python3_toolchain")
-+
-+# Dev dependencies
-+
-+bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest", dev_dependency = True)

--- a/modules/jsonnet/0.20.0/patches/module_dot_bazel.patch
+++ b/modules/jsonnet/0.20.0/patches/module_dot_bazel.patch
@@ -1,0 +1,20 @@
+diff --git MODULE.bazel MODULE.bazel
+new file mode 100644
+index 0000000..0fddb83
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,14 @@
++module(name = "jsonnet", version = "0.20.0")
++
++build_defs = use_extension("//tools/build_defs:extensions.bzl", "build_defs")
++use_repo(
++    build_defs,
++    "default_python3_headers",
++    "io_bazel_rules_jsonnet",
++)
++
++register_toolchains("//platform_defs:default_python3_toolchain")
++
++# Dev dependencies
++
++bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest", dev_dependency = True)

--- a/modules/jsonnet/0.20.0/patches/module_dot_bazel.patch
+++ b/modules/jsonnet/0.20.0/patches/module_dot_bazel.patch
@@ -4,7 +4,7 @@ index 0000000..94ac264
 --- /dev/null
 +++ MODULE.bazel
 @@ -0,0 +1,12 @@
-+module(name = "jsonnet", version = "0.0.0")
++module(name = "jsonnet", version = "0.20.0")
 +
 +bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest")
 +

--- a/modules/jsonnet/0.20.0/presubmit.yml
+++ b/modules/jsonnet/0.20.0/presubmit.yml
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bcr_test_module:
-  matrix:
-    platform: ["debian11", "macos", "ubuntu2004", "windows"]
-  tasks:
-    verify_targets:
-      name: Verify build targets
-      platform: ${{ platform }}
-      build_targets:
-      - '@jsonnet//...'
+matrix:
+  platform: ["debian11", "macos", "ubuntu2004", "windows"]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@jsonnet//...'

--- a/modules/jsonnet/0.20.0/presubmit.yml
+++ b/modules/jsonnet/0.20.0/presubmit.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 matrix:
-  platform: ["debian11", "macos", "ubuntu2004", "windows"]
+  platform: ["debian11", "macos", "ubuntu2004"]
 tasks:
   verify_targets:
     name: Verify build targets

--- a/modules/jsonnet/0.20.0/presubmit.yml
+++ b/modules/jsonnet/0.20.0/presubmit.yml
@@ -1,0 +1,23 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bcr_test_module:
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2004", "windows"]
+  tasks:
+    verify_targets:
+      name: Verify build targets
+      platform: ${{ platform }}
+      build_targets:
+      - '@jsonnet//...'

--- a/modules/jsonnet/0.20.0/source.json
+++ b/modules/jsonnet/0.20.0/source.json
@@ -2,7 +2,7 @@
     "url": "https://github.com/google/jsonnet/archive/refs/tags/v0.20.0.zip",
     "integrity": "sha256-Z0/yQbHE2OFbGYwy1d50fUklc/lbS9MesYZNm9m7CYU=",
     "patches": {
-        "module_dot_bazel.patch": "sha256-Wx+CWVBptVQc5mUNYdxA5DA52Oth0pL8s14FveE4uDY=",
+        "module_dot_bazel.patch": "sha256-0PZlNxaqX9zqp8zKgCK0JNNZGejMkIDP7VTxjrKV11I=",
         "extensions_dot_bzl.patch": "sha256-p3qnA50AsZHbXG1TkLthairYn0MsqtpQiY41C2VHUx4="
     },
     "strip_prefix": "jsonnet-0.20.0",

--- a/modules/jsonnet/0.20.0/source.json
+++ b/modules/jsonnet/0.20.0/source.json
@@ -2,7 +2,7 @@
     "url": "https://github.com/google/jsonnet/archive/refs/tags/v0.20.0.zip",
     "integrity": "sha256-Z0/yQbHE2OFbGYwy1d50fUklc/lbS9MesYZNm9m7CYU=",
     "patches": {
-        "module_dot_bazel.patch": "zQSfOyaUBgmoR51TJwX4JWdL/tUnjOWtpjWECRtsywc=",
+	"module_dot_bazel.patch": "sha256-zQSfOyaUBgmoR51TJwX4JWdL/tUnjOWtpjWECRtsywc=",
         "extensions_dot_bzl.patch": "sha256-p3qnA50AsZHbXG1TkLthairYn0MsqtpQiY41C2VHUx4="
     },
     "strip_prefix": "jsonnet-0.20.0",

--- a/modules/jsonnet/0.20.0/source.json
+++ b/modules/jsonnet/0.20.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/google/jsonnet/archive/refs/tags/v0.20.0.zip",
+    "integrity": "sha256-Z0/yQbHE2OFbGYwy1d50fUklc/lbS9MesYZNm9m7CYU=",
+    "patches": {
+        "module_dot_bazel.patch": "sha256-Wx+CWVBptVQc5mUNYdxA5DA52Oth0pL8s14FveE4uDY=",
+        "extensions_dot_bzl.patch": "sha256-p3qnA50AsZHbXG1TkLthairYn0MsqtpQiY41C2VHUx4="
+    },
+    "strip_prefix": "jsonnet-0.20.0",
+    "patch_strip": 0
+}

--- a/modules/jsonnet/0.20.0/source.json
+++ b/modules/jsonnet/0.20.0/source.json
@@ -2,7 +2,7 @@
     "url": "https://github.com/google/jsonnet/archive/refs/tags/v0.20.0.zip",
     "integrity": "sha256-Z0/yQbHE2OFbGYwy1d50fUklc/lbS9MesYZNm9m7CYU=",
     "patches": {
-        "module_dot_bazel.patch": "sha256-0PZlNxaqX9zqp8zKgCK0JNNZGejMkIDP7VTxjrKV11I=",
+        "module_dot_bazel.patch": "zQSfOyaUBgmoR51TJwX4JWdL/tUnjOWtpjWECRtsywc=",
         "extensions_dot_bzl.patch": "sha256-p3qnA50AsZHbXG1TkLthairYn0MsqtpQiY41C2VHUx4="
     },
     "strip_prefix": "jsonnet-0.20.0",

--- a/modules/jsonnet/metadata.json
+++ b/modules/jsonnet/metadata.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://jsonnet.org",
+    "maintainers": [],
+    "repository": [
+        "github:google/jsonnet"
+    ],
+    "versions": [
+        "0.20.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This adds Jsonnet v0.20.0 to BCR.

Jsonnet recently accepted a patch to add a MODULE.bazel (+ an extension) to the project. As there hasn't been a release yet that includes this, this PR also adds these files using patches.
There are some interdependencies between jsonnet, go-jsonnet and rules_jsonnet, and it would be very nice not to have to wait until jsonnet cuts a release before moving forward with introducing go-jsonnet and rules_jsonnet to BCR.

I've tested this by building/testing jsonnet itself, as well as building/testing go-jsonnet while depending on this module using a BCR fork.