### PR TITLE
jsoncpp@1.9.5

### DIFF
--- a/modules/jsoncpp/1.9.5/MODULE.bazel
+++ b/modules/jsoncpp/1.9.5/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "jsoncpp",
+    version = "1.9.5",
+    compatibility_level = 1,
+)

--- a/modules/jsoncpp/1.9.5/patches/build_dot_bazel.patch
+++ b/modules/jsoncpp/1.9.5/patches/build_dot_bazel.patch
@@ -1,0 +1,15 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 6d7ac3d..b013e4f 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -14,9 +14,9 @@ cc_library(
+         "include/json/allocator.h",
+         "include/json/assertions.h",
+         "include/json/config.h",
+-        "include/json/json_features.h",
+         "include/json/forwards.h",
+         "include/json/json.h",
++        "include/json/json_features.h",
+         "include/json/reader.h",
+         "include/json/value.h",
+         "include/json/version.h",

--- a/modules/jsoncpp/1.9.5/patches/module_dot_bazel.patch
+++ b/modules/jsoncpp/1.9.5/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- a/MODULE.bazel
++++ a/MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "jsoncpp",
++    version = "1.9.5",
++    compatibility_level = 1,
++)

--- a/modules/jsoncpp/1.9.5/presubmit.yml
+++ b/modules/jsoncpp/1.9.5/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@jsoncpp//...'

--- a/modules/jsoncpp/1.9.5/source.json
+++ b/modules/jsoncpp/1.9.5/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.5.tar.gz",
+    "integrity": "sha256-9AmFblkgwY0ML7hSduJO5gfSoJtefV8KNxNokDwnXaI=",
+    "strip_prefix": "jsoncpp-1.9.5",
+    "patches": {
+        "build_dot_bazel.patch": "sha256-Vj8diXSWps8I8h5cdEqBDYmKBA2ulvWxMZBEQlIgcpU=",
+        "module_dot_bazel.patch": "sha256-7RC7fS8N11vcyeDEaUZ05yBqr0YY7OzuzqaWz5W2XDo="
+    },
+    "patch_strip": 1
+}

--- a/modules/jsoncpp/metadata.json
+++ b/modules/jsoncpp/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/open-source-parsers/jsoncpp",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:open-source-parsers/jsoncpp"
+    ],
+    "versions": [
+        "1.9.5"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/open-source-parsers/jsoncpp/releases/tag/1.9.5

Used by:
* https://github.com/protocolbuffers/protobuf