### PR TITLE
liburing@2.5: build against (default) libc

### DIFF
--- a/modules/liburing/2.5/patches/add_build_file.patch
+++ b/modules/liburing/2.5/patches/add_build_file.patch
@@ -26,7 +26,7 @@
 +            # switch to the package dir to execute "configure" right there
 +            pushd $$(dirname $(location configure))
 +              mkdir -p src/include/liburing
-+              ./configure
++              ./configure --use-libc
 +            popd
 +
 +            # collect the outputs

--- a/modules/liburing/2.5/source.json
+++ b/modules/liburing/2.5/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-RW9fiCFlYw8Nx7dej9U70BqVXV1HIHKbQyMJfm6fKpg=",
     "strip_prefix": "liburing-liburing-2.5",
     "patches": {
-        "add_build_file.patch": "sha256-iaxBTReaJ8Aa/C3ux3n85EekDamjwfkv6HZ6aRHo5zo=",
+        "add_build_file.patch": "sha256-bSFDyIEyJYYP0sXNNePKjbnLKGMveouIm6pZ6fRY9Yc=",
         "module_dot_bazel.patch": "sha256-YB8pxLkYyg8znqTewNFcc9D/bPjQ30plU+xoLEKWSco="
     },
     "patch_strip": 1


### PR DESCRIPTION
The default `./configure` invocation sets up the build for static linking (skipping any std library dependencies). That causes this module to be broken as is. It builds, but it can't be linked against as the built-in libc replacement functionality from src/nolibc.c is not compiled along. Fix this by following distributions like Debian and Fedora, and build the package against the supplied libc by specifying `--use-libc`.

It is unlikely that somebody already used this module as it was broken and only merged a few days ago.