### PR TITLE
Fix missing maintainers field for libdeflate

### DIFF
--- a/modules/libdeflate/metadata.json
+++ b/modules/libdeflate/metadata.json
@@ -3,6 +3,7 @@
     "repository": [
         "github:ebiggers/libdeflate"
     ],
+    "maintainers": [],
     "versions": [
         "1.18"
     ],


### PR DESCRIPTION
https://github.com/bazelbuild/bazel-central-registry/pull/835 introduced a `metadata.json` without a `maintainers` field, breaking build of bcr-ui (see https://github.com/bazel-contrib/bcr-ui/issues/77).

To me it also seems that according to BCR policy, the PR shouldn't have been accepted without a maintainer for the module specified.

Optimally this PR would be amended with the contact info of @Vertexwahn as a module maintainer.