### PR TITLE
Yank RE2 releases `2023-06-02` and `2023-08-01`.

### DIFF
--- a/modules/re2/metadata.json
+++ b/modules/re2/metadata.json
@@ -16,5 +16,8 @@
         "2023-08-01",
         "2023-09-01"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "2023-06-02": "bad compatibility_level, upgrade to 2023-09-01 or newer",
+        "2023-08-01": "bad compatibility_level, upgrade to 2023-09-01 or newer"
+    }
 }


### PR DESCRIPTION
As discussed on https://github.com/bazelbuild/bazel-central-registry/pull/806, setting `compatibility_level = 11` to match the `SONAME` doesn't make sense in the Bazel model.

Neither version of RE2 is used by anything in BCR. All versions of gRPC so far have specified `2021-09-01`.