### PR TITLE
Replace //external:protocol_compiler with //third_party:protocol_compiler

### DIFF
--- a/modules/grpc/1.48.1/patches/protocol-compiler-alias-for-bind.patch
+++ b/modules/grpc/1.48.1/patches/protocol-compiler-alias-for-bind.patch
@@ -1,0 +1,57 @@
+diff --git a/bazel/generate_cc.bzl b/bazel/generate_cc.bzl
+index bd1d545..10d7750 100644
+--- a/bazel/generate_cc.bzl
++++ b/bazel/generate_cc.bzl
+@@ -187,7 +187,7 @@ _generate_cc = rule(
+             mandatory = False,
+         ),
+         "_protoc": attr.label(
+-            default = Label("//external:protocol_compiler"),
++            default = Label("//third_party:protocol_compiler"),
+             executable = True,
+             cfg = "host",
+         ),
+diff --git a/bazel/generate_objc.bzl b/bazel/generate_objc.bzl
+index b0e9211..22aa0fa 100644
+--- a/bazel/generate_objc.bzl
++++ b/bazel/generate_objc.bzl
+@@ -180,7 +180,7 @@ generate_objc = rule(
+             default = "@com_google_protobuf//:well_known_protos",
+         ),
+         "_protoc": attr.label(
+-            default = Label("//external:protocol_compiler"),
++            default = Label("//third_party:protocol_compiler"),
+             executable = True,
+             cfg = "host",
+         ),
+diff --git a/bazel/python_rules.bzl b/bazel/python_rules.bzl
+index a39159a..967a26c 100644
+--- a/bazel/python_rules.bzl
++++ b/bazel/python_rules.bzl
+@@ -104,7 +104,7 @@ _gen_py_aspect = aspect(
+     fragments = ["py"],
+     attrs = {
+         "_protoc": attr.label(
+-            default = Label("//external:protocol_compiler"),
++            default = Label("//third_party:protocol_compiler"),
+             providers = ["files_to_run"],
+             executable = True,
+             cfg = "host",
+@@ -160,7 +160,7 @@ py_proto_library = rule(
+             aspects = [_gen_py_aspect],
+         ),
+         "_protoc": attr.label(
+-            default = Label("//external:protocol_compiler"),
++            default = Label("//third_party:protocol_compiler"),
+             providers = ["files_to_run"],
+             executable = True,
+             cfg = "host",
+@@ -248,7 +248,7 @@ _generate_pb2_grpc_src = rule(
+             executable = True,
+             providers = ["files_to_run"],
+             cfg = "host",
+-            default = Label("//external:protocol_compiler"),
++            default = Label("//third_party:protocol_compiler"),
+         ),
+         "_grpc_library": attr.label(
+             default = Label("//src/python/grpcio/grpc:grpcio"),

--- a/modules/grpc/1.48.1/source.json
+++ b/modules/grpc/1.48.1/source.json
@@ -3,7 +3,8 @@
     "integrity": "sha256-MgNmZl0ZAnzah7I2jAOTkAajfgOIv9EJHI0qlvvJO9g=",
     "strip_prefix": "grpc-1.48.1",
     "patches": {
-        "adopt_bzlmod.patch": "sha256-A5ftSJ/R0TNxKNHqyO0gg3uCGfwJ4TlfUaLt48cREXo="
+        "adopt_bzlmod.patch": "sha256-A5ftSJ/R0TNxKNHqyO0gg3uCGfwJ4TlfUaLt48cREXo=",
+	"protocol-compiler-alias-for-bind.patch": "sha256-MiO46C+EvMs1sAbZIHR9uFHNeUGCprBGCELLUA6OUHo="
     },
     "patch_strip": 1
 }


### PR DESCRIPTION
As `bind()` is not compatible with bzlmod, use the `alias()` targets instead.