### PR TITLE
feat: add `ape@1.0.0-beta.5`

### DIFF
--- a/modules/ape/1.0.0-alpha.5/MODULE.bazel
+++ b/modules/ape/1.0.0-alpha.5/MODULE.bazel
@@ -1,0 +1,271 @@
+module(
+    name = "ape",
+    version = "1.0.0-alpha.5",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_curl", version = "1.0.0-alpha.6", dev_dependency = True)
+
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.3")
+bazel_dep(name = "download_utils", version = "1.0.0-beta.1")
+
+download_archive = use_repo_rule("@download_utils//download/archive:defs.bzl", "download_archive")
+
+download_file = use_repo_rule("@download_utils//download/file:defs.bzl", "download_file")
+
+[
+    download_file(
+        name = binary,
+        executable = True,
+        integrity = integrity,
+        output = "ape",
+        urls = [
+            "https://gitlab.arm.com/api/v4/projects/bazel%2Fape/packages/generic/cosmo.zip/3.2.4/{}".format(binary),
+            "https://cosmo.zip/pub/cosmos/v/3.2.4/bin/{}".format(binary),
+        ],
+    )
+    for binary, integrity in {
+        "ape-arm64.elf": "sha256-h3zL1GUkMGVCbLSjyrQ1GsrZGGSfhlZVa7YEiC7q0I8=",
+        "ape-x86_64.elf": "sha256-fBz4sk4bbdatfaOBcEXVgq2hRrTW7AxqRb6oMOOmX00=",
+        "ape-x86_64.macho": "sha256-btvd3YJTsgZojeJJGIrf2OuFDpw9nxmEMleBS5NsWZg=",
+    }.items()
+]
+
+pe = use_repo_rule("//ape/pe:repository.bzl", "pe")
+
+pe(name = "ape.pe")
+
+select = use_repo_rule("@toolchain_utils//toolchain/local/select:defs.bzl", "toolchain_local_select")
+
+select(
+    name = "launcher",
+    map = {
+        "arm64-linux": "@ape-arm64.elf",
+        "amd64-linux": "@ape-x86_64.elf",
+        "amd64-darwin": "@ape-x86_64.macho",
+        "windows": "@ape.pe",
+    },
+)
+
+ape_entrypoint = use_repo_rule("//ape/entrypoint:defs.bzl", "ape_entrypoint")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+
+[
+    (
+        download_file(
+            name = "cosmos-{}".format(binary),
+            executable = True,
+            integrity = integrity,
+            output = binary,
+            urls = [
+                "https://gitlab.arm.com/api/v4/projects/bazel%2Fape/packages/generic/cosmo.zip/3.2.4/{}".format(binary),
+                "https://cosmo.zip/pub/cosmos/v/3.2.4/bin/{}".format(binary),
+            ],
+        ),
+        ape_entrypoint(
+            name = binary,
+            binary = "@cosmos-{}//:{}".format(binary, binary),
+        ),
+        export.symlink(
+            name = "ape-{}".format(binary),
+            target = "@{}".format(binary),
+        ),
+    )
+    for binary, integrity in {
+        "awk": "sha256-f+uWrpvZmKp0icmVlTusCWs4TvqR2FrmOkQ1E7JEo/Q=",
+        "b2sum": "sha256-C0A+VvLQwqWyZ43zLhgi3tX5X8mCSGUT4kBoTsCtsOA=",
+        "base32": "sha256-UKvhDPWxj5CBiJcC8v22sLAkAMRbeyr0HgsQT3aRpJo=",
+        "base64": "sha256-Ma0Uq9TjmARCgwZWzTBcuEFyIkMXUahQqms9sUQPYjE=",
+        "basename": "sha256-wVt/L/UlzFofy0HnJzUxwSipYmqvpnWSYNffI6kHSOg=",
+        "basenc": "sha256-ss0EQU9BQPJDOhFS2kyr39G9ql6cme2hKhJ5LXu41No=",
+        "bash": "sha256-817s6bXbU96XAE/lpw/bVjtaG/HZNkiM2orJBhKWaXY=",
+        "berry": "sha256-iRihZOPxJy8riq00G9QqyuDphQGZW87arvQa7wu5WJ0=",
+        "brotli": "sha256-5dbhyGt64HdqXrSmTVdOlpyVgW3A3FTcRy9JNKlETbE=",
+        "bzip2": "sha256-i0jxsBCz1axEaa9Kd1TFPTFwAVYFhbR6dGqUl/OfwYQ=",
+        "cat": "sha256-hxd0pfBMmXT44ii103FiMUI3pQYHj7UmNW4pqnw12HY=",
+        "chcon": "sha256-NKrTh2us8Pc67LI7udJg9JhlhobHU03laNr4U+5DhF8=",
+        "chgrp": "sha256-7KvHpFFsvhK981vIlGyegWuQhIzxY87lYcYfNB/qdC8=",
+        "chown": "sha256-XlKnJcZ1t7cdBKC2twaXC8/X6p7bSpnFoIDQ0xxdrhQ=",
+        "chroot": "sha256-lN46T08G7T85BC9L/q4k9vlLwNKWbyD0YkAclHWUGuw=",
+        "cksum": "sha256-ZN7kzOdpdzCUsa+1+2dsZ19980fhL5x7tnYdKRqW7OY=",
+        "clang-format": "sha256-t1/HDaTZ/klR+VFONNcqj5uxgIm37dafKu5Mp99ecVQ=",
+        "comm": "sha256-Z4pMcRlfC6n9KC5Z8cSZT5NA+e/0Zl30tW4zRB+Ml7I=",
+        "cpuid": "sha256-KZ7I9Vj0m0SYjYdlFCDsWAeZZHq5CL2V2/DiBJgVPFE=",
+        "csplit": "sha256-PnfIPYD2n2cZ8rxV26jvFiE6e+XROXGwhE6sbpjbPSY=",
+        "ctags": "sha256-6GwrTt16hCzJ8EoVXQXoetwnOIOhBR4T4gX2PO/wIfQ=",
+        "curl": "sha256-jc8LNKBMlWgGeHW3Tum9M6AfV2a5PlLmJunmfs00q/M=",
+        "cut": "sha256-N6iYRU/Ue0YN1tW0YElHjCVe0aPrUtbSxWFaJUPXGAE=",
+        "dash": "sha256-DQjaobzAoYxtxBvvDdyQLbTvjPV61HLMOahNEXz8dOM=",
+        "datasette": "sha256-ohY3OEDwK6DOSWfLFlUa/4MTTHd9kKGN8NYTwGyWOZA=",
+        "date": "sha256-4r91y6qrOb4PK5AQ23uY2lskgprTRGLwDTBOkMPF1/c=",
+        "df": "sha256-rrkKRiH346Qfr/uwtOFe5x+Q3X1yajhCndbTxnkkiSI=",
+        "dir": "sha256-XfB99aziyrFfAHbOzI36cXPn+633uND4y02Mn9wTx98=",
+        "dircolors": "sha256-FTu1gC+xUzR1NTxaXk9ZLu4Gp2ACwnQC2FvHJySd1/Q=",
+        "dirname": "sha256-F9LmexRfLOqVyybPSXv+2xBhLakd8fnV01T/yZK78EU=",
+        "du": "sha256-cwPg/fIABRhBnlWOXTpC7GaIEi/L2vgMqPUAZ8vnxLA=",
+        "emacs": "sha256-FHVaf2drHxbWKWpCc0pBlt8NNLiR6x6pX9KrhCkI5zM=",
+        "emacsclient": "sha256-2p9WFK4fF0vnJDUyNTd6a4jigqsQpp0aG41e0MQSJOM=",
+        "env": "sha256-KSmB7dXht0FmmkJB8JQnUw6uQIfG36SugQXyMdPKPso=",
+        "expand": "sha256-GDxdiCM3bnYQtE+brm6GgDN7EyjV+5vxYj1McQ/YGLQ=",
+        "expr": "sha256-GD2DSrlrlym+z+57/BUKL50paNN1QU6FGe1D3wxtnnk=",
+        "factor": "sha256-Pmziyh/iAkeaU/XHmAblS/4QfA6YDbml6qSX/yqVj6s=",
+        "false": "sha256-FuIagCcD2snlx2D2D2k5+qhA2KXgWcoxMDY7O1qlE74=",
+        "find": "sha256-k3BJOldX6NzX1Aq/RX6Q6PQts/3l9IFR7BILMIDUkg8=",
+        "fmt": "sha256-ZjBJtahjGrr6Xll85ZZo+lTGEZNdaSksUNqpkpMqyrY=",
+        "fold": "sha256-u5I83GpxaXBKFtzsJVJEWdQ1hJkpRmJGbQVHzjOYJ3w=",
+        "gmake": "sha256-o5a22Uli7i9upNh3z9qwPRFv3vIF7hOSdYMCXz8ioQc=",
+        "greenbean": "sha256-2e6ANHtNrFdAKdmSAVBOYWacqaF9SxOhrwKesYwIfSc=",
+        "grep": "sha256-btb7IC+1GiiU+CTMX4F7F8ESESShnVx90+Vz8uhgkkA=",
+        "groups": "sha256-1hRskXbgQrpy3YedFo9SmYix5KUTJAV9cL6I0T/DF7c=",
+        "head": "sha256-I4EetDV9GYYKHCNANar3iwNNZMJhJ9+KaQBkWyA0r7o=",
+        "id": "sha256-JtW0OHrUUwEaHsb03yfoawekOVad+XZ2sl8ZnM0+rYc=",
+        "install": "sha256-FT0vE0RtmwB2+ArCfbm59mou/sLQzymNvTqogiVpRTg=",
+        "join": "sha256-KVBK8dBkDM+LijUS4hi7zNsa18hZvJqNS6uWQMvxgWs=",
+        "kill": "sha256-+4mYRIwPgtQ7BEoK7/E6vXx5iriV3vpk0eNrNI2kNh8=",
+        "less": "sha256-ku05PfJLk7zICV/ljbzXavHBvnMlitaLcd3uJvfZcfU=",
+        "life": "sha256-8XQ3CXLLxo7ykT/+jGJovYCAzSEih6H4wnQ26+Q04lM=",
+        "link": "sha256-MRqILGFYuhtO470TDsIxfQe7NE1GrHjbWCnU2nb31QQ=",
+        "links": "sha256-Px+ZWWbcFLnnjuORljLehyqLBW3UIuGtEqQf3vnJXgo=",
+        "ln": "sha256-QevM7NFKo4T79iCOOu6JjAxVuoQHAiSi3zkYf3HQoHI=",
+        "locate": "sha256-zsyqygY6K+gwbw9Cw7j+JEjd1W4T66xKil7PqeFtfA8=",
+        "logname": "sha256-if+qby9Pyn2PT53NEIoPXW/xusX5N8TK6lFNhOYEk7A=",
+        "ls": "sha256-09ABdeL9W/aloHvspUOTk4s1qXPKelusGWs/fI5elBY=",
+        "lua": "sha256-xuf+7nkxzN/uNIJ8j7adEqf6dvm3X+QT4LeDtRBeoBM=",
+        "lz4": "sha256-hS8xfK0iRyQ51wndmPpRqC2iJfJzvk4OSPtdBNoDzIg=",
+        "make": "sha256-oxtmxi2jmEKg2EX4gzBsmikSI3H56Cb4TL5JDLrHmes=",
+        "md5sum": "sha256-V02adwdclgCCznwYMv8TzulmGsJCj0nY6BbLm9+3BmI=",
+        "mkfifo": "sha256-Qn7ki2D6CeAj35bXjjdtn8uoTIWvQzrJQgQW5YwVjNE=",
+        "mknod": "sha256-WuoCTQkW92gL+rkPEsIVekSW3T5jWpLe4d0tkEEVlto=",
+        "mktemp": "sha256-e4OIGcZD2+IeoysBxEx3+PzbkFxduS3t17Xh6APVTg0=",
+        "mktemper": "sha256-ukMdMND+GwcBR+OdH6KDdHTYSOc1pKWAbYomyj9ZoOo=",
+        "nano": "sha256-E8aX3D/XXItFzwVS7UO3tCD2I4gCx9K7oqFjkWC+hEA=",
+        "nesemu1": "sha256-3tEEU6VMPK8bwloRQ2CkLXD8+icXne+EBdHUtfYPsmw=",
+        "nice": "sha256-ukGk1uudFSnluQXKEtGsAIzL6JhXe4NaLC53QdcyK+E=",
+        "ninja": "sha256-6vNW/WRG9QrsaksgbhhdEPyb9VgzATt2AEJj6jlyfmo=",
+        "nl": "sha256-per3cJdCvbTUMe1rs76QJ/E9eQYfUl4VVPafj0yJFHk=",
+        "nohup": "sha256-4eCoAypbSFOk/Bgq8jfyv2BPPP78iNLXb711CK8buGU=",
+        "nproc": "sha256-uKzADOYvOwHwG9Wc7v0EHPJdidt7Vx1CY0ur9QL0ziM=",
+        "numfmt": "sha256-CT5axyDY1ASWxzGJb+hDVTRiWqU2f8+CSzhehOdR/wY=",
+        "od": "sha256-Hy0uDDsgdci74s+jI+R2Bkgj4LVaW0djddoqkzTebSE=",
+        "paste": "sha256-Sa5G8cxyh5Vsr6kkf/wmwnos0KYwIUHNI1/dZ16n24U=",
+        "pathchk": "sha256-ZjR+IGm8fv0b/hy4hmdi1xuxpoA5A7MR0AnGndlfTvc=",
+        "pigz": "sha256-KReMrcHfifpjgxeb/k4WNl6ZtgJwfDIf9mTbcEldR0w=",
+        "pinky": "sha256-ObmAOis790fvuP+YpdxP9cyR5ISU6BB4G/8un3xR4ns=",
+        "pledge": "sha256-rcK6umgSKLv06PIV+glVDhKgPr79vfIodUEsZ7WyGaM=",
+        "pr": "sha256-FVC8+/eRiBZ2MHpZNZRHrRMoDFLi4S9NRMVPQSWimOo=",
+        "printenv": "sha256-zoWUC3FJVC6a8iM2vmiEVNa4mjhmLo76aPkh2TXB+bc=",
+        "printimage": "sha256-myO0x/BQSNFuWWwDop0ph/WmO8tBsnxuTIoIzC6Xsaw=",
+        "ptx": "sha256-x6abLQHeAmLQN213aU0nx+4xfZSfWqlYWP7Fe+wueEs=",
+        "pwd": "sha256-RdIwQz9MZ5PaDIT9y0AY3YZHKYA/tUm8ylYf5RD0S8U=",
+        "pypack1": "sha256-mb3fmOwEqmunaoKZahHdRh2K8OuOSHFQQIc8Yddppic=",
+        "python": "sha256-RvuLtLNsExsN10Mipa/ewh1Qr95a0dpOOJ+j3BBht2g=",
+        "qjs": "sha256-RmszlYwDkeSbX3xZ/0m/yQCgfbJNCflaQ0KHuz1lo/w=",
+        "readlink": "sha256-3/0q9jntaXuBK5+3+FFiUHfnZhVsJILGRyw9C9jsDrM=",
+        "realpath": "sha256-+Wo9k1u/CGPqtTKgHDjdu6z7UraE444Ez82h69SIKm0=",
+        "redbean": "sha256-+zB9iVZklOfgaynLhwQG1qTP+/xUZE2A2UyTTIz9iCk=",
+        "rmdir": "sha256-olbEjveooS5XCXiLtsvXacsfR1l7AFndDB7XRLr3HwU=",
+        "rsync": "sha256-bAJZ6fMDcOpiZ9eNiC/KySEoanb8ZnXL+LBgpOuc8s4=",
+        "runcon": "sha256-m+7V7IWXjMBts1GcBvTn9yLZrekeJ2PnTIZPDPqbHyg=",
+        "script": "sha256-gF6Ux0AVHv3VK3ynVCDfwWSzCzcM6tbYUtAEYkE/Lto=",
+        "sed": "sha256-mLD3mRX7R9we3IQpAZKC7c4mF2Nz7sG8s63Is0TkYcM=",
+        "seq": "sha256-AkvogLBC9nwhq2rpaA1kL0Q4beb00QMrptcxpzXKjE0=",
+        "sha1sum": "sha256-wDWmXDgJmeEuJUd5ER9ed1rGZRxJMwEe1uR7Jrm4r2o=",
+        "sha224sum": "sha256-DPOKHJa+e04UNJm0ptGNf79Qpvdf3OCbAlHKLPFq3oM=",
+        "sha256sum": "sha256-BpxhJqv/rboyFhYy31eq5Ym3eriHcGRqOGDdmbWwAuw=",
+        "sha384sum": "sha256-Ak4+xM3+eGqXyWVghrgtAo80Fgeo6iXd10+K7tOd5HE=",
+        "sha512sum": "sha256-qq4HW+6hZ26U/TiN50QPdd710RpiPDjhrG/XfILWxE0=",
+        "shred": "sha256-7/edcRznrBT9DOKb05J39nRsjJ30LkH9Pz/5QUlsDH4=",
+        "shuf": "sha256-X1v5hF6yG2zM78Qg85wcENzihXXmMZnBTZNleRCscL4=",
+        "sleep": "sha256-esGxinA9WyISgkcQ7sPIuC7B1SwQHMXmGTYHOhZvAx0=",
+        "sort": "sha256-Ar+SpUClNPT5OItQMiiYH7CBHnSoKHa1jjN32BjqMF4=",
+        "split": "sha256-A5nEGoaZdJ5p1j3s54rgp8/BEoBVakaRE4YAqAMMZbQ=",
+        "sqlite3": "sha256-IICFVnTkqMZ/c5PPtIStX89WtBnsmIg3z1qfFJEOXlE=",
+        "stat": "sha256-KO2xc+Vf2HdfUZPh2ItTxfun5CwFNsPQArjJ22fw/a8=",
+        "stty": "sha256-S2BXpqZxSI493gq3piyCqH3dwE+yxvvAL1WWxRVd844=",
+        "sum": "sha256-Uoro6aH+YK1IIBditsXeyXhwAlR9vqLnLOQ9K8PRSuM=",
+        "sync": "sha256-1iFwSaaAXI3pdNdfrMI9PychzSGJhy0UpDCDTwCn8/U=",
+        "tac": "sha256-RG/VXzGH2MSwHLSQIG61wDmoNR5xYch3+xNbtDUROB4=",
+        "tail": "sha256-hdbjryLVn6c7MR/XX/UhaOS7+QKLYhrJUo+DsE3Xz/E=",
+        "tar": "sha256-bK1q+UwoTLgbDi6UeY20FCH3MtJaoRpWV3DHd2U7Mbw=",
+        "tee": "sha256-TJTxJe2mWPIizG4s3vwgg3wrKjew5E+1wGKRrtx+el4=",
+        "test": "sha256-djzefI/wv2XCnNfvFpjfTIJVly06qkSAsV4BoV0gUEo=",
+        "tidy": "sha256-20zyJkRs1n5tzbPTbXPfAt9CaVDsbpGZws8bddOY16E=",
+        "timeout": "sha256-aasJBcTgrDU0Xs4V4UkUW8Wsle1EdXnPdf0Fymw0Fpc=",
+        "tmux": "sha256-ZbW548NXsKv7puCJc+hHvF2hpYI7MQvZc//FAH7oTUI=",
+        "touch": "sha256-Qtxc3zlOZg2B3dXeUABQUcyFdjFCV6WPVQUr8DQP1qk=",
+        "tr": "sha256-1l1OkCTePV8SDxVQyoTtvK0fHCR9Hf+ebHGh5gEriyY=",
+        "tree": "sha256-B0m9Z2PoklikdfkbU1QyFsjlFkVzUemLSGmQTC/OL5I=",
+        "true": "sha256-Cp9RvWCvc8NmfZbMhdDz38cA8YJDVRswENEggHgEoVY=",
+        "truncate": "sha256-/u7bZBCAYeEeEeST5/9z3pmy6bgP0FAGUaUOED/Rppo=",
+        "tsort": "sha256-uTgUXY/AU+WyqjwbCR5AS8O7wzN5pROWV1Jp0hmpykc=",
+        "tty": "sha256-q7ACSLuBRoj8S/6SACtld7x6LC/HbxTjGeY7vu/8ENg=",
+        "ttyinfo": "sha256-30KPzAvNZ0hGPsi+hFXWgEQhItcB1bvRNJY+cokdcTo=",
+        "unbourne": "sha256-Q7/iZUHTlmCUQN6rw8cg7V+tb2A8RCDOnRfR9TZoMq4=",
+        "unexpand": "sha256-1aCgwxoQk7SzJXBlADz3cf/V2vMMcys0MQ3fwaICx2U=",
+        "uniq": "sha256-A6UVJI2TAChs4PaCnCbjOYK74QvhoPef+7iVhgV4urA=",
+        "unlink": "sha256-utJGVV1+wC3tQEdJ9kvr1c17Co2ljegM/+0ASl1WlUQ=",
+        "unzip": "sha256-CuORPmGI+lGcTM34owoLe6NA5O3sO2z6s/u32+52Ay8=",
+        "uptime": "sha256-m/S29ntFqzWNnInIxt6M+G0bXQVRRJullJ6+Cn0t5FM=",
+        "users": "sha256-i5UF16OR/uwcu/Zawzk0Qnj8ng5gKbwWcJQ075HRT/Y=",
+        "vdir": "sha256-iXYsmmp973x1uSnX+4na5G8sHJ5K4Y9en1GX1h8w/Xc=",
+        "verynice": "sha256-49xc858RJTKnORI8VR/qm+rWmw8685O40dyO3xA9MX4=",
+        "vim": "sha256-wf8JV2UJG15mrkruoVW5mCYRziO5+mYtoinHR/MH88o=",
+        "wall": "sha256-yPDUoIdP/jcggElRwyiHqkS89gnVDzBzkCNwJfe8E9U=",
+        "wc": "sha256-0QcoEnBZYML3zxx+8F5OywXn5KlJ2put3tVTtenRivU=",
+        "wget": "sha256-Cc6S4q1wHliGSWDZl2WVxDz+9YEdum6tFA7PLvw/UII=",
+        "who": "sha256-f/7aVNcB5lYIhOpfxiqch8S22b+nI25TrI2C2bSKXI8=",
+        "whoami": "sha256-71b9T2z17+0j8711Eyw1rWrrTBv39cIgqEk85KlWSXw=",
+        "xargs": "sha256-bP3uyxPEzbL5QeMJCTtvQPrhpiXut+iHTTeGuOCpNJg=",
+        "xz": "sha256-gTBKAnJyqP88kGYtlkZcdldoFU2J6VtcQCtfXfhrJDE=",
+        "yes": "sha256-ZGiA91He1rL0kZKHXUUH8qWmaLly/3QxtKO0R8avkbA=",
+        "zip": "sha256-Pba62aWW0gpT1wJK8Aa7HWwf3foaXnEUMxkfN8pZ01E=",
+        "zsh": "sha256-JKePwqxk9+6vQbRdaGA/nZg0hNBn40mE3sKY1ftzxtQ=",
+        "zstd": "sha256-NBtbg/4vD4sgHfqxK9DiUzdtJgu3+lER8GYZ8irR40E=",
+    }.items()
+]
+
+# TODO: Switch these to `cosmo.zip` when they are added
+download_file(
+    name = "cli.zip",
+    executable = False,
+    integrity = "sha256-ky+wwBWUS38eUFu5O3q/w7S2l7UGSJEDZAuYLmKGjc8=",
+    output = "cli.zip",
+    urls = [
+        "https://gitlab.arm.com/api/v4/projects/bazel%2Fape/packages/generic/superconfigure/0.0.33/cli.zip",
+        "https://github.com/ahgamut/superconfigure/releases/download/z0.0.33/cli.zip",
+    ],
+)
+
+download_archive(
+    name = "cli",
+    srcs = ["bin/*"],
+    integrity = "sha256-ky+wwBWUS38eUFu5O3q/w7S2l7UGSJEDZAuYLmKGjc8=",
+    urls = [
+        "https://gitlab.arm.com/api/v4/projects/bazel%2Fape/packages/generic/superconfigure/0.0.33/cli.zip",
+        "https://github.com/ahgamut/superconfigure/releases/download/z0.0.33/cli.zip",
+    ],
+)
+
+[
+    (
+        ape_entrypoint(
+            name = binary,
+            binary = "@cli//:bin/{}".format(binary),
+        ),
+        export.symlink(
+            name = "ape-{}".format(binary),
+            target = "@{}".format(binary),
+        ),
+    )
+    for binary in (
+        "diff",
+        "diff3",
+        "sdiff",
+        "cmp",
+        "patch",
+    )
+]

--- a/modules/ape/1.0.0-alpha.5/presubmit.yml
+++ b/modules/ape/1.0.0-alpha.5/presubmit.yml
@@ -1,0 +1,25 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2004_arm64
+      - ubuntu2204
+      - fedora39
+      - macos
+      # TODO: module needs to build the custom launcher on Apple silicon
+      # - macos_arm64
+      # TODO: enable when the Windows BuildKite runner has had a certificate refresh
+      # - windows
+  tasks:
+    run_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/ape/1.0.0-alpha.5/source.json
+++ b/modules/ape/1.0.0-alpha.5/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/ape/-/releases/v1.0.0-alpha.5/downloads/src.tar.gz",
+  "integrity": "sha512-ON9wXzk1v7hh1gUEZR4S1rNm8ryM3IUMYY8PPHQ4+KxRTKuu5YpvUh95e1QHZxWGXA3V0JqJmmsmk2HvwjJ+yA==",
+  "strip_prefix": "ape-v1.0.0-alpha.5"
+}

