### PR TITLE
Update GitHub Actions for automating PR review

### DIFF
--- a/.github/workflows/dismiss_approvals.yml
+++ b/.github/workflows/dismiss_approvals.yml
@@ -17,7 +17,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@a4d362a00e617f2f99250cf03f5476c52b85d65f # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@86c86121365e310cc41484d65fa3985ab763e8ab # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/dismiss_approvals.yml
+++ b/.github/workflows/dismiss_approvals.yml
@@ -1,16 +1,14 @@
-name: Notify Module Maintainers For PR Review
+name: Dismiss Stale PR Approvals
 on:
   pull_request_target:
+    types: [synchronize]
     branches:
       - main
     paths:
       - 'modules/**'
 
-permissions:
-  pull-requests: write
-
 jobs:
-  notify:
+  dismiss_approvals:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -18,8 +16,9 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Run BCR PR Review Notifier
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-review-notifier@6109f3be479ab3c3efc5f190b4443b009d659da9 # master
+      - name: Run BCR PR Reviewer
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@a4d362a00e617f2f99250cf03f5476c52b85d65f # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}
+          action-type: dismiss_approvals

--- a/.github/workflows/notify_maintainers.yml
+++ b/.github/workflows/notify_maintainers.yml
@@ -1,0 +1,23 @@
+name: Notify Module Maintainers For PR Review
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - 'modules/**'
+
+jobs:
+  notify_maintainers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
+
+      - name: Run BCR PR Reviewer
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@a4d362a00e617f2f99250cf03f5476c52b85d65f # master
+        with:
+          # This token needs to be updated annually on Feb 05.
+          token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}
+          action-type: notify_maintainers

--- a/.github/workflows/notify_maintainers.yml
+++ b/.github/workflows/notify_maintainers.yml
@@ -16,7 +16,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@a4d362a00e617f2f99250cf03f5476c52b85d65f # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@86c86121365e310cc41484d65fa3985ab763e8ab # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/review_prs.yml
+++ b/.github/workflows/review_prs.yml
@@ -14,7 +14,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@a4d362a00e617f2f99250cf03f5476c52b85d65f # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@86c86121365e310cc41484d65fa3985ab763e8ab # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/review_prs.yml
+++ b/.github/workflows/review_prs.yml
@@ -1,0 +1,21 @@
+name: Review BCR Pull Requests
+on:
+  schedule:
+    - cron: "*/10 * * * *" # Run this action every 10 mins
+  workflow_dispatch:       # So that this can be triggered manually
+
+jobs:
+  review_prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        with:
+          egress-policy: audit
+
+      - name: Run BCR PR Reviewer
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@a4d362a00e617f2f99250cf03f5476c52b85d65f # master
+        with:
+          # This token needs to be updated annually on Feb 05.
+          token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}
+          action-type: review_prs


### PR DESCRIPTION
The GitHub Action was implemented in https://github.com/bazelbuild/continuous-integration/pull/1887

This PR updated/created three workflows from the same GitHub Action, distinguished by `action-type`:
- `notify_maintainers`: Notify module maintainers whenever a PR is opened, updated or re-opened for the main branch with changes under "modules" directory.
- `dismiss_approvals`: Dismisses stale approvals whenever a PR is updated. We need this because the `Dismiss stale pull request approvals when new commits are pushed` branch protection from GitHub doesn't work for reviewers who is not a repo maintainer.
- `review_prs`: 
    -  Review all open PRs every 10 mins. 
    - Approve a PR if the latest change is approved by at least one module maintainer for each modified module. (Not yet) 
    - Merge the PR if presubmit passes. (I'm not turning on this for now in case there is still something we are missing, instead it will ping the bcr maintainers to take a final look.)

Fixes https://github.com/bazelbuild/bazel-central-registry/issues/130 