### PR TITLE
add yanked_versions field for debian_dependency_bazelizer/metadata.json

### DIFF
--- a/modules/debian_dependency_bazelizer/metadata.json
+++ b/modules/debian_dependency_bazelizer/metadata.json
@@ -10,5 +10,6 @@
     "repository": [
         "github:shabanzd/debian_dependency_bazelizer"
     ],
-    "versions": ["0.5.0"]
+    "versions": ["0.5.0"],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
fix https://github.com/bazelbuild/bazel-central-registry/issues/1254