### PR TITLE
Validate HTTP respositories and non-sha256 integrity source tarballs

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -137,6 +137,10 @@ class BcrValidator:
       if repo_type == "github":
         parts = urlparse(source_url)
         matched = parts.scheme == "https" and parts.netloc == "github.com" and os.path.abspath(parts.path).startswith(f"/{repo_path}/")
+      elif repo_type == "https":
+        repo = urlparse(source_repository)
+        parts = urlparse(source_url)
+        matched = parts.scheme == repo.scheme and parts.netloc == repo.netloc and os.path.abspath(parts.path).startswith(f"{repo.path}/")
     if not matched:
       self.report(BcrValidationResult.FAILED, f"The source URL of {module_name}@{version} ({source_url}) doesn't match any of the module's source repositories {source_repositories}.")
     else:

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -163,7 +163,8 @@ class BcrValidator:
     """Verify the integrity value of the URL is correct."""
     source_url = self.registry.get_source(module_name, version)["url"]
     expected_integrity = self.registry.get_source(module_name, version)["integrity"]
-    real_integrity = integrity(download(source_url))
+    algorithm, _ = expected_integrity.split("-", 1)
+    real_integrity = integrity(download(source_url), algorithm)
     if real_integrity != expected_integrity:
       self.report(BcrValidationResult.FAILED, f"{module_name}@{version}'s source archive `{source_url}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{real_integrity}`!")
     else:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -66,9 +66,11 @@ def read(path):
     return file.read()
 
 
-def integrity(data):
-  hash_value = hashlib.sha256(data)
-  return "sha256-" + base64.b64encode(hash_value.digest()).decode()
+def integrity(data, algorithm="sha256"):
+  assert algorithm in {"sha224", "sha256", "sha384", "sha512"}, "Unsupported SRI algorithm"
+  hash = getattr(hashlib, algorithm)(data)
+  encoded = base64.b64encode(hash.digest()).decode()
+  return f"{algorithm}-{encoded}"
 
 
 def json_dump(file, data, sort_keys=True):


### PR DESCRIPTION
Adds validation of `https` protocol source tarballs. Previously, we only supported `github` URI protocols.

Adds support for integrity algorithms other than `sha256`. Uses the same algorithm as the expected integrity for validation.