### PR TITLE
Switch to pull_request_target event

### DIFF
--- a/.github/workflows/bcr_pr_review_notifier.yml
+++ b/.github/workflows/bcr_pr_review_notifier.yml
@@ -19,7 +19,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Review Notifier
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-review-notifier@98021a23708b61580168002bdce84f459ac00750
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-review-notifier@6109f3be479ab3c3efc5f190b4443b009d659da9 # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/bcr_pr_review_notifier.yml
+++ b/.github/workflows/bcr_pr_review_notifier.yml
@@ -1,6 +1,8 @@
 name: Notify Module Maintainers For PR Review
 on:
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
     paths:
       - 'modules/**'
 


### PR DESCRIPTION
Allow the github secret to be passed for PRs from a forked repo. This is safe for the PR review notifier github action since we don't "check out, build, or run untrusted code from the pull request with this event."

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target