### PR TITLE
Add Eigen 3.4.0 to Bazel Central Registry

### DIFF
--- a/modules/eigen/3.4.0/MODULE.bazel
+++ b/modules/eigen/3.4.0/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "eigen",
+    version = "3.4.0",
+    compatibility_level = 1,
+)

--- a/modules/eigen/3.4.0/patches/add_build_file.patch
+++ b/modules/eigen/3.4.0/patches/add_build_file.patch
@@ -1,0 +1,11 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,8 @@
++package(default_visibility = ["//visibility:public"])
++
++cc_library(
++    name = "eigen",
++    srcs = [],
++    hdrs = glob(['Eigen/**']),
++    includes = ["."],
++)

--- a/modules/eigen/3.4.0/patches/module_dot_bazel.patch
+++ b/modules/eigen/3.4.0/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "eigen",
++    version = "3.4.0",
++    compatibility_level = 1,
++)

--- a/modules/eigen/3.4.0/presubmit.yml
+++ b/modules/eigen/3.4.0/presubmit.yml
@@ -1,0 +1,12 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@eigen//:eigen'

--- a/modules/eigen/3.4.0/source.json
+++ b/modules/eigen/3.4.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip",
+    "integrity": "sha256-HMqrv+hw9grz1qUZxT4J89z2MCBzId/6VTVkqOdcT8g=",
+    "strip_prefix": "eigen-3.4.0",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-wuOxV4nxufkyDCw+HWCn5D9vik84RuLacFT5ashhC58=",
+        "module_dot_bazel.patch": "sha256-xDle81SJcU6payWsaWbrWyrFbalx9tSW4bKuTBUVBV4="
+    }
+}

--- a/modules/eigen/metadata.json
+++ b/modules/eigen/metadata.json
@@ -1,0 +1,9 @@
+{
+    "homepage": "https://gitlab.com/libeigen/eigen",
+    "maintainers": [],
+    "repository": [],
+    "versions": [
+        "3.4.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Note that this project from GoogleVR adds some exclusions to the headers (not sure why), as well as a couple of preprocessor defines:

https://github.com/googlevr/seurat/blob/master/third_party/eigen.BUILD

Let me know if I should add these to the BUILD file patch.