### PR TITLE
Revert "Yank obsolete rules_go and gazelle versions"

### DIFF
--- a/modules/gazelle/metadata.json
+++ b/modules/gazelle/metadata.json
@@ -19,9 +19,5 @@
         "0.31.0",
         "0.31.1"
     ],
-    "yanked_versions": {
-        "0.26.0": "Obsolete experimental version that emits debug prints. Update to 0.29.0 or higher.",
-        "0.27.0": "Obsolete experimental version that emits debug prints. Update to 0.29.0 or higher.",
-        "0.28.0": "Obsolete experimental version that emits debug prints. Update to 0.29.0 or higher."
-    }
+    "yanked_versions": {}
 }

--- a/modules/rules_go/metadata.json
+++ b/modules/rules_go/metadata.json
@@ -23,11 +23,5 @@
         "0.40.0",
         "0.40.1"
     ],
-    "yanked_versions": {
-        "0.33.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
-        "0.34.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
-        "0.35.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
-        "0.36.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
-        "0.37.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher."
-    }
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Reverts bazelbuild/bazel-central-registry#725

This is breaking bazel's CI: https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/16408 and all other builds on master since this landed have failed due to a grpc@1.48.1 -> rules_go@0.34.0 chain. The rules_go version may be fluid enough to change for grpc, but since CI guards against this with "Existing modules should not be changed" checks, bazel CI will be broken until a new version of grpc is released to BCR *and* bazel is made to depend upon it, for which there may not be an upstream version that is compatible without further changes to bazel core.