### PR TITLE
User agent added to module downloading

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -42,17 +42,18 @@ def log(msg):
 
 def download(url):
   parts = urllib.parse.urlparse(url)
+  headers = {'User-Agent': 'Mozilla/5.0'}  # Set the User-Agent header
   try:
     authenticators = netrc.netrc().authenticators(parts.netloc)
   except FileNotFoundError:
     authenticators = None
   if authenticators != None:
     (login, _, password) = authenticators
-    req = urllib.request.Request(url)
+    req = urllib.request.Request(url, headers=headers)
     creds = base64.b64encode(str.encode('%s:%s' % (login, password))).decode()
     req.add_header("Authorization", "Basic %s" % creds)
   else:
-    req = url
+    req = urllib.request.Request(url, headers=headers)
 
   with urllib.request.urlopen(req) as response:
     return response.read()


### PR DESCRIPTION
User agent added to module downloading to prevent failures on sites that check and 403 against requests that don't have a user agent. For example, https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sample_templates/XPSDK401.zip

Also requested in CI/CD pipeline [here](https://github.com/bazelbuild/continuous-integration/pull/1851) to fix failing PR #1304 