### PR TITLE
feat: add `rules_diff@1.0.0-alpha.3`

### DIFF
--- a/modules/rules_diff/1.0.0-alpha.3/MODULE.bazel
+++ b/modules/rules_diff/1.0.0-alpha.3/MODULE.bazel
@@ -1,0 +1,33 @@
+module(
+    name = "rules_diff",
+    version = "1.0.0-alpha.3",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.1")
+bazel_dep(name = "ape", version = "1.0.0-alpha.3")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+[
+    (
+        use_repo(export, "ape-{}".format(tool)),
+        export.symlink(
+            name = tool,
+            target = "@ape-{}".format(tool),
+        ),
+        use_repo(export, tool),
+        resolved(
+            name = "resolved-{}".format(tool),
+            toolchain_type = "//diff/toolchain/{}:type".format(tool),
+        ),
+    )
+    for tool in ("diff", "diff3", "sdiff", "cmp")
+]
+
+register_toolchains("//diff/toolchain/...")

--- a/modules/rules_diff/1.0.0-alpha.3/presubmit.yml
+++ b/modules/rules_diff/1.0.0-alpha.3/presubmit.yml
@@ -1,0 +1,20 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - debian10
+      - ubuntu2004
+      - macos
+      # TODO: we need `ape` to support `macos_arm64`
+      # - macos_arm64
+      # TODO: enable this once the `gitlab.arm.com` certificate is validated on BuildKite runner
+      # - windows
+  tasks:
+    run_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_diff/1.0.0-alpha.3/source.json
+++ b/modules/rules_diff/1.0.0-alpha.3/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_diff/-/releases/v1.0.0-alpha.3/downloads/src.tar.gz",
+  "integrity": "sha512-g8eVWXWcRpkiWjxs54Zua9tjdX/mTZV2yWslBrFqftvHDaCLxJQ1uXb4fRqC3pM1XKFouelMkviYZSMJaVAT8w==",
+  "strip_prefix": "rules_diff-v1.0.0-alpha.3"
+}

--- a/modules/rules_diff/metadata.json
+++ b/modules/rules_diff/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://gitlab.arm.com/bazel/rules_diff",
+    "repository": [
+        "https://gitlab.arm.com/bazel/rules_diff"
+    ],
+    "versions":[
+        "1.0.0-alpha.3"
+    ],
+    "maintainers": [
+        {
+            "email": "matthew.clarkson@arm.com",
+            "github": "mattyclarkson",
+            "name": "Matt Clarkson"
+        }
+    ]
+}


### PR DESCRIPTION
Brings two rules:

- `diff_file_test`
- `diff_directory_test`

Uses `diff` from `ape` so is hermetic and consistent across operating systems, even Windows.

Negates the non-hermetic-ness of `bazel_skylib#diff_test` that uses `diff` from the system.

A new module for `diff` related rules makes sense, in the future we may want to enable a three file comparison rule with `diff3`, byte-by-byte comparison with `cmp` or other possible differencing rules.

This module also exposes the hermetic toolchains for use in other modules:

- `@rules_diff//diff/toolchain/diff:type`
- `@rules_diff//diff/toolchain/diff3:type`
- `@rules_diff//diff/toolchain/sdiff:type`
- `@rules_diff//diff/toolchain/cmp:type`

At this time, we're in alpha as the rules need to be fleshed out and tested in more situations. For example, we are not fully testing with all possible combinations of runfiles.