### PR TITLE
fix: remove empty glob in spdlog BUILD file

### DIFF
--- a/modules/spdlog/1.11.0/patches/add_build_file.patch
+++ b/modules/spdlog/1.11.0/patches/add_build_file.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ BUILD.bazel
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,17 @@
 +load("@rules_cc//cc:defs.bzl", "cc_library")
 +
 +licenses(["notice"])  # Apache 2

--- a/modules/spdlog/1.11.0/patches/add_build_file.patch
+++ b/modules/spdlog/1.11.0/patches/add_build_file.patch
@@ -12,7 +12,6 @@
 +cc_library(
 +    name = "spdlog",
 +    hdrs = glob([
-+        "include/**/*.cc",
 +        "include/**/*.h",
 +    ]),
 +    defines = ["SPDLOG_FMT_EXTERNAL"],

--- a/modules/spdlog/1.11.0/source.json
+++ b/modules/spdlog/1.11.0/source.json
@@ -2,7 +2,7 @@
     "integrity": "sha256-ylyujWysFdrg7GOyHWrTUwBwZQ9oB286SoYsopOoWLs=",
     "patch_strip": 0,
     "patches": {
-        "add_build_file.patch": "sha256-G4/iVL0sDRRdcC8X+DCRN2l6oDVNE2TxJ6Vj8IaNct4=",
+        "add_build_file.patch": "sha256-2EkMPf83xdmU7yHjaR/nIfiKcGNZKqhVsXKPl8/0qsU=",
         "module_dot_bazel.patch": "sha256-I2IS/xHAmpQmE3Imurb6lHqZg/X3bul9P59NN7FSJn0="
     },
     "strip_prefix": "spdlog-1.11.0",


### PR DESCRIPTION
There are no `.cc` files in the `include` directory of spdlog, so the pattern is not matching anything and the module does not work when `--incompatible_disallow_empty_glob` is set. This commit removes that pattern from the injected BUILD file so this does not happen.