### PR TITLE
Fix include issue in glm

### DIFF
--- a/modules/glm/0.9.9.8.bcr.1/MODULE.bazel
+++ b/modules/glm/0.9.9.8.bcr.1/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+  name = "glm", 
+  version = "0.9.9.8.bcr.1"
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/glm/0.9.9.8.bcr.1/patches/add_build_file.patch
+++ b/modules/glm/0.9.9.8.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,13 @@
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -0,0 +1,10 @@
++cc_library(
++    name = "glm",
++    hdrs = glob([
++        "glm/**/*.h",
++        "glm/**/*.hpp",
++    ]),
++    includes = ["."],
++    textual_hdrs = glob(["glm/**/*.inl"]),
++    visibility = ["//visibility:public"],
++)

--- a/modules/glm/0.9.9.8.bcr.1/patches/add_module_dot_bazel.patch
+++ b/modules/glm/0.9.9.8.bcr.1/patches/add_module_dot_bazel.patch
@@ -1,0 +1,9 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,6 @@
++module(
++  name = "glm", 
++  version = "0.9.9.8.bcr.1"
++)
++
++bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/glm/0.9.9.8.bcr.1/presubmit.yml
+++ b/modules/glm/0.9.9.8.bcr.1/presubmit.yml
@@ -1,0 +1,11 @@
+matrix:
+  platform:
+    - ubuntu2204
+    - macos
+    - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+      - '@glm//:glm'

--- a/modules/glm/0.9.9.8.bcr.1/source.json
+++ b/modules/glm/0.9.9.8.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-N+Kj1i6jMi5DWTw0uuKfV+PiUeqJ9AZ1BslAQ3aa3kw=",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-Jly6TRWYbakaz6jgvF5tqcIvQ+O6sUrqQOF9bf8QvVM=",
+        "add_module_dot_bazel.patch": "sha256-j6YJ2hKZJYvL6cGy8RnnC6rTjBmrIsBp8/Bdrr7E9bk="
+    },
+    "strip_prefix": "glm",
+    "url": "https://github.com/g-truc/glm/releases/download/0.9.9.8/glm-0.9.9.8.zip"
+}

--- a/modules/glm/metadata.json
+++ b/modules/glm/metadata.json
@@ -11,7 +11,8 @@
         "github:g-truc/glm"
     ],
     "versions": [
-        "0.9.9.8"
+        "0.9.9.8",
+        "0.9.9.8.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Fix include issue in glm.

Code such as 

```
#include <glm/vec3.hpp> // glm::vec3
#include <glm/vec4.hpp> // glm::vec4
#include <glm/mat4x4.hpp> // glm::mat4
#include <glm/ext/matrix_transform.hpp> // glm::translate, glm::rotate, glm::scale
#include <glm/ext/matrix_clip_space.hpp> // glm::perspective
#include <glm/ext/scalar_constants.hpp> // glm::pi

glm::mat4 camera(float Translate, glm::vec2 const& Rotate)
{
	glm::mat4 Projection = glm::perspective(glm::pi<float>() * 0.25f, 4.0f / 3.0f, 0.1f, 100.f);
	glm::mat4 View = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, -Translate));
	View = glm::rotate(View, Rotate.y, glm::vec3(-1.0f, 0.0f, 0.0f));
	View = glm::rotate(View, Rotate.x, glm::vec3(0.0f, 1.0f, 0.0f));
	glm::mat4 Model = glm::scale(glm::mat4(1.0f), glm::vec3(0.5f));
	return Projection * View * Model;
}
```
should compile (currently it doesn't - glm has to be stripped from includes - which is not wanted)

By changing `includes = ['.'],` this issue can be fixed.

This was also discussed in #1064 and proposed by @phaedon 

Should compile without changes - so the module is currently wrong -