--- a/modules/ape/metadata.json
+++ b/modules/ape/metadata.json
@@ -1,18 +1,19 @@
 {
-    "homepage": "https://gitlab.arm.com/bazel/ape",
-    "repository": [
-        "https://gitlab.arm.com/bazel/ape"
-    ],
-    "versions":[
-        "1.0.0-alpha.1",
-        "1.0.0-alpha.2",
-        "1.0.0-alpha.3"
-    ],
-    "maintainers": [
-        {
-            "email": "matthew.clarkson@arm.com",
-            "github": "mattyclarkson",
-            "name": "Matt Clarkson"
-        }
-    ]
+  "homepage": "https://gitlab.arm.com/bazel/ape",
+  "repository": [
+    "https://gitlab.arm.com/bazel/ape"
+  ],
+  "versions": [
+    "1.0.0-alpha.1",
+    "1.0.0-alpha.2",
+    "1.0.0-alpha.3",
+    "1.0.0-alpha.5"
+  ],
+  "maintainers": [
+    {
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson",
+      "github": "mattyclarkson"
+    }
+  ]
 }


### PR DESCRIPTION
Brings:

- Mirroring of upstream binaries into GitLab Package Registry
- Mirroring of `superconfigure` source code into GitLab `superconfigure/main`
- A new `ape_toolchain` macro for registering toolchains for the supported platforms
- Document that Apple silicon is currently unsupported in the ruleset in the `README.md`

Apple silicon support is being tracked in upstream [bazel/ape#1]

[bazel/ape#1]: https://gitlab.arm.com/bazel/ape/-/issues/1