### PR TITLE
feat: add `toolchain_utils@1.0.0-beta.1`

### DIFF
--- a/modules/toolchain_utils/1.0.0-beta.1/MODULE.bazel
+++ b/modules/toolchain_utils/1.0.0-beta.1/MODULE.bazel
@@ -1,0 +1,23 @@
+module(
+    name = "toolchain_utils",
+    version = "1.0.0-beta.1",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.4.2")
+bazel_dep(name = "platforms", version = "0.0.7")
+
+triplet = use_repo_rule("//toolchain/local/triplet:defs.bzl", "toolchain_local_triplet")
+
+triplet(
+    name = "local",
+)
+
+launcher = use_repo_rule("//toolchain/launcher:repository.bzl", "launcher")
+
+launcher(
+    name = "launcher",
+)

--- a/modules/toolchain_utils/1.0.0-beta.1/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.1/presubmit.yml
@@ -1,0 +1,17 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    platform:
+      - debian10
+      - ubuntu2004
+      - macos
+      - macos_arm64
+      # TODO: enable this once the `gitlab.arm.com` does not use a self-signed certificate
+      # - windows
+  tasks:
+    run_tests:
+      name: Run end-to-end Tests
+      bazel: 7.x
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/toolchain_utils/1.0.0-beta.1/source.json
+++ b/modules/toolchain_utils/1.0.0-beta.1/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/toolchain_utils/-/releases/v1.0.0-beta.1/downloads/src.tar.gz",
+  "integrity": "sha512-HLLFtjDIzM5Ir1n8Z/npX8Cpbah0K80n1SYmFASOIi5rjHm3AB4PfITmDLjhietfUhgYofq5EFR6uoigJ6gKCw==",
+  "strip_prefix": "toolchain_utils-v1.0.0-beta.1"
+}

--- a/modules/toolchain_utils/metadata.json
+++ b/modules/toolchain_utils/metadata.json
@@ -1,15 +1,17 @@
 {
-  "homepage": "https://gitlab.arm.com/bazel/rules_toolchain",
+  "homepage": "https://gitlab.arm.com/bazel/toolchain_utils",
   "repository": [
-    "https://gitlab.arm.com/bazel/rules_toolchain"
+    "https://gitlab.arm.com/bazel/rules_toolchain",
+    "https://gitlab.arm.com/bazel/toolchain_utils"
   ],
   "versions": [
-    "1.0.0-alpha.16"
+    "1.0.0-alpha.16",
+    "1.0.0-beta.1"
   ],
   "maintainers": [
     {
-      "email": "bcr-maintainers@bazel.build",
-      "name": "No Maintainer Specified"
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson"
     }
   ]
 }


### PR DESCRIPTION
The upstream repository has moved from https://gitlab.arm.com/bazel/rules_toolchain to https://gitlab.arm.com/bazel/toolchain_utils. This keeps the naming consistency for the module. No renaming patches are needed anymore.

Moving to beta as we feel the module has the functionality to satisfy the constrainted scope of reducing the boilerplate to define a toolchain. Looking to get a stable once we have wider usage/testing.