### PR TITLE
Exclude yanked modules from print all

### DIFF
--- a/tools/print_all_src_urls.py
+++ b/tools/print_all_src_urls.py
@@ -24,7 +24,7 @@ from registry import RegistryClient
 
 def main():
   client = RegistryClient(".")
-  for name, version in client.get_all_module_versions():
+  for name, version in client.get_all_module_versions(include_yanked=False):
     print(client.get_source(name, version)["url"])
 
 if __name__ == "__main__":

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -223,17 +223,21 @@ module(
     modules_dir = self.root.joinpath("modules")
     return [path.name for path in modules_dir.iterdir()]
 
-  def get_module_versions(self, module_name):
+  def get_module_versions(self, module_name, include_yanked=True):
     module_versions = []
     metadata = self.get_metadata(module_name)
     for version in metadata["versions"]:
       module_versions.append((module_name, version))
+    if not include_yanked and "yanked_versions" in metadata:
+      for yanked in metadata["yanked_versions"].keys():
+        if yanked in metadata["versions"]:
+          module_versions.remove((module_name, yanked))
     return module_versions
 
-  def get_all_module_versions(self):
+  def get_all_module_versions(self, include_yanked=True):
     module_versions = []
     for module_name in self.get_all_modules():
-      module_versions.extend(self.get_module_versions(module_name))
+      module_versions.extend(self.get_module_versions(module_name, include_yanked))
     return module_versions
 
   def get_metadata(self, module_name):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -227,11 +227,8 @@ module(
     module_versions = []
     metadata = self.get_metadata(module_name)
     for version in metadata["versions"]:
-      module_versions.append((module_name, version))
-    if not include_yanked and "yanked_versions" in metadata:
-      for yanked in metadata["yanked_versions"].keys():
-        if yanked in metadata["versions"]:
-          module_versions.remove((module_name, yanked))
+      if include_yanked or version not in metadata.get("yanked_versions", {}):
+        module_versions.append((module_name, version))
     return module_versions
 
   def get_all_module_versions(self, include_yanked=True):


### PR DESCRIPTION
The documented method for listing artifacts to mirror is `bazel run //tools:print_all_src_urls`. This should not include yanked modules.