### PR TITLE
Add yaml-cpp-0.8.0

### DIFF
--- a/modules/yaml-cpp/0.8.0/MODULE.bazel
+++ b/modules/yaml-cpp/0.8.0/MODULE.bazel
@@ -1,0 +1,14 @@
+"""
+yaml-cpp is a YAML parser and emitter in c++ matching the YAML specification.
+"""
+
+module(
+    name = "yaml-cpp",
+    compatibility_level = 1,
+    version = "0.8.0",
+)
+
+bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "rules_cc", version = "0.0.8")
+
+bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)

--- a/modules/yaml-cpp/0.8.0/patches/module_dot_bazel.patch
+++ b/modules/yaml-cpp/0.8.0/patches/module_dot_bazel.patch
@@ -1,0 +1,20 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..7119060
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,14 @@
++"""
++yaml-cpp is a YAML parser and emitter in c++ matching the YAML specification.
++"""
++
++module(
++    name = "yaml-cpp",
++    compatibility_level = 1,
++    version = "0.8.0",
++)
++
++bazel_dep(name = "platforms", version = "0.0.7")
++bazel_dep(name = "rules_cc", version = "0.0.8")
++
++bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)

--- a/modules/yaml-cpp/0.8.0/presubmit.yml
+++ b/modules/yaml-cpp/0.8.0/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@yaml-cpp//:yaml-cpp'

--- a/modules/yaml-cpp/0.8.0/source.json
+++ b/modules/yaml-cpp/0.8.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/stonier/yaml-cpp/releases/download/0.8.0/yaml-cpp-0.8.0.tar.gz",
+    "integrity": "sha256-++dLvc7iHWVnFWiHBto8i+z9lG2SzURwXMYJi7I7OhY=",
+    "strip_prefix": "yaml-cpp-0.8.0",
+    "patches": {
+        "module_dot_bazel.patch": "sha256-YM6xq0Mtu51Okntj5lRQ3V04DyZNm4hZdrSDMio1KeU="
+    },
+    "patch_strip": 1
+}

--- a/modules/yaml-cpp/metadata.json
+++ b/modules/yaml-cpp/metadata.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://github.com/jbeder/yaml-cpp",
+    "maintainers": [],
+    "repository": [
+        "github:stonier/yaml-cpp"
+    ],
+    "versions": [
+        "0.8.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This is currently:

* Patching bzlmod functionality in for the 0.8.0 release
* Pointing at a release asset on a fork. This is exactly the download tarball provided on the unstable URL's at https://github.com/jbeder/yaml-cpp/releases/tag/0.8.0

NB:

1. Bzlmod functionality went in upstream with https://github.com/jbeder/yaml-cpp/pull/1224. We should be able to drop the patches in future releases.
2. Discussing getting a stable release asset url in https://github.com/jbeder/yaml-cpp/issues/1229 so we don't have to use the fork.
