### PR TITLE
[rules_java] Mark v6.5.1 as compatible with `>=6.4.0`

### DIFF
--- a/modules/rules_java/6.5.1/MODULE.bazel
+++ b/modules/rules_java/6.5.1/MODULE.bazel
@@ -2,6 +2,8 @@ module(
     name = "rules_java",
     version = "6.5.1",
     compatibility_level = 1,
+    # Requires @bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type.
+    bazel_compatibility = [">=6.4.0"],
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")

--- a/modules/rules_java/6.5.1/patches/module_dot_bazel_incompatibility.patch
+++ b/modules/rules_java/6.5.1/patches/module_dot_bazel_incompatibility.patch
@@ -1,0 +1,11 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -2,6 +2,8 @@ module(
+     name = "rules_java",
+     version = "6.5.1",
+     compatibility_level = 1,
++    # Requires @bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type.
++    bazel_compatibility = [">=6.4.0"],
+ )
+
+ bazel_dep(name = "platforms", version = "0.0.4")

--- a/modules/rules_java/6.5.1/source.json
+++ b/modules/rules_java/6.5.1/source.json
@@ -1,5 +1,9 @@
 {
     "integrity": "sha256-ew2bohbIIe6Gl97cD50KcFlZrORio4hf6boDR7qVARE=",
     "strip_prefix": "",
-    "url": "https://github.com/bazelbuild/rules_java/releases/download/6.5.1/rules_java-6.5.1.tar.gz"
+    "url": "https://github.com/bazelbuild/rules_java/releases/download/6.5.1/rules_java-6.5.1.tar.gz",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel_incompatibility.patch": "sha256-MDztCS/eZJxhlACyz8g0A+PMlaFxj2DkQl8oaiXe5dA="
+    }
 }


### PR DESCRIPTION
This release requires `@bazel_tools//tools/jdk:bootstrap_runtime_toolchain_type`, which is only available as of https://github.com/bazelbuild/bazel/commit/783a50e6489f6a212ac01cfaa6f6576b51ae1c93.