### PR TITLE
opentracing-cpp@1.6.0

### DIFF
--- a/modules/opentracing-cpp/1.6.0/MODULE.bazel
+++ b/modules/opentracing-cpp/1.6.0/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "opentracing-cpp",
+    version = "1.6.0",
+    compatibility_level = 1,
+)

--- a/modules/opentracing-cpp/1.6.0/patches/module_dot_bazel.patch
+++ b/modules/opentracing-cpp/1.6.0/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "opentracing-cpp",
++    version = "1.6.0",
++    compatibility_level = 1,
++)

--- a/modules/opentracing-cpp/1.6.0/presubmit.yml
+++ b/modules/opentracing-cpp/1.6.0/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  linux_platform: ["debian10", "ubuntu2004"]
+  osx_platform: ["macos", "macos_arm64"]
+  bazel: ["7.x", "6.x"]
+
+tasks:
+  verify_linux_targets:
+    name: Verify linux build and test targets
+    platform: ${{ linux_platform }}
+    shell_commands:
+    - sudo apt-get update
+    - sudo apt-get install cmake -y
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@opentracing-cpp//:opentracing'
+  verify_osx_targets:
+    name: Verify osx build and test targets
+    platform: ${{ osx_platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@opentracing-cpp//:opentracing'

--- a/modules/opentracing-cpp/1.6.0/source.json
+++ b/modules/opentracing-cpp/1.6.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/opentracing/opentracing-cpp/archive/refs/tags/v1.6.0.tar.gz",
+    "integrity": "sha256-WxcAQtpNHEwjHfZZTaEgh1Qp1SMem6pReYIu6NEFSsM=",
+    "strip_prefix": "opentracing-cpp-1.6.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-Nq2stVYG8NW6QVnQLlhzD55Llshidjb/0EVi8LhWFys="
+    }
+}

--- a/modules/opentracing-cpp/metadata.json
+++ b/modules/opentracing-cpp/metadata.json
@@ -12,7 +12,5 @@
     "versions": [
         "1.6.0"
     ],
-    "yanked_versions": {
-        "1.6.0": "use opentracing-cpp@1.6.0 instead"
-    }
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/opentracing/opentracing-cpp/releases/tag/v1.6.0