### PR TITLE
Fix rules_go and gazelle yank reasons

### DIFF
--- a/modules/gazelle/metadata.json
+++ b/modules/gazelle/metadata.json
@@ -20,8 +20,8 @@
         "0.31.1"
     ],
     "yanked_versions": {
-        "0.26.0": "Obsolete experimental version that emits debug prints. Update to 0.29.0 or higher.",
-        "0.27.0": "Obsolete experimental version that emits debug prints. Update to 0.29.0 or higher.",
-        "0.28.0": "Obsolete experimental version that emits debug prints. Update to 0.29.0 or higher."
+        "0.26.0": "Obsolete experimental version that emits debug prints. Update to 0.30.0 or higher",
+        "0.27.0": "Obsolete experimental version that emits debug prints. Update to 0.30.0 or higher",
+        "0.28.0": "Obsolete experimental version that emits debug prints. Update to 0.30.0 or higher"
     }
 }

--- a/modules/rules_go/metadata.json
+++ b/modules/rules_go/metadata.json
@@ -24,10 +24,10 @@
         "0.40.1"
     ],
     "yanked_versions": {
-        "0.33.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
-        "0.34.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
-        "0.35.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
-        "0.36.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher.",
-        "0.37.0": "Obsolete experimental version that emits debug prints. Update to 0.38.1 or higher."
+        "0.33.0": "Obsolete experimental version that emits debug prints. Update to 0.39.1 or higher",
+        "0.34.0": "Obsolete experimental version that emits debug prints. Update to 0.39.1 or higher",
+        "0.35.0": "Obsolete experimental version that emits debug prints. Update to 0.39.1 or higher",
+        "0.36.0": "Obsolete experimental version that emits debug prints. Update to 0.39.1 or higher",
+        "0.37.0": "Obsolete experimental version that emits debug prints. Update to 0.39.1 or higher"
     }
 }


### PR DESCRIPTION
Since rules_go and gazelle cyclically depend on each other, users of only one of these modules need to depend on a higher version so that no yanked version of the other module is pulled in.

Also remove the trailing period as it is added automatically.