### PR TITLE
test(metadata): enforce that maintainers property is non-empty

### DIFF
--- a/metadata.schema.json
+++ b/metadata.schema.json
@@ -8,6 +8,7 @@
       "maintainers": {
         "description": "Individuals who can be notified when the module requires human attention",
         "type": "array",
+        "minItems": 1,
         "items": {
           "type": "object",
           "properties": {
@@ -46,5 +47,5 @@
       }
     },
     "additionalProperties": false,
-    "required": ["homepage", "versions"]
+    "required": ["homepage", "versions", "maintainers"]
 }

--- a/modules/abseil-py/metadata.json
+++ b/modules/abseil-py/metadata.json
@@ -1,9 +1,16 @@
 {
-    "homepage": "https://github.com/abseil/abseil-py",
-    "maintainers": [],
-    "repository": [
-        "github:abseil/abseil-py"
-    ],
-    "versions": ["1.4.0"],
-    "yanked_versions": {}
+  "homepage": "https://github.com/abseil/abseil-py",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:abseil/abseil-py"
+  ],
+  "versions": [
+    "1.4.0"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/blake3/metadata.json
+++ b/modules/blake3/metadata.json
@@ -1,12 +1,17 @@
 {
-    "homepage": "https://github.com/BLAKE3-team/BLAKE3",
-    "maintainers": [],
-    "repository": [
-        "github:BLAKE3-team/BLAKE3"
-    ],
-    "versions": [
-        "1.3.3",
-        "1.3.3.bcr.1"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/BLAKE3-team/BLAKE3",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:BLAKE3-team/BLAKE3"
+  ],
+  "versions": [
+    "1.3.3",
+    "1.3.3.bcr.1"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/blaze-math/metadata.json
+++ b/modules/blaze-math/metadata.json
@@ -1,9 +1,14 @@
 {
-    "homepage": "https://bitbucket.org/blaze-lib/blaze",
-    "maintainers": [],
-    "repository": [],
-    "versions": [
-        "3.8.2"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://bitbucket.org/blaze-lib/blaze",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [],
+  "versions": [
+    "3.8.2"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/boringssl/metadata.json
+++ b/modules/boringssl/metadata.json
@@ -1,12 +1,17 @@
 {
-    "homepage": "https://github.com/google/boringssl",
-    "maintainers": [],
-    "repository": [
-        "github:google/boringssl"
-    ],
-    "versions": [
-        "0.0.0-20211025-d4f1ab9",
-        "0.0.0-20230215-5c22014"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/google/boringssl",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:google/boringssl"
+  ],
+  "versions": [
+    "0.0.0-20211025-d4f1ab9",
+    "0.0.0-20230215-5c22014"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/bzip2/metadata.json
+++ b/modules/bzip2/metadata.json
@@ -1,8 +1,13 @@
 {
-    "homepage": "https://www.sourceware.org/bzip2/",
-    "maintainers": [],
-    "versions": [
-        "1.0.8"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://www.sourceware.org/bzip2/",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "versions": [
+    "1.0.8"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/c-ares/metadata.json
+++ b/modules/c-ares/metadata.json
@@ -1,12 +1,17 @@
 {
-    "homepage": "https://github.com/c-ares/c-ares",
-    "maintainers": [],
-    "repository": [
-        "github:c-ares/c-ares"
-    ],
-    "versions": [
-        "1.15.0",
-        "1.16.1"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/c-ares/c-ares",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:c-ares/c-ares"
+  ],
+  "versions": [
+    "1.15.0",
+    "1.16.1"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/circl/metadata.json
+++ b/modules/circl/metadata.json
@@ -1,10 +1,15 @@
 {
-    "homepage": "https://github.com/cloudflare/circl",
-    "maintainers": [],
-    "repository": [],
-    "versions": [
-        "1.3.3",
-        "1.3.7"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/cloudflare/circl",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [],
+  "versions": [
+    "1.3.3",
+    "1.3.7"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/eigen/metadata.json
+++ b/modules/eigen/metadata.json
@@ -1,10 +1,15 @@
 {
-    "homepage": "https://gitlab.com/libeigen/eigen",
-    "maintainers": [],
-    "repository": [],
-    "versions": [
-        "3.4.0",
-        "3.4.0.bcr.1"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://gitlab.com/libeigen/eigen",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [],
+  "versions": [
+    "3.4.0",
+    "3.4.0.bcr.1"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/foonathan_memory/metadata.json
+++ b/modules/foonathan_memory/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/foonathan/memory",
-    "maintainers": [],
-    "repository": [
-        "github:foonathan/memory"
-    ],
-    "versions": [
-        "0.7.3"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/foonathan/memory",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:foonathan/memory"
+  ],
+  "versions": [
+    "0.7.3"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/gflags/metadata.json
+++ b/modules/gflags/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://gflags.github.io/gflags/",
-    "maintainers": [],
-    "repository": [
-        "github:gflags/gflags"
-    ],
-    "versions": [
-        "2.2.2"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://gflags.github.io/gflags/",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:gflags/gflags"
+  ],
+  "versions": [
+    "2.2.2"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/giflib/metadata.json
+++ b/modules/giflib/metadata.json
@@ -1,9 +1,14 @@
 {
-    "homepage": "https://giflib.sourceforge.net/",
-    "maintainers": [],
-    "repository": [],
-    "versions": [
-        "5.2.1"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://giflib.sourceforge.net/",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [],
+  "versions": [
+    "5.2.1"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/glog/metadata.json
+++ b/modules/glog/metadata.json
@@ -1,12 +1,17 @@
 {
-    "homepage": "https://github.com/google/glog",
-    "maintainers": [],
-    "repository": [
-        "github:google/glog"
-    ],
-    "versions": [
-        "0.5.0",
-        "0.6.0"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/google/glog",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:google/glog"
+  ],
+  "versions": [
+    "0.5.0",
+    "0.6.0"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/google_benchmark/metadata.json
+++ b/modules/google_benchmark/metadata.json
@@ -1,12 +1,17 @@
 {
-    "homepage": "https://github.com/google/benchmark",
-    "maintainers": [],
-    "repository": [
-        "github:google/benchmark"
-    ],
-    "versions": [
-        "1.8.2",
-        "1.8.3"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/google/benchmark",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:google/benchmark"
+  ],
+  "versions": [
+    "1.8.2",
+    "1.8.3"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/googletest/metadata.json
+++ b/modules/googletest/metadata.json
@@ -1,15 +1,20 @@
 {
-    "homepage": "https://google.github.io/googletest/",
-    "maintainers": [],
-    "repository": [
-        "github:google/googletest"
-    ],
-    "versions": [
-        "1.11.0",
-        "1.12.1",
-        "1.13.0",
-        "1.14.0",
-        "1.14.0.bcr.1"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://google.github.io/googletest/",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:google/googletest"
+  ],
+  "versions": [
+    "1.11.0",
+    "1.12.1",
+    "1.13.0",
+    "1.14.0",
+    "1.14.0.bcr.1"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/grpc/metadata.json
+++ b/modules/grpc/metadata.json
@@ -1,17 +1,22 @@
 {
-    "homepage": "https://github.com/grpc/grpc",
-    "maintainers": [],
-    "repository": [
-        "github:grpc/grpc"
-    ],
-    "versions": [
-        "1.41.0",
-        "1.47.0",
-        "1.48.1",
-        "1.48.1.bcr.1",
-        "1.48.1.bcr.2",
-        "1.48.1.bcr.3",
-        "1.56.3"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/grpc/grpc",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:grpc/grpc"
+  ],
+  "versions": [
+    "1.41.0",
+    "1.47.0",
+    "1.48.1",
+    "1.48.1.bcr.1",
+    "1.48.1.bcr.2",
+    "1.48.1.bcr.3",
+    "1.56.3"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/jsonnet/metadata.json
+++ b/modules/jsonnet/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://jsonnet.org",
-    "maintainers": [],
-    "repository": [
-        "github:google/jsonnet"
-    ],
-    "versions": [
-        "0.20.0"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://jsonnet.org",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:google/jsonnet"
+  ],
+  "versions": [
+    "0.20.0"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/jsonnet_go/metadata.json
+++ b/modules/jsonnet_go/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/google/go-jsonnet",
-    "maintainers": [],
-    "repository": [
-        "github:google/go-jsonnet"
-    ],
-    "versions": [
-        "0.20.0"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/google/go-jsonnet",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:google/go-jsonnet"
+  ],
+  "versions": [
+    "0.20.0"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/libpfm/metadata.json
+++ b/modules/libpfm/metadata.json
@@ -1,9 +1,14 @@
 {
-    "homepage": "https://perfmon2.sourceforge.net",
-    "maintainers": [],
-    "repository": [],
-    "versions": [
-        "4.11.0"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://perfmon2.sourceforge.net",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [],
+  "versions": [
+    "4.11.0"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/llvm-project/metadata.json
+++ b/modules/llvm-project/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://llvm.org/",
-    "maintainers": [],
-    "repository": [
-        "github:llvm/llvm-project"
-    ],
-    "versions": [
-        "17.0.3"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://llvm.org/",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:llvm/llvm-project"
+  ],
+  "versions": [
+    "17.0.3"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/lz4/metadata.json
+++ b/modules/lz4/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/lz4/lz4",
-    "maintainers": [],
-    "repository": [
-        "github:lz4/lz4"
-    ],
-    "versions": [
-        "1.9.4"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/lz4/lz4",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:lz4/lz4"
+  ],
+  "versions": [
+    "1.9.4"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/mcap/metadata.json
+++ b/modules/mcap/metadata.json
@@ -1,12 +1,17 @@
 {
-    "homepage": "https://github.com/foxglove/mcap",
-    "maintainers": [],
-    "repository": [
-        "github:foxglove/mcap"
-    ],
-    "versions": [
-        "0.8.0",
-        "1.2.1"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/foxglove/mcap",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:foxglove/mcap"
+  ],
+  "versions": [
+    "0.8.0",
+    "1.2.1"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/nanobind/metadata.json
+++ b/modules/nanobind/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/wjakob/nanobind",
-    "maintainers": [],
-    "repository": [
-        "github:wjakob/nanobind"
-    ],
-    "versions": [
-        "1.2.0"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/wjakob/nanobind",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:wjakob/nanobind"
+  ],
+  "versions": [
+    "1.2.0"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -1,18 +1,23 @@
 {
-    "homepage": "https://github.com/protocolbuffers/protobuf",
-    "maintainers": [],
-    "repository": [
-        "github:protocolbuffers/protobuf"
-    ],
-    "versions": [
-        "3.19.0",
-        "3.19.2",
-        "3.19.6",
-        "21.7",
-        "23.1"
-    ],
-    "yanked_versions": {
-        "3.19.0": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)",
-        "3.19.2": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)"
+  "homepage": "https://github.com/protocolbuffers/protobuf",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
     }
+  ],
+  "repository": [
+    "github:protocolbuffers/protobuf"
+  ],
+  "versions": [
+    "3.19.0",
+    "3.19.2",
+    "3.19.6",
+    "21.7",
+    "23.1"
+  ],
+  "yanked_versions": {
+    "3.19.0": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)",
+    "3.19.2": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)"
+  }
 }

--- a/modules/pugixml/metadata.json
+++ b/modules/pugixml/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/zeux/pugixml.git",
-    "maintainers": [],
-    "repository": [
-        "github:zeux/pugixml"
-    ],
-    "versions": [
-        "1.14"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/zeux/pugixml.git",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:zeux/pugixml"
+  ],
+  "versions": [
+    "1.14"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/rapidjson/metadata.json
+++ b/modules/rapidjson/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/Tencent/rapidjson",
-    "maintainers": [],
-    "repository": [
-        "github:Tencent/rapidjson"
-    ],
-    "versions": [
-        "1.1.0"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/Tencent/rapidjson",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:Tencent/rapidjson"
+  ],
+  "versions": [
+    "1.1.0"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/readerwriterqueue/metadata.json
+++ b/modules/readerwriterqueue/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/cameron314/readerwriterqueue",
-    "maintainers": [],
-    "repository": [
-        "github:cameron314/readerwriterqueue"
-    ],
-    "versions": [
-        "1.0.6"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/cameron314/readerwriterqueue",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:cameron314/readerwriterqueue"
+  ],
+  "versions": [
+    "1.0.6"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/robin-map/metadata.json
+++ b/modules/robin-map/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/Tessil/robin-map",
-    "maintainers": [],
-    "repository": [
-        "github:Tessil/robin-map"
-    ],
-    "versions": [
-        "1.2.1"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/Tessil/robin-map",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:Tessil/robin-map"
+  ],
+  "versions": [
+    "1.2.1"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/rules_android/metadata.json
+++ b/modules/rules_android/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/bazelbuild/rules_android",
-    "maintainers": [],
-    "repository": [
-        "github:bazelbuild/rules_android"
-    ],
-    "versions": [
-        "0.1.1"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/bazelbuild/rules_android",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:bazelbuild/rules_android"
+  ],
+  "versions": [
+    "0.1.1"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/rules_appimage/metadata.json
+++ b/modules/rules_appimage/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/lalten/rules_appimage",
-    "maintainers": [],
-    "repository": [
-        "github:lalten/rules_appimage"
-    ],
-    "versions": [
-        "1.6.0"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/lalten/rules_appimage",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:lalten/rules_appimage"
+  ],
+  "versions": [
+    "1.6.0"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/rules_cc/metadata.json
+++ b/modules/rules_cc/metadata.json
@@ -1,14 +1,19 @@
 {
-    "homepage": "https://github.com/bazelbuild/rules_cc",
-    "maintainers": [],
-    "versions": [
-        "0.0.1",
-        "0.0.2",
-        "0.0.4",
-        "0.0.5",
-        "0.0.6",
-        "0.0.8",
-        "0.0.9"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/bazelbuild/rules_cc",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "versions": [
+    "0.0.1",
+    "0.0.2",
+    "0.0.4",
+    "0.0.5",
+    "0.0.6",
+    "0.0.8",
+    "0.0.9"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/rules_distroless/metadata.json
+++ b/modules/rules_distroless/metadata.json
@@ -1,12 +1,17 @@
 {
-    "homepage": "https://github.com/GoogleContainerTools/rules_distroless",
-    "maintainers": [],
-    "repository": [
-        "github:GoogleContainerTools/rules_distroless"
-    ],
-    "versions": [
-        "0.1.2",
-        "0.1.3"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/GoogleContainerTools/rules_distroless",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:GoogleContainerTools/rules_distroless"
+  ],
+  "versions": [
+    "0.1.2",
+    "0.1.3"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/rules_java/metadata.json
+++ b/modules/rules_java/metadata.json
@@ -1,40 +1,45 @@
 {
-    "homepage": "https://github.com/bazelbuild/rules_java",
-    "maintainers": [],
-    "versions": [
-        "4.0.0",
-        "5.0.0",
-        "5.1.0",
-        "5.3.5",
-        "5.4.0",
-        "5.4.1",
-        "5.5.0",
-        "5.5.1",
-        "6.0.0",
-        "6.1.0",
-        "6.1.1",
-        "6.2.2",
-        "6.3.0",
-        "6.3.1",
-        "6.3.2",
-        "6.3.3",
-        "6.4.0",
-        "6.5.0",
-        "6.5.1",
-        "6.5.2",
-        "7.0.0",
-        "7.0.6",
-        "7.1.0",
-        "7.2.0",
-        "7.3.0",
-        "7.3.1",
-        "7.3.2"
-    ],
-    "yanked_versions": {
-        "6.3.3": "6.3.3 is a broken version.",
-        "7.0.0": "7.0.0 is a broken version."
-    },
-    "repository": [
-        "github:bazelbuild/rules_java"
-    ]
+  "homepage": "https://github.com/bazelbuild/rules_java",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "versions": [
+    "4.0.0",
+    "5.0.0",
+    "5.1.0",
+    "5.3.5",
+    "5.4.0",
+    "5.4.1",
+    "5.5.0",
+    "5.5.1",
+    "6.0.0",
+    "6.1.0",
+    "6.1.1",
+    "6.2.2",
+    "6.3.0",
+    "6.3.1",
+    "6.3.2",
+    "6.3.3",
+    "6.4.0",
+    "6.5.0",
+    "6.5.1",
+    "6.5.2",
+    "7.0.0",
+    "7.0.6",
+    "7.1.0",
+    "7.2.0",
+    "7.3.0",
+    "7.3.1",
+    "7.3.2"
+  ],
+  "yanked_versions": {
+    "6.3.3": "6.3.3 is a broken version.",
+    "7.0.0": "7.0.0 is a broken version."
+  },
+  "repository": [
+    "github:bazelbuild/rules_java"
+  ]
 }

--- a/modules/rules_pkg/metadata.json
+++ b/modules/rules_pkg/metadata.json
@@ -1,16 +1,21 @@
 {
-    "homepage": "https://github.com/bazelbuild/rules_pkg.git",
-    "maintainers": [],
-    "repository": [
-        "github:bazelbuild/rules_pkg"
-    ],
-    "versions": [
-        "0.5.1",
-        "0.7.0",
-        "0.8.1",
-        "0.9.0",
-        "0.9.1",
-        "0.10.0"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/bazelbuild/rules_pkg.git",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:bazelbuild/rules_pkg"
+  ],
+  "versions": [
+    "0.5.1",
+    "0.7.0",
+    "0.8.1",
+    "0.9.0",
+    "0.9.1",
+    "0.10.0"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/sqlite3/metadata.json
+++ b/modules/sqlite3/metadata.json
@@ -1,9 +1,14 @@
 {
-    "homepage": "https://sqlite.org/",
-    "maintainers": [],
-    "versions": [
-        "3.42.0",
-        "3.42.0.bcr.1"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://sqlite.org/",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "versions": [
+    "3.42.0",
+    "3.42.0.bcr.1"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/stardoc/metadata.json
+++ b/modules/stardoc/metadata.json
@@ -1,18 +1,23 @@
 {
-    "homepage": "https://github.com/bazelbuild/stardoc",
-    "maintainers": [],
-    "repository": [
-        "github:bazelbuild/stardoc"
-    ],
-    "versions": [
-        "0.5.0",
-        "0.5.1",
-        "0.5.3",
-        "0.5.4",
-        "0.5.6",
-        "0.6.0",
-        "0.6.1",
-        "0.6.2"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/bazelbuild/stardoc",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:bazelbuild/stardoc"
+  ],
+  "versions": [
+    "0.5.0",
+    "0.5.1",
+    "0.5.3",
+    "0.5.4",
+    "0.5.6",
+    "0.6.0",
+    "0.6.1",
+    "0.6.2"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/tinyxml2/metadata.json
+++ b/modules/tinyxml2/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/leethomason/tinyxml2",
-    "maintainers": [],
-    "repository": [
-        "github:leethomason/tinyxml2"
-    ],
-    "versions": [
-        "9.0.0"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/leethomason/tinyxml2",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:leethomason/tinyxml2"
+  ],
+  "versions": [
+    "9.0.0"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/toolchain_utils/metadata.json
+++ b/modules/toolchain_utils/metadata.json
@@ -1,9 +1,15 @@
 {
-    "homepage": "https://gitlab.arm.com/bazel/rules_toolchain",
-    "repository": [
-        "https://gitlab.arm.com/bazel/rules_toolchain"
-    ],
-    "versions":[
-        "1.0.0-alpha.16"
-    ]
+  "homepage": "https://gitlab.arm.com/bazel/rules_toolchain",
+  "repository": [
+    "https://gitlab.arm.com/bazel/rules_toolchain"
+  ],
+  "versions": [
+    "1.0.0-alpha.16"
+  ],
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ]
 }

--- a/modules/upb/metadata.json
+++ b/modules/upb/metadata.json
@@ -1,14 +1,19 @@
 {
-    "homepage": "https://github.com/protocolbuffers/upb",
-    "maintainers": [],
-    "repository": [
-        "github:protocolbuffers/upb"
-    ],
-    "versions": [
-        "0.0.0-20211020-160625a",
-        "0.0.0-20220602-e5f2601",
-        "0.0.0-20220923-a547704",
-        "0.0.0-20230516-61a97ef"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/protocolbuffers/upb",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:protocolbuffers/upb"
+  ],
+  "versions": [
+    "0.0.0-20211020-160625a",
+    "0.0.0-20220602-e5f2601",
+    "0.0.0-20220923-a547704",
+    "0.0.0-20230516-61a97ef"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/yaml-cpp/metadata.json
+++ b/modules/yaml-cpp/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/jbeder/yaml-cpp",
-    "maintainers": [],
-    "repository": [
-        "github:stonier/yaml-cpp"
-    ],
-    "versions": [
-        "0.8.0"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/jbeder/yaml-cpp",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:stonier/yaml-cpp"
+  ],
+  "versions": [
+    "0.8.0"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/zstd-jni/metadata.json
+++ b/modules/zstd-jni/metadata.json
@@ -1,13 +1,18 @@
 {
-    "homepage": "https://github.com/luben/zstd-jni",
-    "maintainers": [],
-    "repository": [
-        "github:luben/zstd-jni"
-    ],
-    "versions": [
-        "1.5.0-4",
-        "1.5.2-3",
-        "1.5.2-3.bcr.1"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/luben/zstd-jni",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:luben/zstd-jni"
+  ],
+  "versions": [
+    "1.5.0-4",
+    "1.5.2-3",
+    "1.5.2-3.bcr.1"
+  ],
+  "yanked_versions": {}
 }

--- a/modules/zstd/metadata.json
+++ b/modules/zstd/metadata.json
@@ -1,11 +1,16 @@
 {
-    "homepage": "https://github.com/facebook/zstd",
-    "maintainers": [],
-    "repository": [
-        "github:facebook/zstd"
-    ],
-    "versions": [
-        "1.5.5"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/facebook/zstd",
+  "maintainers": [
+    {
+      "email": "bcr-maintainers@bazel.build",
+      "name": "No Maintainer Specified"
+    }
+  ],
+  "repository": [
+    "github:facebook/zstd"
+  ],
+  "versions": [
+    "1.5.5"
+  ],
+  "yanked_versions": {}
 }


### PR DESCRIPTION
Followup to https://github.com/bazel-contrib/bcr-ui/issues/77#issuecomment-1682754865
and preparation for #130 

For modules that had zero maintainers, just point to the email address that was created for governance issues in the registry.
We could do a later pass through these to find more specific maintainers, but this prevents the problem getting worse.
Use the name field to indicate that this is not a real maintainer.