### PR TITLE
Update grpc dependencies to unyanked rules_go

### DIFF
--- a/modules/grpc/1.47.0/MODULE.bazel
+++ b/modules/grpc/1.47.0/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "rules_proto", version = "4.0.0")
 bazel_dep(name = "upb", version = "0.0.0-20220602-e5f2601")
 bazel_dep(name = "zlib", version = "1.2.12")
 bazel_dep(name = "rules_java", version = "5.1.0")
-bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.34.0")
+bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.38.1")
 
 grpc_repo_deps_ext = use_extension("//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")
 

--- a/modules/grpc/1.47.0/patches/adopt_bzlmod.patch
+++ b/modules/grpc/1.47.0/patches/adopt_bzlmod.patch
@@ -27,7 +27,7 @@ index 0000000000..9483873850
 +bazel_dep(name = "upb", version = "0.0.0-20220602-e5f2601")
 +bazel_dep(name = "zlib", version = "1.2.12")
 +bazel_dep(name = "rules_java", version = "5.1.0")
-+bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.34.0")
++bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.38.1")
 +
 +grpc_repo_deps_ext = use_extension("//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")
 +

--- a/modules/grpc/1.48.1/MODULE.bazel
+++ b/modules/grpc/1.48.1/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(name = "rules_proto", version = "4.0.0")
 bazel_dep(name = "upb", version = "0.0.0-20220602-e5f2601")
 bazel_dep(name = "zlib", version = "1.2.12")
 bazel_dep(name = "rules_java", version = "5.1.0")
-bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.34.0")
+bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.38.1")
 
 grpc_repo_deps_ext = use_extension("//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")
 

--- a/modules/grpc/1.48.1/patches/adopt_bzlmod.patch
+++ b/modules/grpc/1.48.1/patches/adopt_bzlmod.patch
@@ -27,7 +27,7 @@ index 0000000000..9483873850
 +bazel_dep(name = "upb", version = "0.0.0-20220602-e5f2601")
 +bazel_dep(name = "zlib", version = "1.2.12")
 +bazel_dep(name = "rules_java", version = "5.1.0")
-+bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.34.0")
++bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.38.1")
 +
 +grpc_repo_deps_ext = use_extension("//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")
 +


### PR DESCRIPTION
Bazel depends upon grpc@1.48.1 in master with no later version available. Migrate to rules_go@0.38.1 to fix bazel CI.