### PR TITLE
Add missing entry for bazel version for test module

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -415,6 +415,7 @@ module(
             "module_path": module.test_module_path,
             "matrix": {
                 "platform": PLATFORMS.copy(),
+                "bazel": BAZEL_VERSIONS.copy(),
             },
             "tasks": {
                 "run_test_module": task


### PR DESCRIPTION
This was missing from https://github.com/bazelbuild/bazel-central-registry/pull/1373