### PR TITLE
chore(rules_python_gazelle_plugin): add latest releases

### DIFF
--- a/modules/rules_python_gazelle_plugin/0.30.0/MODULE.bazel
+++ b/modules/rules_python_gazelle_plugin/0.30.0/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "rules_python", version = "0.18.0")
 bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "gazelle", version = "0.33.0", repo_name = "bazel_gazelle")

--- a/modules/rules_python_gazelle_plugin/0.30.0/MODULE.bazel
+++ b/modules/rules_python_gazelle_plugin/0.30.0/MODULE.bazel
@@ -1,0 +1,20 @@
+module(
+    name = "rules_python_gazelle_plugin",
+    version = "0.30.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_python", version = "0.18.0")
+bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.33.0", repo_name = "bazel_gazelle")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bazelbuild_buildtools",
+    "com_github_bmatcuk_doublestar",
+    "com_github_emirpasic_gods",
+    "com_github_ghodss_yaml",
+    "in_gopkg_yaml_v2",
+)

--- a/modules/rules_python_gazelle_plugin/0.30.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_python_gazelle_plugin/0.30.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_python_gazelle_plugin",
+-    version = "0.0.0",
++    version = "0.30.0",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "rules_python", version = "0.18.0")

--- a/modules/rules_python_gazelle_plugin/0.30.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_python_gazelle_plugin/0.30.0/patches/module_dot_bazel_version.patch
@@ -9,4 +9,4 @@
      compatibility_level = 1,
  )
  
- bazel_dep(name = "rules_python", version = "0.18.0")
+ bazel_dep(name = "bazel_skylib", version = "1.5.0")

--- a/modules/rules_python_gazelle_plugin/0.30.0/presubmit.yml
+++ b/modules/rules_python_gazelle_plugin/0.30.0/presubmit.yml
@@ -1,0 +1,27 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bcr_test_module:
+  module_path: "../examples/bzlmod_build_file_generation"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2004", "windows"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      build_targets:
+        - "//..."
+        - ":modules_map"
+      test_targets:
+        - "//..."

--- a/modules/rules_python_gazelle_plugin/0.30.0/presubmit.yml
+++ b/modules/rules_python_gazelle_plugin/0.30.0/presubmit.yml
@@ -16,10 +16,12 @@ bcr_test_module:
   module_path: "../examples/bzlmod_build_file_generation"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       build_targets:
         - "//..."
         - ":modules_map"

--- a/modules/rules_python_gazelle_plugin/0.30.0/source.json
+++ b/modules/rules_python_gazelle_plugin/0.30.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-O4tM3Jkbyd74gz0RjkyFDxt0mLPWXVaY7qksNSi4zyw=",
+    "strip_prefix": "rules_python-0.30.0/gazelle",
+    "url": "https://github.com/bazelbuild/rules_python/releases/download/0.30.0/rules_python-0.30.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-DnOs+KqW1MpWYFuCj2pLLImKTJFZRAhcxInTimysrfo="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_python_gazelle_plugin/0.30.0/source.json
+++ b/modules/rules_python_gazelle_plugin/0.30.0/source.json
@@ -3,7 +3,7 @@
     "strip_prefix": "rules_python-0.30.0/gazelle",
     "url": "https://github.com/bazelbuild/rules_python/releases/download/0.30.0/rules_python-0.30.0.tar.gz",
     "patches": {
-        "module_dot_bazel_version.patch": "sha256-DnOs+KqW1MpWYFuCj2pLLImKTJFZRAhcxInTimysrfo="
+        "module_dot_bazel_version.patch": "sha256-uOz9S71NSc8+z/I1GcoepF7BmkDFrCzKicZEuau9NIE="
     },
     "patch_strip": 1
 }

--- a/modules/rules_python_gazelle_plugin/0.31.0/MODULE.bazel
+++ b/modules/rules_python_gazelle_plugin/0.31.0/MODULE.bazel
@@ -4,6 +4,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "rules_python", version = "0.18.0")
 bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "gazelle", version = "0.33.0", repo_name = "bazel_gazelle")

