### PR TITLE
Add GitHub Action for automatically notifying module maintainers for PR review

### DIFF
--- a/.github/workflows/bcr_pr_review_notifier.yml
+++ b/.github/workflows/bcr_pr_review_notifier.yml
@@ -1,0 +1,22 @@
+name: Notify Module Maintainers For PR Review
+on:
+  pull_request:
+    paths:
+      - 'modules/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
+
+      - name: Run BCR PR Review Notifier
+        uses: bazelbuild/continuous-integration/actions/bcr-helper@a0536955f617b399be786d30093188bc9b14c985
+        with:
+          token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/bcr_pr_review_notifier.yml
+++ b/.github/workflows/bcr_pr_review_notifier.yml
@@ -17,7 +17,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Review Notifier
-        uses: bazelbuild/continuous-integration/actions/bcr-helper@a0536955f617b399be786d30093188bc9b14c985
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-review-notifier@98021a23708b61580168002bdce84f459ac00750
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/bcr_pr_review_notifier.yml
+++ b/.github/workflows/bcr_pr_review_notifier.yml
@@ -19,4 +19,5 @@ jobs:
       - name: Run BCR PR Review Notifier
         uses: bazelbuild/continuous-integration/actions/bcr-helper@a0536955f617b399be786d30093188bc9b14c985
         with:
+          # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}


### PR DESCRIPTION
Following up https://github.com/bazelbuild/continuous-integration/pull/1865

The next step is to auto-approve and merge PRs that passes presubmit and received module maintainer approval.

Working towards: https://github.com/bazelbuild/bazel-central-registry/issues/130