### PR TITLE
Add llvm-project 17.0.3

### DIFF
--- a/modules/llvm-project/17.0.3/MODULE.bazel
+++ b/modules/llvm-project/17.0.3/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "llvm-project",
+    version = "17.0.3",
+)
+
+# Skylark depedndencies
+bazel_dep(name = "bazel_skylib", version = "1.3.0")
+
+# Library dependencies
+bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/llvm-project/17.0.3/patches/0001-Add-Bazel-files-to-.gitignore.patch
+++ b/modules/llvm-project/17.0.3/patches/0001-Add-Bazel-files-to-.gitignore.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Thu, 19 Oct 2023 14:55:33 +0000
+Subject: [PATCH] Add Bazel files to `.gitignore`
+
+---
+ .gitignore | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/.gitignore b/.gitignore
+index 20c4f52cd..6d630bf1b 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -70,3 +70,11 @@ pythonenv*
+ /clang/utils/analyzer/projects/*/RefScanBuildResults
+ # automodapi puts generated documentation files here.
+ /lldb/docs/python_api/
++
++#==============================================================================
++#
++# Bazel paths to ignore
++#==============================================================================
++.bazelrc
++.bazelversion
++/bazel-*

--- a/modules/llvm-project/17.0.3/patches/0002-Add-LLVM-Bazel-overlay-files.patch
+++ b/modules/llvm-project/17.0.3/patches/0002-Add-LLVM-Bazel-overlay-files.patch
@@ -1,0 +1,2265 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Thu, 19 Oct 2023 14:56:38 +0000
+Subject: [PATCH] Add LLVM Bazel overlay files
+
+This commit copies the files from the LLVM Bazel overlay.
+
+```
+cp -r utils/bazel/llvm-project-overlay/* .
+rm -rf utils/bazel
+```
+---
+ .../bolt => bolt}/BUILD.bazel                 |   0
+ .../clang-tidy/BUILD.bazel                    |   0
+ .../clang-tidy/defs.bzl                       |   0
+ .../include-cleaner/BUILD.bazel               |   0
+ .../unittests/BUILD.bazel                     |   0
+ .../clang => clang}/BUILD.bazel               |   0
+ .../include/clang/Config/config.h             |   0
+ .../clang => clang}/unittests/BUILD.bazel     |   0
+ .../libc => libc}/BUILD.bazel                 |   0
+ .../libc => libc}/libc_build_rules.bzl        |   0
+ .../libc => libc}/platforms.bzl               |   0
+ .../libc => libc}/test/BUILD.bazel            |   0
+ .../libc => libc}/test/UnitTest/BUILD.bazel   |   0
+ .../libc => libc}/test/libc_test_rules.bzl    |   0
+ .../libc => libc}/test/src/fenv/BUILD.bazel   |   0
+ .../test/src/inttypes/BUILD.bazel             |   0
+ .../libc => libc}/test/src/math/BUILD.bazel   |   0
+ .../test/src/math/libc_math_test_rules.bzl    |   0
+ .../libc => libc}/test/src/stdio/BUILD.bazel  |   0
+ .../libc => libc}/test/src/stdlib/BUILD.bazel |   0
+ .../libc => libc}/test/src/string/BUILD.bazel |   0
+ .../utils/MPFRWrapper/BUILD.bazel             |   0
+ .../libunwind => libunwind}/BUILD.bazel       |   0
+ .../lld => lld}/BUILD.bazel                   |   0
+ .../llvm => llvm}/BUILD.bazel                 |   0
+ .../llvm => llvm}/binary_alias.bzl            |   0
+ .../llvm => llvm}/cc_plugin_library.bzl       |   0
+ .../llvm => llvm}/config.bzl                  |   0
+ .../llvm => llvm}/enum_targets_gen.bzl        |   0
+ .../include/llvm/Config/config.h              |   0
+ .../include/llvm/Config/llvm-config.h         |   0
+ .../llvm => llvm}/lit_test.bzl                |   0
+ .../llvm => llvm}/tblgen.bzl                  |   0
+ .../llvm => llvm}/unittests/BUILD.bazel       |   0
+ .../llvm => llvm}/utils/lit/tests/BUILD.bazel |   0
+ .../mlir => mlir}/BUILD.bazel                 |   0
+ .../mlir => mlir}/build_defs.bzl              |   0
+ .../examples/toy/Ch1/BUILD.bazel              |   0
+ .../examples/toy/Ch2/BUILD.bazel              |   0
+ .../examples/toy/Ch3/BUILD.bazel              |   0
+ .../examples/toy/Ch4/BUILD.bazel              |   0
+ .../examples/toy/Ch5/BUILD.bazel              |   0
+ .../examples/toy/Ch6/BUILD.bazel              |   0
+ .../examples/toy/Ch7/BUILD.bazel              |   0
+ .../mlir => mlir}/linalggen.bzl               |   0
+ .../mlir => mlir}/python/BUILD.bazel          |   0
+ .../mlir => mlir}/tblgen.bzl                  |   0
+ .../mlir => mlir}/test/Analysis/BUILD.bazel   |   0
+ .../mlir => mlir}/test/BUILD.bazel            |   0
+ .../mlir => mlir}/test/Conversion/BUILD.bazel |   0
+ .../mlir => mlir}/test/Dialect/BUILD.bazel    |   0
+ .../mlir => mlir}/test/IR/BUILD.bazel         |   0
+ .../mlir => mlir}/test/Pass/BUILD.bazel       |   0
+ .../mlir => mlir}/test/Rewrite/BUILD.bazel    |   0
+ .../mlir => mlir}/test/Target/BUILD.bazel     |   0
+ .../mlir => mlir}/test/Transforms/BUILD.bazel |   0
+ .../test/mlir-linalg-ods-gen/BUILD.bazel      |   0
+ .../test/mlir-lsp-server/BUILD.bazel          |   0
+ .../mlir => mlir}/test/mlir-opt/BUILD.bazel   |   0
+ .../mlir => mlir}/test/mlir-pdll/BUILD.bazel  |   0
+ .../test/mlir-tblgen/BUILD.bazel              |   0
+ .../mlir => mlir}/test/python/BUILD.bazel     |   0
+ .../mlir => mlir}/unittests/BUILD.bazel       |   0
+ .../unittest/BUILD.bazel                      |   0
+ utils/bazel/.bazelignore                      |   2 -
+ utils/bazel/.bazelrc                          | 198 -----------
+ utils/bazel/.bazelversion                     |   1 -
+ utils/bazel/.gitignore                        |   5 -
+ utils/bazel/BUILD.bazel                       |   5 -
+ utils/bazel/README.md                         | 111 ------
+ utils/bazel/WORKSPACE                         | 118 ------
+ utils/bazel/configure.bzl                     | 174 ---------
+ utils/bazel/examples/http_archive/WORKSPACE   |  40 ---
+ utils/bazel/examples/submodule/WORKSPACE      |  29 --
+ utils/bazel/llvm-project-overlay/.bazelignore |   6 -
+ utils/bazel/llvm_configs/BUILD.bazel          |  30 --
+ utils/bazel/llvm_configs/abi-breaking.h.cmake |  62 ----
+ utils/bazel/llvm_configs/config.h.cmake       | 336 ------------------
+ utils/bazel/llvm_configs/llvm-config.h.cmake  | 129 -------
+ utils/bazel/overlay_directories.py            |  99 ------
+ utils/bazel/third_party_build/BUILD           |   5 -
+ utils/bazel/third_party_build/gmp.BUILD       |  20 --
+ utils/bazel/third_party_build/mpfr.BUILD      |  33 --
+ utils/bazel/third_party_build/pfm.BUILD       |  31 --
+ .../third_party_build/vulkan_headers.BUILD    |  30 --
+ utils/bazel/third_party_build/zlib-ng.BUILD   | 108 ------
+ utils/bazel/third_party_build/zstd.BUILD      |  54 ---
+ utils/bazel/vulkan_sdk.bzl                    |  43 ---
+ .../workspace_root.bzl => workspace_root.bzl  |   0
+ 89 files changed, 1669 deletions(-)
+ rename {utils/bazel/llvm-project-overlay/bolt => bolt}/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/clang-tools-extra => clang-tools-extra}/clang-tidy/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/clang-tools-extra => clang-tools-extra}/clang-tidy/defs.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/clang-tools-extra => clang-tools-extra}/include-cleaner/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/clang-tools-extra => clang-tools-extra}/unittests/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/clang => clang}/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/clang => clang}/include/clang/Config/config.h (100%)
+ rename {utils/bazel/llvm-project-overlay/clang => clang}/unittests/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/libc_build_rules.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/platforms.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/test/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/test/UnitTest/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/test/libc_test_rules.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/test/src/fenv/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/test/src/inttypes/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/test/src/math/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/test/src/math/libc_math_test_rules.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/test/src/stdio/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/test/src/stdlib/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/test/src/string/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/libc => libc}/utils/MPFRWrapper/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/libunwind => libunwind}/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/lld => lld}/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/llvm => llvm}/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/llvm => llvm}/binary_alias.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/llvm => llvm}/cc_plugin_library.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/llvm => llvm}/config.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/llvm => llvm}/enum_targets_gen.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/llvm => llvm}/include/llvm/Config/config.h (100%)
+ rename {utils/bazel/llvm-project-overlay/llvm => llvm}/include/llvm/Config/llvm-config.h (100%)
+ rename {utils/bazel/llvm-project-overlay/llvm => llvm}/lit_test.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/llvm => llvm}/tblgen.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/llvm => llvm}/unittests/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/llvm => llvm}/utils/lit/tests/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/build_defs.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/examples/toy/Ch1/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/examples/toy/Ch2/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/examples/toy/Ch3/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/examples/toy/Ch4/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/examples/toy/Ch5/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/examples/toy/Ch6/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/examples/toy/Ch7/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/linalggen.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/python/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/tblgen.bzl (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/Analysis/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/Conversion/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/Dialect/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/IR/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/Pass/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/Rewrite/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/Target/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/Transforms/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/mlir-linalg-ods-gen/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/mlir-lsp-server/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/mlir-opt/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/mlir-pdll/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/mlir-tblgen/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/test/python/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/mlir => mlir}/unittests/BUILD.bazel (100%)
+ rename {utils/bazel/llvm-project-overlay/third-party => third-party}/unittest/BUILD.bazel (100%)
+ delete mode 100644 utils/bazel/.bazelignore
+ delete mode 100644 utils/bazel/.bazelrc
+ delete mode 100644 utils/bazel/.bazelversion
+ delete mode 100644 utils/bazel/.gitignore
+ delete mode 100644 utils/bazel/BUILD.bazel
+ delete mode 100644 utils/bazel/README.md
+ delete mode 100644 utils/bazel/WORKSPACE
+ delete mode 100644 utils/bazel/configure.bzl
+ delete mode 100644 utils/bazel/examples/http_archive/WORKSPACE
+ delete mode 100644 utils/bazel/examples/submodule/WORKSPACE
+ delete mode 100644 utils/bazel/llvm-project-overlay/.bazelignore
+ delete mode 100644 utils/bazel/llvm_configs/BUILD.bazel
+ delete mode 100644 utils/bazel/llvm_configs/abi-breaking.h.cmake
+ delete mode 100644 utils/bazel/llvm_configs/config.h.cmake
+ delete mode 100644 utils/bazel/llvm_configs/llvm-config.h.cmake
+ delete mode 100755 utils/bazel/overlay_directories.py
+ delete mode 100644 utils/bazel/third_party_build/BUILD
+ delete mode 100644 utils/bazel/third_party_build/gmp.BUILD
+ delete mode 100644 utils/bazel/third_party_build/mpfr.BUILD
+ delete mode 100644 utils/bazel/third_party_build/pfm.BUILD
+ delete mode 100644 utils/bazel/third_party_build/vulkan_headers.BUILD
+ delete mode 100644 utils/bazel/third_party_build/zlib-ng.BUILD
+ delete mode 100644 utils/bazel/third_party_build/zstd.BUILD
+ delete mode 100644 utils/bazel/vulkan_sdk.bzl
+ rename utils/bazel/llvm-project-overlay/workspace_root.bzl => workspace_root.bzl (100%)
+
+diff --git a/utils/bazel/llvm-project-overlay/bolt/BUILD.bazel b/bolt/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/bolt/BUILD.bazel
+rename to bolt/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/clang-tools-extra/clang-tidy/BUILD.bazel b/clang-tools-extra/clang-tidy/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/clang-tools-extra/clang-tidy/BUILD.bazel
+rename to clang-tools-extra/clang-tidy/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/clang-tools-extra/clang-tidy/defs.bzl b/clang-tools-extra/clang-tidy/defs.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/clang-tools-extra/clang-tidy/defs.bzl
+rename to clang-tools-extra/clang-tidy/defs.bzl
+diff --git a/utils/bazel/llvm-project-overlay/clang-tools-extra/include-cleaner/BUILD.bazel b/clang-tools-extra/include-cleaner/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/clang-tools-extra/include-cleaner/BUILD.bazel
+rename to clang-tools-extra/include-cleaner/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/clang-tools-extra/unittests/BUILD.bazel b/clang-tools-extra/unittests/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/clang-tools-extra/unittests/BUILD.bazel
+rename to clang-tools-extra/unittests/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel b/clang/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+rename to clang/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/clang/include/clang/Config/config.h b/clang/include/clang/Config/config.h
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/clang/include/clang/Config/config.h
+rename to clang/include/clang/Config/config.h
+diff --git a/utils/bazel/llvm-project-overlay/clang/unittests/BUILD.bazel b/clang/unittests/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/clang/unittests/BUILD.bazel
+rename to clang/unittests/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel b/libc/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+rename to libc/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl b/libc/libc_build_rules.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+rename to libc/libc_build_rules.bzl
+diff --git a/utils/bazel/llvm-project-overlay/libc/platforms.bzl b/libc/platforms.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/platforms.bzl
+rename to libc/platforms.bzl
+diff --git a/utils/bazel/llvm-project-overlay/libc/test/BUILD.bazel b/libc/test/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/test/BUILD.bazel
+rename to libc/test/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel b/libc/test/UnitTest/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
+rename to libc/test/UnitTest/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl b/libc/test/libc_test_rules.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
+rename to libc/test/libc_test_rules.bzl
+diff --git a/utils/bazel/llvm-project-overlay/libc/test/src/fenv/BUILD.bazel b/libc/test/src/fenv/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/test/src/fenv/BUILD.bazel
+rename to libc/test/src/fenv/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/libc/test/src/inttypes/BUILD.bazel b/libc/test/src/inttypes/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/test/src/inttypes/BUILD.bazel
+rename to libc/test/src/inttypes/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel b/libc/test/src/math/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/test/src/math/BUILD.bazel
+rename to libc/test/src/math/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/libc/test/src/math/libc_math_test_rules.bzl b/libc/test/src/math/libc_math_test_rules.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/test/src/math/libc_math_test_rules.bzl
+rename to libc/test/src/math/libc_math_test_rules.bzl
+diff --git a/utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel b/libc/test/src/stdio/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel
+rename to libc/test/src/stdio/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel b/libc/test/src/stdlib/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
+rename to libc/test/src/stdlib/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel b/libc/test/src/string/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
+rename to libc/test/src/string/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/libc/utils/MPFRWrapper/BUILD.bazel b/libc/utils/MPFRWrapper/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libc/utils/MPFRWrapper/BUILD.bazel
+rename to libc/utils/MPFRWrapper/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/libunwind/BUILD.bazel b/libunwind/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/libunwind/BUILD.bazel
+rename to libunwind/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/lld/BUILD.bazel b/lld/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/lld/BUILD.bazel
+rename to lld/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel b/llvm/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+rename to llvm/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/llvm/binary_alias.bzl b/llvm/binary_alias.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/llvm/binary_alias.bzl
+rename to llvm/binary_alias.bzl
+diff --git a/utils/bazel/llvm-project-overlay/llvm/cc_plugin_library.bzl b/llvm/cc_plugin_library.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/llvm/cc_plugin_library.bzl
+rename to llvm/cc_plugin_library.bzl
+diff --git a/utils/bazel/llvm-project-overlay/llvm/config.bzl b/llvm/config.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/llvm/config.bzl
+rename to llvm/config.bzl
+diff --git a/utils/bazel/llvm-project-overlay/llvm/enum_targets_gen.bzl b/llvm/enum_targets_gen.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/llvm/enum_targets_gen.bzl
+rename to llvm/enum_targets_gen.bzl
+diff --git a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h b/llvm/include/llvm/Config/config.h
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/config.h
+rename to llvm/include/llvm/Config/config.h
+diff --git a/utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h b/llvm/include/llvm/Config/llvm-config.h
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/llvm/include/llvm/Config/llvm-config.h
+rename to llvm/include/llvm/Config/llvm-config.h
+diff --git a/utils/bazel/llvm-project-overlay/llvm/lit_test.bzl b/llvm/lit_test.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/llvm/lit_test.bzl
+rename to llvm/lit_test.bzl
+diff --git a/utils/bazel/llvm-project-overlay/llvm/tblgen.bzl b/llvm/tblgen.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/llvm/tblgen.bzl
+rename to llvm/tblgen.bzl
+diff --git a/utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel b/llvm/unittests/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel
+rename to llvm/unittests/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/llvm/utils/lit/tests/BUILD.bazel b/llvm/utils/lit/tests/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/llvm/utils/lit/tests/BUILD.bazel
+rename to llvm/utils/lit/tests/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel b/mlir/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+rename to mlir/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/build_defs.bzl b/mlir/build_defs.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/build_defs.bzl
+rename to mlir/build_defs.bzl
+diff --git a/utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch1/BUILD.bazel b/mlir/examples/toy/Ch1/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch1/BUILD.bazel
+rename to mlir/examples/toy/Ch1/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch2/BUILD.bazel b/mlir/examples/toy/Ch2/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch2/BUILD.bazel
+rename to mlir/examples/toy/Ch2/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch3/BUILD.bazel b/mlir/examples/toy/Ch3/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch3/BUILD.bazel
+rename to mlir/examples/toy/Ch3/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch4/BUILD.bazel b/mlir/examples/toy/Ch4/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch4/BUILD.bazel
+rename to mlir/examples/toy/Ch4/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch5/BUILD.bazel b/mlir/examples/toy/Ch5/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch5/BUILD.bazel
+rename to mlir/examples/toy/Ch5/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch6/BUILD.bazel b/mlir/examples/toy/Ch6/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch6/BUILD.bazel
+rename to mlir/examples/toy/Ch6/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch7/BUILD.bazel b/mlir/examples/toy/Ch7/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/examples/toy/Ch7/BUILD.bazel
+rename to mlir/examples/toy/Ch7/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/linalggen.bzl b/mlir/linalggen.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/linalggen.bzl
+rename to mlir/linalggen.bzl
+diff --git a/utils/bazel/llvm-project-overlay/mlir/python/BUILD.bazel b/mlir/python/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/python/BUILD.bazel
+rename to mlir/python/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl b/mlir/tblgen.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
+rename to mlir/tblgen.bzl
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/Analysis/BUILD.bazel b/mlir/test/Analysis/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/Analysis/BUILD.bazel
+rename to mlir/test/Analysis/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel b/mlir/test/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/BUILD.bazel
+rename to mlir/test/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/Conversion/BUILD.bazel b/mlir/test/Conversion/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/Conversion/BUILD.bazel
+rename to mlir/test/Conversion/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/Dialect/BUILD.bazel b/mlir/test/Dialect/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/Dialect/BUILD.bazel
+rename to mlir/test/Dialect/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/IR/BUILD.bazel b/mlir/test/IR/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/IR/BUILD.bazel
+rename to mlir/test/IR/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/Pass/BUILD.bazel b/mlir/test/Pass/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/Pass/BUILD.bazel
+rename to mlir/test/Pass/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/Rewrite/BUILD.bazel b/mlir/test/Rewrite/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/Rewrite/BUILD.bazel
+rename to mlir/test/Rewrite/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/Target/BUILD.bazel b/mlir/test/Target/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/Target/BUILD.bazel
+rename to mlir/test/Target/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/Transforms/BUILD.bazel b/mlir/test/Transforms/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/Transforms/BUILD.bazel
+rename to mlir/test/Transforms/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/mlir-linalg-ods-gen/BUILD.bazel b/mlir/test/mlir-linalg-ods-gen/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/mlir-linalg-ods-gen/BUILD.bazel
+rename to mlir/test/mlir-linalg-ods-gen/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/mlir-lsp-server/BUILD.bazel b/mlir/test/mlir-lsp-server/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/mlir-lsp-server/BUILD.bazel
+rename to mlir/test/mlir-lsp-server/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/mlir-opt/BUILD.bazel b/mlir/test/mlir-opt/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/mlir-opt/BUILD.bazel
+rename to mlir/test/mlir-opt/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/mlir-pdll/BUILD.bazel b/mlir/test/mlir-pdll/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/mlir-pdll/BUILD.bazel
+rename to mlir/test/mlir-pdll/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/mlir-tblgen/BUILD.bazel b/mlir/test/mlir-tblgen/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/mlir-tblgen/BUILD.bazel
+rename to mlir/test/mlir-tblgen/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/test/python/BUILD.bazel b/mlir/test/python/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/test/python/BUILD.bazel
+rename to mlir/test/python/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/mlir/unittests/BUILD.bazel b/mlir/unittests/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/mlir/unittests/BUILD.bazel
+rename to mlir/unittests/BUILD.bazel
+diff --git a/utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel b/third-party/unittest/BUILD.bazel
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/third-party/unittest/BUILD.bazel
+rename to third-party/unittest/BUILD.bazel
+diff --git a/utils/bazel/.bazelignore b/utils/bazel/.bazelignore
+deleted file mode 100644
+index 1463bcc9c..000000000
+--- a/utils/bazel/.bazelignore
++++ /dev/null
+@@ -1,2 +0,0 @@
+-llvm-project-overlay
+-examples
+diff --git a/utils/bazel/.bazelrc b/utils/bazel/.bazelrc
+deleted file mode 100644
+index c06e9b341..000000000
+--- a/utils/bazel/.bazelrc
++++ /dev/null
+@@ -1,198 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-###############################################################################
+-# Common flags that apply to all configurations.
+-# Use sparingly for things common to all compilers and platforms.
+-###############################################################################
+-# Prevent invalid caching if input files are modified during a build.
+-build --experimental_guard_against_concurrent_changes
+-
+-# In opt mode, bazel by default builds both PIC and non-PIC object files for
+-# tests vs binaries. We don't need this feature and it slows down opt builds
+-# considerably.
+-build --force_pic
+-
+-# Shared objects take up more space. With fast linkers and binaries that aren't
+-# super large, the benefits of shared objects are minimal.
+-build --dynamic_mode=off
+-
+-# Rely on compiler flags to compile with debug info/strip rather than stripping
+-# based on compilation_mode.
+-build --strip=never
+-
+-# Add layering check to all projects.
+-build --features=layering_check
+-
+-# Opt out of legacy lax behavior implicitly exporting files that are rule inputs
+-# with default visibility.
+-# See: https://bazel.build/reference/be/functions#exports_files
+-build --incompatible_no_implicit_file_export
+-
+-###############################################################################
+-# Options to select different strategies for linking potential dependent
+-# libraries. The default leaves it disabled.
+-###############################################################################
+-
+-build:zlib_external --repo_env=BAZEL_LLVM_ZLIB_STRATEGY=external
+-build:zlib_system --repo_env=BAZEL_LLVM_ZLIB_STRATEGY=system
+-
+-build:terminfo_external --repo_env=BAZEL_LLVM_TERMINFO_STRATEGY=external
+-build:terminfo_system --repo_env=BAZEL_LLVM_TERMINFO_STRATEGY=system
+-
+-###############################################################################
+-# Options for "generic_clang" builds: these options should generally apply to
+-# builds using a Clang-based compiler, and default to the `clang` executable on
+-# the `PATH`. While these are provided for convenience and may serve as a
+-# reference, it would be preferable for users to configure an explicit C++
+-# toolchain instead of relying on `.bazelrc` files.
+-###############################################################################
+-
+-# Set the default compiler to the `clang` binary on the `PATH`.
+-build:generic_clang --repo_env=CC=clang
+-
+-# C++17 standard version is required.
+-build:generic_clang --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
+-
+-# Use `-Wall` for Clang.
+-build:generic_clang --copt=-Wall --host_copt=-Wall
+-
+-# The Clang available on MacOS has a warning that isn't clean on MLIR code. The
+-# warning doesn't show up with more recent Clangs, so just disable for now.
+-build:generic_clang --cxxopt=-Wno-range-loop-analysis --host_cxxopt=-Wno-range-loop-analysis
+-
+-# Build errors are not a helpful way to enforce deprecation in-repo and it is
+-# not the point of the Bazel build to catch usage of deprecated APIs.
+-build:generic_clang --copt=-Wno-deprecated --host_copt=-Wno-deprecated
+-
+-# lld links faster than other linkers. Assume that anybody using clang also has
+-# lld available.
+-build:generic_clang --linkopt=-fuse-ld=lld --host_linkopt=-fuse-ld=lld
+-
+-###############################################################################
+-# Options for "generic_gcc" builds: these options should generally apply to
+-# builds using a GCC-based compiler, and default to the `gcc` executable on
+-# the `PATH`. While these are provided for convenience and may serve as a
+-# reference, it would be preferable for users to configure an explicit C++
+-# toolchain instead of relying on `.bazelrc` files.
+-###############################################################################
+-
+-# Set the default compiler to the `gcc` binary on the `PATH`.
+-build:generic_gcc --repo_env=CC=gcc
+-
+-# C++17 standard version is required.
+-build:generic_gcc --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
+-
+-# Build errors are not a helpful way to enforce deprecation in-repo and it is
+-# not the point of the Bazel build to catch usage of deprecated APIs.
+-build:generic_gcc --copt=-Wno-deprecated --host_copt=-Wno-deprecated
+-
+-# Disable GCC warnings that are noisy and/or false positives on LLVM code.
+-# These need to be global as some code triggering these is in header files.
+-build:generic_gcc --copt=-Wno-unused-parameter --host_copt=-Wno-unused-parameter
+-build:generic_gcc --copt=-Wno-comment --host_copt=-Wno-comment
+-build:generic_gcc --cxxopt=-Wno-class-memaccess --host_cxxopt=-Wno-class-memaccess
+-build:generic_gcc --copt=-Wno-maybe-uninitialized --host_copt=-Wno-maybe-uninitialized
+-build:generic_gcc --copt=-Wno-misleading-indentation --host_copt=-Wno-misleading-indentation
+-
+-###############################################################################
+-# Generic Windows flags common to both MSVC and Clang.
+-###############################################################################
+-
+-# C++17 standard version is required.
+-build:windows --cxxopt=/std:c++17 --host_cxxopt=/std:c++17
+-
+-# Other generic dialect flags.
+-build:windows --copt=/Zc:strictStrings --host_copt=/Zc:strictStrings
+-build:windows --copt=/Oi --host_copt=/Oi
+-build:windows --cxxopt=/Zc:rvalueCast --host_cxxopt=/Zc:rvalueCast
+-
+-# Use the more flexible bigobj format for C++ files that have lots of symbols.
+-build:windows --cxxopt=/bigobj --host_cxxopt=/bigobj
+-
+-###############################################################################
+-# Windows specific flags for building with MSVC.
+-###############################################################################
+-
+-build:msvc --config=windows
+-
+-build:msvc --copt=/WX --host_copt=/WX    # Treat warnings as errors...
+-# ...but disable the ones that are violated
+-build:msvc --copt=/wd4141 --host_copt=/wd4141 # inline used more than once
+-build:msvc --copt=/wd4244 --host_copt=/wd4244 # conversion type -> type
+-build:msvc --copt=/wd4267 --host_copt=/wd4267 # conversion size_t -> type
+-build:msvc --copt=/wd4273 --host_copt=/wd4273 # multiple definitions with different dllimport
+-build:msvc --copt=/wd4319 --host_copt=/wd4319 # zero-extending after complement
+-build:msvc --copt=/wd4624 --host_copt=/wd4624 # destructor was implicitly defined as deleted
+-build:msvc --copt=/wd4804 --host_copt=/wd4804 # comparisons between bool and int
+-build:msvc --copt=/wd4805 --host_copt=/wd4805 # comparisons between bool and int
+-
+-build:msvc --linkopt=/WX --host_linkopt=/WX # Treat warnings as errors...
+-# ...but disable the ones that are violated.
+-build:msvc --linkopt=/IGNORE:4001 --host_linkopt=/IGNORE:4001 # no object files
+-
+-###############################################################################
+-# Options for Windows `clang-cl` builds.
+-###############################################################################
+-
+-# We just start with the baseline Windows config as `clang-cl` doesn't accept
+-# some of the generic Clang flags.
+-build:clang-cl --config=windows
+-
+-# Switch from MSVC to the `clang-cl` compiler.
+-build:clang-cl --compiler=clang-cl
+-
+-# Use Clang's internal warning flags instead of the ones that sometimes map
+-# through to MSVC's flags.
+-build:clang-cl --copt=/clang:-Wall --host_copt=/clang:-Wall
+-build:clang-cl --copt=/clang:-Werror --host_copt=/clang:-Werror
+-
+-# This doesn't appear to be enforced by any upstream bot.
+-build:clang-cl --copt=/clang:-Wno-unused --host_copt=/clang:-Wno-unused
+-
+-# There appears to be an unused constant in GoogleTest on Windows.
+-build:clang-cl --copt=/clang:-Wno-unused-const-variable --host_copt=/clang:-Wno-unused-const-variable
+-
+-# Disable some warnings hit even with `clang-cl` in Clang's own code.
+-build:clang-cl --copt=/clang:-Wno-inconsistent-dllimport --host_copt=/clang:-Wno-inconsistent-dllimport
+-build:clang-cl --cxxopt=/clang:-Wno-c++11-narrowing --host_cxxopt=/clang:-Wno-c++11-narrowing
+-
+-###############################################################################
+-# Options for continuous integration.
+-###############################################################################
+-
+-# -O1 tries to provide a reasonable tradeoff between compile times and runtime
+-# performance. However, if we start running more tests (e.g. all of
+-# check-clang) we may want more optimizations.
+-# Note for anybody considering using --compilation_mode=opt in CI, it builds
+-# most files twice, one PIC version for shared libraries in tests, and one
+-# non-PIC version for binaries.
+-build:ci --copt=-O1
+-
+-# Use clang.
+-build:ci --config=generic_clang
+-
+-# Speedup bazel using a ramdisk.
+-build:ci --sandbox_base=/dev/shm
+-
+-# Use system's mpfr and pfm instead of building it from source.
+-# This is non hermetic but helps with compile time.
+-build:ci --@llvm-project//libc:mpfr=system
+-build:ci --@llvm-project//llvm:pfm=system
+-
+-# Don't build/test targets tagged with "nobuildkite".
+-build:ci --build_tag_filters=-nobuildkite
+-build:ci --test_tag_filters=-nobuildkite
+-
+-# Show as many errors as possible.
+-build:ci --keep_going
+-
+-# Show test errors.
+-build:ci --test_output=errors
+-
+-###############################################################################
+-
+-# The user.bazelrc file is not checked in but available for local mods.
+-# Always keep this at the end of the file so that user flags override.
+-try-import %workspace%/user.bazelrc
+diff --git a/utils/bazel/.bazelversion b/utils/bazel/.bazelversion
+deleted file mode 100644
+index 5e3254243..000000000
+--- a/utils/bazel/.bazelversion
++++ /dev/null
+@@ -1 +0,0 @@
+-6.1.2
+diff --git a/utils/bazel/.gitignore b/utils/bazel/.gitignore
+deleted file mode 100644
+index 6bb9fd1ef..000000000
+--- a/utils/bazel/.gitignore
++++ /dev/null
+@@ -1,5 +0,0 @@
+-# Bazel artifacts
+-**/bazel-*
+-
+-# Per-user bazelrc files
+-user.bazelrc
+diff --git a/utils/bazel/BUILD.bazel b/utils/bazel/BUILD.bazel
+deleted file mode 100644
+index dd837093c..000000000
+--- a/utils/bazel/BUILD.bazel
++++ /dev/null
+@@ -1,5 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-# Required to reference .bzl files in this package
+diff --git a/utils/bazel/README.md b/utils/bazel/README.md
+deleted file mode 100644
+index ba74947b6..000000000
+--- a/utils/bazel/README.md
++++ /dev/null
+@@ -1,111 +0,0 @@
+-# Introduction
+-
+-*Warning* The Bazel build is experimental and best-effort, supported in line
+-with the policy for
+-[LLVM's peripheral support tier](https://llvm.org/docs/SupportPolicy.html).
+-LLVM's official build system is CMake. If in doubt use that. If you make changes
+-to LLVM, you're expected to update the CMake build but you don't need to update
+-Bazel build files. Reviewers should not ask authors to update Bazel build files
+-unless the author has opted in to support Bazel. Keeping the Bazel build files
+-up-to-date is on the people who use the Bazel build.
+-
+-[Bazel](https://bazel.build/) is a multi-language build system focused on
+-reproducible builds to enable dependency analysis and caching for fast
+-incremental builds.
+-
+-The main motivation behind the existence of an LLVM Bazel build is that a number
+-of projects that depend on LLVM use Bazel, and Bazel works best when it knows
+-about the whole source tree (as opposed to installing artifacts coming from
+-another build system). Community members are also welcome to use Bazel for their
+-own development as long as they continue to maintain the official CMake build
+-system. See also, the
+-[proposal](https://github.com/llvm/llvm-www/blob/main/proposals/LP0002-BazelBuildConfiguration.md)
+-for adding this configuration.
+-
+-# Quick Start
+-
+-1. `git clone https://github.com/llvm/llvm-project.git; cd llvm-project` if
+-   you don't have a checkout yet.
+-2. Install Bazel at the version indicated by [.bazelversion](./.bazelversion),
+-   following the official instructions, if you don't have it installed yet:
+-   https://docs.bazel.build/versions/main/install.html.
+-   * You can also install and use
+-     [bazelisk](https://github.com/bazelbuild/bazelisk) which automates
+-     downloading the proper bazel version
+-3. `cd utils/bazel`
+-4. `bazel build --config=generic_clang @llvm-project//...`
+-   * If you're using clang, it's expected that lld is also available
+-   * If you're using MSVC or gcc, instead of `--config=generic_clang`, pass
+-   `--config=generic_gcc` or `--config=msvc`
+-   * To specify a specific local compiler to use, add the following bazel
+-     flag: `--repo_env=CC=/usr/bin/clang`
+-     * `--config=generic_clang`/`--config=generic_gcc` by default set
+-       `--repo_env=CC=clang`/`--repo_env=CC=gcc`, using `clang`/`gcc` on the
+-       `PATH`
+-
+-# Configuration
+-
+-The repository `.bazelrc` will import user-specific settings from a
+-`user.bazelrc` file (in addition to the standard locations). Adding your typical
+-config setting is recommended.
+-
+-```.bazelrc
+-build --config=generic_clang
+-```
+-
+-You can enable
+-[disk caching](https://docs.bazel.build/versions/main/remote-caching.html#disk-cache),
+-which will cache build results
+-
+-```.bazelrc
+-build --disk_cache=~/.cache/bazel-disk-cache
+-```
+-
+-You can instruct Bazel to use a ramdisk for its sandboxing operations via
+-[--sandbox_base](https://docs.bazel.build/versions/main/command-line-reference.html#flag--sandbox_base),
+-which can help avoid IO bottlenecks for the symlink strategy used for
+-sandboxing. This is especially important with many inputs and many cores (see
+-https://github.com/bazelbuild/bazel/issues/11868):
+-
+-```.bazelrc
+-build --sandbox_base=/dev/shm
+-```
+-
+-Bear in mind that this requires that your ramdisk is of sufficient size to hold
+-any temporary files. Anecdotally, 1GB should be sufficient.
+-
+-# Coverage
+-
+-The LLVM, MLIR, and Clang subprojects have configurations for Linux (Clang and
+-GCC), Mac (Clang and GCC), and Windows (MSVC). Configuration options that are
+-platform-specific are selected for in defines. Many are also hardcoded to the
+-values currently used by all supported configurations. If there is a
+-configuration you'd like to use that isn't supported, please send a patch.
+-
+-# Continuous Testing
+-
+-A [Buildkite pipeline](https://buildkite.com/llvm-project/upstream-bazel)
+-runs the full Bazel build on every commit to the main branch. Notifications of
+-failures are sent to the
+-[llvm-bazel-alerts google group](https://groups.google.com/g/llvm-bazel-alerts),
+-which anyone is free to join. Currently, the behavior is just to send an email
+-on each failure using Buildkite's built-in notification system, so if you
+-subscribe, it is highly recommended that you set up email filters or some other
+-mechanism to not flood your inbox. More sophisticated notifications, e.g. only
+-on status change or routed based on blamelist are TODO (contributions welcome).
+-
+-# Pre-merge Testing
+-
+-A Buildkite pipeline runs the full Bazel build as a pre-merge test using the 
+-[LLVM pre-merge testing](https://github.com/google/llvm-premerge-checks/). It
+-is triggered on all changes to the utils/bazel directory and when the patch
+-author is a member of the
+-[Bazel Phabricator project](https://reviews.llvm.org/project/members/107/). If
+-you use or benefit from the Bazel build, please join the project so that you
+-can help keep it green. As a bonus, it runs in under 5 minutes, much faster
+-than any of the other pre-merge builds.
+-
+-# Usage in Downstream Projects
+-
+-To use in dependent projects using Bazel, you can import LLVM and then use the
+-provided configuration rule. See example usage in the `examples/` directory.
+diff --git a/utils/bazel/WORKSPACE b/utils/bazel/WORKSPACE
+deleted file mode 100644
+index c33465825..000000000
+--- a/utils/bazel/WORKSPACE
++++ /dev/null
+@@ -1,118 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+-
+-SKYLIB_VERSION = "1.3.0"
+-
+-http_archive(
+-    name = "bazel_skylib",
+-    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
+-    urls = [
+-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz".format(version=SKYLIB_VERSION),
+-        "https://github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz".format(version=SKYLIB_VERSION),
+-    ],
+-)
+-
+-new_local_repository(
+-    name = "llvm-raw",
+-    build_file_content = "# empty",
+-    path = "../../",
+-)
+-
+-load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
+-
+-llvm_configure(name = "llvm-project")
+-
+-maybe(
+-    http_archive,
+-    name = "llvm_zlib",
+-    build_file = "@llvm-raw//utils/bazel/third_party_build:zlib-ng.BUILD",
+-    sha256 = "e36bb346c00472a1f9ff2a0a4643e590a254be6379da7cddd9daeb9a7f296731",
+-    strip_prefix = "zlib-ng-2.0.7",
+-    urls = [
+-        "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.zip",
+-    ],
+-)
+-
+-maybe(
+-    http_archive,
+-    name = "vulkan_headers",
+-    build_file = "@llvm-raw//utils/bazel/third_party_build:vulkan_headers.BUILD",
+-    sha256 = "19f491784ef0bc73caff877d11c96a48b946b5a1c805079d9006e3fbaa5c1895",
+-    strip_prefix = "Vulkan-Headers-9bd3f561bcee3f01d22912de10bb07ce4e23d378",
+-    urls = [
+-        "https://github.com/KhronosGroup/Vulkan-Headers/archive/9bd3f561bcee3f01d22912de10bb07ce4e23d378.tar.gz",
+-    ],
+-)
+-
+-load("@llvm-raw//utils/bazel:vulkan_sdk.bzl", "vulkan_sdk_setup")
+-
+-maybe(
+-    vulkan_sdk_setup,
+-    name = "vulkan_sdk",
+-)
+-
+-# llvm libc math tests reply on `mpfr`.
+-# The availability of `mpfr` is controlled by a flag and can be either `disable`, `system` or `external`.
+-# Continuous integration uses `system` to speed up the build process (see .bazelrc).
+-# Otherwise by default it is set to `external`: `mpfr` and `gmp` are built from source by using `rules_foreign_cc`.
+-# Note: that building from source requires `m4` to be installed on the host machine.
+-# This is a known issue: https://github.com/bazelbuild/rules_foreign_cc/issues/755.
+-
+-git_repository(
+-    name = "rules_foreign_cc",
+-    remote = "https://github.com/bazelbuild/rules_foreign_cc.git",
+-    tag = "0.9.0",
+-)
+-
+-load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+-
+-rules_foreign_cc_dependencies()
+-
+-maybe(
+-    http_archive,
+-    name = "gmp",
+-    build_file = "@llvm-raw//utils/bazel/third_party_build:gmp.BUILD",
+-    sha256 = "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2",
+-    strip_prefix = "gmp-6.2.1",
+-    urls = [
+-        "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz",
+-        "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz",
+-    ],
+-)
+-
+-# https://www.mpfr.org/mpfr-current/
+-#
+-# When updating to a newer version, don't use URLs with "mpfr-current" in them.
+-# Instead, find a stable URL like the one used currently.
+-maybe(
+-    http_archive,
+-    name = "mpfr",
+-    build_file = "@llvm-raw//utils/bazel/third_party_build:mpfr.BUILD",
+-    sha256 = "9cbed5d0af0d9ed5e9f8dd013e17838eb15e1db9a6ae0d371d55d35f93a782a7",
+-    strip_prefix = "mpfr-4.1.1",
+-    urls = ["https://www.mpfr.org/mpfr-4.1.1/mpfr-4.1.1.tar.gz"],
+-)
+-
+-maybe(
+-    new_git_repository,
+-    name = "pfm",
+-    build_file = "@llvm-raw//utils/bazel/third_party_build:pfm.BUILD",
+-    remote = "https://git.code.sf.net/p/perfmon2/libpfm4",
+-    tag = "v4.12.1",
+-)
+-
+-maybe(
+-    http_archive,
+-    name = "llvm_zstd",
+-    build_file = "@llvm-raw//utils/bazel/third_party_build:zstd.BUILD",
+-    sha256 = "7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0",
+-    strip_prefix = "zstd-1.5.2",
+-    urls = [
+-        "https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz"
+-    ],
+-)
+diff --git a/utils/bazel/configure.bzl b/utils/bazel/configure.bzl
+deleted file mode 100644
+index 88a576548..000000000
+--- a/utils/bazel/configure.bzl
++++ /dev/null
+@@ -1,174 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-"""Helper macros to configure the LLVM overlay project."""
+-
+-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+-
+-# Directory of overlay files relative to WORKSPACE
+-DEFAULT_OVERLAY_PATH = "llvm-project-overlay"
+-
+-DEFAULT_TARGETS = [
+-    "AArch64",
+-    "AMDGPU",
+-    "ARM",
+-    "AVR",
+-    "BPF",
+-    "Hexagon",
+-    "Lanai",
+-    "LoongArch",
+-    "Mips",
+-    "MSP430",
+-    "NVPTX",
+-    "PowerPC",
+-    "RISCV",
+-    "Sparc",
+-    "SystemZ",
+-    "VE",
+-    "WebAssembly",
+-    "X86",
+-    "XCore",
+-]
+-
+-def _overlay_directories(repository_ctx):
+-    src_path = repository_ctx.path(Label("@llvm-raw//:WORKSPACE")).dirname
+-    bazel_path = src_path.get_child("utils").get_child("bazel")
+-    overlay_path = bazel_path.get_child("llvm-project-overlay")
+-    script_path = bazel_path.get_child("overlay_directories.py")
+-
+-    python_bin = repository_ctx.which("python3")
+-    if not python_bin:
+-        # Windows typically just defines "python" as python3. The script itself
+-        # contains a check to ensure python3.
+-        python_bin = repository_ctx.which("python")
+-
+-    if not python_bin:
+-        fail("Failed to find python3 binary")
+-
+-    cmd = [
+-        python_bin,
+-        script_path,
+-        "--src",
+-        src_path,
+-        "--overlay",
+-        overlay_path,
+-        "--target",
+-        ".",
+-    ]
+-    exec_result = repository_ctx.execute(cmd, timeout = 20)
+-
+-    if exec_result.return_code != 0:
+-        fail(("Failed to execute overlay script: '{cmd}'\n" +
+-              "Exited with code {return_code}\n" +
+-              "stdout:\n{stdout}\n" +
+-              "stderr:\n{stderr}\n").format(
+-            cmd = " ".join([str(arg) for arg in cmd]),
+-            return_code = exec_result.return_code,
+-            stdout = exec_result.stdout,
+-            stderr = exec_result.stderr,
+-        ))
+-
+-def _extract_cmake_settings(repository_ctx, llvm_cmake):
+-    # The list to be written to vars.bzl
+-    # `CMAKE_CXX_STANDARD` may be used from WORKSPACE for the toolchain.
+-    c = {
+-        "CMAKE_CXX_STANDARD": None,
+-        "LLVM_VERSION_MAJOR": None,
+-        "LLVM_VERSION_MINOR": None,
+-        "LLVM_VERSION_PATCH": None,
+-    }
+-
+-    # It would be easier to use external commands like sed(1) and python.
+-    # For portability, the parser should run on Starlark.
+-    llvm_cmake_path = repository_ctx.path(Label("//:" + llvm_cmake))
+-    for line in repository_ctx.read(llvm_cmake_path).splitlines():
+-        # Extract "set ( FOO bar ... "
+-        setfoo = line.partition("(")
+-        if setfoo[1] != "(":
+-            continue
+-        if setfoo[0].strip().lower() != "set":
+-            continue
+-
+-        # `kv` is assumed as \s*KEY\s+VAL\s*\).*
+-        # Typical case is like
+-        #   LLVM_REQUIRED_CXX_STANDARD 17)
+-        # Possible case -- It should be ignored.
+-        #   CMAKE_CXX_STANDARD ${...} CACHE STRING "...")
+-        kv = setfoo[2].strip()
+-        i = kv.find(" ")
+-        if i < 0:
+-            continue
+-        k = kv[:i]
+-
+-        # Prefer LLVM_REQUIRED_CXX_STANDARD instead of CMAKE_CXX_STANDARD
+-        if k == "LLVM_REQUIRED_CXX_STANDARD":
+-            k = "CMAKE_CXX_STANDARD"
+-            c[k] = None
+-        if k not in c:
+-            continue
+-
+-        # Skip if `CMAKE_CXX_STANDARD` is set with
+-        # `LLVM_REQUIRED_CXX_STANDARD`.
+-        # Then `v` will not be desired form, like "${...} CACHE"
+-        if c[k] != None:
+-            continue
+-
+-        # Pick up 1st word as the value.
+-        # Note: It assumes unquoted word.
+-        v = kv[i:].strip().partition(")")[0].partition(" ")[0]
+-        c[k] = v
+-
+-    # Synthesize `LLVM_VERSION` for convenience.
+-    c["LLVM_VERSION"] = "{}.{}.{}".format(
+-        c["LLVM_VERSION_MAJOR"],
+-        c["LLVM_VERSION_MINOR"],
+-        c["LLVM_VERSION_PATCH"],
+-    )
+-
+-    return c
+-
+-def _write_dict_to_file(repository_ctx, filepath, header, vars):
+-    # (fci + individual vars) + (fcd + dict items) + (fct)
+-    fci = header
+-    fcd = "\nllvm_vars={\n"
+-    fct = "}\n"
+-
+-    for k, v in vars.items():
+-        fci += '{} = "{}"\n'.format(k, v)
+-        fcd += '    "{}": "{}",\n'.format(k, v)
+-
+-    repository_ctx.file(filepath, content = fci + fcd + fct)
+-
+-def _llvm_configure_impl(repository_ctx):
+-    _overlay_directories(repository_ctx)
+-
+-    llvm_cmake = "llvm/CMakeLists.txt"
+-    vars = _extract_cmake_settings(
+-        repository_ctx,
+-        llvm_cmake,
+-    )
+-
+-    _write_dict_to_file(
+-        repository_ctx,
+-        filepath = "vars.bzl",
+-        header = "# Generated from {}\n\n".format(llvm_cmake),
+-        vars = vars,
+-    )
+-
+-    # Create a starlark file with the requested LLVM targets.
+-    targets = repository_ctx.attr.targets
+-    repository_ctx.file(
+-        "llvm/targets.bzl",
+-        content = "llvm_targets = " + str(targets),
+-        executable = False,
+-    )
+-
+-llvm_configure = repository_rule(
+-    implementation = _llvm_configure_impl,
+-    local = True,
+-    configure = True,
+-    attrs = {
+-        "targets": attr.string_list(default = DEFAULT_TARGETS),
+-    },
+-)
+diff --git a/utils/bazel/examples/http_archive/WORKSPACE b/utils/bazel/examples/http_archive/WORKSPACE
+deleted file mode 100644
+index 6b54802f1..000000000
+--- a/utils/bazel/examples/http_archive/WORKSPACE
++++ /dev/null
+@@ -1,40 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-"""An example WORKSPACE for configuring LLVM using http_archive."""
+-
+-workspace(name = "http_archive_example")
+-
+-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+-
+-SKYLIB_VERSION = "1.0.3"
+-
+-http_archive(
+-    name = "bazel_skylib",
+-    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+-    urls = [
+-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz".format(version=SKYLIB_VERSION),
+-        "https://github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz".format(version=SKYLIB_VERSION),
+-    ],
+-)
+-
+-# Replace with the LLVM commit you want to use.
+-LLVM_COMMIT = "81d5412439efd0860c0a8dd51b831204f118d485"
+-
+-# The easiest way to calculate this for a new commit is to set it to empty and
+-# then run a bazel build and it will report the digest necessary to cache the
+-# archive and make the build reproducible.
+-LLVM_SHA256 = "50b3ef31b228ea0c96ae074005bfac087c56e6a4b1c147592dd33f41cad0706b"
+-
+-http_archive(
+-    name = "llvm-raw",
+-    build_file_content = "# empty",
+-    sha256 = LLVM_SHA256,
+-    strip_prefix = "llvm-project-" + LLVM_COMMIT,
+-    urls = ["https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT)],
+-)
+-
+-load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure", "llvm_disable_optional_support_deps")
+-
+-llvm_configure(name = "llvm-project")
+diff --git a/utils/bazel/examples/submodule/WORKSPACE b/utils/bazel/examples/submodule/WORKSPACE
+deleted file mode 100644
+index 33736d1a6..000000000
+--- a/utils/bazel/examples/submodule/WORKSPACE
++++ /dev/null
+@@ -1,29 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-"""An example WORKSPACE for configuring LLVM using a git submodule."""
+-
+-workspace(name = "submodule_example")
+-
+-SKYLIB_VERSION = "1.0.3"
+-
+-http_archive(
+-    name = "bazel_skylib",
+-    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+-    urls = [
+-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz".format(version=SKYLIB_VERSION),
+-        "https://github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz".format(version=SKYLIB_VERSION),
+-    ],
+-)
+-
+-new_local_repository(
+-    name = "llvm-raw",
+-    build_file_content = "# empty",
+-    # Or wherever your submodule is located.
+-    path = "third_party/llvm-project",
+-)
+-
+-load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure", "llvm_disable_optional_support_deps")
+-
+-llvm_configure(name = "llvm-project")
+diff --git a/utils/bazel/llvm-project-overlay/.bazelignore b/utils/bazel/llvm-project-overlay/.bazelignore
+deleted file mode 100644
+index f3d19a942..000000000
+--- a/utils/bazel/llvm-project-overlay/.bazelignore
++++ /dev/null
+@@ -1,6 +0,0 @@
+-# Ignore the utils/bazel directory when this is overlayed onto the repo root.
+-utils/bazel
+-# Ignore third-party projects. These should be configured separately and some
+-# include Bazel configs.
+-libcxx/utils/google-benchmark
+-third-party/benchmark
+diff --git a/utils/bazel/llvm_configs/BUILD.bazel b/utils/bazel/llvm_configs/BUILD.bazel
+deleted file mode 100644
+index 5a4f9970c..000000000
+--- a/utils/bazel/llvm_configs/BUILD.bazel
++++ /dev/null
+@@ -1,30 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-# These diff tests ensure that the current Bazel configuration does not drift
+-# from the configuration in the .cmake files, since we don't alway use them
+-# directly (and even if we did we wouldn't necessarily pick up changes there).
+-# These are literal change-detector tests. We perform diff testing here since
+-# it isn't really part of building LLVM and we don't want to include the config
+-# copies in the workspace used by dependent projects.
+-
+-load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+-
+-diff_test(
+-    name = "diff_config.h.cmake",
+-    file1 = "@llvm-project//llvm:include/llvm/Config/config.h.cmake",
+-    file2 = "config.h.cmake",
+-)
+-
+-diff_test(
+-    name = "diff_llvm-config.h.cmake",
+-    file1 = "@llvm-project//llvm:include/llvm/Config/llvm-config.h.cmake",
+-    file2 = "llvm-config.h.cmake",
+-)
+-
+-diff_test(
+-    name = "diff_abi-breaking.h.cmake",
+-    file1 = "@llvm-project//llvm:include/llvm/Config/abi-breaking.h.cmake",
+-    file2 = "abi-breaking.h.cmake",
+-)
+diff --git a/utils/bazel/llvm_configs/abi-breaking.h.cmake b/utils/bazel/llvm_configs/abi-breaking.h.cmake
+deleted file mode 100644
+index 2d27e02b1..000000000
+--- a/utils/bazel/llvm_configs/abi-breaking.h.cmake
++++ /dev/null
+@@ -1,62 +0,0 @@
+-/*===------- llvm/Config/abi-breaking.h - llvm configuration -------*- C -*-===*/
+-/*                                                                            */
+-/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+-/* Exceptions.                                                                */
+-/* See https://llvm.org/LICENSE.txt for license information.                  */
+-/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+-/*                                                                            */
+-/*===----------------------------------------------------------------------===*/
+-
+-/* This file controls the C++ ABI break introduced in LLVM public header. */
+-
+-#ifndef LLVM_ABI_BREAKING_CHECKS_H
+-#define LLVM_ABI_BREAKING_CHECKS_H
+-
+-/* Define to enable checks that alter the LLVM C++ ABI */
+-#cmakedefine01 LLVM_ENABLE_ABI_BREAKING_CHECKS
+-
+-/* Define to enable reverse iteration of unordered llvm containers */
+-#cmakedefine01 LLVM_ENABLE_REVERSE_ITERATION
+-
+-/* Allow selectively disabling link-time mismatch checking so that header-only
+-   ADT content from LLVM can be used without linking libSupport. */
+-#if !defined(LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING) || !LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+-
+-// ABI_BREAKING_CHECKS protection: provides link-time failure when clients build
+-// mismatch with LLVM
+-#if defined(_MSC_VER)
+-// Use pragma with MSVC
+-#define LLVM_XSTR(s) LLVM_STR(s)
+-#define LLVM_STR(s) #s
+-#pragma detect_mismatch("LLVM_ENABLE_ABI_BREAKING_CHECKS", LLVM_XSTR(LLVM_ENABLE_ABI_BREAKING_CHECKS))
+-#undef LLVM_XSTR
+-#undef LLVM_STR
+-#elif defined(_WIN32) || defined(__CYGWIN__) // Win32 w/o #pragma detect_mismatch
+-// FIXME: Implement checks without weak.
+-#elif defined(__cplusplus)
+-#if !(defined(_AIX) && defined(__GNUC__) && !defined(__clang__))
+-#define LLVM_HIDDEN_VISIBILITY __attribute__ ((visibility("hidden")))
+-#else
+-// GCC on AIX does not support visibility attributes. Symbols are not
+-// exported by default on AIX.
+-#define LLVM_HIDDEN_VISIBILITY
+-#endif
+-namespace llvm {
+-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
+-extern int EnableABIBreakingChecks;
+-LLVM_HIDDEN_VISIBILITY
+-__attribute__((weak)) int *VerifyEnableABIBreakingChecks =
+-    &EnableABIBreakingChecks;
+-#else
+-extern int DisableABIBreakingChecks;
+-LLVM_HIDDEN_VISIBILITY
+-__attribute__((weak)) int *VerifyDisableABIBreakingChecks =
+-    &DisableABIBreakingChecks;
+-#endif
+-}
+-#undef LLVM_HIDDEN_VISIBILITY
+-#endif // _MSC_VER
+-
+-#endif // LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+-
+-#endif
+diff --git a/utils/bazel/llvm_configs/config.h.cmake b/utils/bazel/llvm_configs/config.h.cmake
+deleted file mode 100644
+index fc1f9bf34..000000000
+--- a/utils/bazel/llvm_configs/config.h.cmake
++++ /dev/null
+@@ -1,336 +0,0 @@
+-#ifndef CONFIG_H
+-#define CONFIG_H
+-
+-// Include this header only under the llvm source tree.
+-// This is a private header.
+-
+-/* Exported configuration */
+-#include "llvm/Config/llvm-config.h"
+-
+-/* Bug report URL. */
+-#define BUG_REPORT_URL "${BUG_REPORT_URL}"
+-
+-/* Define to 1 to enable backtraces, and to 0 otherwise. */
+-#cmakedefine01 ENABLE_BACKTRACES
+-
+-/* Define to 1 to enable crash overrides, and to 0 otherwise. */
+-#cmakedefine01 ENABLE_CRASH_OVERRIDES
+-
+-/* Define to 1 to enable crash memory dumps, and to 0 otherwise. */
+-#cmakedefine01 LLVM_ENABLE_CRASH_DUMPS
+-
+-/* Define to 1 to prefer forward slashes on Windows, and to 0 prefer
+-   backslashes. */
+-#cmakedefine01 LLVM_WINDOWS_PREFER_FORWARD_SLASH
+-
+-/* Define to 1 if you have the `backtrace' function. */
+-#cmakedefine HAVE_BACKTRACE ${HAVE_BACKTRACE}
+-
+-#define BACKTRACE_HEADER <${BACKTRACE_HEADER}>
+-
+-/* Define to 1 if you have the <CrashReporterClient.h> header file. */
+-#cmakedefine HAVE_CRASHREPORTERCLIENT_H
+-
+-/* can use __crashreporter_info__ */
+-#cmakedefine01 HAVE_CRASHREPORTER_INFO
+-
+-/* Define to 1 if you have the declaration of `arc4random', and to 0 if you
+-   don't. */
+-#cmakedefine01 HAVE_DECL_ARC4RANDOM
+-
+-/* Define to 1 if you have the declaration of `FE_ALL_EXCEPT', and to 0 if you
+-   don't. */
+-#cmakedefine01 HAVE_DECL_FE_ALL_EXCEPT
+-
+-/* Define to 1 if you have the declaration of `FE_INEXACT', and to 0 if you
+-   don't. */
+-#cmakedefine01 HAVE_DECL_FE_INEXACT
+-
+-/* Define to 1 if you have the declaration of `strerror_s', and to 0 if you
+-   don't. */
+-#cmakedefine01 HAVE_DECL_STRERROR_S
+-
+-/* Define to 1 if you have the <dlfcn.h> header file. */
+-#cmakedefine HAVE_DLFCN_H ${HAVE_DLFCN_H}
+-
+-/* Define if dlopen() is available on this platform. */
+-#cmakedefine HAVE_DLOPEN ${HAVE_DLOPEN}
+-
+-/* Define if dladdr() is available on this platform. */
+-#cmakedefine HAVE_DLADDR ${HAVE_DLADDR}
+-
+-/* Define to 1 if we can register EH frames on this platform. */
+-#cmakedefine HAVE_REGISTER_FRAME ${HAVE_REGISTER_FRAME}
+-
+-/* Define to 1 if we can deregister EH frames on this platform. */
+-#cmakedefine HAVE_DEREGISTER_FRAME ${HAVE_DEREGISTER_FRAME}
+-
+-/* Define if __unw_add_dynamic_fde() is available on this platform. */
+-#cmakedefine HAVE_UNW_ADD_DYNAMIC_FDE ${HAVE_UNW_ADD_DYNAMIC_FDE}
+-
+-/* Define to 1 if you have the <errno.h> header file. */
+-#cmakedefine HAVE_ERRNO_H ${HAVE_ERRNO_H}
+-
+-/* Define to 1 if you have the <fcntl.h> header file. */
+-#cmakedefine HAVE_FCNTL_H ${HAVE_FCNTL_H}
+-
+-/* Define to 1 if you have the <fenv.h> header file. */
+-#cmakedefine HAVE_FENV_H ${HAVE_FENV_H}
+-
+-/* Define if libffi is available on this platform. */
+-#cmakedefine HAVE_FFI_CALL ${HAVE_FFI_CALL}
+-
+-/* Define to 1 if you have the <ffi/ffi.h> header file. */
+-#cmakedefine HAVE_FFI_FFI_H ${HAVE_FFI_FFI_H}
+-
+-/* Define to 1 if you have the <ffi.h> header file. */
+-#cmakedefine HAVE_FFI_H ${HAVE_FFI_H}
+-
+-/* Define to 1 if you have the `futimens' function. */
+-#cmakedefine HAVE_FUTIMENS ${HAVE_FUTIMENS}
+-
+-/* Define to 1 if you have the `futimes' function. */
+-#cmakedefine HAVE_FUTIMES ${HAVE_FUTIMES}
+-
+-/* Define to 1 if you have the `getpagesize' function. */
+-#cmakedefine HAVE_GETPAGESIZE ${HAVE_GETPAGESIZE}
+-
+-/* Define to 1 if you have the `getrlimit' function. */
+-#cmakedefine HAVE_GETRLIMIT ${HAVE_GETRLIMIT}
+-
+-/* Define to 1 if you have the `getrusage' function. */
+-#cmakedefine HAVE_GETRUSAGE ${HAVE_GETRUSAGE}
+-
+-/* Define to 1 if you have the `isatty' function. */
+-#cmakedefine HAVE_ISATTY 1
+-
+-/* Define to 1 if you have the `edit' library (-ledit). */
+-#cmakedefine HAVE_LIBEDIT ${HAVE_LIBEDIT}
+-
+-/* Define to 1 if you have the `pfm' library (-lpfm). */
+-#cmakedefine HAVE_LIBPFM ${HAVE_LIBPFM}
+-
+-/* Define to 1 if the `perf_branch_entry' struct has field cycles. */
+-#cmakedefine LIBPFM_HAS_FIELD_CYCLES ${LIBPFM_HAS_FIELD_CYCLES}
+-
+-/* Define to 1 if you have the `psapi' library (-lpsapi). */
+-#cmakedefine HAVE_LIBPSAPI ${HAVE_LIBPSAPI}
+-
+-/* Define to 1 if you have the `pthread' library (-lpthread). */
+-#cmakedefine HAVE_LIBPTHREAD ${HAVE_LIBPTHREAD}
+-
+-/* Define to 1 if you have the `pthread_getname_np' function. */
+-#cmakedefine HAVE_PTHREAD_GETNAME_NP ${HAVE_PTHREAD_GETNAME_NP}
+-
+-/* Define to 1 if you have the `pthread_setname_np' function. */
+-#cmakedefine HAVE_PTHREAD_SETNAME_NP ${HAVE_PTHREAD_SETNAME_NP}
+-
+-/* Define to 1 if you have the <link.h> header file. */
+-#cmakedefine HAVE_LINK_H ${HAVE_LINK_H}
+-
+-/* Define to 1 if you have the <mach/mach.h> header file. */
+-#cmakedefine HAVE_MACH_MACH_H ${HAVE_MACH_MACH_H}
+-
+-/* Define to 1 if you have the `mallctl' function. */
+-#cmakedefine HAVE_MALLCTL ${HAVE_MALLCTL}
+-
+-/* Define to 1 if you have the `mallinfo' function. */
+-#cmakedefine HAVE_MALLINFO ${HAVE_MALLINFO}
+-
+-/* Define to 1 if you have the `mallinfo2' function. */
+-#cmakedefine HAVE_MALLINFO2 ${HAVE_MALLINFO2}
+-
+-/* Define to 1 if you have the <malloc/malloc.h> header file. */
+-#cmakedefine HAVE_MALLOC_MALLOC_H ${HAVE_MALLOC_MALLOC_H}
+-
+-/* Define to 1 if you have the `malloc_zone_statistics' function. */
+-#cmakedefine HAVE_MALLOC_ZONE_STATISTICS ${HAVE_MALLOC_ZONE_STATISTICS}
+-
+-/* Define to 1 if you have the `posix_spawn' function. */
+-#cmakedefine HAVE_POSIX_SPAWN ${HAVE_POSIX_SPAWN}
+-
+-/* Define to 1 if you have the `pread' function. */
+-#cmakedefine HAVE_PREAD ${HAVE_PREAD}
+-
+-/* Define to 1 if you have the <pthread.h> header file. */
+-#cmakedefine HAVE_PTHREAD_H ${HAVE_PTHREAD_H}
+-
+-/* Have pthread_mutex_lock */
+-#cmakedefine HAVE_PTHREAD_MUTEX_LOCK ${HAVE_PTHREAD_MUTEX_LOCK}
+-
+-/* Have pthread_rwlock_init */
+-#cmakedefine HAVE_PTHREAD_RWLOCK_INIT ${HAVE_PTHREAD_RWLOCK_INIT}
+-
+-/* Define to 1 if you have the `sbrk' function. */
+-#cmakedefine HAVE_SBRK ${HAVE_SBRK}
+-
+-/* Define to 1 if you have the `setenv' function. */
+-#cmakedefine HAVE_SETENV ${HAVE_SETENV}
+-
+-/* Define to 1 if you have the `setrlimit' function. */
+-#cmakedefine HAVE_SETRLIMIT ${HAVE_SETRLIMIT}
+-
+-/* Define to 1 if you have the `sigaltstack' function. */
+-#cmakedefine HAVE_SIGALTSTACK ${HAVE_SIGALTSTACK}
+-
+-/* Define to 1 if you have the <signal.h> header file. */
+-#cmakedefine HAVE_SIGNAL_H ${HAVE_SIGNAL_H}
+-
+-/* Define to 1 if you have the `strerror_r' function. */
+-#cmakedefine HAVE_STRERROR_R ${HAVE_STRERROR_R}
+-
+-/* Define to 1 if you have the `sysconf' function. */
+-#cmakedefine HAVE_SYSCONF ${HAVE_SYSCONF}
+-
+-/* Define to 1 if you have the <sys/ioctl.h> header file. */
+-#cmakedefine HAVE_SYS_IOCTL_H ${HAVE_SYS_IOCTL_H}
+-
+-/* Define to 1 if you have the <sys/mman.h> header file. */
+-#cmakedefine HAVE_SYS_MMAN_H ${HAVE_SYS_MMAN_H}
+-
+-/* Define to 1 if you have the <sys/param.h> header file. */
+-#cmakedefine HAVE_SYS_PARAM_H ${HAVE_SYS_PARAM_H}
+-
+-/* Define to 1 if you have the <sys/resource.h> header file. */
+-#cmakedefine HAVE_SYS_RESOURCE_H ${HAVE_SYS_RESOURCE_H}
+-
+-/* Define to 1 if you have the <sys/stat.h> header file. */
+-#cmakedefine HAVE_SYS_STAT_H ${HAVE_SYS_STAT_H}
+-
+-/* Define to 1 if you have the <sys/time.h> header file. */
+-#cmakedefine HAVE_SYS_TIME_H ${HAVE_SYS_TIME_H}
+-
+-/* Define to 1 if stat struct has st_mtimespec member .*/
+-#cmakedefine HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC ${HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC}
+-
+-/* Define to 1 if stat struct has st_mtim member. */
+-#cmakedefine HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC ${HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC}
+-
+-/* Define to 1 if you have the <sys/types.h> header file. */
+-#cmakedefine HAVE_SYS_TYPES_H ${HAVE_SYS_TYPES_H}
+-
+-/* Define if the setupterm() function is supported this platform. */
+-#cmakedefine LLVM_ENABLE_TERMINFO ${LLVM_ENABLE_TERMINFO}
+-
+-/* Define to 1 if you have the <termios.h> header file. */
+-#cmakedefine HAVE_TERMIOS_H ${HAVE_TERMIOS_H}
+-
+-/* Define to 1 if you have the <unistd.h> header file. */
+-#cmakedefine HAVE_UNISTD_H ${HAVE_UNISTD_H}
+-
+-/* Define to 1 if you have the <valgrind/valgrind.h> header file. */
+-#cmakedefine HAVE_VALGRIND_VALGRIND_H ${HAVE_VALGRIND_VALGRIND_H}
+-
+-/* Have host's _alloca */
+-#cmakedefine HAVE__ALLOCA ${HAVE__ALLOCA}
+-
+-/* Define to 1 if you have the `_chsize_s' function. */
+-#cmakedefine HAVE__CHSIZE_S ${HAVE__CHSIZE_S}
+-
+-/* Define to 1 if you have the `_Unwind_Backtrace' function. */
+-#cmakedefine HAVE__UNWIND_BACKTRACE ${HAVE__UNWIND_BACKTRACE}
+-
+-/* Have host's __alloca */
+-#cmakedefine HAVE___ALLOCA ${HAVE___ALLOCA}
+-
+-/* Have host's __ashldi3 */
+-#cmakedefine HAVE___ASHLDI3 ${HAVE___ASHLDI3}
+-
+-/* Have host's __ashrdi3 */
+-#cmakedefine HAVE___ASHRDI3 ${HAVE___ASHRDI3}
+-
+-/* Have host's __chkstk */
+-#cmakedefine HAVE___CHKSTK ${HAVE___CHKSTK}
+-
+-/* Have host's __chkstk_ms */
+-#cmakedefine HAVE___CHKSTK_MS ${HAVE___CHKSTK_MS}
+-
+-/* Have host's __cmpdi2 */
+-#cmakedefine HAVE___CMPDI2 ${HAVE___CMPDI2}
+-
+-/* Have host's __divdi3 */
+-#cmakedefine HAVE___DIVDI3 ${HAVE___DIVDI3}
+-
+-/* Have host's __fixdfdi */
+-#cmakedefine HAVE___FIXDFDI ${HAVE___FIXDFDI}
+-
+-/* Have host's __fixsfdi */
+-#cmakedefine HAVE___FIXSFDI ${HAVE___FIXSFDI}
+-
+-/* Have host's __floatdidf */
+-#cmakedefine HAVE___FLOATDIDF ${HAVE___FLOATDIDF}
+-
+-/* Have host's __lshrdi3 */
+-#cmakedefine HAVE___LSHRDI3 ${HAVE___LSHRDI3}
+-
+-/* Have host's __main */
+-#cmakedefine HAVE___MAIN ${HAVE___MAIN}
+-
+-/* Have host's __moddi3 */
+-#cmakedefine HAVE___MODDI3 ${HAVE___MODDI3}
+-
+-/* Have host's __udivdi3 */
+-#cmakedefine HAVE___UDIVDI3 ${HAVE___UDIVDI3}
+-
+-/* Have host's __umoddi3 */
+-#cmakedefine HAVE___UMODDI3 ${HAVE___UMODDI3}
+-
+-/* Have host's ___chkstk */
+-#cmakedefine HAVE____CHKSTK ${HAVE____CHKSTK}
+-
+-/* Have host's ___chkstk_ms */
+-#cmakedefine HAVE____CHKSTK_MS ${HAVE____CHKSTK_MS}
+-
+-/* Linker version detected at compile time. */
+-#cmakedefine HOST_LINK_VERSION "${HOST_LINK_VERSION}"
+-
+-/* Define if overriding target triple is enabled */
+-#cmakedefine LLVM_TARGET_TRIPLE_ENV "${LLVM_TARGET_TRIPLE_ENV}"
+-
+-/* Whether tools show host and target info when invoked with --version */
+-#cmakedefine01 LLVM_VERSION_PRINTER_SHOW_HOST_TARGET_INFO
+-
+-/* Define if libxml2 is supported on this platform. */
+-#cmakedefine LLVM_ENABLE_LIBXML2 ${LLVM_ENABLE_LIBXML2}
+-
+-/* Define to the extension used for shared libraries, say, ".so". */
+-#cmakedefine LTDL_SHLIB_EXT "${LTDL_SHLIB_EXT}"
+-
+-/* Define to the extension used for plugin libraries, say, ".so". */
+-#cmakedefine LLVM_PLUGIN_EXT "${LLVM_PLUGIN_EXT}"
+-
+-/* Define to the address where bug reports for this package should be sent. */
+-#cmakedefine PACKAGE_BUGREPORT "${PACKAGE_BUGREPORT}"
+-
+-/* Define to the full name of this package. */
+-#cmakedefine PACKAGE_NAME "${PACKAGE_NAME}"
+-
+-/* Define to the full name and version of this package. */
+-#cmakedefine PACKAGE_STRING "${PACKAGE_STRING}"
+-
+-/* Define to the version of this package. */
+-#cmakedefine PACKAGE_VERSION "${PACKAGE_VERSION}"
+-
+-/* Define to the vendor of this package. */
+-#cmakedefine PACKAGE_VENDOR "${PACKAGE_VENDOR}"
+-
+-/* Define to a function implementing stricmp */
+-#cmakedefine stricmp ${stricmp}
+-
+-/* Define to a function implementing strdup */
+-#cmakedefine strdup ${strdup}
+-
+-/* Whether GlobalISel rule coverage is being collected */
+-#cmakedefine01 LLVM_GISEL_COV_ENABLED
+-
+-/* Define to the default GlobalISel coverage file prefix */
+-#cmakedefine LLVM_GISEL_COV_PREFIX "${LLVM_GISEL_COV_PREFIX}"
+-
+-/* Whether Timers signpost passes in Xcode Instruments */
+-#cmakedefine01 LLVM_SUPPORT_XCODE_SIGNPOSTS
+-
+-#cmakedefine HAVE_PROC_PID_RUSAGE 1
+-
+-#cmakedefine HAVE_BUILTIN_THREAD_POINTER ${HAVE_BUILTIN_THREAD_POINTER}
+-
+-#endif
+diff --git a/utils/bazel/llvm_configs/llvm-config.h.cmake b/utils/bazel/llvm_configs/llvm-config.h.cmake
+deleted file mode 100644
+index 012ae2174..000000000
+--- a/utils/bazel/llvm_configs/llvm-config.h.cmake
++++ /dev/null
+@@ -1,129 +0,0 @@
+-/*===------- llvm/Config/llvm-config.h - llvm configuration -------*- C -*-===*/
+-/*                                                                            */
+-/* Part of the LLVM Project, under the Apache License v2.0 with LLVM          */
+-/* Exceptions.                                                                */
+-/* See https://llvm.org/LICENSE.txt for license information.                  */
+-/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    */
+-/*                                                                            */
+-/*===----------------------------------------------------------------------===*/
+-
+-/* This file enumerates variables from the LLVM configuration so that they
+-   can be in exported headers and won't override package specific directives.
+-   This is a C header that can be included in the llvm-c headers. */
+-
+-#ifndef LLVM_CONFIG_H
+-#define LLVM_CONFIG_H
+-
+-/* Define if LLVM_ENABLE_DUMP is enabled */
+-#cmakedefine LLVM_ENABLE_DUMP
+-
+-/* Target triple LLVM will generate code for by default */
+-/* Doesn't use `cmakedefine` because it is allowed to be empty. */
+-#define LLVM_DEFAULT_TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}"
+-
+-/* Define if threads enabled */
+-#cmakedefine01 LLVM_ENABLE_THREADS
+-
+-/* Has gcc/MSVC atomic intrinsics */
+-#cmakedefine01 LLVM_HAS_ATOMICS
+-
+-/* Host triple LLVM will be executed on */
+-#cmakedefine LLVM_HOST_TRIPLE "${LLVM_HOST_TRIPLE}"
+-
+-/* LLVM architecture name for the native architecture, if available */
+-#cmakedefine LLVM_NATIVE_ARCH ${LLVM_NATIVE_ARCH}
+-
+-/* LLVM name for the native AsmParser init function, if available */
+-#cmakedefine LLVM_NATIVE_ASMPARSER LLVMInitialize${LLVM_NATIVE_ARCH}AsmParser
+-
+-/* LLVM name for the native AsmPrinter init function, if available */
+-#cmakedefine LLVM_NATIVE_ASMPRINTER LLVMInitialize${LLVM_NATIVE_ARCH}AsmPrinter
+-
+-/* LLVM name for the native Disassembler init function, if available */
+-#cmakedefine LLVM_NATIVE_DISASSEMBLER LLVMInitialize${LLVM_NATIVE_ARCH}Disassembler
+-
+-/* LLVM name for the native Target init function, if available */
+-#cmakedefine LLVM_NATIVE_TARGET LLVMInitialize${LLVM_NATIVE_ARCH}Target
+-
+-/* LLVM name for the native TargetInfo init function, if available */
+-#cmakedefine LLVM_NATIVE_TARGETINFO LLVMInitialize${LLVM_NATIVE_ARCH}TargetInfo
+-
+-/* LLVM name for the native target MC init function, if available */
+-#cmakedefine LLVM_NATIVE_TARGETMC LLVMInitialize${LLVM_NATIVE_ARCH}TargetMC
+-
+-/* LLVM name for the native target MCA init function, if available */
+-#cmakedefine LLVM_NATIVE_TARGETMCA LLVMInitialize${LLVM_NATIVE_ARCH}TargetMCA
+-
+-/* Define if this is Unixish platform */
+-#cmakedefine LLVM_ON_UNIX ${LLVM_ON_UNIX}
+-
+-/* Define if we have the Intel JIT API runtime support library */
+-#cmakedefine01 LLVM_USE_INTEL_JITEVENTS
+-
+-/* Define if we have the oprofile JIT-support library */
+-#cmakedefine01 LLVM_USE_OPROFILE
+-
+-/* Define if we have the perf JIT-support library */
+-#cmakedefine01 LLVM_USE_PERF
+-
+-/* Major version of the LLVM API */
+-#define LLVM_VERSION_MAJOR ${LLVM_VERSION_MAJOR}
+-
+-/* Minor version of the LLVM API */
+-#define LLVM_VERSION_MINOR ${LLVM_VERSION_MINOR}
+-
+-/* Patch version of the LLVM API */
+-#define LLVM_VERSION_PATCH ${LLVM_VERSION_PATCH}
+-
+-/* LLVM version string */
+-#define LLVM_VERSION_STRING "${PACKAGE_VERSION}"
+-
+-/* Whether LLVM records statistics for use with GetStatistics(),
+- * PrintStatistics() or PrintStatisticsJSON()
+- */
+-#cmakedefine01 LLVM_FORCE_ENABLE_STATS
+-
+-/* Define if we have z3 and want to build it */
+-#cmakedefine LLVM_WITH_Z3 ${LLVM_WITH_Z3}
+-
+-/* Define if we have curl and want to use it */
+-#cmakedefine LLVM_ENABLE_CURL ${LLVM_ENABLE_CURL}
+-
+-/* Define if we have cpp-httplib and want to use it */
+-#cmakedefine LLVM_ENABLE_HTTPLIB ${LLVM_ENABLE_HTTPLIB}
+-
+-/* Define if zlib compression is available */
+-#cmakedefine01 LLVM_ENABLE_ZLIB
+-
+-/* Define if zstd compression is available */
+-#cmakedefine01 LLVM_ENABLE_ZSTD
+-
+-/* Define if LLVM is using tflite instead of libtensorflow */
+-#cmakedefine LLVM_HAVE_TFLITE
+-
+-/* Define to 1 if you have the <sysexits.h> header file. */
+-#cmakedefine HAVE_SYSEXITS_H ${HAVE_SYSEXITS_H}
+-
+-/* Define if the xar_open() function is supported on this platform. */
+-#cmakedefine LLVM_HAVE_LIBXAR ${LLVM_HAVE_LIBXAR}
+-
+-/* Define if building libLLVM shared library */
+-#cmakedefine LLVM_BUILD_LLVM_DYLIB
+-
+-/* Define if building LLVM with BUILD_SHARED_LIBS */
+-#cmakedefine LLVM_BUILD_SHARED_LIBS
+-
+-/* Define if building LLVM with LLVM_FORCE_USE_OLD_TOOLCHAIN_LIBS */
+-#cmakedefine LLVM_FORCE_USE_OLD_TOOLCHAIN ${LLVM_FORCE_USE_OLD_TOOLCHAIN}
+-
+-/* Define if llvm_unreachable should be optimized with undefined behavior
+- * in non assert builds */
+-#cmakedefine01 LLVM_UNREACHABLE_OPTIMIZE
+-
+-/* Define to 1 if you have the DIA SDK installed, and to 0 if you don't. */
+-#cmakedefine01 LLVM_ENABLE_DIA_SDK
+-
+-/* Define if plugins enabled */
+-#cmakedefine LLVM_ENABLE_PLUGINS
+-
+-#endif
+diff --git a/utils/bazel/overlay_directories.py b/utils/bazel/overlay_directories.py
+deleted file mode 100755
+index 526a78e97..000000000
+--- a/utils/bazel/overlay_directories.py
++++ /dev/null
+@@ -1,99 +0,0 @@
+-#!/bin/python3
+-
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-"""Overlays two directories into a target directory using symlinks.
+-
+-Tries to minimize the number of symlinks created (that is, does not symlink
+-every single file). Symlinks every file in the overlay directory. Only symlinks
+-individual files in the source directory if their parent directory is also
+-contained in the overlay directory tree.
+-"""
+-
+-import argparse
+-import errno
+-import os
+-import sys
+-
+-
+-def _check_python_version():
+-    if sys.version_info[0] < 3:
+-        raise RuntimeError(
+-            "Must be invoked with a python 3 interpreter but was %s" % sys.executable
+-        )
+-
+-
+-def _check_dir_exists(path):
+-    if not os.path.isdir(path):
+-        raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), path)
+-
+-
+-def parse_arguments():
+-    parser = argparse.ArgumentParser(
+-        description="""
+-    Overlays two directories into a target directory using symlinks.
+-
+-    Tries to minimize the number of symlinks created (that is, does not symlink
+-    every single file). Symlinks every file in the overlay directory. Only
+-    symlinks individual files in the source directory if their parent directory
+-    is also contained in the overlay directory tree.
+-    """
+-    )
+-    parser.add_argument(
+-        "--src",
+-        required=True,
+-        help="Directory that contains most of the content to symlink.",
+-    )
+-    parser.add_argument(
+-        "--overlay",
+-        required=True,
+-        help="Directory to overlay on top of the source directory.",
+-    )
+-    parser.add_argument(
+-        "--target",
+-        required=True,
+-        help="Directory in which to place the fused symlink directories.",
+-    )
+-
+-    args = parser.parse_args()
+-
+-    _check_dir_exists(args.target)
+-    _check_dir_exists(args.overlay)
+-    _check_dir_exists(args.src)
+-
+-    return args
+-
+-
+-def _symlink_abs(from_path, to_path):
+-    os.symlink(os.path.abspath(from_path), os.path.abspath(to_path))
+-
+-
+-def main(args):
+-    for root, dirs, files in os.walk(args.overlay):
+-        # We could do something more intelligent here and only symlink individual
+-        # files if the directory is present in both overlay and src. This could also
+-        # be generalized to an arbitrary number of directories without any
+-        # "src/overlay" distinction. In the current use case we only have two and
+-        # the overlay directory is always small, so putting that off for now.
+-        rel_root = os.path.relpath(root, start=args.overlay)
+-        if rel_root != ".":
+-            os.mkdir(os.path.join(args.target, rel_root))
+-
+-        for file in files:
+-            relpath = os.path.join(rel_root, file)
+-            _symlink_abs(
+-                os.path.join(args.overlay, relpath), os.path.join(args.target, relpath)
+-            )
+-
+-        for src_entry in os.listdir(os.path.join(args.src, rel_root)):
+-            if src_entry not in dirs:
+-                relpath = os.path.join(rel_root, src_entry)
+-                _symlink_abs(
+-                    os.path.join(args.src, relpath), os.path.join(args.target, relpath)
+-                )
+-
+-
+-if __name__ == "__main__":
+-    _check_python_version()
+-    main(parse_arguments())
+diff --git a/utils/bazel/third_party_build/BUILD b/utils/bazel/third_party_build/BUILD
+deleted file mode 100644
+index 98077a065..000000000
+--- a/utils/bazel/third_party_build/BUILD
++++ /dev/null
+@@ -1,5 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-licenses(["notice"])
+diff --git a/utils/bazel/third_party_build/gmp.BUILD b/utils/bazel/third_party_build/gmp.BUILD
+deleted file mode 100644
+index fb0c3bf75..000000000
+--- a/utils/bazel/third_party_build/gmp.BUILD
++++ /dev/null
+@@ -1,20 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make_variant")
+-
+-filegroup(
+-    name = "sources",
+-    srcs = glob(["**"]),
+-)
+-
+-configure_make_variant(
+-    name = "gmp",
+-    configure_options = ["--with-pic"],
+-    copts = ["-w"],
+-    lib_name = "libgmp",
+-    lib_source = ":sources",
+-    toolchain = "@rules_foreign_cc//toolchains:preinstalled_autoconf_toolchain",
+-    visibility = ["//visibility:public"],
+-)
+diff --git a/utils/bazel/third_party_build/mpfr.BUILD b/utils/bazel/third_party_build/mpfr.BUILD
+deleted file mode 100644
+index 6b4787482..000000000
+--- a/utils/bazel/third_party_build/mpfr.BUILD
++++ /dev/null
+@@ -1,33 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make_variant")
+-
+-filegroup(
+-    name = "sources",
+-    srcs = glob(["**"]),
+-)
+-
+-configure_make_variant(
+-    name = "mpfr",
+-    configure_options = ["--with-pic"],
+-    copts = ["-w"],
+-    lib_name = "libmpfr",
+-    lib_source = ":sources",
+-    toolchain = "@rules_foreign_cc//toolchains:preinstalled_autoconf_toolchain",
+-    visibility = ["//visibility:public"],
+-    deps = ["@gmp//:gmp_"],
+-)
+-
+-alias(
+-    name = "mpfr_external",
+-    actual = "@mpfr//:mpfr_",
+-    visibility = ["//visibility:public"],
+-)
+-
+-cc_library(
+-    name = "mpfr_system",
+-    linkopts = ["-lmpfr"],
+-    visibility = ["//visibility:public"],
+-)
+diff --git a/utils/bazel/third_party_build/pfm.BUILD b/utils/bazel/third_party_build/pfm.BUILD
+deleted file mode 100644
+index fe908d474..000000000
+--- a/utils/bazel/third_party_build/pfm.BUILD
++++ /dev/null
+@@ -1,31 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-load("@rules_foreign_cc//foreign_cc:defs.bzl", "make_variant")
+-
+-filegroup(
+-    name = "sources",
+-    srcs = glob(["**"]),
+-)
+-
+-make_variant(
+-    name = "pfm",
+-    copts = ["-w"],
+-    lib_name = "libpfm",
+-    lib_source = ":sources",
+-    toolchain = "@rules_foreign_cc//toolchains:preinstalled_autoconf_toolchain",
+-    visibility = ["//visibility:public"],
+-)
+-
+-alias(
+-    name = "pfm_external",
+-    actual = "@pfm//:pfm_",
+-    visibility = ["//visibility:public"],
+-)
+-
+-cc_library(
+-    name = "pfm_system",
+-    linkopts = ["-lpfm"],
+-    visibility = ["//visibility:public"],
+-)
+diff --git a/utils/bazel/third_party_build/vulkan_headers.BUILD b/utils/bazel/third_party_build/vulkan_headers.BUILD
+deleted file mode 100644
+index 33c0d98f5..000000000
+--- a/utils/bazel/third_party_build/vulkan_headers.BUILD
++++ /dev/null
+@@ -1,30 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-package(
+-    default_visibility = ["//visibility:public"],
+-    licenses = ["notice"],
+-)
+-
+-# Exports all headers but defining VK_NO_PROTOTYPES to disable the
+-# inclusion of C function prototypes. Useful if dynamically loading
+-# all symbols via dlopen/etc.
+-# Not all headers are hermetic, so they are just included as textual
+-# headers to disable additional validation.
+-cc_library(
+-    name = "vulkan_headers_no_prototypes",
+-    defines = ["VK_NO_PROTOTYPES"],
+-    includes = ["include"],
+-    textual_hdrs = glob(["include/vulkan/*.h"]),
+-)
+-
+-# Exports all headers, including C function prototypes. Useful if statically
+-# linking against the Vulkan SDK.
+-# Not all headers are hermetic, so they are just included as textual
+-# headers to disable additional validation.
+-cc_library(
+-    name = "vulkan_headers",
+-    includes = ["include"],
+-    textual_hdrs = glob(["include/vulkan/*.h"]),
+-)
+diff --git a/utils/bazel/third_party_build/zlib-ng.BUILD b/utils/bazel/third_party_build/zlib-ng.BUILD
+deleted file mode 100644
+index c41ea450f..000000000
+--- a/utils/bazel/third_party_build/zlib-ng.BUILD
++++ /dev/null
+@@ -1,108 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+-load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+-
+-package(
+-    default_visibility = ["//visibility:public"],
+-    # BSD/MIT-like license (for zlib)
+-    licenses = ["notice"],
+-)
+-
+-bool_flag(
+-    name = "llvm_enable_zlib",
+-    build_setting_default = True,
+-)
+-
+-config_setting(
+-    name = "llvm_zlib_enabled",
+-    flag_values = {":llvm_enable_zlib": "true"},
+-)
+-
+-genrule(
+-    # The input template is identical to the CMake output.
+-    name = "zconf_gen",
+-    srcs = ["zconf.h.in"],
+-    outs = ["zconf.h"],
+-    cmd = "cp $(SRCS) $(OUTS)",
+-)
+-
+-cc_library(
+-    name = "zlib",
+-    srcs = select({
+-        ":llvm_zlib_enabled": [
+-            "adler32_p.h",
+-            "chunkset_tpl.h",
+-            "crc32_p.h",
+-            "crc32_tbl.h",
+-            "crc32_comb_tbl.h",
+-            "deflate.h",
+-            "deflate_p.h",
+-            "functable.h",
+-            "fallback_builtins.h",
+-            "inffast.h",
+-            "inffixed_tbl.h",
+-            "inflate.h",
+-            "inflate_p.h",
+-            "inftrees.h",
+-            "insert_string_tpl.h",
+-            "match_tpl.h",
+-            "trees.h",
+-            "trees_emit.h",
+-            "trees_tbl.h",
+-            "zbuild.h",
+-            "zendian.h",
+-            "zutil.h",
+-            "adler32.c",
+-            "chunkset.c",
+-            "compare258.c",
+-            "compress.c",
+-            "crc32.c",
+-            "crc32_comb.c",
+-            "deflate.c",
+-            "deflate_fast.c",
+-            "deflate_medium.c",
+-            "deflate_quick.c",
+-            "deflate_slow.c",
+-            "functable.c",
+-            "infback.c",
+-            "inffast.c",
+-            "inflate.c",
+-            "inftrees.c",
+-            "insert_string.c",
+-            "trees.c",
+-            "uncompr.c",
+-            "zutil_p.h",
+-            "zutil.c",
+-        ],
+-        "//conditions:default": [],
+-    }),
+-    hdrs = select({
+-        ":llvm_zlib_enabled": [
+-            "zlib.h",
+-            ":zconf_gen",
+-        ],
+-        "//conditions:default": [],
+-    }),
+-    copts = [
+-        "-std=c11",
+-        "-DZLIB_COMPAT",
+-        "-DWITH_GZFILEOP",
+-        "-DWITH_OPTIM",
+-        "-DWITH_NEW_STRATEGIES",
+-        # For local builds you might want to add "-DWITH_NATIVE_INSTRUCTIONS"
+-        # here to improve performance. Native instructions aren't enabled in
+-        # the default config for reproducibility.
+-    ],
+-    defines = select({
+-        ":llvm_zlib_enabled": [
+-            "LLVM_ENABLE_ZLIB=1",
+-        ],
+-        "//conditions:default": [],
+-    }),
+-    # Clang includes zlib with angled instead of quoted includes, so we need
+-    # strip_include_prefix here.
+-    strip_include_prefix = ".",
+-    visibility = ["//visibility:public"],
+-)
+diff --git a/utils/bazel/third_party_build/zstd.BUILD b/utils/bazel/third_party_build/zstd.BUILD
+deleted file mode 100644
+index 510c46139..000000000
+--- a/utils/bazel/third_party_build/zstd.BUILD
++++ /dev/null
+@@ -1,54 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+-
+-package(
+-    default_visibility = ["//visibility:public"],
+-    # BSD/MIT-like license (for zstd)
+-    licenses = ["notice"],
+-)
+-
+-bool_flag(
+-    name = "llvm_enable_zstd",
+-    build_setting_default = True,
+-)
+-
+-config_setting(
+-    name = "llvm_zstd_enabled",
+-    flag_values = {":llvm_enable_zstd": "true"},
+-)
+-
+-cc_library(
+-    name = "zstd",
+-    srcs = select({
+-        ":llvm_zstd_enabled": glob([
+-            "lib/common/*.c",
+-            "lib/common/*.h",
+-            "lib/compress/*.c",
+-            "lib/compress/*.h",
+-            "lib/decompress/*.c",
+-            "lib/decompress/*.h",
+-            "lib/decompress/*.S",
+-            "lib/dictBuilder/*.c",
+-            "lib/dictBuilder/*.h",
+-        ]),
+-        "//conditions:default": [],
+-    }),
+-    hdrs = select({
+-        ":llvm_zstd_enabled": [
+-            "lib/zstd.h",
+-            "lib/zdict.h",
+-            "lib/zstd_errors.h",
+-        ],
+-        "//conditions:default": [],
+-    }),
+-    defines = select({
+-        ":llvm_zstd_enabled": [
+-            "LLVM_ENABLE_ZSTD=1",
+-            "ZSTD_MULTITHREAD",
+-        ],
+-        "//conditions:default": [],
+-    }),
+-    strip_include_prefix = "lib",
+-)
+diff --git a/utils/bazel/vulkan_sdk.bzl b/utils/bazel/vulkan_sdk.bzl
+deleted file mode 100644
+index e23dc4213..000000000
+--- a/utils/bazel/vulkan_sdk.bzl
++++ /dev/null
+@@ -1,43 +0,0 @@
+-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+-# See https://llvm.org/LICENSE.txt for license information.
+-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-
+-"""Repository rule to statically link against the Vulkan SDK.
+-
+-Requires installing the Vulkan SDK from https://vulkan.lunarg.com/.
+-
+-If the Vulkan SDK is not installed, this generates an empty rule and you may
+-encounter linker errors like `error: undefined reference to 'vkCreateInstance'`.
+-"""
+-
+-def _impl(repository_ctx):
+-    if "VULKAN_SDK" in repository_ctx.os.environ:
+-        sdk_path = repository_ctx.os.environ["VULKAN_SDK"]
+-        repository_ctx.symlink(sdk_path, "vulkan-sdk")
+-
+-        repository_ctx.file("BUILD", """
+-cc_library(
+-    name = "sdk",
+-    srcs = select({
+-        "@platforms//os:windows": [
+-            "vulkan-sdk/Lib/vulkan-1.lib"
+-        ],
+-        "//conditions:default": [
+-            "vulkan-sdk/lib/libvulkan.so.1",
+-        ],
+-    }),
+-    visibility = ["//visibility:public"],
+-)""")
+-    else:
+-        # Empty rule. Will fail to link for just targets that use Vulkan.
+-        repository_ctx.file("BUILD", """
+-cc_library(
+-    name = "sdk",
+-    srcs = [],
+-    visibility = ["//visibility:public"],
+-)""")
+-
+-vulkan_sdk_setup = repository_rule(
+-    implementation = _impl,
+-    local = True,
+-)
+diff --git a/utils/bazel/llvm-project-overlay/workspace_root.bzl b/workspace_root.bzl
+similarity index 100%
+rename from utils/bazel/llvm-project-overlay/workspace_root.bzl
+rename to workspace_root.bzl

--- a/modules/llvm-project/17.0.3/patches/0003-Add-MODULE.bazel.patch
+++ b/modules/llvm-project/17.0.3/patches/0003-Add-MODULE.bazel.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Thu, 19 Oct 2023 14:58:38 +0000
+Subject: [PATCH] Add `MODULE.bazel`
+
+---
+ MODULE.bazel | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+ create mode 100644 MODULE.bazel
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 000000000..f945718c2
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,11 @@
++module(
++    name = "llvm-project",
++    version = "17.0.3",
++)
++
++# Skylark depedndencies
++bazel_dep(name = "bazel_skylib", version = "1.3.0")
++
++# Library dependencies
++bazel_dep(name = "platforms", version = "0.0.7")
++bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/llvm-project/17.0.3/patches/0004-Add-BUILD.bazel.patch
+++ b/modules/llvm-project/17.0.3/patches/0004-Add-BUILD.bazel.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Thu, 19 Oct 2023 15:05:58 +0000
+Subject: [PATCH] Add `BUILD.bazel`
+
+---
+ BUILD.bazel | 4 ++++
+ 1 file changed, 4 insertions(+)
+ create mode 100644 BUILD.bazel
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 000000000..05c507654
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,4 @@
++# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
++# See https://llvm.org/LICENSE.txt for license information.
++# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
++

--- a/modules/llvm-project/17.0.3/patches/0005-Add-Bazel-LLVM-targets.patch
+++ b/modules/llvm-project/17.0.3/patches/0005-Add-Bazel-LLVM-targets.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Thu, 19 Oct 2023 15:00:17 +0000
+Subject: [PATCH] Add Bazel LLVM targets
+
+The repository configuration step of the overlay generates the
+`llvm/targets.bzl`. We can generate it ourselves by using the
+`DEFAULT_TARGETS`:
+
+```sh
+tr '\n' ' ' < utils/bazel/configure.bzl |
+grep -o 'DEFAULT_TARGETS *= *\[[^]]\+\]' |
+sed \
+  -e 's|DEFAULT_TARGETS|llvm_targets|' \
+  -e 's|,\( *\)|,\n\1|g' \
+  -e 's|\[|[\n|' \
+> llvm/targets.bzl
+```
+---
+ llvm/targets.bzl | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+ create mode 100644 llvm/targets.bzl
+
+diff --git a/llvm/targets.bzl b/llvm/targets.bzl
+new file mode 100644
+index 000000000..7a31d801e
+--- /dev/null
++++ b/llvm/targets.bzl
+@@ -0,0 +1,21 @@
++llvm_targets = [
++    "AArch64",
++    "AMDGPU",
++    "ARM",
++    "AVR",
++    "BPF",
++    "Hexagon",
++    "Lanai",
++    "LoongArch",
++    "Mips",
++    "MSP430",
++    "NVPTX",
++    "PowerPC",
++    "RISCV",
++    "Sparc",
++    "SystemZ",
++    "VE",
++    "WebAssembly",
++    "X86",
++    "XCore",
++]

--- a/modules/llvm-project/17.0.3/patches/0006-Add-LLVM-version-vars.patch
+++ b/modules/llvm-project/17.0.3/patches/0006-Add-LLVM-version-vars.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Thu, 19 Oct 2023 15:01:20 +0000
+Subject: [PATCH] Add LLVM version vars
+
+The repository configuration step of the overlay generates the
+`vars.bzl`. We have to add it manually.
+---
+ vars.bzl | 5 +++++
+ 1 file changed, 5 insertions(+)
+ create mode 100644 vars.bzl
+
+diff --git a/vars.bzl b/vars.bzl
+new file mode 100644
+index 000000000..d744043d9
+--- /dev/null
++++ b/vars.bzl
+@@ -0,0 +1,5 @@
++LLVM_VERSION = "17.0.3"
++LLVM_VERSION_MAJOR = 17
++LLVM_VERSION_MINOR = 0
++LLVM_VERSION_PATCH = 3
++

--- a/modules/llvm-project/17.0.3/patches/0007-Guard-against-empty-workspace-root.patch
+++ b/modules/llvm-project/17.0.3/patches/0007-Guard-against-empty-workspace-root.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Thu, 19 Oct 2023 15:02:08 +0000
+Subject: [PATCH] Guard against empty workspace root
+
+The workspace root in `llvm/tblgen.bzl` is empty when running the build
+from the root directory of the project. Default to `"."` to avoid
+include errors resulting from this.
+---
+ llvm/tblgen.bzl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/llvm/tblgen.bzl b/llvm/tblgen.bzl
+index d43390918..9486edf29 100644
+--- a/llvm/tblgen.bzl
++++ b/llvm/tblgen.bzl
+@@ -35,7 +35,7 @@ def gentbl(
+       tblgen_args: Extra arguments string to pass to the tblgen binary.
+       **kwargs: Keyword arguments to pass to subsidiary cc_library() rule.
+     """
+-    llvm_project_execroot_path = Label("//llvm:tblgen.bzl").workspace_root
++    llvm_project_execroot_path = Label("//llvm:tblgen.bzl").workspace_root or "."
+ 
+     if td_file not in td_srcs:
+         td_srcs += [td_file]

--- a/modules/llvm-project/17.0.3/patches/0008-Correct-builtin-headers-prefix.patch
+++ b/modules/llvm-project/17.0.3/patches/0008-Correct-builtin-headers-prefix.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Fri, 20 Oct 2023 10:57:18 +0000
+Subject: [PATCH] Correct builtin headers prefix
+
+`$${src#*clang/lib/Headers}` works when building from the
+`llvm-project` root as well.
+---
+ clang/BUILD.bazel | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/clang/BUILD.bazel b/clang/BUILD.bazel
+index 037719a51..ec87a37e2 100644
+--- a/clang/BUILD.bazel
++++ b/clang/BUILD.bazel
+@@ -1691,7 +1691,7 @@ genrule(
+     outs = [hdr.replace("lib/Headers/", "staging/include/") for hdr in builtin_headers],
+     cmd = """
+        for src in $(SRCS); do
+-         relsrc=$${src#*"$(WORKSPACE_ROOT)"/clang/lib/Headers}
++         relsrc=$${src#*clang/lib/Headers}
+          target=$(@D)/staging/include/$$relsrc
+          mkdir -p $$(dirname $$target)
+          cp $$src $$target

--- a/modules/llvm-project/17.0.3/patches/0009-Fix-an-operator-overload-for-GCC-8.3.patch
+++ b/modules/llvm-project/17.0.3/patches/0009-Fix-an-operator-overload-for-GCC-8.3.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Tue, 24 Oct 2023 11:48:21 +0000
+Subject: [PATCH] Fix an operator overload for GCC 8.3
+
+Rewrite an operator overload to be more explicit to make GCC 8.3 happy.
+This is not needed for GCC 8.4+ and Clang.
+---
+ llvm/include/llvm/ADT/STLExtras.h | 37 ++++++++++++++++++++++---------
+ 1 file changed, 27 insertions(+), 10 deletions(-)
+
+diff --git a/llvm/include/llvm/ADT/STLExtras.h b/llvm/include/llvm/ADT/STLExtras.h
+index 7edc58263..3195c007d 100644
+--- a/llvm/include/llvm/ADT/STLExtras.h
++++ b/llvm/include/llvm/ADT/STLExtras.h
+@@ -1292,16 +1292,16 @@ public:
+   }
+ 
+   /// Compare this range with another.
+-  template <typename OtherT>
+-  friend bool operator==(const indexed_accessor_range_base &lhs,
+-                         const OtherT &rhs) {
+-    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+-  }
+-  template <typename OtherT>
+-  friend bool operator!=(const indexed_accessor_range_base &lhs,
+-                         const OtherT &rhs) {
+-    return !(lhs == rhs);
+-  }
++  template <typename DerivedT0, typename BaseT0, typename T0,
++            typename PointerT0, typename ReferenceT0,
++            typename OtherT>
++  friend bool operator==(const indexed_accessor_range_base<DerivedT0, BaseT0, T0, PointerT0, ReferenceT0> &lhs,
++                         const OtherT &rhs);
++  template <typename DerivedT0, typename BaseT0, typename T0,
++            typename PointerT0, typename ReferenceT0,
++            typename OtherT>
++  friend bool operator!=(const indexed_accessor_range_base<DerivedT0, BaseT0, T0, PointerT0, ReferenceT0> &lhs,
++                         const OtherT &rhs);
+ 
+   /// Return the size of this range.
+   size_t size() const { return count; }
+@@ -1365,6 +1365,23 @@ protected:
+   /// The size from the owning range.
+   ptrdiff_t count;
+ };
++
++template <typename DerivedT, typename BaseT, typename T,
++          typename PointerT, typename ReferenceT,
++          typename OtherT>
++bool operator==(const indexed_accessor_range_base<DerivedT, BaseT, T, PointerT, ReferenceT> &lhs,
++                const OtherT &rhs) {
++  return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
++}
++
++template <typename DerivedT, typename BaseT, typename T,
++          typename PointerT, typename ReferenceT,
++          typename OtherT>
++bool operator!=(const indexed_accessor_range_base<DerivedT, BaseT, T, PointerT, ReferenceT> &lhs,
++                const OtherT &rhs) {
++  return !(lhs == rhs);
++}
++
+ } // end namespace detail
+ 
+ /// This class provides an implementation of a range of

--- a/modules/llvm-project/17.0.3/patches/0010-Use-TEST_TMPDIR-on-Unix-when-it-is-set.patch
+++ b/modules/llvm-project/17.0.3/patches/0010-Use-TEST_TMPDIR-on-Unix-when-it-is-set.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Tue, 24 Oct 2023 12:29:50 +0000
+Subject: [PATCH] Use `TEST_TMPDIR` on Unix when it is set
+
+Other directories (`TMPDIR`, `TMP`, `TEMP`, etc) might not be
+available, so use Bazel's `TEST_TMPDIR` when it is set.
+---
+ llvm/lib/Support/Unix/Path.inc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/llvm/lib/Support/Unix/Path.inc b/llvm/lib/Support/Unix/Path.inc
+index e2aece49c..52ef00e4d 100644
+--- a/llvm/lib/Support/Unix/Path.inc
++++ b/llvm/lib/Support/Unix/Path.inc
+@@ -1427,7 +1427,7 @@ bool cache_directory(SmallVectorImpl<char> &result) {
+ static const char *getEnvTempDir() {
+   // Check whether the temporary directory is specified by an environment
+   // variable.
+-  const char *EnvironmentVariables[] = {"TMPDIR", "TMP", "TEMP", "TEMPDIR"};
++  const char *EnvironmentVariables[] = {"TEST_TMPDIR", "TMPDIR", "TMP", "TEMP", "TEMPDIR"};
+   for (const char *Env : EnvironmentVariables) {
+     if (const char *Dir = std::getenv(Env))
+       return Dir;

--- a/modules/llvm-project/17.0.3/patches/0011-Use-Windows-assembly-files-for-BLAKE3-on-Windows.patch
+++ b/modules/llvm-project/17.0.3/patches/0011-Use-Windows-assembly-files-for-BLAKE3-on-Windows.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Tue, 24 Oct 2023 14:52:10 +0000
+Subject: [PATCH] Use Windows assembly files for BLAKE3 on Windows
+
+Use Windows assembly files instead of Unix ones when running on
+Windows.
+---
+ llvm/BUILD.bazel | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/llvm/BUILD.bazel b/llvm/BUILD.bazel
+index a7e9398ea..ef5299138 100644
+--- a/llvm/BUILD.bazel
++++ b/llvm/BUILD.bazel
+@@ -220,6 +220,12 @@ cc_library(
+         "@platforms//cpu:aarch64": [
+             "lib/Support/BLAKE3/blake3_neon.c",
+         ],
++        "@bazel_tools//src/conditions:windows_x64": [
++            "lib/Support/BLAKE3/blake3_avx2_x86-64_windows_msvc.asm",
++            "lib/Support/BLAKE3/blake3_avx512_x86-64_windows_msvc.asm",
++            "lib/Support/BLAKE3/blake3_sse2_x86-64_windows_msvc.asm",
++            "lib/Support/BLAKE3/blake3_sse41_x86-64_windows_msvc.asm",
++        ],
+         "@platforms//cpu:x86_64": [
+             "lib/Support/BLAKE3/blake3_avx2_x86-64_unix.S",
+             "lib/Support/BLAKE3/blake3_avx512_x86-64_unix.S",

--- a/modules/llvm-project/17.0.3/patches/0012-Add-scope-resolution-operators-for-MSVC-2019.patch
+++ b/modules/llvm-project/17.0.3/patches/0012-Add-scope-resolution-operators-for-MSVC-2019.patch
@@ -1,0 +1,140 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Wed, 25 Oct 2023 17:35:31 +0000
+Subject: [PATCH] Add scope resolution operators for MSVC 2019
+
+In several places MSVC 2019 cannot determine which namespace `llvm`
+refers to. Adding explicit `::` fixes this.
+---
+ llvm/include/llvm/ADT/DenseMap.h            |  2 +-
+ llvm/include/llvm/ADT/bit.h                 | 20 ++++++++++----------
+ llvm/include/llvm/Support/MathExtras.h      |  2 +-
+ llvm/include/llvm/Support/TrailingObjects.h |  2 +-
+ 4 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/llvm/include/llvm/ADT/DenseMap.h b/llvm/include/llvm/ADT/DenseMap.h
+index 3ef6a7cd1..5a0121fd5 100644
+--- a/llvm/include/llvm/ADT/DenseMap.h
++++ b/llvm/include/llvm/ADT/DenseMap.h
+@@ -933,7 +933,7 @@ class SmallDenseMap
+ public:
+   explicit SmallDenseMap(unsigned NumInitBuckets = 0) {
+     if (NumInitBuckets > InlineBuckets)
+-      NumInitBuckets = llvm::bit_ceil(NumInitBuckets);
++      NumInitBuckets = ::llvm::bit_ceil(NumInitBuckets);
+     init(NumInitBuckets);
+   }
+ 
+diff --git a/llvm/include/llvm/ADT/bit.h b/llvm/include/llvm/ADT/bit.h
+index 2840c5f60..8a9832e48 100644
+--- a/llvm/include/llvm/ADT/bit.h
++++ b/llvm/include/llvm/ADT/bit.h
+@@ -96,8 +96,8 @@ template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+ #elif defined(_MSC_VER) && !defined(_DEBUG)
+     return _byteswap_uint64(UV);
+ #else
+-    uint64_t Hi = llvm::byteswap<uint32_t>(UV);
+-    uint32_t Lo = llvm::byteswap<uint32_t>(UV >> 32);
++    uint64_t Hi = ::llvm::byteswap<uint32_t>(UV);
++    uint32_t Lo = ::llvm::byteswap<uint32_t>(UV >> 32);
+     return (Hi << 32) | Lo;
+ #endif
+   } else {
+@@ -179,7 +179,7 @@ template <typename T> struct TrailingZerosCounter<T, 8> {
+ template <typename T> [[nodiscard]] int countr_zero(T Val) {
+   static_assert(std::is_unsigned_v<T>,
+                 "Only unsigned integral types are allowed.");
+-  return llvm::detail::TrailingZerosCounter<T, sizeof(T)>::count(Val);
++  return ::llvm::detail::TrailingZerosCounter<T, sizeof(T)>::count(Val);
+ }
+ 
+ namespace detail {
+@@ -245,7 +245,7 @@ template <typename T> struct LeadingZerosCounter<T, 8> {
+ template <typename T> [[nodiscard]] int countl_zero(T Val) {
+   static_assert(std::is_unsigned_v<T>,
+                 "Only unsigned integral types are allowed.");
+-  return llvm::detail::LeadingZerosCounter<T, sizeof(T)>::count(Val);
++  return ::llvm::detail::LeadingZerosCounter<T, sizeof(T)>::count(Val);
+ }
+ 
+ /// Count the number of ones from the most significant bit to the first
+@@ -258,7 +258,7 @@ template <typename T> [[nodiscard]] int countl_zero(T Val) {
+ template <typename T> [[nodiscard]] int countl_one(T Value) {
+   static_assert(std::is_unsigned_v<T>,
+                 "Only unsigned integral types are allowed.");
+-  return llvm::countl_zero<T>(~Value);
++  return ::llvm::countl_zero<T>(~Value);
+ }
+ 
+ /// Count the number of ones from the least significant bit to the first
+@@ -271,7 +271,7 @@ template <typename T> [[nodiscard]] int countl_one(T Value) {
+ template <typename T> [[nodiscard]] int countr_one(T Value) {
+   static_assert(std::is_unsigned_v<T>,
+                 "Only unsigned integral types are allowed.");
+-  return llvm::countr_zero<T>(~Value);
++  return ::llvm::countr_zero<T>(~Value);
+ }
+ 
+ /// Returns the number of bits needed to represent Value if Value is nonzero.
+@@ -281,7 +281,7 @@ template <typename T> [[nodiscard]] int countr_one(T Value) {
+ template <typename T> [[nodiscard]] int bit_width(T Value) {
+   static_assert(std::is_unsigned_v<T>,
+                 "Only unsigned integral types are allowed.");
+-  return std::numeric_limits<T>::digits - llvm::countl_zero(Value);
++  return std::numeric_limits<T>::digits - ::llvm::countl_zero(Value);
+ }
+ 
+ /// Returns the largest integral power of two no greater than Value if Value is
+@@ -308,7 +308,7 @@ template <typename T> [[nodiscard]] T bit_ceil(T Value) {
+                 "Only unsigned integral types are allowed.");
+   if (Value < 2)
+     return 1;
+-  return T(1) << llvm::bit_width<T>(Value - 1u);
++  return T(1) << ::llvm::bit_width<T>(Value - 1u);
+ }
+ 
+ namespace detail {
+@@ -363,7 +363,7 @@ template <typename T, typename = std::enable_if_t<std::is_unsigned_v<T>>>
+     return V;
+ 
+   if (R < 0)
+-    return llvm::rotr(V, -R);
++    return ::llvm::rotr(V, -R);
+ 
+   return (V << R) | (V >> (N - R));
+ }
+@@ -376,7 +376,7 @@ template <typename T, typename> [[nodiscard]] constexpr T rotr(T V, int R) {
+     return V;
+ 
+   if (R < 0)
+-    return llvm::rotl(V, -R);
++    return ::llvm::rotl(V, -R);
+ 
+   return (V >> R) | (V << (N - R));
+ }
+diff --git a/llvm/include/llvm/Support/MathExtras.h b/llvm/include/llvm/Support/MathExtras.h
+index dc095941f..f76f042a8 100644
+--- a/llvm/include/llvm/Support/MathExtras.h
++++ b/llvm/include/llvm/Support/MathExtras.h
+@@ -300,7 +300,7 @@ inline bool isShiftedMask_64(uint64_t Value, unsigned &MaskIdx,
+ /// Compile time Log2.
+ /// Valid only for positive powers of two.
+ template <size_t kValue> constexpr inline size_t CTLog2() {
+-  static_assert(kValue > 0 && llvm::isPowerOf2_64(kValue),
++  static_assert(kValue > 0 && ::llvm::isPowerOf2_64(kValue),
+                 "Value is not a valid power of 2");
+   return 1 + CTLog2<kValue / 2>();
+ }
+diff --git a/llvm/include/llvm/Support/TrailingObjects.h b/llvm/include/llvm/Support/TrailingObjects.h
+index f8a546b5c..ab82acd6e 100644
+--- a/llvm/include/llvm/Support/TrailingObjects.h
++++ b/llvm/include/llvm/Support/TrailingObjects.h
+@@ -177,7 +177,7 @@ protected:
+       size_t SizeSoFar, size_t Count1,
+       typename ExtractSecondType<MoreTys, size_t>::type... MoreCounts) {
+     return ParentType::additionalSizeToAllocImpl(
+-        (requiresRealignment() ? llvm::alignTo<alignof(NextTy)>(SizeSoFar)
++        (requiresRealignment() ? ::llvm::alignTo<alignof(NextTy)>(SizeSoFar)
+                                : SizeSoFar) +
+             sizeof(NextTy) * Count1,
+         MoreCounts...);

--- a/modules/llvm-project/17.0.3/patches/0013-Disable-zlib-zstd-mpfr-and-pfm.patch
+++ b/modules/llvm-project/17.0.3/patches/0013-Disable-zlib-zstd-mpfr-and-pfm.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander Khabarov <alexander.khabarov@arm.com>
+Date: Thu, 19 Oct 2023 15:07:57 +0000
+Subject: [PATCH] Disable `zlib`, `zstd`, `mpfr` and `pfm`
+
+`zlib`, `zstd`, `mpfr` and `pfm` are optional dependencies.
+---
+ libc/BUILD.bazel |  2 +-
+ lld/BUILD.bazel  |  4 ++--
+ llvm/BUILD.bazel | 12 +++---------
+ 3 files changed, 6 insertions(+), 12 deletions(-)
+
+diff --git a/libc/BUILD.bazel b/libc/BUILD.bazel
+index 0ee339526..51676d039 100644
+--- a/libc/BUILD.bazel
++++ b/libc/BUILD.bazel
+@@ -39,7 +39,7 @@ MEMORY_COPTS = [
+ # Flag documentation: https://bazel.build/extending/config
+ string_flag(
+     name = "mpfr",
+-    build_setting_default = "external",
++    build_setting_default = "disable",
+     values = [
+         "disable",  # Skip tests that need mpfr
+         "external",  # Build mpfr from source
+diff --git a/lld/BUILD.bazel b/lld/BUILD.bazel
+index fb6e2397c..2cb2fab44 100644
+--- a/lld/BUILD.bazel
++++ b/lld/BUILD.bazel
+@@ -108,8 +108,8 @@ cc_library(
+         "//llvm:TargetParser",
+         "//llvm:TransformUtils",
+         "//llvm:config",
+-        "@llvm_zlib//:zlib",
+-        "@llvm_zstd//:zstd",
++        # "@llvm_zlib//:zlib",
++        # "@llvm_zstd//:zstd",
+     ],
+ )
+ 
+diff --git a/llvm/BUILD.bazel b/llvm/BUILD.bazel
+index ef5299138..836d4049e 100644
+--- a/llvm/BUILD.bazel
++++ b/llvm/BUILD.bazel
+@@ -291,14 +291,8 @@ cc_library(
+     deps = [
+         ":config",
+         ":Demangle",
+-        # We unconditionally depend on the custom LLVM zlib wrapper. This will
+-        # be an empty library unless zlib is enabled, in which case it will
+-        # both provide the necessary dependencies and configuration defines.
+-        "@llvm_zlib//:zlib",
+-        # We unconditionally depend on the custom LLVM zstd wrapper. This will
+-        # be an empty library unless zstd is enabled, in which case it will
+-        # both provide the necessary dependencies and configuration defines.
+-        "@llvm_zstd//:zstd",
++        # "@llvm_zlib//:zlib",
++        # "@llvm_zstd//:zstd",
+     ],
+ )
+ 
+@@ -2959,7 +2953,7 @@ cc_library(
+ # Flag documentation: https://bazel.build/extending/config
+ string_flag(
+     name = "pfm",
+-    build_setting_default = "external",
++    build_setting_default = "disable",
+     values = [
+         "disable",  # Don't include pfm at all
+         "external",  # Build pfm from source

--- a/modules/llvm-project/17.0.3/presubmit.yml
+++ b/modules/llvm-project/17.0.3/presubmit.yml
@@ -1,0 +1,42 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+tasks:
+  run_tests:
+    name: Run LLVM unit tests
+    platform: ${{ platform }}
+    test_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    test_targets:
+    - '@llvm-project//llvm/unittests:all'
+    - '@llvm-project//clang/unittests:all'
+  run_tests_macos:
+    name: Run LLVM unit tests
+    platform: macos
+    test_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    - '--test_tmpdir=ci' # Avoid CI permissions error on macOS
+    test_targets:
+    - '@llvm-project//llvm/unittests:all'
+    - '@llvm-project//clang/unittests:all'
+  run_tests_macos_arm64:
+    name: Run LLVM unit tests
+    platform: macos_arm64
+    test_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    - '--test_tmpdir=ci' # Avoid CI permissions error on macOS
+    test_targets:
+    - '@llvm-project//llvm/unittests:all'
+    - '@llvm-project//clang/unittests:all'
+  run_tests_windows:
+    name: Run LLVM unit tests
+    platform: windows
+    test_flags:
+    - '--cxxopt=/std:c++17'
+    - '--host_cxxopt=/std:c++17'
+    test_targets:
+    - '@llvm-project//llvm/unittests:ir_tests'

--- a/modules/llvm-project/17.0.3/source.json
+++ b/modules/llvm-project/17.0.3/source.json
@@ -1,0 +1,21 @@
+{
+    "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.3/llvm-project-17.0.3.src.tar.xz",
+    "integrity": "sha256-vloeRNZPMGu0T859NuOzmTaU6OYSKyNIYIkGKDwXbbg=",
+    "strip_prefix": "llvm-project-17.0.3.src",
+    "patches": {
+        "0001-Add-Bazel-files-to-.gitignore.patch": "sha256-JC5X1fmrDR0auseyjZxlo9zyb242FgjaXPqkVewh7uc=",
+        "0002-Add-LLVM-Bazel-overlay-files.patch": "sha256-w7Lz/Km3RGzKCW4IwFI61p8nNjRMMcT8T0uK4Y1aans=",
+        "0003-Add-MODULE.bazel.patch": "sha256-M/vflD6/P1+V5o2a/1YtVZbx4uFyKyVYiwpadptgWNs=",
+        "0004-Add-BUILD.bazel.patch": "sha256-CEeI0zIB9Q2Gmg+bHl9+xlOMPCektFA1CuiDVJUuJvY=",
+        "0005-Add-Bazel-LLVM-targets.patch": "sha256-2MqswOFWJWqE4Dh/iWsinsVgEatqT6DtE9f4gx8+SgA=",
+        "0006-Add-LLVM-version-vars.patch": "sha256-pMrccxE0q/iD6T97t1x9QFCdndi9zUrhF6mY/o+TXt8=",
+        "0007-Guard-against-empty-workspace-root.patch": "sha256-8X3dV9gO0IYBCZ+KLNIV2YqzYQU2lZVJVPIKeLz00zI=",
+        "0008-Correct-builtin-headers-prefix.patch": "sha256-jlbVGyo5Hy+HWhs6GkLKKltOdlKC42DUqzwm6X0oePw=",
+        "0009-Fix-an-operator-overload-for-GCC-8.3.patch": "sha256-H6g6djsyxbtUISZFUPJJwuw2zqPHs6dqDQF7I5Gkwzs=",
+        "0010-Use-TEST_TMPDIR-on-Unix-when-it-is-set.patch": "sha256-ksYPHSFXRpLuLo8n4XDsP2RT+2zoFZvIiXU+STwHHBs=",
+        "0011-Use-Windows-assembly-files-for-BLAKE3-on-Windows.patch": "sha256-AZxMGVz4kbGkUrEH5oIySlHLGeCqtB929Wrd82VVk7M=",
+        "0012-Add-scope-resolution-operators-for-MSVC-2019.patch": "sha256-PsrLVgyyXWW/+Xe49INQPxObNVJk+zWjCgm3BOL8Yfk=",
+        "0013-Disable-zlib-zstd-mpfr-and-pfm.patch": "sha256-XbSq5b7eS9Kc9weOGiWDVJA5L43E/4jMbvJaYMCvxrA="
+    },
+    "patch_strip": 1
+}

--- a/modules/llvm-project/TODO.md
+++ b/modules/llvm-project/TODO.md
@@ -1,0 +1,21 @@
+# TODO
+
+In increasing difficultly order:
+
+- [ ] Figure out why permissions tests on Mac do not work with default temporary directory
+- [ ] Run `//llvm/unittests:all` on Windows
+    - [ ] Validate why LLVM `LegalizerInfoTest.SizeChangeStrategy` fails on Windows
+    - [ ] Validate why LLVM `SMEAttributes.Constructors` fails on Windows
+    - [ ] Validate why LLVM `AttributorTestBase.AAReachabilityTest` fails on Windows
+- [ ] Add optional dependencies
+    - [ ] Add `zlib` (or `zlib-ng`)
+    - [ ] Add `zstd`
+    - [ ] Add `pfm`
+    - [ ] Add `mpfr` (and by extension, `gmp`)
+- [ ] Use `blake3` from BCR
+- [ ] Get `//clang` building on Windows
+- [ ] Get Clang unit tests passing on Windows
+- Run all LLVM project tests (`bazel test //...`)
+    - [ ] Linux
+    - [ ] Mac
+    - [ ] Windows

--- a/modules/llvm-project/metadata.json
+++ b/modules/llvm-project/metadata.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://llvm.org/",
+    "maintainers": [],
+    "repository": [
+        "github:llvm/llvm-project"
+    ],
+    "versions": [
+        "17.0.3"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Related issue: #206 
This PR adds LLVM (https://github.com/llvm/llvm-project) to BCR. While we could wait for LLVM to get Bzlmod support, I think adding it to BCR without waiting for that would be beneficial.

Optional dependencies (`zlib-ng`, `zstd`, `pfm`, `mpfr`) are currently disabled in the patches. I am not sure if the BCR module should have those enabled or not. I've done some experimenting locally and adding `zlib-ng` to BCR appears to be relatively straightforward. It is also possible to just use `zlib` that is already in BCR instead of `zlib-ng`, since `zlib-ng` has `zlib` compatibility enabled in the LLVM Bazel overlay. 

In terms of testing, `presubmit.yml` currently runs `@llvm-project//llvm/unittests:all`, i.e. the unit tests for the LLVM Core component. If this is not good enough in terms of CI usage, I guess we can change this to `@llvm-project//clang:clang` as suggested in #206.