### PR TITLE
Update BCR review github actions

### DIFF
--- a/.github/workflows/dismiss_approvals.yml
+++ b/.github/workflows/dismiss_approvals.yml
@@ -17,7 +17,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@86c86121365e310cc41484d65fa3985ab763e8ab # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@4b83ef1d08decb055ac7a6f864c3759fa22984a4 # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/dismiss_approvals.yml
+++ b/.github/workflows/dismiss_approvals.yml
@@ -4,8 +4,6 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
-    paths:
-      - 'modules/**'
 
 jobs:
   dismiss_approvals:

--- a/.github/workflows/notify_maintainers.yml
+++ b/.github/workflows/notify_maintainers.yml
@@ -16,7 +16,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@86c86121365e310cc41484d65fa3985ab763e8ab # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@4b83ef1d08decb055ac7a6f864c3759fa22984a4 # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/review_prs.yml
+++ b/.github/workflows/review_prs.yml
@@ -14,7 +14,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@86c86121365e310cc41484d65fa3985ab763e8ab # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@4b83ef1d08decb055ac7a6f864c3759fa22984a4 # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}


### PR DESCRIPTION
- Getting the fix from https://github.com/bazelbuild/continuous-integration/pull/1920
- Also removed `paths` filter for `dismiss_approvals` workflow since it'll be a presubmit check for all PRs.