### PR TITLE
Add swift-syntax patched version

### DIFF
--- a/modules/swift-syntax/509.0.0.1/MODULE.bazel
+++ b/modules/swift-syntax/509.0.0.1/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "swift-syntax",
+    version = "509.0.0.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_swift", version = "1.5.1", repo_name = "build_bazel_rules_swift")

--- a/modules/swift-syntax/509.0.0.1/patches/deps.patch
+++ b/modules/swift-syntax/509.0.0.1/patches/deps.patch
@@ -1,0 +1,8 @@
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -44,4 +44,5 @@ swift_syntax_library(
+     name = "SwiftSyntaxMacroExpansion",
+     deps = [
++        ":SwiftOperators",
+         ":SwiftSyntax",
+         ":SwiftSyntaxMacros",

--- a/modules/swift-syntax/509.0.0.1/patches/module_dot_bazel.patch
+++ b/modules/swift-syntax/509.0.0.1/patches/module_dot_bazel.patch
@@ -1,0 +1,5 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -3 +3 @@ module(
+-    version = "0",  # Update on release/* branches
++    version = "509.0.0.1",

--- a/modules/swift-syntax/509.0.0.1/presubmit.yml
+++ b/modules/swift-syntax/509.0.0.1/presubmit.yml
@@ -1,0 +1,8 @@
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: macos
+    build_targets:
+      - '@swift-syntax//...'
+    build_flags:
+      - --macos_minimum_os=12.0

--- a/modules/swift-syntax/509.0.0.1/source.json
+++ b/modules/swift-syntax/509.0.0.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/apple/swift-syntax/archive/refs/tags/509.0.0.tar.gz",
+    "integrity": "sha256-HN3an30klhLj111Mqo/ZU0wGIbiokKfXUkpGibzmRPE=",
+    "strip_prefix": "swift-syntax-509.0.0",
+    "patches": {
+        "module_dot_bazel.patch": "sha256-vkME0kQun6YyPtTEHbuWJI3ZxVD5c/p0wT3/aFiJx3I="
+    },
+    "patch_strip": 0
+}

--- a/modules/swift-syntax/509.0.0.1/source.json
+++ b/modules/swift-syntax/509.0.0.1/source.json
@@ -3,6 +3,7 @@
     "integrity": "sha256-HN3an30klhLj111Mqo/ZU0wGIbiokKfXUkpGibzmRPE=",
     "strip_prefix": "swift-syntax-509.0.0",
     "patches": {
+        "deps.patch": "sha256-pHcJF+vWNqs2H8khN4tC3LcrSr0KxWY6G1Tr9m2I5V4=",
         "module_dot_bazel.patch": "sha256-vkME0kQun6YyPtTEHbuWJI3ZxVD5c/p0wT3/aFiJx3I="
     },
     "patch_strip": 0

--- a/modules/swift-syntax/metadata.json
+++ b/modules/swift-syntax/metadata.json
@@ -11,7 +11,8 @@
         "github:apple/swift-syntax"
     ],
     "versions": [
-        "509.0.0"
+        "509.0.0",
+        "509.0.0.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
The upstream tag was created before a BUILD file patch to make sure everything built.