### PR TITLE
feat: add `download_utils@1.0.0-beta.1`

### DIFF
--- a/modules/download_utils/1.0.0-beta.1/MODULE.bazel
+++ b/modules/download_utils/1.0.0-beta.1/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "download_utils",
+    version = "1.0.0-beta.1",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.4.2", dev_dependency = True)

--- a/modules/download_utils/1.0.0-beta.1/presubmit.yml
+++ b/modules/download_utils/1.0.0-beta.1/presubmit.yml
@@ -1,0 +1,18 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - debian10
+      - ubuntu2004
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    run_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/download_utils/1.0.0-beta.1/presubmit.yml
+++ b/modules/download_utils/1.0.0-beta.1/presubmit.yml
@@ -8,7 +8,8 @@ bcr_test_module:
       - ubuntu2004
       - macos
       - macos_arm64
-      - windows
+      # TODO: enable this once the `gitlab.arm.com` does not use a self-signed certificate
+      # - windows
   tasks:
     run_tests:
       name: Run end-to-end Tests

--- a/modules/download_utils/1.0.0-beta.1/source.json
+++ b/modules/download_utils/1.0.0-beta.1/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/download_utils/-/releases/v1.0.0-beta.1/downloads/src.tar.gz",
+  "integrity": "sha512-MGz3+3iDOc8wod5Qhc1uiQTM34QS64cVlSR4RSzCFV6yCRkrWZR555IuxHzOsvpths80rYe42C2JdwmXtKSFnw==",
+  "strip_prefix": "download_utils-v1.0.0-beta.1"
+}

--- a/modules/download_utils/metadata.json
+++ b/modules/download_utils/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://gitlab.arm.com/bazel/download_utils",
+    "repository": [
+        "https://gitlab.arm.com/bazel/download_utils"
+    ],
+    "versions":[
+        "1.0.0-beta.1"
+    ],
+    "maintainers": [
+        {
+            "email": "matthew.clarkson@arm.com",
+            "github": "mattyclarkson",
+            "name": "Matt Clarkson"
+        }
+    ]
+}


### PR DESCRIPTION
This module implements repository rules that are helpful for downloading remote resources hermetically.

It currently has three repository rules for use in `MODULE.bazel`:

- `download_file`: download a single file
- `download_archive`: download a optionally compressed archive/tarball
- `download_deb`: download a debian package and unpack the contained data tarball

The rules add two novel things:

- Allow setting up (sym|hard)links after the artifact has been downloaded
- Run hermetic commands provided via `tools` and using `$(location )` replacement

Running for post download hermetic commands is a cruicial feature to make sure we depend on nothing in the host.

See the [readme](https://gitlab.arm.com/bazel/rules_download#getting-started) for example usage.