### PR TITLE
add mingw_gcc_compiler config_setting to add_build_file.patch

### DIFF
--- a/modules/zlib/1.3.1/patches/add_build_file.patch
+++ b/modules/zlib/1.3.1/patches/add_build_file.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ BUILD.bazel
-@@ -0,0 +1,105 @@
+@@ -0,0 +1,116 @@
 +# Copied from https://github.com/protocolbuffers/protobuf/blob/master/third_party/zlib.BUILD
 +
 +#  Copyright 2008 Google Inc.  All rights reserved.
@@ -72,6 +72,14 @@
 +    ),
 +)
 +
++config_setting(
++    name = "mingw_gcc_compiler",
++    flag_values = {
++        "@bazel_tools//tools/cpp:compiler": "mingw-gcc",
++    },
++    visibility = [":__subpackages__"],
++)
++
 +cc_library(
 +    name = "zlib",
 +    srcs = [
@@ -96,6 +104,9 @@
 +    ] + _ZLIB_HEADERS,
 +    hdrs = _ZLIB_PREFIXED_HEADERS,
 +    copts = select({
++        ":mingw_gcc_compiler": [
++            "-fpermissive",
++        ],
 +        "@platforms//os:windows": [],
 +        "//conditions:default": [
 +            "-Wno-deprecated-non-prototype",

--- a/modules/zlib/1.3.1/source.json
+++ b/modules/zlib/1.3.1/source.json
@@ -2,8 +2,8 @@
     "integrity": "sha256-mpOyt9/ax3zrpaVYpYDnRmfdb+3kWFuR7vtg8Dty3yM=",
     "patch_strip": 0,
     "patches": {
-        "add_build_file.patch": "sha256-Ei+FYaaOo7A3jTKunMEodTI0Uw5NXQyZEcboMC8JskY=",
-        "module_dot_bazel.patch": "sha256-IFCFES6KY2jaryT+Kq2NemDn7hgdZYH0kZC1esA4cyE="
+        "add_build_file.patch": "sha256-Mv8cFtXM1dniGsiOYqQm16RyZeVkaY0ka8UonnPLtwQ=",
+        "module_dot_bazel.patch": "sha256-Mq1kxwk8lipDzIN0f7584Dpwmzv1feVSmk/JLb4WJws="
     },
     "strip_prefix": "zlib-1.3.1",
     "url": "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"


### PR DESCRIPTION
Building zlib under Windows MINGW GCC toolchain fails with `[-fpermissive]` errors.

[Here](https://github.com/vvviktor/zlib-build-fails-example.git) is failure reproduction example. The command is `bazel build @zlib//:zlib`

Toolchain along with setup instructions is [here](https://github.com/vvviktor/bazel-mingw-toolchain.gitl).

My workaround is to add config_setting rule for mingw-gcc compiler. So it will add `-fpermissive` flag if `CCToolchainInfo.compiler` is set to `mingw-gcc`.