### PR TITLE
Support `pure = "on"` for `circl@1.3.7`

### DIFF
--- a/modules/circl/1.3.7.bcr.1/MODULE.bazel
+++ b/modules/circl/1.3.7.bcr.1/MODULE.bazel
@@ -1,0 +1,16 @@
+module(
+    name = "circl",
+    version = "1.3.7.bcr.1",
+)
+
+bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.31.0")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bwesterb_go_ristretto",
+    "org_golang_x_crypto",
+    "org_golang_x_sys",
+)

--- a/modules/circl/1.3.7.bcr.1/patches/add_module_file.patch
+++ b/modules/circl/1.3.7.bcr.1/patches/add_module_file.patch
@@ -1,0 +1,28 @@
+commit f88c99d4b8d02731ede3fd7e3a5f01fe84336c31
+Author: Fabian Meumertzheim <fabian@meumertzhe.im>
+Date:   Tue Jan 9 08:55:10 2024 +0100
+
+    Add MODULE.bazel
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..9754824
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,16 @@
++module(
++    name = "circl",
++    version = "1.3.7.bcr.1",
++)
++
++bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
++bazel_dep(name = "gazelle", version = "0.31.0")
++
++go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
++go_deps.from_file(go_mod = "//:go.mod")
++use_repo(
++    go_deps,
++    "com_github_bwesterb_go_ristretto",
++    "org_golang_x_crypto",
++    "org_golang_x_sys",
++)

