### PR TITLE
opentracing-cpp@1.6.0

### DIFF
--- a/modules/io_opentracing_cpp/1.6.0/MODULE.bazel
+++ b/modules/io_opentracing_cpp/1.6.0/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "io_opentracing_cpp",
+    version = "1.6.0",
+)

--- a/modules/io_opentracing_cpp/1.6.0/patches/module_dot_bazel.patch
+++ b/modules/io_opentracing_cpp/1.6.0/patches/module_dot_bazel.patch
@@ -1,0 +1,7 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,4 @@
++module(
++    name = "io_opentracing_cpp",
++    version = "1.6.0",
++)

--- a/modules/io_opentracing_cpp/1.6.0/presubmit.yml
+++ b/modules/io_opentracing_cpp/1.6.0/presubmit.yml
@@ -1,0 +1,34 @@
+verify_linux_targets:
+  name: Verify linux build and test targets
+  platform: ${{ platform }}
+  matrix:
+    platform:
+    - debian10
+    - ubuntu2004
+    bazel:
+    - 7.x
+    - 6.x
+  shell_commands:
+  - ./ci/setup_linux_environment.sh
+  bazel: ${{ bazel }}
+  build_targets:
+  - '@io_opentracing_cpp//...'
+  test_targets:
+  - '@io_opentracing_cpp//...'
+verify_osx_targets:
+  name: Verify osx build and test targets
+  platform: ${{ platform }}
+  matrix:
+    platform:
+    - macos
+    - macos_arm64
+    bazel:
+    - 7.x
+    - 6.x
+  shell_commands:
+  - ./ci/setup_osx_environment.sh
+  bazel: ${{ bazel }}
+  build_targets:
+  - '@io_opentracing_cpp//...'
+  test_targets:
+  - '@io_opentracing_cpp//...'

--- a/modules/io_opentracing_cpp/1.6.0/source.json
+++ b/modules/io_opentracing_cpp/1.6.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/opentracing/opentracing-cpp/archive/refs/tags/v1.6.0.tar.gz",
+    "integrity": "sha256-WxcAQtpNHEwjHfZZTaEgh1Qp1SMem6pReYIu6NEFSsM=",
+    "strip_prefix": "opentracing-cpp-1.6.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-cvGgNUsSk1Igso2vS6bcWAC9+kJZR70iTidZlfigLyQ="
+    }
+}

--- a/modules/io_opentracing_cpp/metadata.json
+++ b/modules/io_opentracing_cpp/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/opentracing/opentracing-cpp",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:opentracing/opentracing-cpp"
+    ],
+    "versions": [
+        "1.6.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
opentracing-cpp is archived but it is still used by several projects

Add opentracing-cpp v1.6.0