### PR TITLE
Publish google/go-jsonnet@0.20.0

### DIFF
--- a/modules/jsonnet_go/0.20.0/MODULE.bazel
+++ b/modules/jsonnet_go/0.20.0/MODULE.bazel
@@ -1,0 +1,14 @@
+module(name = "jsonnet_go", version = "0.20.0")
+
+bazel_dep(name = "gazelle", version = "0.30.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "jsonnet", version = "0.20.0", repo_name = "cpp_jsonnet")
+bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "@jsonnet_go//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_fatih_color",
+    "com_github_sergi_go_diff",
+    "io_k8s_sigs_yaml",
+)

--- a/modules/jsonnet_go/0.20.0/patches/module_dot_bazel.patch
+++ b/modules/jsonnet_go/0.20.0/patches/module_dot_bazel.patch
@@ -1,0 +1,20 @@
+diff --git MODULE.bazel MODULE.bazel
+new file mode 100644
+index 0000000..4bc91ae
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,14 @@
++module(name = "jsonnet_go", version = "0.20.0")
++
++bazel_dep(name = "gazelle", version = "0.30.0", repo_name = "bazel_gazelle")
++bazel_dep(name = "jsonnet", version = "0.20.0", repo_name = "cpp_jsonnet")
++bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
++
++go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
++go_deps.from_file(go_mod = "@jsonnet_go//:go.mod")
++use_repo(
++    go_deps,
++    "com_github_fatih_color",
++    "com_github_sergi_go_diff",
++    "io_k8s_sigs_yaml",
++)

--- a/modules/jsonnet_go/0.20.0/presubmit.yml
+++ b/modules/jsonnet_go/0.20.0/presubmit.yml
@@ -1,0 +1,22 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+matrix:
+  platform: ["debian11", "macos", "ubuntu2004"]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@jsonnet_go//...'

--- a/modules/jsonnet_go/0.20.0/source.json
+++ b/modules/jsonnet_go/0.20.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/google/go-jsonnet/archive/refs/tags/v0.20.0.zip",
+    "integrity": "sha256-EZ9sbQ3D/JrhR3GoerP+X6dOQOPj207dv0yjh5Z453c=",
+    "patches": {
+	"module_dot_bazel.patch": "sha256-7/AtC31dhw3fhB7N8XIId8R5ZkJ80Y1k6BVne8xt3eo="
+    },
+    "strip_prefix": "go-jsonnet-0.20.0",
+    "patch_strip": 0
+}

--- a/modules/jsonnet_go/metadata.json
+++ b/modules/jsonnet_go/metadata.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://github.com/google/go-jsonnet",
+    "maintainers": [],
+    "repository": [
+        "github:google/go-jsonnet"
+    ],
+    "versions": [
+        "0.20.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Related to https://github.com/bazelbuild/bazel-central-registry/pull/667 which added jsonnet to BCR, and https://github.com/google/go-jsonnet/pull/698 which will add a MODULE.bazel (with the same contents as the patch in this PR) to the upstream project.

This will add go-jsonnet to BCR, which is used among others by rules_jsonnet. There is no source archive added to their release process today, but I will try to make that happen.