### PR TITLE
feat: add `rules_curl@1.0.0-alpha.6`

### DIFF
--- a/modules/rules_curl/1.0.0-alpha.6/MODULE.bazel
+++ b/modules/rules_curl/1.0.0-alpha.6/MODULE.bazel
@@ -1,0 +1,28 @@
+module(
+    name = "rules_curl",
+    version = "1.0.0-alpha.6",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.1")
+bazel_dep(name = "ape", version = "1.0.0-alpha.1")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+use_repo(export, "ape-curl")
+export.symlink(
+    name = "curl",
+    target = "@ape-curl",
+)
+use_repo(export, "curl")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+resolved(
+    name = "resolved-curl",
+    toolchain_type = "//curl/toolchain/cli:type",
+)
+
+register_toolchains("//curl/toolchain/cli:all")

--- a/modules/rules_curl/1.0.0-alpha.6/presubmit.yml
+++ b/modules/rules_curl/1.0.0-alpha.6/presubmit.yml
@@ -1,0 +1,21 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - debian10
+      - ubuntu2004
+      - macos
+      # TODO: enable this once `ape` has working launcher for Apple silicon
+      # - macos_arm64
+      # TODO: enable this once the `gitlab.arm.com` does not use a self-signed certificate
+      # TODO: enable this once `curl_upload_file` has a Batch script to work on Windows
+      # - windows
+  tasks:
+    run_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_curl/1.0.0-alpha.6/source.json
+++ b/modules/rules_curl/1.0.0-alpha.6/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_curl/-/releases/v1.0.0-alpha.6/downloads/src.tar.gz",
+  "integrity": "sha512-bVBNf7SH5rgyb41fUfzi3ouQ5mw3Ab7CXn3KDUZdntlnzdT3GcQz6aL2YTbOqlzzUCLZrs5Pp3VOkFWeX4/lzg==",
+  "strip_prefix": "rules_curl-v1.0.0-alpha.6"
+}

--- a/modules/rules_curl/metadata.json
+++ b/modules/rules_curl/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://gitlab.arm.com/bazel/rules_curl",
+    "repository": [
+        "https://gitlab.arm.com/bazel/rules_curl"
+    ],
+    "versions":[
+        "1.0.0-alpha.6"
+    ],
+    "maintainers": [
+        {
+            "email": "matthew.clarkson@arm.com",
+            "github": "mattyclarkson",
+            "name": "Matt Clarkson"
+        }
+    ]
+}


### PR DESCRIPTION
This uses the pre-built `curl` executable provided by the `ape` BCR module to be hermetic.

It only implements *one* (!) rule: `curl_upload_file` at this time.

We expect to add more `curl` rules in the future, plus Windows support.