### PR TITLE
feat: add `rules_coreutils@1.0.0-alpha.7`

### DIFF
--- a/modules/rules_coreutils/1.0.0-alpha.7/MODULE.bazel
+++ b/modules/rules_coreutils/1.0.0-alpha.7/MODULE.bazel
@@ -1,0 +1,195 @@
+module(
+    name = "rules_coreutils",
+    version = "1.0.0-alpha.7",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.1")
+bazel_dep(name = "download_utils", version = "1.0.0-beta.1")
+
+archive = use_repo_rule("@download_utils//download/archive:defs.bzl", "download_archive")
+
+archive(
+    name = "coreutils-arm64-linux-gnu",
+    srcs = ["entrypoint"],
+    integrity = "sha256-8wMVMgAgf8JQ2+2LdoewkyDo416VEsf9RlMJl4jiBjk=",
+    links = {
+        "coreutils": "entrypoint",
+    },
+    strip_prefix = "coreutils-0.0.23-aarch64-unknown-linux-gnu",
+    urls = ["https://github.com/uutils/coreutils/releases/download/0.0.23/coreutils-0.0.23-aarch64-unknown-linux-gnu.tar.gz"],
+)
+
+archive(
+    name = "coreutils-amd64-linux-gnu",
+    srcs = ["entrypoint"],
+    integrity = "sha256-u7OMW43Y46aXRRIKULfKdfUW51WJn6G70s5Xxwb6/1g=",
+    links = {
+        "coreutils": "entrypoint",
+    },
+    strip_prefix = "coreutils-0.0.23-x86_64-unknown-linux-gnu",
+    urls = ["https://github.com/uutils/coreutils/releases/download/0.0.23/coreutils-0.0.23-x86_64-unknown-linux-gnu.tar.gz"],
+)
+
+archive(
+    name = "coreutils-amd64-windows-msvc",
+    srcs = ["entrypoint"],
+    integrity = "sha256-aglIj5JvFGLm2ABwRzWAsZRTTD3X444V3GxHM9pGJS4=",
+    links = {
+        "coreutils.exe": "entrypoint",
+    },
+    strip_prefix = "coreutils-0.0.23-x86_64-pc-windows-msvc",
+    urls = ["https://github.com/uutils/coreutils/releases/download/0.0.23/coreutils-0.0.23-x86_64-pc-windows-msvc.zip"],
+)
+
+archive(
+    name = "coreutils-arm64-macos-darwin",
+    srcs = ["entrypoint"],
+    integrity = "sha256-KP90sjKxtXDbLC+o5f4+gQnvP3Tr7O0RopME4g9QF5E=",
+    links = {
+        "coreutils": "entrypoint",
+    },
+    strip_prefix = "coreutils-0.0.23-aarch64-apple-darwin",
+    urls = ["https://github.com/uutils/coreutils/releases/download/0.0.23/coreutils-0.0.23-aarch64-apple-darwin.tar.gz"],
+)
+
+archive(
+    name = "coreutils-amd64-macos-darwin",
+    srcs = ["entrypoint"],
+    integrity = "sha256-SswetVAuK/hMK1r9uBvNnKj5JpSgD0bzkbsHTxOabCo=",
+    links = {
+        "coreutils": "entrypoint",
+    },
+    strip_prefix = "coreutils-0.0.23-x86_64-apple-darwin",
+    urls = ["https://github.com/uutils/coreutils/releases/download/0.0.23/coreutils-0.0.23-x86_64-apple-darwin.tar.gz"],
+)
+
+select = use_repo_rule("@toolchain_utils//toolchain/local/select:defs.bzl", "toolchain_local_select")
+
+select(
+    name = "coreutils",
+    map = {
+        "amd64-linux-gnu": "@coreutils-amd64-linux-gnu",
+        "arm64-linux-gnu": "@coreutils-arm64-linux-gnu",
+        "amd64-windows": "@coreutils-amd64-windows-msvc",
+        "arm64-macos-darwin": "@coreutils-arm64-macos-darwin",
+        "amd64-macos-darwin": "@coreutils-amd64-macos-darwin",
+    },
+)
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+export.symlink(
+    name = "coreutils",
+    target = "@coreutils",
+)
+
+deb = use_repo_rule("@download_utils//download/deb:defs.bzl", "download_deb")
+
+deb(
+    name = "busybox-arm64-linux",
+    srcs = ["busybox"],
+    integrity = "sha256-C0+0zi0/0Woc11BTX5d1ugxC2GOeE9ZjUka6g6DUvc8=",
+    strip_prefix = "bin",
+    urls = ["http://ftp.uk.debian.org/debian/pool/main/b/busybox/busybox-static_1.35.0-4+b3_arm64.deb"],
+)
+
+deb(
+    name = "busybox-amd64-linux",
+    srcs = ["busybox"],
+    integrity = "sha256-rMRMIHKVuGEU2kiV71Ouvxhr8839wmmloaCer6xqYNs=",
+    strip_prefix = "bin",
+    urls = ["http://ftp.uk.debian.org/debian/pool/main/b/busybox/busybox-static_1.35.0-4+b3_amd64.deb"],
+)
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+which = use_repo_rule("@toolchain_utils//toolchain/local/which:defs.bzl", "toolchain_local_which")
+
+[
+    (
+        resolved(
+            name = "resolved-{}".format(tool),
+            basename = tool,
+            toolchain_type = "//coreutils/toolchain/{}:type".format(tool),
+        ),
+        which(
+            name = "which-{}".format(tool),
+            basename = tool,
+        ),
+    )
+    for tool in (
+        "busybox",
+        "coreutils",
+        "arch",
+        "base64",
+        "basename",
+        "cat",
+        "chmod",
+        "chown",
+        "cp",
+        "cut",
+        "date",
+        "dd",
+        "df",
+        "dirname",
+        "du",
+        "echo",
+        "env",
+        "expand",
+        "expr",
+        "factor",
+        "false",
+        "fold",
+        "head",
+        "hostname",
+        "install",
+        "link",
+        "ln",
+        "ls",
+        "md5sum",
+        "mkdir",
+        "mktemp",
+        "more",
+        "mv",
+        "nl",
+        "nproc",
+        "od",
+        "paste",
+        "printf",
+        "pwd",
+        "readlink",
+        "realpath",
+        "rm",
+        "rmdir",
+        "seq",
+        "sha1sum",
+        "sha256sum",
+        "sha3sum",
+        "sha512sum",
+        "shred",
+        "shuf",
+        "sleep",
+        "sort",
+        "sync",
+        "tac",
+        "tail",
+        "tee",
+        "test",
+        "touch",
+        "tr",
+        "true",
+        "truncate",
+        "uname",
+        "unexpand",
+        "uniq",
+        "unlink",
+        "wc",
+        "whoami",
+        "yes",
+    )
+]
+
+register_toolchains("//coreutils/toolchain/...")

--- a/modules/rules_coreutils/1.0.0-alpha.7/presubmit.yml
+++ b/modules/rules_coreutils/1.0.0-alpha.7/presubmit.yml
@@ -1,0 +1,19 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - debian10
+      - ubuntu2004
+      - macos
+      - macos_arm64
+      # TODO: enable this once the `gitlab.arm.com` does not use a self-signed certificate
+      # - windows
+  tasks:
+    run_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_coreutils/1.0.0-alpha.7/source.json
+++ b/modules/rules_coreutils/1.0.0-alpha.7/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_coreutils/-/releases/v1.0.0-alpha.7/downloads/src.tar.gz",
+  "integrity": "sha512-x67O5V7ht6zZXiE5kVbaJK9clGpKki8h98bFLC4G8cbaHNyUXYYgPCVZUPec8EP8N7cVdozyqiEpyJT5lnZH4w==",
+  "strip_prefix": "rules_coreutils-v1.0.0-alpha.7"
+}

