### PR TITLE
feat: add `rules_squashfs@1.0.0-alpha.1`

### DIFF
--- a/modules/rules_squashfs/1.0.0-alpha.1/MODULE.bazel
+++ b/modules/rules_squashfs/1.0.0-alpha.1/MODULE.bazel
@@ -1,0 +1,34 @@
+module(
+    name = "rules_squashfs",
+    version = "1.0.0-alpha.1",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_coreutils", version = "1.0.0-alpha.7")
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.1")
+bazel_dep(name = "squashfs-tools", version = "4.6.1")
+
+bazel_dep(name = "hermetic_cc_toolchain", version = "2.2.3", dev_dependency = True)
+
+which = use_repo_rule("@toolchain_utils//toolchain/local/which:defs.bzl", "toolchain_local_which")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+[
+    (
+        which(
+            name = "which-{}".format(tool),
+        ),
+        resolved(
+            name = "resolved-{}".format(tool),
+            basename = tool,
+            toolchain_type = "//squashfs/toolchain/{}:type".format(tool),
+        ),
+    )
+    for tool in ("mksquashfs", "unsquashfs", "sqfstar")
+]
+
+register_toolchains("//squashfs/toolchain/...")

--- a/modules/rules_squashfs/1.0.0-alpha.1/presubmit.yml
+++ b/modules/rules_squashfs/1.0.0-alpha.1/presubmit.yml
@@ -1,0 +1,22 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian11
+      - ubuntu2004
+      - ubuntu2004_arm64
+      - ubuntu2204
+      - fedora39
+      # TODO: implement functionality on Mac
+      # - macos
+      # - macos_arm64
+  tasks:
+    run_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_squashfs/1.0.0-alpha.1/source.json
+++ b/modules/rules_squashfs/1.0.0-alpha.1/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_squashfs/-/releases/v1.0.0-alpha.1/downloads/src.tar.gz",
+  "integrity": "sha512-VFu+J0ZA+gShK+vSZIcVjwskaSZP3YugRI3coCj/ffHn5m4aAb7bcd2V0SR3F5f0LnWaENeB1IzgZKggnQc0Xg==",
+  "strip_prefix": "rules_squashfs-v1.0.0-alpha.1"
+}

--- a/modules/rules_squashfs/metadata.json
+++ b/modules/rules_squashfs/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://gitlab.arm.com/bazel/rules_squashfs",
+    "repository": [
+        "https://gitlab.arm.com/bazel/rules_squashfs"
+    ],
+    "versions":[
+        "1.0.0-alpha.1"
+    ],
+    "maintainers": [
+        {
+            "email": "matthew.clarkson@arm.com",
+            "github": "mattyclarkson",
+            "name": "Matt Clarkson"
+        }
+    ]
+}


### PR DESCRIPTION
Brings two main rules:

- `squashfs_tar`: build a SquashFS from a collection of tar archives
- `squashfs_unpack`: unpackages a SquashFS into a declared directory (`TreeArtifact`)

Provides toolchains for usage in other rules:

- `@rules_squashfs//squashfs/toolchain/mksquashfs`
- `@rules_squashfs//squashfs/toolchain/sqfstar`
- `@rules_squashfs//squashfs/toolchain/unsquashfs`

Is hermetic if the user provides a hermetic C/C++ toolchain, otherwise everything else is hermetically provided via `rules_coreutils`.