### PR TITLE
Add Sophus version 1.22.10

### DIFF
--- a/modules/sophus/1.22.10/MODULE.bazel
+++ b/modules/sophus/1.22.10/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "sophus",
+    version = "1.22.10",
+    compatibility_level = 1,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "eigen", version = "3.4.0.bcr.1")

--- a/modules/sophus/1.22.10/patches/add_build_file.patch
+++ b/modules/sophus/1.22.10/patches/add_build_file.patch
@@ -1,0 +1,39 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,36 @@
++""" Builds Sophus.
++"""
++
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "sophus",
++    hdrs = [
++        "sophus/average.hpp",
++        "sophus/cartesian.hpp",
++        "sophus/ceres_local_parameterization.hpp",
++        "sophus/ceres_manifold.hpp",
++        "sophus/ceres_typetraits.hpp",
++        "sophus/common.hpp",
++        "sophus/geometry.hpp",
++        "sophus/interpolate.hpp",
++        "sophus/interpolate_details.hpp",
++        "sophus/num_diff.hpp",
++        "sophus/rotation_matrix.hpp",
++        "sophus/rxso2.hpp",
++        "sophus/rxso3.hpp",
++        "sophus/se2.hpp",
++        "sophus/se3.hpp",
++        "sophus/sim2.hpp",
++        "sophus/sim3.hpp",
++        "sophus/sim_details.hpp",
++        "sophus/so2.hpp",
++        "sophus/so3.hpp",
++        "sophus/spline.hpp",
++        "sophus/types.hpp",
++        "sophus/velocities.hpp"
++    ],
++    visibility = ["//visibility:public"],
++    deps = [ "@eigen" ],
++)
++

--- a/modules/sophus/1.22.10/patches/module_dot_bazel.patch
+++ b/modules/sophus/1.22.10/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "sophus",
++    version = "1.22.10",
++    compatibility_level = 1,
++)
++bazel_dep(name = "rules_cc", version = "0.0.9")
++bazel_dep(name = "eigen", version = "3.4.0.bcr.1")

--- a/modules/sophus/1.22.10/presubmit.yml
+++ b/modules/sophus/1.22.10/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@sophus'

--- a/modules/sophus/1.22.10/source.json
+++ b/modules/sophus/1.22.10/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/strasdat/Sophus/archive/refs/tags/1.22.10.tar.gz",
+    "integrity": "sha256-6x2kQOYlDF78djegYRpbiIiHXOasIr9/9rZ2m7yVgII=",
+    "strip_prefix": "Sophus-1.22.10",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-W2UbaeeqTQAG+P3Ak647CbSuZltPVMiTgov+to78czY=",
+        "add_build_file.patch": "sha256-MV8UMgIIQmxUAuQ8VR9P+v7MkmejDWBVHYRga+qrfOY="
+    }
+}

--- a/modules/sophus/metadata.json
+++ b/modules/sophus/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/strasdat/Sophus",
+    "maintainers": [
+        {
+            "email": "git@van-opdenbosch.net",
+            "github": "d-vo",
+            "name": "Dominik Van Opdenbosch"
+        }
+    ],
+    "repository": [
+        "github:strasdat/Sophus"
+    ],
+    "versions": [
+        "1.22.10"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This adds sophus (wrapper around Eigen providing Lie algebra) in version 1.22.10. 

Unfortunately again, there is no link in the desired format. 