--- a/modules/rules_coreutils/metadata.json
+++ b/modules/rules_coreutils/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://gitlab.arm.com/bazel/rules_coreutils",
+    "repository": [
+        "https://gitlab.arm.com/bazel/rules_coreutils"
+    ],
+    "versions":[
+        "1.0.0-alpha.7"
+    ],
+    "maintainers": [
+        {
+            "email": "matthew.clarkson@arm.com",
+            "github": "mattyclarkson",
+            "name": "Matt Clarkson"
+        }
+    ]
+}


### PR DESCRIPTION
Each core utility has it's own toolchain definition. These toolchains are backed by `uutils/coreutils` for all machines and statically compiled `busybox` on Linux machines.

It is important to register them as separate toolchains so rules can selectively decide which core utilities they depend on. It may be the case that a rule needs a specific feature for a particular core utility. This can be then handled with constraints and toolchain resolution for that particular core utility. The other benefit is that we can register the individual GNU core utilities to each toolchain, if one has a hermetic build of GNU coreutils. We will be upstreaming a separate PR for a module that provides some of those.

In general, rules should only rely on POSIX specified functionality of core utilities as it is not guaranteed that a GNU alternative is provided.

Naming this `rules_coreutils` makes sense: we hope to have a rounded set of rules that wrap the various tools. Currently, the only one is `coreutils_dd` in this alpha release. Future rules are in staging and will land in subsequent alpha releases before the inevitable beta.

Getting this into the BCR opens the door for rulesets to become more hermetic by using core utilites from the module rather than assuming that core utilities are available on the host.

More information is available in the [README](https://gitlab.arm.com/bazel/rules_coreutils/-/blob/main/README.md)