### PR TITLE
Add sqlite3 v3.42.0.bcr.1

### DIFF
--- a/modules/sqlite3/3.42.0.bcr.1/MODULE.bazel
+++ b/modules/sqlite3/3.42.0.bcr.1/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "sqlite3",
+    version = "3.42.0.bcr.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.6")

--- a/modules/sqlite3/3.42.0.bcr.1/patches/add_build_file.patch
+++ b/modules/sqlite3/3.42.0.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,38 @@
+--- /dev/null	2023-05-24 18:19:58.364000393 +0900
++++ BUILD.bazel	2023-06-16 20:02:51.840261418 +0900
+@@ -0,0 +1,35 @@
++cc_binary(
++    name = "shell",
++    srcs = ["shell.c"],
++    # Disable Bazel's default behavior of linking to `libstdc++` / `libc++`.
++    features = ["-default_link_libs"],
++    visibility = ["//visibility:public"],
++    deps = [":sqlite3"],
++)
++
++cc_library(
++    name = "sqlite3",
++    srcs = ["sqlite3.c"],
++    hdrs = ["sqlite3.h"],
++    includes = ["."],
++    # Some Unix platforms have pthread and/or dlopen in separate libraries.
++    linkopts = select({
++        "@platforms//os:freebsd": ["-lpthread"],
++        "@platforms//os:linux": [
++            "-lpthread",
++            "-ldl",
++        ],
++        "@platforms//os:netbsd": ["-lpthread"],
++        "@platforms//os:openbsd": ["-lpthread"],
++        "//conditions:default": [],
++    }),
++    visibility = ["//visibility:public"],
++)
++
++cc_library(
++    name = "sqlite3ext",
++    hdrs = ["sqlite3ext.h"],
++    includes = ["."],
++    visibility = ["//visibility:public"],
++    deps = [":sqlite3"],
++)

--- a/modules/sqlite3/3.42.0.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/sqlite3/3.42.0.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "sqlite3",
++    version = "3.42.0.bcr.1",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "platforms", version = "0.0.6")

--- a/modules/sqlite3/3.42.0.bcr.1/presubmit.yml
+++ b/modules/sqlite3/3.42.0.bcr.1/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@sqlite3//:sqlite3'
+    - '@sqlite3//:shell'
+    - '@sqlite3//:sqlite3ext'

--- a/modules/sqlite3/3.42.0.bcr.1/source.json
+++ b/modules/sqlite3/3.42.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://sqlite.org/2023/sqlite-amalgamation-3420000.zip",
+    "integrity": "sha256-HMgk0PXmdYKfo3AYMY/agz6lb36d4rQe3dn3ZDtewp4=",
+    "strip_prefix": "sqlite-amalgamation-3420000",
+    "patches": {
+        "add_build_file.patch": "sha256-jv2puH58Mvf5zg3l26JdJHsAHBjb743lE3uV0FvSAd8=",
+        "module_dot_bazel.patch": "sha256-0nVrZCj8DjLNzeeLpBtVT9X0s4BQXqANYyu++q7Ikv8="
+    },
+    "patch_strip": 0
+}

--- a/modules/sqlite3/metadata.json
+++ b/modules/sqlite3/metadata.json
@@ -2,7 +2,8 @@
     "homepage": "https://sqlite.org/",
     "maintainers": [],
     "versions": [
-        "3.42.0"
+        "3.42.0",
+        "3.42.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel-central-registry/issues/697

Side note regarding BCR testing: currently it supports testing an "example" sub-module, but this is fairly inconvenient when the package doesn't natively use Bazel as its build system -- the patches become quite large. It would be nice if it were possible to have the test module in the BCR repo instead.