### PR TITLE
toolchains_llvm@1.0.0

### DIFF
--- a/modules/toolchains_llvm/1.0.0/MODULE.bazel
+++ b/modules/toolchains_llvm/1.0.0/MODULE.bazel
@@ -1,0 +1,24 @@
+# Copyright 2023 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "toolchains_llvm",
+    version = "1.0.0",
+    compatibility_level = 0,
+    bazel_compatibility = [">=7.0.0"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.8")

--- a/modules/toolchains_llvm/1.0.0/presubmit.yml
+++ b/modules/toolchains_llvm/1.0.0/presubmit.yml
@@ -1,0 +1,25 @@
+matrix:
+  bazel: [7.x]
+  platform: [ubuntu2004, macos, macos_arm64]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    bazel: ${{ bazel }}
+    platform: ${{ platform }}
+    build_targets:
+    - '@toolchains_llvm//toolchain:all'
+    - '@toolchains_llvm//platforms:all'
+bcr_test_module:
+  module_path: tests
+  matrix:
+    bazel: [7.x]
+    platform: [ubuntu2004, macos, macos_arm64]
+  tasks:
+    run_test_module:
+      name: Run test module
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      build_targets:
+      - //:all
+      test_targets:
+      - //:all

--- a/modules/toolchains_llvm/1.0.0/source.json
+++ b/modules/toolchains_llvm/1.0.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/bazel-contrib/toolchains_llvm/releases/download/1.0.0/toolchains_llvm-1.0.0.tar.gz",
+    "integrity": "sha256-6RxDYfmQEaVIFOGvvlxDbg0ymHEUajzVjCOitK+1Bzc=",
+    "strip_prefix": "toolchains_llvm-1.0.0"
+}

--- a/modules/toolchains_llvm/metadata.json
+++ b/modules/toolchains_llvm/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/grailbio/bazel-toolchain",
+    "homepage": "https://github.com/bazel-contrib/toolchains_llvm",
     "maintainers": [
         {
             "email": "starsid@gmail.com",
@@ -8,10 +8,11 @@
         }
     ],
     "repository": [
-        "github:grailbio/bazel-toolchain"
+        "github:bazel-contrib/toolchains_llvm"
     ],
     "versions": [
-        "0.10.3"
+        "0.10.3",
+        "1.0.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/bazel-contrib/toolchains_llvm/releases/tag/1.0.0