--- a/modules/circl/1.3.7.bcr.1/patches/add_pure_tests_for_mathmatical_libraries.patch
+++ b/modules/circl/1.3.7.bcr.1/patches/add_pure_tests_for_mathmatical_libraries.patch
@@ -1,0 +1,59 @@
+From a8c4375a01c55eaef53e457a045e9874fc930d88 Mon Sep 17 00:00:00 2001
+From: Matt Clarkson <mattyclarkson@gmail.com>
+Date: Fri, 15 Mar 2024 12:10:45 +0000
+Subject: [PATCH] Add pure tests for mathmatical libraries
+
+The libraries have `noasm` support. These tests validate that support does not regress.
+---
+ dh/x25519/BUILD.bazel | 16 ++++++++++++++++
+ dh/x448/BUILD.bazel   | 16 ++++++++++++++++
+ 2 files changed, 32 insertions(+)
+
+diff --git a/dh/x25519/BUILD.bazel b/dh/x25519/BUILD.bazel
+index cacfcf1..7464c66 100644
+--- a/dh/x25519/BUILD.bazel
++++ b/dh/x25519/BUILD.bazel
+@@ -41,3 +41,19 @@ go_test(
+         "//math/fp25519",
+     ],
+ )
++
++go_test(
++    name = "x25519_pure_test",
++    srcs = [
++        "curve_test.go",
++        "key_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":x25519"],
++    pure = "on",
++    deps = [
++        "//internal/conv",
++        "//internal/test",
++        "//math/fp25519",
++    ],
++)
+diff --git a/dh/x448/BUILD.bazel b/dh/x448/BUILD.bazel
+index 94a7b2b..b96c160 100644
+--- a/dh/x448/BUILD.bazel
++++ b/dh/x448/BUILD.bazel
+@@ -41,3 +41,19 @@ go_test(
+         "//math/fp448",
+     ],
+ )
++
++go_test(
++    name = "x448_pure_test",
++    srcs = [
++        "curve_test.go",
++        "key_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":x448"],
++    pure = "on",
++    deps = [
++        "//internal/conv",
++        "//internal/test",
++        "//math/fp448",
++    ],
++)

--- a/modules/circl/1.3.7.bcr.1/patches/generate_build_files.patch
+++ b/modules/circl/1.3.7.bcr.1/patches/generate_build_files.patch
@@ -1,0 +1,2904 @@
+commit a5d8db1c16c1cee3ab1f42426651ebb43a3f4623
+Author: Fabian Meumertzheim <fabian@meumertzhe.im>
+Date:   Tue Jan 9 08:56:43 2024 +0100
+
+    Generate BUILD files with Gazelle
+    
+    Generated using Gazelle 0.35.0 via:
+    gazelle -repo_root . -go_prefix github.com/cloudflare/circl
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 0000000..2adadb2
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "circl",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl",
++    visibility = ["//visibility:public"],
++)
+diff --git a/abe/BUILD.bazel b/abe/BUILD.bazel
+new file mode 100644
+index 0000000..54702a6
+--- /dev/null
++++ b/abe/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "abe",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/abe",
++    visibility = ["//visibility:public"],
++)
+diff --git a/abe/cpabe/BUILD.bazel b/abe/cpabe/BUILD.bazel
+new file mode 100644
+index 0000000..9860497
+--- /dev/null
++++ b/abe/cpabe/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "cpabe",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/abe/cpabe",
++    visibility = ["//visibility:public"],
++)
+diff --git a/abe/cpabe/tkn20/BUILD.bazel b/abe/cpabe/tkn20/BUILD.bazel
+new file mode 100644
+index 0000000..fa79e2c
+--- /dev/null
++++ b/abe/cpabe/tkn20/BUILD.bazel
+@@ -0,0 +1,25 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "tkn20",
++    srcs = ["tkn20.go"],
++    importpath = "github.com/cloudflare/circl/abe/cpabe/tkn20",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//abe/cpabe/tkn20/internal/dsl",
++        "//abe/cpabe/tkn20/internal/tkn",
++    ],
++)
++
++go_test(
++    name = "tkn20_test",
++    srcs = [
++        "bench_test.go",
++        "example_test.go",
++        "format_test.go",
++        "tkn20_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":tkn20"],
++    deps = ["@org_golang_x_crypto//nacl/box:go_default_library"],
++)
+diff --git a/abe/cpabe/tkn20/internal/dsl/BUILD.bazel b/abe/cpabe/tkn20/internal/dsl/BUILD.bazel
+new file mode 100644
+index 0000000..bbf4455
+--- /dev/null
++++ b/abe/cpabe/tkn20/internal/dsl/BUILD.bazel
+@@ -0,0 +1,28 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "dsl",
++    srcs = [
++        "ast.go",
++        "dsl.go",
++        "expr.go",
++        "interpreter.go",
++        "lexer.go",
++        "parser.go",
++        "tokens.go",
++        "util.go",
++    ],
++    importpath = "github.com/cloudflare/circl/abe/cpabe/tkn20/internal/dsl",
++    visibility = ["//abe/cpabe/tkn20:__subpackages__"],
++    deps = ["//abe/cpabe/tkn20/internal/tkn"],
++)
++
++go_test(
++    name = "dsl_test",
++    srcs = [
++        "dsl_test.go",
++        "lexer_test.go",
++    ],
++    embed = [":dsl"],
++    deps = ["//abe/cpabe/tkn20/internal/tkn"],
++)
+diff --git a/abe/cpabe/tkn20/internal/tkn/BUILD.bazel b/abe/cpabe/tkn20/internal/tkn/BUILD.bazel
+new file mode 100644
+index 0000000..6141033
+--- /dev/null
++++ b/abe/cpabe/tkn20/internal/tkn/BUILD.bazel
+@@ -0,0 +1,42 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "tkn",
++    srcs = [
++        "bk.go",
++        "formula.go",
++        "matrixG1.go",
++        "matrixG2.go",
++        "matrixGT.go",
++        "matrixZp.go",
++        "pairAccum.go",
++        "policy.go",
++        "tk.go",
++        "util.go",
++    ],
++    importpath = "github.com/cloudflare/circl/abe/cpabe/tkn20/internal/tkn",
++    visibility = ["//abe/cpabe/tkn20:__subpackages__"],
++    deps = [
++        "//ecc/bls12381",
++        "@org_golang_x_crypto//blake2b:go_default_library",
++    ],
++)
++
++go_test(
++    name = "tkn_test",
++    srcs = [
++        "bk_test.go",
++        "formula_test.go",
++        "matrixG1_test.go",
++        "matrixG2_test.go",
++        "matrixGT_test.go",
++        "matrixZp_test.go",
++        "policy_test.go",
++        "tk_test.go",
++    ],
++    embed = [":tkn"],
++    deps = [
++        "//ecc/bls12381",
++        "//ecc/bls12381/ff",
++    ],
++)
+diff --git a/blindsign/BUILD.bazel b/blindsign/BUILD.bazel
+new file mode 100644
+index 0000000..dd9100c
+--- /dev/null
++++ b/blindsign/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "blindsign",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/blindsign",
++    visibility = ["//visibility:public"],
++)
+diff --git a/blindsign/blindrsa/BUILD.bazel b/blindsign/blindrsa/BUILD.bazel
+new file mode 100644
+index 0000000..86efe37
+--- /dev/null
++++ b/blindsign/blindrsa/BUILD.bazel
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "blindrsa",
++    srcs = ["brsa.go"],
++    importpath = "github.com/cloudflare/circl/blindsign/blindrsa",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//blindsign/blindrsa/internal/common",
++        "//blindsign/blindrsa/internal/keys",
++    ],
++)
++
++go_test(
++    name = "blindrsa_test",
++    srcs = ["brsa_test.go"],
++    data = glob(["testdata/**"]),
++    embed = [":blindrsa"],
++    deps = ["//internal/test"],
++)
+diff --git a/blindsign/blindrsa/internal/common/BUILD.bazel b/blindsign/blindrsa/internal/common/BUILD.bazel
+new file mode 100644
+index 0000000..b310afb
+--- /dev/null
++++ b/blindsign/blindrsa/internal/common/BUILD.bazel
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "common",
++    srcs = [
++        "common.go",
++        "pss.go",
++        "rsa.go",
++    ],
++    importpath = "github.com/cloudflare/circl/blindsign/blindrsa/internal/common",
++    visibility = ["//blindsign/blindrsa:__subpackages__"],
++    deps = ["//blindsign/blindrsa/internal/keys"],
++)
+diff --git a/blindsign/blindrsa/internal/keys/BUILD.bazel b/blindsign/blindrsa/internal/keys/BUILD.bazel
+new file mode 100644
+index 0000000..103333a
+--- /dev/null
++++ b/blindsign/blindrsa/internal/keys/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "keys",
++    srcs = ["big_keys.go"],
++    importpath = "github.com/cloudflare/circl/blindsign/blindrsa/internal/keys",
++    visibility = ["//blindsign/blindrsa:__subpackages__"],
++)
+diff --git a/blindsign/blindrsa/partiallyblindrsa/BUILD.bazel b/blindsign/blindrsa/partiallyblindrsa/BUILD.bazel
+new file mode 100644
+index 0000000..93e2588
+--- /dev/null
++++ b/blindsign/blindrsa/partiallyblindrsa/BUILD.bazel
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "partiallyblindrsa",
++    srcs = ["pbrsa.go"],
++    importpath = "github.com/cloudflare/circl/blindsign/blindrsa/partiallyblindrsa",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//blindsign/blindrsa/internal/common",
++        "//blindsign/blindrsa/internal/keys",
++        "@org_golang_x_crypto//hkdf:go_default_library",
++    ],
++)
++
++go_test(
++    name = "partiallyblindrsa_test",
++    srcs = ["pbrsa_test.go"],
++    embed = [":partiallyblindrsa"],
++    deps = ["//blindsign/blindrsa/internal/keys"],
++)
+diff --git a/cipher/BUILD.bazel b/cipher/BUILD.bazel
+new file mode 100644
+index 0000000..a557dd7
+--- /dev/null
++++ b/cipher/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "cipher",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/cipher",
++    visibility = ["//visibility:public"],
++)
+diff --git a/cipher/ascon/BUILD.bazel b/cipher/ascon/BUILD.bazel
+new file mode 100644
+index 0000000..91c0de3
+--- /dev/null
++++ b/cipher/ascon/BUILD.bazel
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "ascon",
++    srcs = ["ascon.go"],
++    importpath = "github.com/cloudflare/circl/cipher/ascon",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "ascon_test",
++    srcs = ["ascon_test.go"],
++    data = glob(["testdata/**"]),
++    deps = [
++        ":ascon",
++        "//internal/test",
++    ],
++)
+diff --git a/dh/BUILD.bazel b/dh/BUILD.bazel
+new file mode 100644
+index 0000000..99f4cb7
+--- /dev/null
++++ b/dh/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "dh",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/dh",
++    visibility = ["//visibility:public"],
++)
+diff --git a/dh/csidh/BUILD.bazel b/dh/csidh/BUILD.bazel
+new file mode 100644
+index 0000000..448b861
+--- /dev/null
++++ b/dh/csidh/BUILD.bazel
+@@ -0,0 +1,37 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "csidh",
++    srcs = [
++        "consts.go",
++        "csidh.go",
++        "curve.go",
++        "doc.go",
++        "fp511.go",
++        "fp511_amd64.go",
++        "fp511_amd64.s",
++        "fp511_generic.go",
++        "fp511_noasm.go",
++    ],
++    importpath = "github.com/cloudflare/circl/dh/csidh",
++    visibility = ["//visibility:public"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++go_test(
++    name = "csidh_test",
++    srcs = [
++        "csidh_test.go",
++        "curve_test.go",
++        "fp511_test.go",
++        "utils_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":csidh"],
++    deps = ["//internal/test"],
++)
+diff --git a/dh/curve4q/BUILD.bazel b/dh/curve4q/BUILD.bazel
+new file mode 100644
+index 0000000..3e71ea9
+--- /dev/null
++++ b/dh/curve4q/BUILD.bazel
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "curve4q",
++    srcs = [
++        "curve4Q.go",
++        "doc.go",
++    ],
++    importpath = "github.com/cloudflare/circl/dh/curve4q",
++    visibility = ["//visibility:public"],
++    deps = ["//ecc/fourq"],
++)
++
++go_test(
++    name = "curve4q_test",
++    srcs = ["curve4Q_test.go"],
++    embed = [":curve4q"],
++    deps = ["//internal/test"],
++)
+diff --git a/dh/sidh/BUILD.bazel b/dh/sidh/BUILD.bazel
+new file mode 100644
+index 0000000..2074b03
+--- /dev/null
++++ b/dh/sidh/BUILD.bazel
+@@ -0,0 +1,33 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "sidh",
++    srcs = [
++        "doc.go",
++        "sidh.go",
++        "sike.go",
++    ],
++    importpath = "github.com/cloudflare/circl/dh/sidh",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//dh/sidh/internal/common",
++        "//dh/sidh/internal/p434",
++        "//dh/sidh/internal/p503",
++        "//dh/sidh/internal/p751",
++        "//internal/sha3",
++    ],
++)
++
++go_test(
++    name = "sidh_test",
++    srcs = [
++        "sidh_test.go",
++        "sike_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":sidh"],
++    deps = [
++        "//dh/sidh/internal/common",
++        "//internal/test",
++    ],
++)
+diff --git a/dh/sidh/internal/common/BUILD.bazel b/dh/sidh/internal/common/BUILD.bazel
+new file mode 100644
+index 0000000..668b224
+--- /dev/null
++++ b/dh/sidh/internal/common/BUILD.bazel
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "common",
++    srcs = [
++        "doc.go",
++        "params.go",
++        "types.go",
++        "utils.go",
++    ],
++    importpath = "github.com/cloudflare/circl/dh/sidh/internal/common",
++    visibility = ["//dh/sidh:__subpackages__"],
++)
+diff --git a/dh/sidh/internal/p434/BUILD.bazel b/dh/sidh/internal/p434/BUILD.bazel
+new file mode 100644
+index 0000000..e667606
+--- /dev/null
++++ b/dh/sidh/internal/p434/BUILD.bazel
+@@ -0,0 +1,40 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "p434",
++    srcs = [
++        "arith_amd64.s",
++        "arith_decl.go",
++        "arith_generic.go",
++        "core.go",
++        "curve.go",
++        "fp2.go",
++        "params.go",
++    ],
++    importpath = "github.com/cloudflare/circl/dh/sidh/internal/p434",
++    visibility = ["//dh/sidh:__subpackages__"],
++    deps = [
++        "//dh/sidh/internal/common",
++        "@org_golang_x_sys//cpu:go_default_library",
++    ],
++)
++
++go_test(
++    name = "p434_test",
++    srcs = [
++        "arith_amd64_test.go",
++        "arith_test.go",
++        "curve_test.go",
++        "fp2_test.go",
++        "params_test.go",
++    ],
++    embed = [":p434"],
++    deps = [
++        "//dh/sidh/internal/common",
++    ] + select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
++)
+diff --git a/dh/sidh/internal/p503/BUILD.bazel b/dh/sidh/internal/p503/BUILD.bazel
+new file mode 100644
+index 0000000..6d64295
+--- /dev/null
++++ b/dh/sidh/internal/p503/BUILD.bazel
+@@ -0,0 +1,42 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "p503",
++    srcs = [
++        "arith_amd64.s",
++        "arith_arm64.s",
++        "arith_decl.go",
++        "arith_generic.go",
++        "core.go",
++        "curve.go",
++        "doc.go",
++        "fp2.go",
++        "params.go",
++    ],
++    importpath = "github.com/cloudflare/circl/dh/sidh/internal/p503",
++    visibility = ["//dh/sidh:__subpackages__"],
++    deps = [
++        "//dh/sidh/internal/common",
++        "@org_golang_x_sys//cpu:go_default_library",
++    ],
++)
++
++go_test(
++    name = "p503_test",
++    srcs = [
++        "arith_amd64_test.go",
++        "arith_test.go",
++        "curve_test.go",
++        "fp2_test.go",
++        "params_test.go",
++    ],
++    embed = [":p503"],
++    deps = [
++        "//dh/sidh/internal/common",
++    ] + select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
++)
+diff --git a/dh/sidh/internal/p751/BUILD.bazel b/dh/sidh/internal/p751/BUILD.bazel
+new file mode 100644
+index 0000000..8b64f66
+--- /dev/null
++++ b/dh/sidh/internal/p751/BUILD.bazel
+@@ -0,0 +1,42 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "p751",
++    srcs = [
++        "arith_amd64.s",
++        "arith_arm64.s",
++        "arith_decl.go",
++        "arith_generic.go",
++        "core.go",
++        "curve.go",
++        "doc.go",
++        "fp2.go",
++        "params.go",
++    ],
++    importpath = "github.com/cloudflare/circl/dh/sidh/internal/p751",
++    visibility = ["//dh/sidh:__subpackages__"],
++    deps = [
++        "//dh/sidh/internal/common",
++        "@org_golang_x_sys//cpu:go_default_library",
++    ],
++)
++
++go_test(
++    name = "p751_test",
++    srcs = [
++        "arith_amd64_test.go",
++        "arith_test.go",
++        "curve_test.go",
++        "fp2_test.go",
++        "params_test.go",
++    ],
++    embed = [":p751"],
++    deps = [
++        "//dh/sidh/internal/common",
++    ] + select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
++)
+diff --git a/dh/x25519/BUILD.bazel b/dh/x25519/BUILD.bazel
+new file mode 100644
+index 0000000..f80aba0
+--- /dev/null
++++ b/dh/x25519/BUILD.bazel
+@@ -0,0 +1,41 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "x25519",
++    srcs = [
++        "curve.go",
++        "curve_amd64.go",
++        "curve_amd64.h",
++        "curve_amd64.s",
++        "curve_generic.go",
++        "curve_noasm.go",
++        "doc.go",
++        "key.go",
++        "table.go",
++    ],
++    importpath = "github.com/cloudflare/circl/dh/x25519",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//math/fp25519",
++    ] + select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++go_test(
++    name = "x25519_test",
++    srcs = [
++        "curve_test.go",
++        "key_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":x25519"],
++    deps = [
++        "//internal/conv",
++        "//internal/test",
++        "//math/fp25519",
++    ],
++)
+diff --git a/dh/x448/BUILD.bazel b/dh/x448/BUILD.bazel
+new file mode 100644
+index 0000000..31278c4
+--- /dev/null
++++ b/dh/x448/BUILD.bazel
+@@ -0,0 +1,41 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "x448",
++    srcs = [
++        "curve.go",
++        "curve_amd64.go",
++        "curve_amd64.h",
++        "curve_amd64.s",
++        "curve_generic.go",
++        "curve_noasm.go",
++        "doc.go",
++        "key.go",
++        "table.go",
++    ],
++    importpath = "github.com/cloudflare/circl/dh/x448",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//math/fp448",
++    ] + select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++go_test(
++    name = "x448_test",
++    srcs = [
++        "curve_test.go",
++        "key_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":x448"],
++    deps = [
++        "//internal/conv",
++        "//internal/test",
++        "//math/fp448",
++    ],
++)
+diff --git a/ecc/BUILD.bazel b/ecc/BUILD.bazel
+new file mode 100644
+index 0000000..4b2df8d
+--- /dev/null
++++ b/ecc/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "ecc",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/ecc",
++    visibility = ["//visibility:public"],
++)
+diff --git a/ecc/bls12381/BUILD.bazel b/ecc/bls12381/BUILD.bazel
+new file mode 100644
+index 0000000..1af5174
+--- /dev/null
++++ b/ecc/bls12381/BUILD.bazel
+@@ -0,0 +1,41 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "bls12381",
++    srcs = [
++        "constants.go",
++        "doc.go",
++        "ec2.go",
++        "g1.go",
++        "g1Isog.go",
++        "g2.go",
++        "g2Isog.go",
++        "gt.go",
++        "pair.go",
++    ],
++    importpath = "github.com/cloudflare/circl/ecc/bls12381",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//ecc/bls12381/ff",
++        "//expander",
++    ],
++)
++
++go_test(
++    name = "bls12381_test",
++    srcs = [
++        "encoding_test.go",
++        "g1_test.go",
++        "g2_test.go",
++        "gt_test.go",
++        "hash_test.go",
++        "pair_test.go",
++        "psi_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":bls12381"],
++    deps = [
++        "//ecc/bls12381/ff",
++        "//internal/test",
++    ],
++)
+diff --git a/ecc/bls12381/ff/BUILD.bazel b/ecc/bls12381/ff/BUILD.bazel
+new file mode 100644
+index 0000000..24960c6
+--- /dev/null
++++ b/ecc/bls12381/ff/BUILD.bazel
+@@ -0,0 +1,39 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "ff",
++    srcs = [
++        "common.go",
++        "cyclo6.go",
++        "doc.go",
++        "fp.go",
++        "fp12.go",
++        "fp12cubic.go",
++        "fp2.go",
++        "fp4.go",
++        "fp6.go",
++        "fpMont381.go",
++        "scMont255.go",
++        "scalar.go",
++        "uroot.go",
++    ],
++    importpath = "github.com/cloudflare/circl/ecc/bls12381/ff",
++    visibility = ["//visibility:public"],
++    deps = ["//internal/conv"],
++)
++
++go_test(
++    name = "ff_test",
++    srcs = [
++        "cyclo6_test.go",
++        "fp12_test.go",
++        "fp12cubic_test.go",
++        "fp2_test.go",
++        "fp6_test.go",
++        "fp_test.go",
++        "scalar_test.go",
++        "uroot_test.go",
++    ],
++    embed = [":ff"],
++    deps = ["//internal/test"],
++)
+diff --git a/ecc/fourq/BUILD.bazel b/ecc/fourq/BUILD.bazel
+new file mode 100644
+index 0000000..8a17589
+--- /dev/null
++++ b/ecc/fourq/BUILD.bazel
+@@ -0,0 +1,54 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "fourq",
++    srcs = [
++        "curve.go",
++        "doc.go",
++        "fp.go",
++        "fp_amd64.go",
++        "fp_amd64.h",
++        "fp_amd64.s",
++        "fp_generic.go",
++        "fp_noasm.go",
++        "fq.go",
++        "fq_amd64.go",
++        "fq_amd64.h",
++        "fq_amd64.s",
++        "fq_generic.go",
++        "fq_noasm.go",
++        "params.go",
++        "point.go",
++        "point_amd64.go",
++        "point_amd64.h",
++        "point_amd64.s",
++        "point_generic.go",
++        "point_noasm.go",
++        "tableBase.go",
++    ],
++    importpath = "github.com/cloudflare/circl/ecc/fourq",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/conv",
++    ] + select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++go_test(
++    name = "fourq_test",
++    srcs = [
++        "curve_test.go",
++        "fp_test.go",
++        "fq_test.go",
++        "point_test.go",
++    ],
++    embed = [":fourq"],
++    deps = [
++        "//internal/conv",
++        "//internal/test",
++    ],
++)
+diff --git a/ecc/goldilocks/BUILD.bazel b/ecc/goldilocks/BUILD.bazel
+new file mode 100644
+index 0000000..19494ff
+--- /dev/null
++++ b/ecc/goldilocks/BUILD.bazel
+@@ -0,0 +1,39 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "goldilocks",
++    srcs = [
++        "constants.go",
++        "curve.go",
++        "isogeny.go",
++        "point.go",
++        "scalar.go",
++        "twist.go",
++        "twistPoint.go",
++        "twistTables.go",
++        "twist_basemult.go",
++    ],
++    importpath = "github.com/cloudflare/circl/ecc/goldilocks",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/conv",
++        "//math",
++        "//math/fp448",
++        "//math/mlsbset",
++    ],
++)
++
++go_test(
++    name = "goldilocks_test",
++    srcs = [
++        "curve_test.go",
++        "isogeny_test.go",
++        "point_test.go",
++        "scalar_test.go",
++    ],
++    embed = [":goldilocks"],
++    deps = [
++        "//internal/conv",
++        "//internal/test",
++    ],
++)
+diff --git a/ecc/p384/BUILD.bazel b/ecc/p384/BUILD.bazel
+new file mode 100644
+index 0000000..d54a233
+--- /dev/null
++++ b/ecc/p384/BUILD.bazel
+@@ -0,0 +1,43 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "p384",
++    srcs = [
++        "arith.go",
++        "arith_amd64.go",
++        "arith_amd64.s",
++        "arith_arm64.s",
++        "doc.go",
++        "p384.go",
++        "p384_generic.go",
++        "p384opt.go",
++        "point.go",
++        "tableBase.go",
++    ],
++    importpath = "github.com/cloudflare/circl/ecc/p384",
++    visibility = ["//visibility:public"],
++    deps = select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "//internal/conv",
++            "//math",
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "@io_bazel_rules_go//go/platform:arm64": [
++            "//internal/conv",
++            "//math",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++go_test(
++    name = "p384_test",
++    srcs = [
++        "arith_test.go",
++        "opt_test.go",
++        "p384_test.go",
++        "point_test.go",
++    ],
++    embed = [":p384"],
++    deps = ["//internal/test"],
++)
+diff --git a/expander/BUILD.bazel b/expander/BUILD.bazel
+new file mode 100644
+index 0000000..99b4486
+--- /dev/null
++++ b/expander/BUILD.bazel
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "expander",
++    srcs = ["expander.go"],
++    importpath = "github.com/cloudflare/circl/expander",
++    visibility = ["//visibility:public"],
++    deps = ["//xof"],
++)
++
++go_test(
++    name = "expander_test",
++    srcs = ["expander_test.go"],
++    data = glob(["testdata/**"]),
++    deps = [
++        ":expander",
++        "//internal/test",
++        "//xof",
++    ],
++)
+diff --git a/group/BUILD.bazel b/group/BUILD.bazel
+new file mode 100644
+index 0000000..b4ec399
+--- /dev/null
++++ b/group/BUILD.bazel
+@@ -0,0 +1,31 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "group",
++    srcs = [
++        "group.go",
++        "hash.go",
++        "ristretto255.go",
++        "short.go",
++    ],
++    importpath = "github.com/cloudflare/circl/group",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//ecc/p384",
++        "//expander",
++        "//internal/conv",
++        "@com_github_bwesterb_go_ristretto//:go_default_library",
++    ],
++)
++
++go_test(
++    name = "group_test",
++    srcs = [
++        "group_test.go",
++        "hash_test.go",
++        "ristretto255_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":group"],
++    deps = ["//internal/test"],
++)
+diff --git a/hpke/BUILD.bazel b/hpke/BUILD.bazel
+new file mode 100644
+index 0000000..4198c0c
+--- /dev/null
++++ b/hpke/BUILD.bazel
+@@ -0,0 +1,45 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "hpke",
++    srcs = [
++        "aead.go",
++        "algs.go",
++        "hpke.go",
++        "hybridkem.go",
++        "kembase.go",
++        "marshal.go",
++        "shortkem.go",
++        "util.go",
++        "xkem.go",
++    ],
++    importpath = "github.com/cloudflare/circl/hpke",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//dh/x25519",
++        "//dh/x448",
++        "//ecc/p384",
++        "//kem",
++        "//kem/kyber/kyber768",
++        "@org_golang_x_crypto//chacha20poly1305:go_default_library",
++        "@org_golang_x_crypto//cryptobyte:go_default_library",
++        "@org_golang_x_crypto//hkdf:go_default_library",
++    ],
++)
++
++go_test(
++    name = "hpke_test",
++    srcs = [
++        "aead_test.go",
++        "hpke_test.go",
++        "marshal_test.go",
++        "vectors_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":hpke"],
++    deps = [
++        "//internal/test",
++        "//kem",
++        "@org_golang_x_crypto//sha3:go_default_library",
++    ],
++)
+diff --git a/internal/conv/BUILD.bazel b/internal/conv/BUILD.bazel
+new file mode 100644
+index 0000000..fbf6252
+--- /dev/null
++++ b/internal/conv/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "conv",
++    srcs = ["conv.go"],
++    importpath = "github.com/cloudflare/circl/internal/conv",
++    visibility = ["//:__subpackages__"],
++)
+diff --git a/internal/nist/BUILD.bazel b/internal/nist/BUILD.bazel
+new file mode 100644
+index 0000000..5284d45
+--- /dev/null
++++ b/internal/nist/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "nist",
++    srcs = ["drbg.go"],
++    importpath = "github.com/cloudflare/circl/internal/nist",
++    visibility = ["//:__subpackages__"],
++)
+diff --git a/internal/sha3/BUILD.bazel b/internal/sha3/BUILD.bazel
+new file mode 100644
+index 0000000..d8057ce
+--- /dev/null
++++ b/internal/sha3/BUILD.bazel
+@@ -0,0 +1,26 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "sha3",
++    srcs = [
++        "doc.go",
++        "hashes.go",
++        "keccakf.go",
++        "rc.go",
++        "sha3.go",
++        "sha3_s390x.s",
++        "shake.go",
++        "xor.go",
++        "xor_generic.go",
++        "xor_unaligned.go",
++    ],
++    importpath = "github.com/cloudflare/circl/internal/sha3",
++    visibility = ["//:__subpackages__"],
++)
++
++go_test(
++    name = "sha3_test",
++    srcs = ["sha3_test.go"],
++    data = glob(["testdata/**"]),
++    embed = [":sha3"],
++)
+diff --git a/internal/test/BUILD.bazel b/internal/test/BUILD.bazel
+new file mode 100644
+index 0000000..099240a
+--- /dev/null
++++ b/internal/test/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "test",
++    srcs = ["test.go"],
++    importpath = "github.com/cloudflare/circl/internal/test",
++    visibility = ["//:__subpackages__"],
++)
+diff --git a/kem/BUILD.bazel b/kem/BUILD.bazel
+new file mode 100644
+index 0000000..7935d6f
+--- /dev/null
++++ b/kem/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "kem",
++    srcs = ["kem.go"],
++    importpath = "github.com/cloudflare/circl/kem",
++    visibility = ["//visibility:public"],
++)
+diff --git a/kem/frodo/BUILD.bazel b/kem/frodo/BUILD.bazel
+new file mode 100644
+index 0000000..20f73d8
+--- /dev/null
++++ b/kem/frodo/BUILD.bazel
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "frodo",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/kem/frodo",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "frodo_test",
++    srcs = ["kat_test.go"],
++    embed = [":frodo"],
++    deps = [
++        "//internal/nist",
++        "//kem/schemes",
++    ],
++)
+diff --git a/kem/frodo/frodo640shake/BUILD.bazel b/kem/frodo/frodo640shake/BUILD.bazel
+new file mode 100644
+index 0000000..1f93c41
+--- /dev/null
++++ b/kem/frodo/frodo640shake/BUILD.bazel
+@@ -0,0 +1,17 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "frodo640shake",
++    srcs = [
++        "frodo.go",
++        "matrix_shake.go",
++        "noise.go",
++        "util.go",
++    ],
++    importpath = "github.com/cloudflare/circl/kem/frodo/frodo640shake",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/sha3",
++        "//kem",
++    ],
++)
+diff --git a/kem/hybrid/BUILD.bazel b/kem/hybrid/BUILD.bazel
+new file mode 100644
+index 0000000..1b5491c
+--- /dev/null
++++ b/kem/hybrid/BUILD.bazel
+@@ -0,0 +1,22 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "hybrid",
++    srcs = [
++        "ckem.go",
++        "hybrid.go",
++        "xkem.go",
++    ],
++    importpath = "github.com/cloudflare/circl/kem/hybrid",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//dh/x25519",
++        "//dh/x448",
++        "//internal/sha3",
++        "//kem",
++        "//kem/kyber/kyber1024",
++        "//kem/kyber/kyber512",
++        "//kem/kyber/kyber768",
++        "//xof",
++    ],
++)
+diff --git a/kem/kyber/BUILD.bazel b/kem/kyber/BUILD.bazel
+new file mode 100644
+index 0000000..5095b53
+--- /dev/null
++++ b/kem/kyber/BUILD.bazel
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "kyber",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/kem/kyber",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "kyber_test",
++    srcs = ["kat_test.go"],
++    embed = [":kyber"],
++    deps = [
++        "//internal/nist",
++        "//kem/schemes",
++    ],
++)
+diff --git a/kem/kyber/kyber1024/BUILD.bazel b/kem/kyber/kyber1024/BUILD.bazel
+new file mode 100644
+index 0000000..252571f
+--- /dev/null
++++ b/kem/kyber/kyber1024/BUILD.bazel
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "kyber1024",
++    srcs = ["kyber.go"],
++    importpath = "github.com/cloudflare/circl/kem/kyber/kyber1024",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/sha3",
++        "//kem",
++        "//pke/kyber/kyber1024",
++    ],
++)
+diff --git a/kem/kyber/kyber512/BUILD.bazel b/kem/kyber/kyber512/BUILD.bazel
+new file mode 100644
+index 0000000..1c810a3
+--- /dev/null
++++ b/kem/kyber/kyber512/BUILD.bazel
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "kyber512",
++    srcs = ["kyber.go"],
++    importpath = "github.com/cloudflare/circl/kem/kyber/kyber512",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/sha3",
++        "//kem",
++        "//pke/kyber/kyber512",
++    ],
++)
+diff --git a/kem/kyber/kyber768/BUILD.bazel b/kem/kyber/kyber768/BUILD.bazel
+new file mode 100644
+index 0000000..63fc99f
+--- /dev/null
++++ b/kem/kyber/kyber768/BUILD.bazel
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "kyber768",
++    srcs = ["kyber.go"],
++    importpath = "github.com/cloudflare/circl/kem/kyber/kyber768",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/sha3",
++        "//kem",
++        "//pke/kyber/kyber768",
++    ],
++)
+diff --git a/kem/kyber/templates/BUILD.bazel b/kem/kyber/templates/BUILD.bazel
+new file mode 100644
+index 0000000..b17878c
+--- /dev/null
++++ b/kem/kyber/templates/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "templates",
++    srcs = ["pkg.templ.go"],
++    importpath = "github.com/cloudflare/circl/kem/kyber/templates",
++    visibility = ["//visibility:public"],
++)
+diff --git a/kem/schemes/BUILD.bazel b/kem/schemes/BUILD.bazel
+new file mode 100644
+index 0000000..99e77c9
+--- /dev/null
++++ b/kem/schemes/BUILD.bazel
+@@ -0,0 +1,23 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "schemes",
++    srcs = ["schemes.go"],
++    importpath = "github.com/cloudflare/circl/kem/schemes",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//hpke",
++        "//kem",
++        "//kem/frodo/frodo640shake",
++        "//kem/hybrid",
++        "//kem/kyber/kyber1024",
++        "//kem/kyber/kyber512",
++        "//kem/kyber/kyber768",
++    ],
++)
++
++go_test(
++    name = "schemes_test",
++    srcs = ["schemes_test.go"],
++    deps = [":schemes"],
++)
+diff --git a/kem/sike/BUILD.bazel b/kem/sike/BUILD.bazel
+new file mode 100644
+index 0000000..029d933
+--- /dev/null
++++ b/kem/sike/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "sike",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/kem/sike",
++    visibility = ["//visibility:public"],
++)
+diff --git a/kem/sike/sikep434/BUILD.bazel b/kem/sike/sikep434/BUILD.bazel
+new file mode 100644
+index 0000000..4c6ac09
+--- /dev/null
++++ b/kem/sike/sikep434/BUILD.bazel
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "sikep434",
++    srcs = ["sike.go"],
++    importpath = "github.com/cloudflare/circl/kem/sike/sikep434",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//dh/sidh",
++        "//internal/sha3",
++        "//kem",
++    ],
++)
+diff --git a/kem/sike/sikep503/BUILD.bazel b/kem/sike/sikep503/BUILD.bazel
+new file mode 100644
+index 0000000..2f9f07e
+--- /dev/null
++++ b/kem/sike/sikep503/BUILD.bazel
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "sikep503",
++    srcs = ["sike.go"],
++    importpath = "github.com/cloudflare/circl/kem/sike/sikep503",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//dh/sidh",
++        "//internal/sha3",
++        "//kem",
++    ],
++)
+diff --git a/kem/sike/sikep751/BUILD.bazel b/kem/sike/sikep751/BUILD.bazel
+new file mode 100644
+index 0000000..bc6686f
+--- /dev/null
++++ b/kem/sike/sikep751/BUILD.bazel
+@@ -0,0 +1,13 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "sikep751",
++    srcs = ["sike.go"],
++    importpath = "github.com/cloudflare/circl/kem/sike/sikep751",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//dh/sidh",
++        "//internal/sha3",
++        "//kem",
++    ],
++)
+diff --git a/kem/sike/templates/BUILD.bazel b/kem/sike/templates/BUILD.bazel
+new file mode 100644
+index 0000000..39cdd9c
+--- /dev/null
++++ b/kem/sike/templates/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "templates",
++    srcs = ["pkg.templ.go"],
++    importpath = "github.com/cloudflare/circl/kem/sike/templates",
++    visibility = ["//visibility:public"],
++)
+diff --git a/math/BUILD.bazel b/math/BUILD.bazel
+new file mode 100644
+index 0000000..223fbbe
+--- /dev/null
++++ b/math/BUILD.bazel
+@@ -0,0 +1,21 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "math",
++    srcs = [
++        "primes.go",
++        "wnaf.go",
++    ],
++    importpath = "github.com/cloudflare/circl/math",
++    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "math_test",
++    srcs = [
++        "primes_test.go",
++        "wnaf_test.go",
++    ],
++    embed = [":math"],
++    deps = ["//internal/test"],
++)
+diff --git a/math/fp25519/BUILD.bazel b/math/fp25519/BUILD.bazel
+new file mode 100644
+index 0000000..f423b16
+--- /dev/null
++++ b/math/fp25519/BUILD.bazel
+@@ -0,0 +1,33 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "fp25519",
++    srcs = [
++        "fp.go",
++        "fp_amd64.go",
++        "fp_amd64.h",
++        "fp_amd64.s",
++        "fp_generic.go",
++        "fp_noasm.go",
++    ],
++    importpath = "github.com/cloudflare/circl/math/fp25519",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/conv",
++    ] + select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++go_test(
++    name = "fp25519_test",
++    srcs = ["fp_test.go"],
++    embed = [":fp25519"],
++    deps = [
++        "//internal/conv",
++        "//internal/test",
++    ],
++)
+diff --git a/math/fp448/BUILD.bazel b/math/fp448/BUILD.bazel
+new file mode 100644
+index 0000000..80715a1
+--- /dev/null
++++ b/math/fp448/BUILD.bazel
+@@ -0,0 +1,36 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "fp448",
++    srcs = [
++        "fp.go",
++        "fp_amd64.go",
++        "fp_amd64.h",
++        "fp_amd64.s",
++        "fp_generic.go",
++        "fp_noasm.go",
++    ],
++    importpath = "github.com/cloudflare/circl/math/fp448",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/conv",
++    ] + select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++go_test(
++    name = "fp448_test",
++    srcs = [
++        "edgecases_test.go",
++        "fp_test.go",
++    ],
++    embed = [":fp448"],
++    deps = [
++        "//internal/conv",
++        "//internal/test",
++    ],
++)
+diff --git a/math/mlsbset/BUILD.bazel b/math/mlsbset/BUILD.bazel
+new file mode 100644
+index 0000000..912357e
+--- /dev/null
++++ b/math/mlsbset/BUILD.bazel
+@@ -0,0 +1,22 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "mlsbset",
++    srcs = [
++        "mlsbset.go",
++        "power.go",
++    ],
++    importpath = "github.com/cloudflare/circl/math/mlsbset",
++    visibility = ["//visibility:public"],
++    deps = ["//internal/conv"],
++)
++
++go_test(
++    name = "mlsbset_test",
++    srcs = ["mlsbset_test.go"],
++    deps = [
++        ":mlsbset",
++        "//internal/conv",
++        "//internal/test",
++    ],
++)
+diff --git a/math/polynomial/BUILD.bazel b/math/polynomial/BUILD.bazel
+new file mode 100644
+index 0000000..11d80e2
+--- /dev/null
++++ b/math/polynomial/BUILD.bazel
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "polynomial",
++    srcs = ["polynomial.go"],
++    importpath = "github.com/cloudflare/circl/math/polynomial",
++    visibility = ["//visibility:public"],
++    deps = ["//group"],
++)
++
++go_test(
++    name = "polynomial_test",
++    srcs = ["polynomial_test.go"],
++    deps = [
++        ":polynomial",
++        "//group",
++        "//internal/test",
++    ],
++)
+diff --git a/oprf/BUILD.bazel b/oprf/BUILD.bazel
+new file mode 100644
+index 0000000..6711ed8
+--- /dev/null
++++ b/oprf/BUILD.bazel
+@@ -0,0 +1,32 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "oprf",
++    srcs = [
++        "client.go",
++        "keys.go",
++        "oprf.go",
++        "server.go",
++    ],
++    importpath = "github.com/cloudflare/circl/oprf",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//group",
++        "//zk/dleq",
++    ],
++)
++
++go_test(
++    name = "oprf_test",
++    srcs = [
++        "oprf_test.go",
++        "vectors_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":oprf"],
++    deps = [
++        "//group",
++        "//internal/test",
++        "//zk/dleq",
++    ],
++)
+diff --git a/ot/BUILD.bazel b/ot/BUILD.bazel
+new file mode 100644
+index 0000000..fe40bd1
+--- /dev/null
++++ b/ot/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "ot",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/ot",
++    visibility = ["//visibility:public"],
++)
+diff --git a/ot/simot/BUILD.bazel b/ot/simot/BUILD.bazel
+new file mode 100644
+index 0000000..a7acdcd
+--- /dev/null
++++ b/ot/simot/BUILD.bazel
+@@ -0,0 +1,22 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "simot",
++    srcs = [
++        "simotlocal.go",
++        "simotparty.go",
++    ],
++    importpath = "github.com/cloudflare/circl/ot/simot",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//group",
++        "@org_golang_x_crypto//sha3:go_default_library",
++    ],
++)
++
++go_test(
++    name = "simot_test",
++    srcs = ["simot_test.go"],
++    embed = [":simot"],
++    deps = ["//group"],
++)
+diff --git a/pke/BUILD.bazel b/pke/BUILD.bazel
+new file mode 100644
+index 0000000..1ca26b4
+--- /dev/null
++++ b/pke/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "pke",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/pke",
++    visibility = ["//visibility:public"],
++)
+diff --git a/pke/kyber/BUILD.bazel b/pke/kyber/BUILD.bazel
+new file mode 100644
+index 0000000..9b7bb3a
+--- /dev/null
++++ b/pke/kyber/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "kyber",
++    srcs = ["kyber.go"],
++    importpath = "github.com/cloudflare/circl/pke/kyber",
++    visibility = ["//visibility:public"],
++)
+diff --git a/pke/kyber/internal/common/BUILD.bazel b/pke/kyber/internal/common/BUILD.bazel
+new file mode 100644
+index 0000000..5da21c0
+--- /dev/null
++++ b/pke/kyber/internal/common/BUILD.bazel
+@@ -0,0 +1,39 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "common",
++    srcs = [
++        "amd64.go",
++        "amd64.s",
++        "field.go",
++        "generic.go",
++        "ntt.go",
++        "params.go",
++        "poly.go",
++        "sample.go",
++        "stubs_amd64.go",
++    ],
++    importpath = "github.com/cloudflare/circl/pke/kyber/internal/common",
++    visibility = ["//pke/kyber:__subpackages__"],
++    deps = [
++        "//internal/sha3",
++        "//pke/kyber/internal/common/params",
++        "//simd/keccakf1600",
++    ] + select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++go_test(
++    name = "common_test",
++    srcs = [
++        "field_test.go",
++        "ntt_test.go",
++        "poly_test.go",
++        "sample_test.go",
++    ],
++    embed = [":common"],
++)
+diff --git a/pke/kyber/internal/common/asm/BUILD.bazel b/pke/kyber/internal/common/asm/BUILD.bazel
+new file mode 100644
+index 0000000..8ab4e7e
+--- /dev/null
++++ b/pke/kyber/internal/common/asm/BUILD.bazel
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "asm_lib",
++    srcs = ["src.go"],
++    importpath = "github.com/cloudflare/circl/pke/kyber/internal/common/asm",
++    visibility = ["//visibility:private"],
++    deps = [
++        "//pke/kyber/internal/common/params",
++        "@com_github_mmcloughlin_avo//build:go_default_library",
++        "@com_github_mmcloughlin_avo//operand:go_default_library",
++        "@com_github_mmcloughlin_avo//reg:go_default_library",
++    ],
++)
++
++go_binary(
++    name = "asm",
++    embed = [":asm_lib"],
++    visibility = ["//pke/kyber:__subpackages__"],
++)
+diff --git a/pke/kyber/internal/common/params/BUILD.bazel b/pke/kyber/internal/common/params/BUILD.bazel
+new file mode 100644
+index 0000000..2f4edff
+--- /dev/null
++++ b/pke/kyber/internal/common/params/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "params",
++    srcs = ["params.go"],
++    importpath = "github.com/cloudflare/circl/pke/kyber/internal/common/params",
++    visibility = ["//pke/kyber:__subpackages__"],
++)
+diff --git a/pke/kyber/kyber1024/BUILD.bazel b/pke/kyber/kyber1024/BUILD.bazel
+new file mode 100644
+index 0000000..d7f61f8
+--- /dev/null
++++ b/pke/kyber/kyber1024/BUILD.bazel
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "kyber1024",
++    srcs = ["kyber.go"],
++    importpath = "github.com/cloudflare/circl/pke/kyber/kyber1024",
++    visibility = ["//visibility:public"],
++    deps = ["//pke/kyber/kyber1024/internal"],
++)
+diff --git a/pke/kyber/kyber1024/internal/BUILD.bazel b/pke/kyber/kyber1024/internal/BUILD.bazel
+new file mode 100644
+index 0000000..8f3eb62
+--- /dev/null
++++ b/pke/kyber/kyber1024/internal/BUILD.bazel
+@@ -0,0 +1,23 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "internal",
++    srcs = [
++        "cpapke.go",
++        "mat.go",
++        "params.go",
++        "vec.go",
++    ],
++    importpath = "github.com/cloudflare/circl/pke/kyber/kyber1024/internal",
++    visibility = ["//pke/kyber/kyber1024:__subpackages__"],
++    deps = [
++        "//internal/sha3",
++        "//pke/kyber/internal/common",
++    ],
++)
++
++go_test(
++    name = "internal_test",
++    srcs = ["cpapke_test.go"],
++    embed = [":internal"],
++)
+diff --git a/pke/kyber/kyber512/BUILD.bazel b/pke/kyber/kyber512/BUILD.bazel
+new file mode 100644
+index 0000000..10e7fef
+--- /dev/null
++++ b/pke/kyber/kyber512/BUILD.bazel
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "kyber512",
++    srcs = ["kyber.go"],
++    importpath = "github.com/cloudflare/circl/pke/kyber/kyber512",
++    visibility = ["//visibility:public"],
++    deps = ["//pke/kyber/kyber512/internal"],
++)
+diff --git a/pke/kyber/kyber512/internal/BUILD.bazel b/pke/kyber/kyber512/internal/BUILD.bazel
+new file mode 100644
+index 0000000..aaa25e5
+--- /dev/null
++++ b/pke/kyber/kyber512/internal/BUILD.bazel
+@@ -0,0 +1,23 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "internal",
++    srcs = [
++        "cpapke.go",
++        "mat.go",
++        "params.go",
++        "vec.go",
++    ],
++    importpath = "github.com/cloudflare/circl/pke/kyber/kyber512/internal",
++    visibility = ["//pke/kyber/kyber512:__subpackages__"],
++    deps = [
++        "//internal/sha3",
++        "//pke/kyber/internal/common",
++    ],
++)
++
++go_test(
++    name = "internal_test",
++    srcs = ["cpapke_test.go"],
++    embed = [":internal"],
++)
+diff --git a/pke/kyber/kyber768/BUILD.bazel b/pke/kyber/kyber768/BUILD.bazel
+new file mode 100644
+index 0000000..13227de
+--- /dev/null
++++ b/pke/kyber/kyber768/BUILD.bazel
+@@ -0,0 +1,9 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "kyber768",
++    srcs = ["kyber.go"],
++    importpath = "github.com/cloudflare/circl/pke/kyber/kyber768",
++    visibility = ["//visibility:public"],
++    deps = ["//pke/kyber/kyber768/internal"],
++)
+diff --git a/pke/kyber/kyber768/internal/BUILD.bazel b/pke/kyber/kyber768/internal/BUILD.bazel
+new file mode 100644
+index 0000000..8a9b34d
+--- /dev/null
++++ b/pke/kyber/kyber768/internal/BUILD.bazel
+@@ -0,0 +1,23 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "internal",
++    srcs = [
++        "cpapke.go",
++        "mat.go",
++        "params.go",
++        "vec.go",
++    ],
++    importpath = "github.com/cloudflare/circl/pke/kyber/kyber768/internal",
++    visibility = ["//pke/kyber/kyber768:__subpackages__"],
++    deps = [
++        "//internal/sha3",
++        "//pke/kyber/internal/common",
++    ],
++)
++
++go_test(
++    name = "internal_test",
++    srcs = ["cpapke_test.go"],
++    embed = [":internal"],
++)
+diff --git a/pke/kyber/templates/BUILD.bazel b/pke/kyber/templates/BUILD.bazel
+new file mode 100644
+index 0000000..9e06cdd
+--- /dev/null
++++ b/pke/kyber/templates/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "templates",
++    srcs = ["pkg.templ.go"],
++    importpath = "github.com/cloudflare/circl/pke/kyber/templates",
++    visibility = ["//visibility:public"],
++)
+diff --git a/pki/BUILD.bazel b/pki/BUILD.bazel
+new file mode 100644
+index 0000000..f85c20c
+--- /dev/null
++++ b/pki/BUILD.bazel
+@@ -0,0 +1,21 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "pki",
++    srcs = ["pki.go"],
++    importpath = "github.com/cloudflare/circl/pki",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//sign",
++        "//sign/schemes",
++    ],
++)
++
++go_test(
++    name = "pki_test",
++    srcs = ["pki_test.go"],
++    deps = [
++        ":pki",
++        "//sign/schemes",
++    ],
++)
+diff --git a/sign/BUILD.bazel b/sign/BUILD.bazel
+new file mode 100644
+index 0000000..efdb94b
+--- /dev/null
++++ b/sign/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "sign",
++    srcs = ["sign.go"],
++    importpath = "github.com/cloudflare/circl/sign",
++    visibility = ["//visibility:public"],
++)
+diff --git a/sign/dilithium/BUILD.bazel b/sign/dilithium/BUILD.bazel
+new file mode 100644
+index 0000000..217276d
+--- /dev/null
++++ b/sign/dilithium/BUILD.bazel
+@@ -0,0 +1,39 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "dilithium",
++    srcs = [
++        "dilithium.go",
++        "mode2.go",
++        "mode2aes.go",
++        "mode3.go",
++        "mode3aes.go",
++        "mode5.go",
++        "mode5aes.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/dilithium",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//sign/dilithium/internal/common",
++        "//sign/dilithium/mode2",
++        "//sign/dilithium/mode2aes",
++        "//sign/dilithium/mode3",
++        "//sign/dilithium/mode3aes",
++        "//sign/dilithium/mode5",
++        "//sign/dilithium/mode5aes",
++    ],
++)
++
++go_test(
++    name = "dilithium_test",
++    srcs = [
++        "dilithium_test.go",
++        "example_test.go",
++        "kat_test.go",
++    ],
++    embed = [":dilithium"],
++    deps = [
++        "//internal/nist",
++        "//internal/sha3",
++    ],
++)
+diff --git a/sign/dilithium/internal/common/BUILD.bazel b/sign/dilithium/internal/common/BUILD.bazel
+new file mode 100644
+index 0000000..5993858
+--- /dev/null
++++ b/sign/dilithium/internal/common/BUILD.bazel
+@@ -0,0 +1,38 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "common",
++    srcs = [
++        "aes.go",
++        "amd64.go",
++        "amd64.s",
++        "field.go",
++        "generic.go",
++        "ntt.go",
++        "pack.go",
++        "params.go",
++        "poly.go",
++        "stubs_amd64.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/internal/common",
++    visibility = ["//sign/dilithium:__subpackages__"],
++    deps = [
++        "//sign/dilithium/internal/common/params",
++    ] + select({
++        "@io_bazel_rules_go//go/platform:amd64": [
++            "@org_golang_x_sys//cpu:go_default_library",
++        ],
++        "//conditions:default": [],
++    }),
++)
++
++go_test(
++    name = "common_test",
++    srcs = [
++        "field_test.go",
++        "ntt_test.go",
++        "pack_test.go",
++        "poly_test.go",
++    ],
++    embed = [":common"],
++)
+diff --git a/sign/dilithium/internal/common/asm/BUILD.bazel b/sign/dilithium/internal/common/asm/BUILD.bazel
+new file mode 100644
+index 0000000..310fca6
+--- /dev/null
++++ b/sign/dilithium/internal/common/asm/BUILD.bazel
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "asm_lib",
++    srcs = ["src.go"],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/internal/common/asm",
++    visibility = ["//visibility:private"],
++    deps = [
++        "//sign/dilithium/internal/common/params",
++        "@com_github_mmcloughlin_avo//build:go_default_library",
++        "@com_github_mmcloughlin_avo//operand:go_default_library",
++        "@com_github_mmcloughlin_avo//reg:go_default_library",
++    ],
++)
++
++go_binary(
++    name = "asm",
++    embed = [":asm_lib"],
++    visibility = ["//sign/dilithium:__subpackages__"],
++)
+diff --git a/sign/dilithium/internal/common/params/BUILD.bazel b/sign/dilithium/internal/common/params/BUILD.bazel
+new file mode 100644
+index 0000000..f4c5aed
+--- /dev/null
++++ b/sign/dilithium/internal/common/params/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "params",
++    srcs = ["params.go"],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/internal/common/params",
++    visibility = ["//sign/dilithium:__subpackages__"],
++)
+diff --git a/sign/dilithium/mode2/BUILD.bazel b/sign/dilithium/mode2/BUILD.bazel
+new file mode 100644
+index 0000000..c4c0d28
+--- /dev/null
++++ b/sign/dilithium/mode2/BUILD.bazel
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "mode2",
++    srcs = ["dilithium.go"],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode2",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//sign/dilithium/internal/common",
++        "//sign/dilithium/mode2/internal",
++    ],
++)
+diff --git a/sign/dilithium/mode2/internal/BUILD.bazel b/sign/dilithium/mode2/internal/BUILD.bazel
+new file mode 100644
+index 0000000..9073293
+--- /dev/null
++++ b/sign/dilithium/mode2/internal/BUILD.bazel
+@@ -0,0 +1,34 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "internal",
++    srcs = [
++        "dilithium.go",
++        "mat.go",
++        "pack.go",
++        "params.go",
++        "rounding.go",
++        "sample.go",
++        "vec.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode2/internal",
++    visibility = ["//sign/dilithium/mode2:__subpackages__"],
++    deps = [
++        "//internal/sha3",
++        "//sign/dilithium/internal/common",
++        "//simd/keccakf1600",
++    ],
++)
++
++go_test(
++    name = "internal_test",
++    srcs = [
++        "dilithium_test.go",
++        "pack_test.go",
++        "params_test.go",
++        "rounding_test.go",
++        "sample_test.go",
++    ],
++    embed = [":internal"],
++    deps = ["//sign/dilithium/internal/common"],
++)
+diff --git a/sign/dilithium/mode2aes/BUILD.bazel b/sign/dilithium/mode2aes/BUILD.bazel
+new file mode 100644
+index 0000000..6b5396a
+--- /dev/null
++++ b/sign/dilithium/mode2aes/BUILD.bazel
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "mode2aes",
++    srcs = ["dilithium.go"],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode2aes",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//sign/dilithium/internal/common",
++        "//sign/dilithium/mode2aes/internal",
++    ],
++)
+diff --git a/sign/dilithium/mode2aes/internal/BUILD.bazel b/sign/dilithium/mode2aes/internal/BUILD.bazel
+new file mode 100644
+index 0000000..d4835d7
+--- /dev/null
++++ b/sign/dilithium/mode2aes/internal/BUILD.bazel
+@@ -0,0 +1,34 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "internal",
++    srcs = [
++        "dilithium.go",
++        "mat.go",
++        "pack.go",
++        "params.go",
++        "rounding.go",
++        "sample.go",
++        "vec.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode2aes/internal",
++    visibility = ["//sign/dilithium/mode2aes:__subpackages__"],
++    deps = [
++        "//internal/sha3",
++        "//sign/dilithium/internal/common",
++        "//simd/keccakf1600",
++    ],
++)
++
++go_test(
++    name = "internal_test",
++    srcs = [
++        "dilithium_test.go",
++        "pack_test.go",
++        "params_test.go",
++        "rounding_test.go",
++        "sample_test.go",
++    ],
++    embed = [":internal"],
++    deps = ["//sign/dilithium/internal/common"],
++)
+diff --git a/sign/dilithium/mode3/BUILD.bazel b/sign/dilithium/mode3/BUILD.bazel
+new file mode 100644
+index 0000000..5275661
+--- /dev/null
++++ b/sign/dilithium/mode3/BUILD.bazel
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "mode3",
++    srcs = ["dilithium.go"],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode3",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//sign/dilithium/internal/common",
++        "//sign/dilithium/mode3/internal",
++    ],
++)
+diff --git a/sign/dilithium/mode3/internal/BUILD.bazel b/sign/dilithium/mode3/internal/BUILD.bazel
+new file mode 100644
+index 0000000..5beb0d7
+--- /dev/null
++++ b/sign/dilithium/mode3/internal/BUILD.bazel
+@@ -0,0 +1,34 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "internal",
++    srcs = [
++        "dilithium.go",
++        "mat.go",
++        "pack.go",
++        "params.go",
++        "rounding.go",
++        "sample.go",
++        "vec.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode3/internal",
++    visibility = ["//sign/dilithium/mode3:__subpackages__"],
++    deps = [
++        "//internal/sha3",
++        "//sign/dilithium/internal/common",
++        "//simd/keccakf1600",
++    ],
++)
++
++go_test(
++    name = "internal_test",
++    srcs = [
++        "dilithium_test.go",
++        "pack_test.go",
++        "params_test.go",
++        "rounding_test.go",
++        "sample_test.go",
++    ],
++    embed = [":internal"],
++    deps = ["//sign/dilithium/internal/common"],
++)
+diff --git a/sign/dilithium/mode3aes/BUILD.bazel b/sign/dilithium/mode3aes/BUILD.bazel
+new file mode 100644
+index 0000000..9349d69
+--- /dev/null
++++ b/sign/dilithium/mode3aes/BUILD.bazel
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "mode3aes",
++    srcs = ["dilithium.go"],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode3aes",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//sign/dilithium/internal/common",
++        "//sign/dilithium/mode3aes/internal",
++    ],
++)
+diff --git a/sign/dilithium/mode3aes/internal/BUILD.bazel b/sign/dilithium/mode3aes/internal/BUILD.bazel
+new file mode 100644
+index 0000000..fc809c4
+--- /dev/null
++++ b/sign/dilithium/mode3aes/internal/BUILD.bazel
+@@ -0,0 +1,34 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "internal",
++    srcs = [
++        "dilithium.go",
++        "mat.go",
++        "pack.go",
++        "params.go",
++        "rounding.go",
++        "sample.go",
++        "vec.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode3aes/internal",
++    visibility = ["//sign/dilithium/mode3aes:__subpackages__"],
++    deps = [
++        "//internal/sha3",
++        "//sign/dilithium/internal/common",
++        "//simd/keccakf1600",
++    ],
++)
++
++go_test(
++    name = "internal_test",
++    srcs = [
++        "dilithium_test.go",
++        "pack_test.go",
++        "params_test.go",
++        "rounding_test.go",
++        "sample_test.go",
++    ],
++    embed = [":internal"],
++    deps = ["//sign/dilithium/internal/common"],
++)
+diff --git a/sign/dilithium/mode5/BUILD.bazel b/sign/dilithium/mode5/BUILD.bazel
+new file mode 100644
+index 0000000..fbf976e
+--- /dev/null
++++ b/sign/dilithium/mode5/BUILD.bazel
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "mode5",
++    srcs = ["dilithium.go"],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode5",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//sign/dilithium/internal/common",
++        "//sign/dilithium/mode5/internal",
++    ],
++)
+diff --git a/sign/dilithium/mode5/internal/BUILD.bazel b/sign/dilithium/mode5/internal/BUILD.bazel
+new file mode 100644
+index 0000000..51975b8
+--- /dev/null
++++ b/sign/dilithium/mode5/internal/BUILD.bazel
+@@ -0,0 +1,34 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "internal",
++    srcs = [
++        "dilithium.go",
++        "mat.go",
++        "pack.go",
++        "params.go",
++        "rounding.go",
++        "sample.go",
++        "vec.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode5/internal",
++    visibility = ["//sign/dilithium/mode5:__subpackages__"],
++    deps = [
++        "//internal/sha3",
++        "//sign/dilithium/internal/common",
++        "//simd/keccakf1600",
++    ],
++)
++
++go_test(
++    name = "internal_test",
++    srcs = [
++        "dilithium_test.go",
++        "pack_test.go",
++        "params_test.go",
++        "rounding_test.go",
++        "sample_test.go",
++    ],
++    embed = [":internal"],
++    deps = ["//sign/dilithium/internal/common"],
++)
+diff --git a/sign/dilithium/mode5aes/BUILD.bazel b/sign/dilithium/mode5aes/BUILD.bazel
+new file mode 100644
+index 0000000..2ef95cf
+--- /dev/null
++++ b/sign/dilithium/mode5aes/BUILD.bazel
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "mode5aes",
++    srcs = ["dilithium.go"],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode5aes",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//sign/dilithium/internal/common",
++        "//sign/dilithium/mode5aes/internal",
++    ],
++)
+diff --git a/sign/dilithium/mode5aes/internal/BUILD.bazel b/sign/dilithium/mode5aes/internal/BUILD.bazel
+new file mode 100644
+index 0000000..85631cb
+--- /dev/null
++++ b/sign/dilithium/mode5aes/internal/BUILD.bazel
+@@ -0,0 +1,34 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "internal",
++    srcs = [
++        "dilithium.go",
++        "mat.go",
++        "pack.go",
++        "params.go",
++        "rounding.go",
++        "sample.go",
++        "vec.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/mode5aes/internal",
++    visibility = ["//sign/dilithium/mode5aes:__subpackages__"],
++    deps = [
++        "//internal/sha3",
++        "//sign/dilithium/internal/common",
++        "//simd/keccakf1600",
++    ],
++)
++
++go_test(
++    name = "internal_test",
++    srcs = [
++        "dilithium_test.go",
++        "pack_test.go",
++        "params_test.go",
++        "rounding_test.go",
++        "sample_test.go",
++    ],
++    embed = [":internal"],
++    deps = ["//sign/dilithium/internal/common"],
++)
+diff --git a/sign/dilithium/templates/BUILD.bazel b/sign/dilithium/templates/BUILD.bazel
+new file mode 100644
+index 0000000..6af9b21
+--- /dev/null
++++ b/sign/dilithium/templates/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "templates",
++    srcs = ["modePkg.templ.go"],
++    importpath = "github.com/cloudflare/circl/sign/dilithium/templates",
++    visibility = ["//visibility:public"],
++)
+diff --git a/sign/ed25519/BUILD.bazel b/sign/ed25519/BUILD.bazel
+new file mode 100644
+index 0000000..d627e13
+--- /dev/null
++++ b/sign/ed25519/BUILD.bazel
+@@ -0,0 +1,41 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "ed25519",
++    srcs = [
++        "ed25519.go",
++        "modular.go",
++        "mult.go",
++        "point.go",
++        "pubkey.go",
++        "pubkey112.go",
++        "signapi.go",
++        "tables.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/ed25519",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/conv",
++        "//math",
++        "//math/fp25519",
++        "//sign",
++    ],
++)
++
++go_test(
++    name = "ed25519_test",
++    srcs = [
++        "ed25519_test.go",
++        "extra_test.go",
++        "modular_test.go",
++        "point_test.go",
++        "rfc8032_test.go",
++        "wycheproof_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    embed = [":ed25519"],
++    deps = [
++        "//internal/conv",
++        "//internal/test",
++    ],
++)
+diff --git a/sign/ed448/BUILD.bazel b/sign/ed448/BUILD.bazel
+new file mode 100644
+index 0000000..e9aad91
+--- /dev/null
++++ b/sign/ed448/BUILD.bazel
+@@ -0,0 +1,30 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "ed448",
++    srcs = [
++        "ed448.go",
++        "signapi.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/ed448",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//ecc/goldilocks",
++        "//internal/sha3",
++        "//sign",
++    ],
++)
++
++go_test(
++    name = "ed448_test",
++    srcs = [
++        "ed448_test.go",
++        "rfc8032_test.go",
++        "wycheproof_test.go",
++    ],
++    data = glob(["testdata/**"]),
++    deps = [
++        ":ed448",
++        "//internal/test",
++    ],
++)
+diff --git a/sign/eddilithium2/BUILD.bazel b/sign/eddilithium2/BUILD.bazel
+new file mode 100644
+index 0000000..8c8cc9c
+--- /dev/null
++++ b/sign/eddilithium2/BUILD.bazel
+@@ -0,0 +1,26 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "eddilithium2",
++    srcs = [
++        "eddilithium.go",
++        "signapi.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/eddilithium2",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/sha3",
++        "//sign",
++        "//sign/dilithium/mode2",
++        "//sign/ed25519",
++    ],
++)
++
++go_test(
++    name = "eddilithium2_test",
++    srcs = [
++        "eddilithium_test.go",
++        "example_test.go",
++    ],
++    deps = [":eddilithium2"],
++)
+diff --git a/sign/eddilithium3/BUILD.bazel b/sign/eddilithium3/BUILD.bazel
+new file mode 100644
+index 0000000..be9c604
+--- /dev/null
++++ b/sign/eddilithium3/BUILD.bazel
+@@ -0,0 +1,26 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "eddilithium3",
++    srcs = [
++        "eddilithium.go",
++        "signapi.go",
++    ],
++    importpath = "github.com/cloudflare/circl/sign/eddilithium3",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/sha3",
++        "//sign",
++        "//sign/dilithium/mode3",
++        "//sign/ed448",
++    ],
++)
++
++go_test(
++    name = "eddilithium3_test",
++    srcs = [
++        "eddilithium_test.go",
++        "example_test.go",
++    ],
++    deps = [":eddilithium3"],
++)
+diff --git a/sign/schemes/BUILD.bazel b/sign/schemes/BUILD.bazel
+new file mode 100644
+index 0000000..fcf2d90
+--- /dev/null
++++ b/sign/schemes/BUILD.bazel
+@@ -0,0 +1,24 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "schemes",
++    srcs = ["schemes.go"],
++    importpath = "github.com/cloudflare/circl/sign/schemes",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//sign",
++        "//sign/ed25519",
++        "//sign/ed448",
++        "//sign/eddilithium2",
++        "//sign/eddilithium3",
++    ],
++)
++
++go_test(
++    name = "schemes_test",
++    srcs = ["schemes_test.go"],
++    deps = [
++        ":schemes",
++        "//sign",
++    ],
++)
+diff --git a/simd/BUILD.bazel b/simd/BUILD.bazel
+new file mode 100644
+index 0000000..7bc8d90
+--- /dev/null
++++ b/simd/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "simd",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/simd",
++    visibility = ["//visibility:public"],
++)
+diff --git a/simd/keccakf1600/BUILD.bazel b/simd/keccakf1600/BUILD.bazel
+new file mode 100644
+index 0000000..a3f8fab
+--- /dev/null
++++ b/simd/keccakf1600/BUILD.bazel
+@@ -0,0 +1,30 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "keccakf1600",
++    srcs = [
++        "f1600x.go",
++        "f1600x2_arm64.go",
++        "f1600x2_arm64.s",
++        "f1600x4_amd64.go",
++        "f1600x4_amd64.s",
++        "f1600x4stubs_amd64.go",
++        "fallback.go",
++    ],
++    importpath = "github.com/cloudflare/circl/simd/keccakf1600",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/sha3",
++        "@org_golang_x_sys//cpu:go_default_library",
++    ],
++)
++
++go_test(
++    name = "keccakf1600_test",
++    srcs = [
++        "example_test.go",
++        "f1600x_test.go",
++    ],
++    embed = [":keccakf1600"],
++    deps = ["//internal/sha3"],
++)
+diff --git a/simd/keccakf1600/internal/asm/BUILD.bazel b/simd/keccakf1600/internal/asm/BUILD.bazel
+new file mode 100644
+index 0000000..b595042
+--- /dev/null
++++ b/simd/keccakf1600/internal/asm/BUILD.bazel
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
++
++go_library(
++    name = "asm_lib",
++    srcs = ["src.go"],
++    importpath = "github.com/cloudflare/circl/simd/keccakf1600/internal/asm",
++    visibility = ["//visibility:private"],
++    deps = [
++        "@com_github_mmcloughlin_avo//build:go_default_library",
++        "@com_github_mmcloughlin_avo//operand:go_default_library",
++    ],
++)
++
++go_binary(
++    name = "asm",
++    embed = [":asm_lib"],
++    visibility = ["//simd/keccakf1600:__subpackages__"],
++)
+diff --git a/tss/BUILD.bazel b/tss/BUILD.bazel
+new file mode 100644
+index 0000000..9de8787
+--- /dev/null
++++ b/tss/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "tss",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/tss",
++    visibility = ["//visibility:public"],
++)
+diff --git a/tss/rsa/BUILD.bazel b/tss/rsa/BUILD.bazel
+new file mode 100644
+index 0000000..8aab8a1
+--- /dev/null
++++ b/tss/rsa/BUILD.bazel
+@@ -0,0 +1,31 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "rsa",
++    srcs = [
++        "keyshare.go",
++        "padding.go",
++        "rsa_threshold.go",
++        "signShare.go",
++        "util.go",
++    ],
++    importpath = "github.com/cloudflare/circl/tss/rsa",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//math",
++        "//tss/rsa/internal",
++        "//tss/rsa/internal/pss",
++    ],
++)
++
++go_test(
++    name = "rsa_test",
++    srcs = [
++        "keyshare_test.go",
++        "rsa_threshold_test.go",
++        "signShare_test.go",
++        "util_test.go",
++    ],
++    embed = [":rsa"],
++    deps = ["//internal/test"],
++)
+diff --git a/tss/rsa/internal/BUILD.bazel b/tss/rsa/internal/BUILD.bazel
+new file mode 100644
+index 0000000..3a5b83b
+--- /dev/null
++++ b/tss/rsa/internal/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "internal",
++    srcs = ["pkcs1v15.go"],
++    importpath = "github.com/cloudflare/circl/tss/rsa/internal",
++    visibility = ["//tss/rsa:__subpackages__"],
++)
+diff --git a/tss/rsa/internal/pss/BUILD.bazel b/tss/rsa/internal/pss/BUILD.bazel
+new file mode 100644
+index 0000000..ac61927
+--- /dev/null
++++ b/tss/rsa/internal/pss/BUILD.bazel
+@@ -0,0 +1,11 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "pss",
++    srcs = [
++        "pss.go",
++        "rsa.go",
++    ],
++    importpath = "github.com/cloudflare/circl/tss/rsa/internal/pss",
++    visibility = ["//tss/rsa:__subpackages__"],
++)
+diff --git a/xof/BUILD.bazel b/xof/BUILD.bazel
+new file mode 100644
+index 0000000..aedc0c6
+--- /dev/null
++++ b/xof/BUILD.bazel
+@@ -0,0 +1,23 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "xof",
++    srcs = ["xof.go"],
++    importpath = "github.com/cloudflare/circl/xof",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/sha3",
++        "//xof/k12",
++        "@org_golang_x_crypto//blake2b:go_default_library",
++        "@org_golang_x_crypto//blake2s:go_default_library",
++    ],
++)
++
++go_test(
++    name = "xof_test",
++    srcs = ["xof_test.go"],
++    deps = [
++        ":xof",
++        "//internal/test",
++    ],
++)
+diff --git a/xof/k12/BUILD.bazel b/xof/k12/BUILD.bazel
+new file mode 100644
+index 0000000..76d78be
+--- /dev/null
++++ b/xof/k12/BUILD.bazel
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "k12",
++    srcs = ["k12.go"],
++    importpath = "github.com/cloudflare/circl/xof/k12",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//internal/sha3",
++        "//simd/keccakf1600",
++    ],
++)
++
++go_test(
++    name = "k12_test",
++    srcs = ["k12_test.go"],
++    embed = [":k12"],
++)
+diff --git a/zk/BUILD.bazel b/zk/BUILD.bazel
+new file mode 100644
+index 0000000..b2f46b1
+--- /dev/null
++++ b/zk/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "zk",
++    srcs = ["doc.go"],
++    importpath = "github.com/cloudflare/circl/zk",
++    visibility = ["//visibility:public"],
++)
+diff --git a/zk/dl/BUILD.bazel b/zk/dl/BUILD.bazel
+new file mode 100644
+index 0000000..3876572
+--- /dev/null
++++ b/zk/dl/BUILD.bazel
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "dl",
++    srcs = ["dl.go"],
++    importpath = "github.com/cloudflare/circl/zk/dl",
++    visibility = ["//visibility:public"],
++    deps = ["//group"],
++)
++
++go_test(
++    name = "dl_test",
++    srcs = ["dl_test.go"],
++    deps = [
++        ":dl",
++        "//group",
++    ],
++)
+diff --git a/zk/dleq/BUILD.bazel b/zk/dleq/BUILD.bazel
+new file mode 100644
+index 0000000..785b5ff
+--- /dev/null
++++ b/zk/dleq/BUILD.bazel
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "dleq",
++    srcs = ["dleq.go"],
++    importpath = "github.com/cloudflare/circl/zk/dleq",
++    visibility = ["//visibility:public"],
++    deps = ["//group"],
++)
++
++go_test(
++    name = "dleq_test",
++    srcs = ["dleq_test.go"],
++    deps = [
++        ":dleq",
++        "//group",
++        "//internal/test",
++    ],
++)