--- a/modules/rules_python_gazelle_plugin/0.31.0/MODULE.bazel
+++ b/modules/rules_python_gazelle_plugin/0.31.0/MODULE.bazel
@@ -1,0 +1,20 @@
+module(
+    name = "rules_python_gazelle_plugin",
+    version = "0.31.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_python", version = "0.18.0")
+bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.33.0", repo_name = "bazel_gazelle")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bazelbuild_buildtools",
+    "com_github_bmatcuk_doublestar",
+    "com_github_emirpasic_gods",
+    "com_github_ghodss_yaml",
+    "in_gopkg_yaml_v2",
+)

--- a/modules/rules_python_gazelle_plugin/0.31.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_python_gazelle_plugin/0.31.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_python_gazelle_plugin",
+-    version = "0.0.0",
++    version = "0.31.0",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "rules_python", version = "0.18.0")

--- a/modules/rules_python_gazelle_plugin/0.31.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_python_gazelle_plugin/0.31.0/patches/module_dot_bazel_version.patch
@@ -9,4 +9,4 @@
      compatibility_level = 1,
  )
  
- bazel_dep(name = "rules_python", version = "0.18.0")
+ bazel_dep(name = "bazel_skylib", version = "1.5.0")

--- a/modules/rules_python_gazelle_plugin/0.31.0/presubmit.yml
+++ b/modules/rules_python_gazelle_plugin/0.31.0/presubmit.yml
@@ -1,0 +1,27 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bcr_test_module:
+  module_path: "../examples/bzlmod_build_file_generation"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2004", "windows"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      build_targets:
+        - "//..."
+        - ":modules_map"
+      test_targets:
+        - "//..."

--- a/modules/rules_python_gazelle_plugin/0.31.0/presubmit.yml
+++ b/modules/rules_python_gazelle_plugin/0.31.0/presubmit.yml
@@ -16,10 +16,12 @@ bcr_test_module:
   module_path: "../examples/bzlmod_build_file_generation"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       build_targets:
         - "//..."
         - ":modules_map"

--- a/modules/rules_python_gazelle_plugin/0.31.0/source.json
+++ b/modules/rules_python_gazelle_plugin/0.31.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-xovcT77CXeW1STuIGc/Id8TqKZwNyxXCRMWgAgjN4xE=",
+    "strip_prefix": "rules_python-0.31.0/gazelle",
+    "url": "https://github.com/bazelbuild/rules_python/releases/download/0.31.0/rules_python-0.31.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-XRn4li28IdY6lIQkWGGhaQxmEnb3YnxzQ9+oBNFRlBQ="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_python_gazelle_plugin/0.31.0/source.json
+++ b/modules/rules_python_gazelle_plugin/0.31.0/source.json
@@ -3,7 +3,7 @@
     "strip_prefix": "rules_python-0.31.0/gazelle",
     "url": "https://github.com/bazelbuild/rules_python/releases/download/0.31.0/rules_python-0.31.0.tar.gz",
     "patches": {
-        "module_dot_bazel_version.patch": "sha256-XRn4li28IdY6lIQkWGGhaQxmEnb3YnxzQ9+oBNFRlBQ="
+        "module_dot_bazel_version.patch": "sha256-lek54NydBI/txXMjO1DQ15VEYqw321ucjdUziPj3olU="
     },
     "patch_strip": 1
 }

--- a/modules/rules_python_gazelle_plugin/metadata.json
+++ b/modules/rules_python_gazelle_plugin/metadata.json
@@ -2,14 +2,14 @@
     "homepage": "https://github.com/bazelbuild/rules_python",
     "maintainers": [
         {
-            "name": "Richard Levasseur",
             "email": "rlevasseur@google.com",
-            "github": "rickeylev"
+            "github": "rickeylev",
+            "name": "Richard Levasseur"
         },
         {
-            "name": "Thulio Ferraz Assis",
             "email": "thulio@aspect.dev",
-            "github": "f0rmiga"
+            "github": "f0rmiga",
+            "name": "Thulio Ferraz Assis"
         }
     ],
     "repository": [
@@ -24,7 +24,9 @@
         "0.26.0",
         "0.27.0",
         "0.27.1",
-        "0.29.0"
+        "0.29.0",
+        "0.30.0",
+        "0.31.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
The BCR publishing app failed with the latest releases.
