### PR TITLE
Yank obsolete rules_go and gazelle versions

### DIFF
--- a/modules/gazelle/metadata.json
+++ b/modules/gazelle/metadata.json
@@ -20,8 +20,8 @@
         "0.31.1"
     ],
     "yanked_versions": {
-        "0.26.0": "Obsolete experimental version that emits debug prints",
-        "0.27.0": "Obsolete experimental version that emits debug prints",
-        "0.28.0": "Obsolete experimental version that emits debug prints"
+        "0.26.0": "Obsolete experimental version that emits debug prints. Update to 0.29.0 or higher.",
+        "0.27.0": "Obsolete experimental version that emits debug prints. Update to 0.29.0 or higher.",
+        "0.28.0": "Obsolete experimental version that emits debug prints. Update to 0.29.0 or higher."
     }
 }

--- a/modules/gazelle/metadata.json
+++ b/modules/gazelle/metadata.json
@@ -19,5 +19,9 @@
         "0.31.0",
         "0.31.1"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "0.26.0": "Obsolete experimental version that emits debug prints",
+        "0.27.0": "Obsolete experimental version that emits debug prints",
+        "0.28.0": "Obsolete experimental version that emits debug prints"
+    }
 }

--- a/modules/rules_go/metadata.json
+++ b/modules/rules_go/metadata.json
@@ -23,5 +23,11 @@
         "0.40.0",
         "0.40.1"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "0.33.0": "Obsolete experimental version that emits debug prints",
+        "0.34.0": "Obsolete experimental version that emits debug prints",
+        "0.35.0": "Obsolete experimental version that emits debug prints",
+        "0.36.0": "Obsolete experimental version that emits debug prints",
+        "0.37.0": "Obsolete experimental version that emits debug prints"
+    }
 }

--- a/modules/rules_go/metadata.json
+++ b/modules/rules_go/metadata.json
@@ -24,10 +24,10 @@
         "0.40.1"
     ],
     "yanked_versions": {
-        "0.33.0": "Obsolete experimental version that emits debug prints",
-        "0.34.0": "Obsolete experimental version that emits debug prints",
-        "0.35.0": "Obsolete experimental version that emits debug prints",
-        "0.36.0": "Obsolete experimental version that emits debug prints",
-        "0.37.0": "Obsolete experimental version that emits debug prints"
+        "0.33.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
+        "0.34.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
+        "0.35.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
+        "0.36.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
+        "0.37.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher."
     }
 }


### PR DESCRIPTION
These version were marked as experimental, which resulted in print warnings whenever their module files are evaluated. As they are still discovered starting from modern versions of these rulesets, the warnings ended up affecting all users. 

By yanking these versions, Bazel 6.3.0 and later will no longer emit the warnings.