### PR TITLE
add debian dependency bazelizer to the bazel central registry

### DIFF
--- a/modules/debian_dependency_bazelizer/0.5.0/MODULE.bazel
+++ b/modules/debian_dependency_bazelizer/0.5.0/MODULE.bazel
@@ -1,0 +1,37 @@
+module(
+    name = "debian_dependency_bazelizer",
+    version = "0.5.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_python", version = "0.27.1")
+
+PYTHON_VERSIONS = [
+    "3.8",
+    "3.9",
+    "3.10",
+    "3.11",
+]
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+
+[
+    python.toolchain(
+        is_default = python_version == PYTHON_VERSIONS[-1],
+        python_version = python_version,
+    )
+    for python_version in PYTHON_VERSIONS
+]
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
+[
+    pip.parse(
+        hub_name = "dep_bazelizer_deps",
+        python_version = python_version,
+        requirements_lock = "//:requirements.txt",
+    )
+    for python_version in PYTHON_VERSIONS
+]
+
+use_repo(pip, "dep_bazelizer_deps")

--- a/modules/debian_dependency_bazelizer/0.5.0/presubmit.yml
+++ b/modules/debian_dependency_bazelizer/0.5.0/presubmit.yml
@@ -1,0 +1,9 @@
+bcr_test_module:
+  module_path: ''
+  matrix:
+    platform: [ ubuntu2004 ]
+  tasks:
+    run_tests:
+      name: Run tests
+      platform: ${{ platform }}
+      test_targets: [ //... ]

--- a/modules/debian_dependency_bazelizer/0.5.0/source.json
+++ b/modules/debian_dependency_bazelizer/0.5.0/source.json
@@ -1,0 +1,6 @@
+{
+    "url": "https://github.com/shabanzd/debian_dependency_bazelizer/releases/download/0.5.0/debian_dependency_bazelizer-0.5.0.tar.gz",
+    "integrity": "sha256-WyM4mf8ZrVujn7gOsE+knrCNE5u39sB3x7TcX/binIg=",
+    "strip_prefix": "debian_dependency_bazelizer-0.5.0"
+}
+  

--- a/modules/debian_dependency_bazelizer/metadata.json
+++ b/modules/debian_dependency_bazelizer/metadata.json
@@ -1,0 +1,14 @@
+{
+    "homepage": "https://github.com/shabanzd/debian_dependency_bazelizer",
+    "maintainers": [
+        {
+            "email": "shaban_ziad@hotmail.com",
+            "github": "shabanzd",
+            "name": "Ziad Shaban"
+        }
+    ],
+    "repository": [
+        "github:shabanzd/debian_dependency_bazelizer"
+    ],
+    "versions": ["0.5.0"]
+}


### PR DESCRIPTION
This PR attempts to add the [debian_dependency_bazelizer](https://github.com/shabanzd/debian_dependency_bazelizer) to the BCR.