### PR TITLE
Add pigz@2.8

### DIFF
--- a/modules/pigz/2.8/MODULE.bazel
+++ b/modules/pigz/2.8/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "pigz",
+    version = "2.8",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "zopfli", version = "1.0.3")
+bazel_dep(name = "zlib", version = "1.3")

--- a/modules/pigz/2.8/patches/add_build_file.patch
+++ b/modules/pigz/2.8/patches/add_build_file.patch
@@ -1,0 +1,28 @@
+--- /dev/null	2023-06-26 14:23:42
++++ BUILD.bazel	2023-06-26 14:23:36
+@@ -0,0 +1,25 @@
++_COPTS = ["-O3", "-Wall", "-Wextra", "-Wno-unknown-pragmas", "-Wcast-qual"]
++
++cc_binary(
++    name = "pigz",
++    srcs = [
++        "pigz.c",
++        "try.c",
++        "try.h",
++        "yarn.c",
++        "yarn.h",
++    ],
++    copts = _COPTS,
++    linkopts = [
++        "-lm",
++        "-lpthread",
++    ],
++    visibility = ["//visibility:public"],
++    deps = ["@zopfli", "@zlib"],
++)
++
++alias(
++    name = "bin",
++    actual = ":pigz",
++    visibility = ["//visibility:public"],
++)

--- a/modules/pigz/2.8/patches/module_dot_bazel.patch
+++ b/modules/pigz/2.8/patches/module_dot_bazel.patch
@@ -1,0 +1,12 @@
+--- /dev/null	2023-06-26 13:35:45
++++ MODULE.bazel	2023-06-26 13:33:20
+@@ -0,0 +1,9 @@
++module(
++    name = "pigz",
++    version = "2.8",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "platforms", version = "0.0.8")
++bazel_dep(name = "zopfli", version = "1.0.3")
++bazel_dep(name = "zlib", version = "1.3")

--- a/modules/pigz/2.8/patches/pigz.c.patch
+++ b/modules/pigz/2.8/patches/pigz.c.patch
@@ -1,0 +1,11 @@
+--- pigz.c
++++ pigz.c
+@@ -429,7 +429,7 @@
+ #endif
+ 
+ #ifndef NOZOPFLI
+-#  include "zopfli/src/zopfli/deflate.h"    // ZopfliDeflatePart(),
++#  include "zopfli/deflate.h"               // ZopfliDeflatePart(),
+                                             // ZopfliInitOptions(),
+                                             // ZopfliOptions
+ #endif

--- a/modules/pigz/2.8/presubmit.yml
+++ b/modules/pigz/2.8/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - debian11
+  - ubuntu2004
+  - ubuntu2204
+  - macos
+  # Failing with pthread.h not found
+  # - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@pigz'

--- a/modules/pigz/2.8/source.json
+++ b/modules/pigz/2.8/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://zlib.net/pigz/pigz-2.8.tar.gz",
+    "integrity": "sha256-64crTw4fDr5Zyfe9jFBsQgSJO6aoSS3jHfQW8NUXD9A=",
+    "strip_prefix": "pigz-2.8",
+    "patches": {
+        "pigz.c.patch": "sha256-hn43ocLFj8X6QOJj5iQj1e2KyZmvvfKQcqE10Kzhaak=",
+        "add_build_file.patch": "sha256-guRDEB3t2BVgJsczmia/0+5xHLH9edmBh8dsGXGO3Yw=",
+        "module_dot_bazel.patch": "sha256-MLC4Fuem38sMA+1vV8/A7n2MizMeuglBSKElOxqcpaI="
+    },
+    "patch_strip": 0
+}

--- a/modules/pigz/metadata.json
+++ b/modules/pigz/metadata.json
@@ -9,7 +9,8 @@
     ],
     "repository": [],
     "versions": [
-        "2.7"
+        "2.7",
+        "2.8"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This is mostly a copy-upgrade from 2.7 that brings the module and its dependencies up to date. Yet, I decided to replace the pigz `cc_library` by a `cc_binary` as that is what pigz actually is and that also makes the binary usable via the label `@pigz`. For backwards compatibility, I kept an alias "bin".