### PR TITLE
tclap@1.2.5

### DIFF
--- a/modules/tclap/1.2.5/MODULE.bazel
+++ b/modules/tclap/1.2.5/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "tclap",
+    version = "1.2.5",
+    compatibility_level = 1,
+)

--- a/modules/tclap/1.2.5/patches/add_build_file.patch
+++ b/modules/tclap/1.2.5/patches/add_build_file.patch
@@ -1,0 +1,9 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,6 @@
++cc_library(
++    name = "tclap",
++    hdrs = glob(["include/tclap/*.h"]),
++    includes = ["include"],
++    visibility = ["//visibility:public"],
++)

--- a/modules/tclap/1.2.5/patches/module_dot_bazel.patch
+++ b/modules/tclap/1.2.5/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "tclap",
++    version = "1.2.5",
++    compatibility_level = 1,
++)

--- a/modules/tclap/1.2.5/presubmit.yml
+++ b/modules/tclap/1.2.5/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@tclap//:tclap'

--- a/modules/tclap/1.2.5/source.json
+++ b/modules/tclap/1.2.5/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/mirror/tclap/archive/refs/tags/v1.2.5.tar.gz",
+    "integrity": "sha256-fofRNzQHb6T2JvYUTOmgJxcZiz8FQ0GmiG4hB7BIsjU=",
+    "strip_prefix": "tclap-1.2.5",
+    "patches": {
+        "add_build_file.patch": "sha256-tCVQ3KII3o22b6T0I7XydMrGvJ90acqdqEHsgj/6Z94=",
+        "module_dot_bazel.patch": "sha256-YJYKrDeaBBPMAdb7XZtAGKIhECPLsAzNitkGweSDgnY="
+    },
+    "patch_strip": 0
+}

--- a/modules/tclap/metadata.json
+++ b/modules/tclap/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/mirror/tclap",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:mirror/tclap"
+    ],
+    "versions": [
+        "1.2.5"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/mirror/tclap/releases/tag/v1.2.5