### PR TITLE
Update dismiss_approvals.yml

### DIFF
--- a/.github/workflows/dismiss_approvals.yml
+++ b/.github/workflows/dismiss_approvals.yml
@@ -1,6 +1,7 @@
 name: Dismiss Stale PR Approvals
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened]
     branches:
       - main
     paths:

--- a/.github/workflows/dismiss_approvals.yml
+++ b/.github/workflows/dismiss_approvals.yml
@@ -1,7 +1,6 @@
 name: Dismiss Stale PR Approvals
 on:
   pull_request_target:
-    types: [synchronize]
     branches:
       - main
     paths:


### PR DESCRIPTION
In order to add this check to presubmit, it has to be triggered not only when a PR is updated, but also when a PR is opened or re-opened, which are the default types.