--- a/modules/circl/1.3.7.bcr.1/patches/modify_build_files.patch
+++ b/modules/circl/1.3.7.bcr.1/patches/modify_build_files.patch
@@ -1,0 +1,143 @@
+commit 9e7940b9be05ca36d3ac2fdfac07b61a6e0dfefd
+Author: Fabian Meumertzheim <fabian@meumertzhe.im>
+Date:   Tue Jan 9 09:00:27 2024 +0100
+
+    Fix Gazelle-generated BUILD files
+    
+    * Added `cc_library` targets for header files referenced across packages
+    * Removed BUILD files for code generators
+
+diff --git a/dh/x25519/BUILD.bazel b/dh/x25519/BUILD.bazel
+index f80aba0..cacfcf1 100644
+--- a/dh/x25519/BUILD.bazel
++++ b/dh/x25519/BUILD.bazel
+@@ -13,6 +13,8 @@ go_library(
+         "key.go",
+         "table.go",
+     ],
++    cgo = True,
++    cdeps = ["//math/fp25519:header"],
+     importpath = "github.com/cloudflare/circl/dh/x25519",
+     visibility = ["//visibility:public"],
+     deps = [
+diff --git a/dh/x448/BUILD.bazel b/dh/x448/BUILD.bazel
+index 31278c4..94a7b2b 100644
+--- a/dh/x448/BUILD.bazel
++++ b/dh/x448/BUILD.bazel
+@@ -13,6 +13,8 @@ go_library(
+         "key.go",
+         "table.go",
+     ],
++    cgo = True,
++    cdeps = ["//math/fp448:header"],
+     importpath = "github.com/cloudflare/circl/dh/x448",
+     visibility = ["//visibility:public"],
+     deps = [
+diff --git a/math/fp25519/BUILD.bazel b/math/fp25519/BUILD.bazel
+index f423b16..8db8f9e 100644
+--- a/math/fp25519/BUILD.bazel
++++ b/math/fp25519/BUILD.bazel
+@@ -1,5 +1,11 @@
+ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+ 
++cc_library(
++    name = "header",
++    hdrs = ["fp_amd64.h"],
++    visibility  = ["//:__subpackages__"],
++)
++
+ go_library(
+     name = "fp25519",
+     srcs = [
+diff --git a/math/fp448/BUILD.bazel b/math/fp448/BUILD.bazel
+index 80715a1..fc50c6e 100644
+--- a/math/fp448/BUILD.bazel
++++ b/math/fp448/BUILD.bazel
+@@ -1,5 +1,11 @@
+ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+ 
++cc_library(
++    name = "header",
++    hdrs = ["fp_amd64.h"],
++    visibility  = ["//:__subpackages__"],
++)
++
+ go_library(
+     name = "fp448",
+     srcs = [
+diff --git a/pke/kyber/internal/common/asm/BUILD.bazel b/pke/kyber/internal/common/asm/BUILD.bazel
+deleted file mode 100644
+index 8ab4e7e..0000000
+--- a/pke/kyber/internal/common/asm/BUILD.bazel
++++ /dev/null
+@@ -1,20 +0,0 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+-
+-go_library(
+-    name = "asm_lib",
+-    srcs = ["src.go"],
+-    importpath = "github.com/cloudflare/circl/pke/kyber/internal/common/asm",
+-    visibility = ["//visibility:private"],
+-    deps = [
+-        "//pke/kyber/internal/common/params",
+-        "@com_github_mmcloughlin_avo//build:go_default_library",
+-        "@com_github_mmcloughlin_avo//operand:go_default_library",
+-        "@com_github_mmcloughlin_avo//reg:go_default_library",
+-    ],
+-)
+-
+-go_binary(
+-    name = "asm",
+-    embed = [":asm_lib"],
+-    visibility = ["//pke/kyber:__subpackages__"],
+-)
+diff --git a/sign/dilithium/internal/common/asm/BUILD.bazel b/sign/dilithium/internal/common/asm/BUILD.bazel
+deleted file mode 100644
+index 310fca6..0000000
+--- a/sign/dilithium/internal/common/asm/BUILD.bazel
++++ /dev/null
+@@ -1,20 +0,0 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+-
+-go_library(
+-    name = "asm_lib",
+-    srcs = ["src.go"],
+-    importpath = "github.com/cloudflare/circl/sign/dilithium/internal/common/asm",
+-    visibility = ["//visibility:private"],
+-    deps = [
+-        "//sign/dilithium/internal/common/params",
+-        "@com_github_mmcloughlin_avo//build:go_default_library",
+-        "@com_github_mmcloughlin_avo//operand:go_default_library",
+-        "@com_github_mmcloughlin_avo//reg:go_default_library",
+-    ],
+-)
+-
+-go_binary(
+-    name = "asm",
+-    embed = [":asm_lib"],
+-    visibility = ["//sign/dilithium:__subpackages__"],
+-)
+diff --git a/simd/keccakf1600/internal/asm/BUILD.bazel b/simd/keccakf1600/internal/asm/BUILD.bazel
+deleted file mode 100644
+index b595042..0000000
+--- a/simd/keccakf1600/internal/asm/BUILD.bazel
++++ /dev/null
+@@ -1,18 +0,0 @@
+-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+-
+-go_library(
+-    name = "asm_lib",
+-    srcs = ["src.go"],
+-    importpath = "github.com/cloudflare/circl/simd/keccakf1600/internal/asm",
+-    visibility = ["//visibility:private"],
+-    deps = [
+-        "@com_github_mmcloughlin_avo//build:go_default_library",
+-        "@com_github_mmcloughlin_avo//operand:go_default_library",
+-    ],
+-)
+-
+-go_binary(
+-    name = "asm",
+-    embed = [":asm_lib"],
+-    visibility = ["//simd/keccakf1600:__subpackages__"],
+-)

--- a/modules/circl/1.3.7.bcr.1/patches/switch_purego_build_tag_to_cgo.patch
+++ b/modules/circl/1.3.7.bcr.1/patches/switch_purego_build_tag_to_cgo.patch
@@ -1,0 +1,364 @@
+From 5355997fc3f6ef137d65df3dfcb234c7df5a49d4 Mon Sep 17 00:00:00 2001
+From: Matt Clarkson <mattyclarkson@gmail.com>
+Date: Fri, 15 Mar 2024 16:37:13 +0000
+Subject: [PATCH] Switch `purego` build tags to `cgo`
+
+`rules_go` does not provide `purego` build tags when `pure = "on"`.
+
+`cgo` build tag is the inverse so we can update the source files
+to conditionally compile on `cgo`.
+---
+ dh/csidh/fp511_amd64.s              | 3 ++-
+ dh/csidh/fp511_noasm.go             | 4 ++--
+ dh/sidh/internal/p434/arith_amd64.s | 3 ++-
+ dh/sidh/internal/p503/arith_amd64.s | 3 ++-
+ dh/sidh/internal/p751/arith_amd64.s | 3 ++-
+ dh/x25519/curve_amd64.go            | 4 ++--
+ dh/x25519/curve_amd64.s             | 3 ++-
+ dh/x25519/curve_noasm.go            | 4 ++--
+ dh/x448/curve_amd64.go              | 4 ++--
+ dh/x448/curve_amd64.s               | 3 ++-
+ dh/x448/curve_noasm.go              | 4 ++--
+ ecc/fourq/fp_amd64.go               | 4 ++--
+ ecc/fourq/fp_amd64.s                | 3 ++-
+ ecc/fourq/fp_noasm.go               | 4 ++--
+ ecc/fourq/fq_amd64.go               | 4 ++--
+ ecc/fourq/fq_amd64.s                | 3 ++-
+ ecc/fourq/fq_noasm.go               | 4 ++--
+ ecc/fourq/point_amd64.go            | 4 ++--
+ ecc/fourq/point_amd64.s             | 3 ++-
+ ecc/fourq/point_generic.go          | 4 ++--
+ ecc/fourq/point_noasm.go            | 4 ++--
+ ecc/p384/arith_amd64.s              | 3 ++-
+ math/fp25519/fp_amd64.go            | 4 ++--
+ math/fp25519/fp_amd64.s             | 3 ++-
+ math/fp25519/fp_noasm.go            | 4 ++--
+ math/fp448/fp_amd64.go              | 4 ++--
+ math/fp448/fp_amd64.s               | 3 ++-
+ math/fp448/fp_noasm.go              | 4 ++--
+ 28 files changed, 56 insertions(+), 44 deletions(-)
+
+diff --git a/dh/csidh/fp511_amd64.s b/dh/csidh/fp511_amd64.s
+index 612a0c5..2a2405c 100644
+--- a/dh/csidh/fp511_amd64.s
++++ b/dh/csidh/fp511_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ #include "textflag.h"
+ 
+diff --git a/dh/csidh/fp511_noasm.go b/dh/csidh/fp511_noasm.go
+index 72b2efd..6018821 100644
+--- a/dh/csidh/fp511_noasm.go
++++ b/dh/csidh/fp511_noasm.go
+@@ -1,5 +1,5 @@
+-//go:build !amd64 || purego
+-// +build !amd64 purego
++//go:build !amd64 || !cgo
++// +build !amd64 !cgo
+ 
+ package csidh
+ 
+diff --git a/dh/sidh/internal/p434/arith_amd64.s b/dh/sidh/internal/p434/arith_amd64.s
+index 785997b..25675d5 100644
+--- a/dh/sidh/internal/p434/arith_amd64.s
++++ b/dh/sidh/internal/p434/arith_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64,!noasm
++//go:build amd64 && cgo
++// +build amd64,cgo,!noasm
+ 
+ #include "textflag.h"
+ 
+diff --git a/dh/sidh/internal/p503/arith_amd64.s b/dh/sidh/internal/p503/arith_amd64.s
+index 2845cbd..7260c28 100644
+--- a/dh/sidh/internal/p503/arith_amd64.s
++++ b/dh/sidh/internal/p503/arith_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64,!noasm
++//go:build amd64 && cgo
++// +build amd64,cgo,!noasm
+ 
+ #include "textflag.h"
+ 
+diff --git a/dh/sidh/internal/p751/arith_amd64.s b/dh/sidh/internal/p751/arith_amd64.s
+index 59f5fa6..488cc97 100644
+--- a/dh/sidh/internal/p751/arith_amd64.s
++++ b/dh/sidh/internal/p751/arith_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64,!noasm
++//go:build amd64 && cgo
++// +build amd64,cgo,!noasm
+ 
+ #include "textflag.h"
+ 
+diff --git a/dh/x25519/curve_amd64.go b/dh/x25519/curve_amd64.go
+index 8a3d54c..07c8224 100644
+--- a/dh/x25519/curve_amd64.go
++++ b/dh/x25519/curve_amd64.go
+@@ -1,5 +1,5 @@
+-//go:build amd64 && !purego
+-// +build amd64,!purego
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ package x25519
+ 
+diff --git a/dh/x25519/curve_amd64.s b/dh/x25519/curve_amd64.s
+index b772318..6309e42 100644
+--- a/dh/x25519/curve_amd64.s
++++ b/dh/x25519/curve_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ #include "textflag.h"
+ 
+diff --git a/dh/x25519/curve_noasm.go b/dh/x25519/curve_noasm.go
+index 07fab97..551eb87 100644
+--- a/dh/x25519/curve_noasm.go
++++ b/dh/x25519/curve_noasm.go
+@@ -1,5 +1,5 @@
+-//go:build !amd64 || purego
+-// +build !amd64 purego
++//go:build !amd64 || !cgo
++// +build !amd64 !cgo
+ 
+ package x25519
+ 
+diff --git a/dh/x448/curve_amd64.go b/dh/x448/curve_amd64.go
+index a062266..2e3805d 100644
+--- a/dh/x448/curve_amd64.go
++++ b/dh/x448/curve_amd64.go
+@@ -1,5 +1,5 @@
+-//go:build amd64 && !purego
+-// +build amd64,!purego
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ package x448
+ 
+diff --git a/dh/x448/curve_amd64.s b/dh/x448/curve_amd64.s
+index 810aa9e..e18a840 100644
+--- a/dh/x448/curve_amd64.s
++++ b/dh/x448/curve_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ #include "textflag.h"
+ 
+diff --git a/dh/x448/curve_noasm.go b/dh/x448/curve_noasm.go
+index 3755b7c..d5aef33 100644
+--- a/dh/x448/curve_noasm.go
++++ b/dh/x448/curve_noasm.go
+@@ -1,5 +1,5 @@
+-//go:build !amd64 || purego
+-// +build !amd64 purego
++//go:build !amd64 || !cgo
++// +build !amd64 !cgo
+ 
+ package x448
+ 
+diff --git a/ecc/fourq/fp_amd64.go b/ecc/fourq/fp_amd64.go
+index da1ba4b..c2f63fc 100644
+--- a/ecc/fourq/fp_amd64.go
++++ b/ecc/fourq/fp_amd64.go
+@@ -1,5 +1,5 @@
+-//go:build amd64 && !purego
+-// +build amd64,!purego
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ package fourq
+ 
+diff --git a/ecc/fourq/fp_amd64.s b/ecc/fourq/fp_amd64.s
+index 9543bd2..0336a12 100644
+--- a/ecc/fourq/fp_amd64.s
++++ b/ecc/fourq/fp_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64,!purego
++//go:build amd64 && cgo
++// +build amd64,cgo,cgo
+ 
+ #include "textflag.h"
+ #include "fp_amd64.h"
+diff --git a/ecc/fourq/fp_noasm.go b/ecc/fourq/fp_noasm.go
+index aa35f52..586475c 100644
+--- a/ecc/fourq/fp_noasm.go
++++ b/ecc/fourq/fp_noasm.go
+@@ -1,5 +1,5 @@
+-//go:build !amd64 || purego
+-// +build !amd64 purego
++//go:build !amd64 || !cgo
++// +build !amd64 !cgo
+ 
+ package fourq
+ 
+diff --git a/ecc/fourq/fq_amd64.go b/ecc/fourq/fq_amd64.go
+index af880cd..579e85e 100644
+--- a/ecc/fourq/fq_amd64.go
++++ b/ecc/fourq/fq_amd64.go
+@@ -1,5 +1,5 @@
+-//go:build amd64 && !purego
+-// +build amd64,!purego
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ package fourq
+ 
+diff --git a/ecc/fourq/fq_amd64.s b/ecc/fourq/fq_amd64.s
+index 415fc13..52adf79 100644
+--- a/ecc/fourq/fq_amd64.s
++++ b/ecc/fourq/fq_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64,!purego
++//go:build amd64 && cgo
++// +build amd64,cgo,cgo
+ 
+ #include "fq_amd64.h"
+ 
+diff --git a/ecc/fourq/fq_noasm.go b/ecc/fourq/fq_noasm.go
+index 1c7716a..c8af974 100644
+--- a/ecc/fourq/fq_noasm.go
++++ b/ecc/fourq/fq_noasm.go
+@@ -1,5 +1,5 @@
+-//go:build !amd64 || purego
+-// +build !amd64 purego
++//go:build !amd64 || !cgo
++// +build !amd64 !cgo
+ 
+ package fourq
+ 
+diff --git a/ecc/fourq/point_amd64.go b/ecc/fourq/point_amd64.go
+index aeb7272..376e190 100644
+--- a/ecc/fourq/point_amd64.go
++++ b/ecc/fourq/point_amd64.go
+@@ -1,5 +1,5 @@
+-//go:build amd64 && !purego
+-// +build amd64,!purego
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ package fourq
+ 
+diff --git a/ecc/fourq/point_amd64.s b/ecc/fourq/point_amd64.s
+index f4dd5dd..90fbe77 100644
+--- a/ecc/fourq/point_amd64.s
++++ b/ecc/fourq/point_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64,!purego
++//go:build amd64 && cgo
++// +build amd64,cgo,cgo
+ 
+ #include "go_asm.h"
+ #include "fq_amd64.h"
+diff --git a/ecc/fourq/point_generic.go b/ecc/fourq/point_generic.go
+index 792cd31..beef6c2 100644
+--- a/ecc/fourq/point_generic.go
++++ b/ecc/fourq/point_generic.go
+@@ -1,5 +1,5 @@
+-//go:build !amd64 || purego
+-// +build !amd64 purego
++//go:build !amd64 || !cgo
++// +build !amd64 !cgo
+ 
+ package fourq
+ 
+diff --git a/ecc/fourq/point_noasm.go b/ecc/fourq/point_noasm.go
+index 22c2695..ab476a4 100644
+--- a/ecc/fourq/point_noasm.go
++++ b/ecc/fourq/point_noasm.go
+@@ -1,5 +1,5 @@
+-//go:build !amd64 || purego
+-// +build !amd64 purego
++//go:build !amd64 || !cgo
++// +build !amd64 !cgo
+ 
+ package fourq
+ 
+diff --git a/ecc/p384/arith_amd64.s b/ecc/p384/arith_amd64.s
+index 5f53c63..33957d1 100644
+--- a/ecc/p384/arith_amd64.s
++++ b/ecc/p384/arith_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64,!noasm
++//go:build amd64 && cgo
++// +build amd64,cgo,!noasm
+ 
+ #include "textflag.h"
+ 
+diff --git a/math/fp25519/fp_amd64.go b/math/fp25519/fp_amd64.go
+index 057f0d2..fb71dbf 100644
+--- a/math/fp25519/fp_amd64.go
++++ b/math/fp25519/fp_amd64.go
+@@ -1,5 +1,5 @@
+-//go:build amd64 && !purego
+-// +build amd64,!purego
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ package fp25519
+ 
+diff --git a/math/fp25519/fp_amd64.s b/math/fp25519/fp_amd64.s
+index 5c4aedd..d8e1eaa 100644
+--- a/math/fp25519/fp_amd64.s
++++ b/math/fp25519/fp_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ #include "textflag.h"
+ #include "fp_amd64.h"
+diff --git a/math/fp25519/fp_noasm.go b/math/fp25519/fp_noasm.go
+index 26ca4d0..1fb7c7a 100644
+--- a/math/fp25519/fp_noasm.go
++++ b/math/fp25519/fp_noasm.go
+@@ -1,5 +1,5 @@
+-//go:build !amd64 || purego
+-// +build !amd64 purego
++//go:build !amd64 || !cgo
++// +build !amd64 !cgo
+ 
+ package fp25519
+ 
+diff --git a/math/fp448/fp_amd64.go b/math/fp448/fp_amd64.go
+index 6a12209..f4097f9 100644
+--- a/math/fp448/fp_amd64.go
++++ b/math/fp448/fp_amd64.go
+@@ -1,5 +1,5 @@
+-//go:build amd64 && !purego
+-// +build amd64,!purego
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ package fp448
+ 
+diff --git a/math/fp448/fp_amd64.s b/math/fp448/fp_amd64.s
+index 435addf..643f07e 100644
+--- a/math/fp448/fp_amd64.s
++++ b/math/fp448/fp_amd64.s
+@@ -1,4 +1,5 @@
+-// +build amd64
++//go:build amd64 && cgo
++// +build amd64,cgo
+ 
+ #include "textflag.h"
+ #include "fp_amd64.h"
+diff --git a/math/fp448/fp_noasm.go b/math/fp448/fp_noasm.go
+index a62225d..f2366c5 100644
+--- a/math/fp448/fp_noasm.go
++++ b/math/fp448/fp_noasm.go
+@@ -1,5 +1,5 @@
+-//go:build !amd64 || purego
+-// +build !amd64 purego
++//go:build !amd64 || !cgo
++// +build !amd64 !cgo
+ 
+ package fp448
+ 

--- a/modules/circl/1.3.7.bcr.1/presubmit.yml
+++ b/modules/circl/1.3.7.bcr.1/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  bazel:
+  - 7.x
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    bazel: ${{ bazel }}
+    platform: ${{ platform }}
+    build_targets:
+    - '@circl//...'

--- a/modules/circl/1.3.7.bcr.1/source.json
+++ b/modules/circl/1.3.7.bcr.1/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://proxy.golang.org/github.com/cloudflare/circl/@v/v1.3.7.zip",
+    "integrity": "sha256-RJcJPLdUTTDp1ddBpeYsFPuJicQnHKCpoKA6c1cLO4M=",
+    "patches": {
+        "add_module_file.patch": "sha256-J34e0IMUvSHyziUYlP6MkSpiOAWiCUHx03IS0q/oee4=",
+        "generate_build_files.patch": "sha256-eeaK8yZzN37I4sMke+y0VZkGs6umdC1NGFNM6oPuMpc=",
+        "modify_build_files.patch": "sha256-tQe2SIRz5t9HN9n5KrWCakNujPWQUcR3AR4uakOBIy8=",
+        "switch_purego_build_tag_to_cgo.patch": "sha256-DYGDDpumZE2vMVWIE1elbsh2ijHW6ef9sYEzRggtg5o=",
+        "add_pure_tests_for_mathmatical_libraries.patch": "sha256-ZuHsv8eolTVrR5XkEGh7AtcKMsGm89X9eS2+pui+mjQ="
+    },
+    "patch_strip": 1,
+    "strip_prefix": "github.com/cloudflare/circl@v1.3.7"
+}

--- a/modules/circl/metadata.json
+++ b/modules/circl/metadata.json
@@ -9,7 +9,8 @@
   "repository": [],
   "versions": [
     "1.3.3",
-    "1.3.7"
+    "1.3.7",
+    "1.3.7.bcr.1"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
This switches out `purego` build tags for the inverse `!cgo` build tags.

The correct files are then conditionally added and compiled.

This supports `pure = "on"` binaries.

A patch adds a `pure = "on"` unit test to prevent regressions.