### PR TITLE
Add GitHub Actions to auto-review BCR PRs

### DIFF
--- a/.github/workflows/bcr_pr_review_approver.yml
+++ b/.github/workflows/bcr_pr_review_approver.yml
@@ -1,7 +1,7 @@
 name: Review BCR Pull Requests
 on:
   schedule:
-    - cron: "0 * * * *"    # Run this action hourly
+    - cron: "*/10 * * * *" # Run this action every 10 mins
   workflow_dispatch:       # So that this can be triggered manually
 
 jobs:

--- a/.github/workflows/bcr_pr_review_approver.yml
+++ b/.github/workflows/bcr_pr_review_approver.yml
@@ -1,0 +1,19 @@
+name: Review BCR Pull Requests
+on:
+  schedule:
+    - cron: "0 * * * *"    # Run this action hourly
+  workflow_dispatch:       # So that this can be triggered manually
+
+jobs:
+  review_prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
+
+      - name: Run BCR PR Review Approver
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-review-approver@b9b7f0dad8ab00a48cc262d1d38339a1dd11c7c5 # master
+        with:
+          token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}


### PR DESCRIPTION
The GitHub Action was implemented in https://github.com/bazelbuild/continuous-integration/pull/1887

The goal of this GitHub Action is to automate and speed up the review process of trivial PRs that add a new version for existing modules without significant changes.

This GitHub Action will do
- Review all open PRs every 10 mins.
- Approve a PR if the latest reviewable commit is approved by at least one module maintainer for each modified module.
- (Not yet) Merge the PR if presubmit passes. (I'm not turning on this for now in case there is still something we are missing, instead it will ping the bcr maintainers to take a final look.)

Fixes https://github.com/bazelbuild/bazel-central-registry/issues/130