### PR TITLE
hdrhistogram_c@0.11.2

### DIFF
--- a/modules/hdrhistogram_c/0.11.2/MODULE.bazel
+++ b/modules/hdrhistogram_c/0.11.2/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "hdrhistogram_c",
+    version = "0.11.2",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "zlib",
+    version = "1.3.1.bcr.1",
+)

--- a/modules/hdrhistogram_c/0.11.2/patches/add_build_file.patch
+++ b/modules/hdrhistogram_c/0.11.2/patches/add_build_file.patch
@@ -1,0 +1,34 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,31 @@
++cc_library(
++    name = "hdrhistogram_c",
++    srcs = [
++        "src/hdr_encoding.c",
++        "src/hdr_histogram.c",
++        "src/hdr_histogram_log.c",
++        "src/hdr_interval_recorder.c",
++        "src/hdr_thread.c",
++        "src/hdr_time.c",
++        "src/hdr_writer_reader_phaser.c",
++    ],
++    hdrs = [
++        "src/hdr_atomic.h",
++        "src/hdr_encoding.h",
++        "src/hdr_endian.h",
++        "src/hdr_histogram.h",
++        "src/hdr_histogram_log.h",
++        "src/hdr_interval_recorder.h",
++        "src/hdr_tests.h",
++        "src/hdr_thread.h",
++        "src/hdr_time.h",
++        "src/hdr_writer_reader_phaser.h",
++    ],
++    copts = [
++        "-std=gnu99",
++        "-Wno-implicit-function-declaration",
++        "-Wno-error",
++    ],
++    visibility = ["//visibility:public"],
++    deps = ["@zlib"],
++)

--- a/modules/hdrhistogram_c/0.11.2/patches/module_dot_bazel.patch
+++ b/modules/hdrhistogram_c/0.11.2/patches/module_dot_bazel.patch
@@ -1,0 +1,13 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,10 @@
++module(
++    name = "hdrhistogram_c",
++    version = "0.11.2",
++    compatibility_level = 1,
++)
++
++bazel_dep(
++    name = "zlib",
++    version = "1.3.1.bcr.1",
++)

--- a/modules/hdrhistogram_c/0.11.2/presubmit.yml
+++ b/modules/hdrhistogram_c/0.11.2/presubmit.yml
@@ -4,7 +4,6 @@ matrix:
   - ubuntu2004
   - macos
   - macos_arm64
-  - windows
   bazel:
   - 7.x
   - 6.x

--- a/modules/hdrhistogram_c/0.11.2/presubmit.yml
+++ b/modules/hdrhistogram_c/0.11.2/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@hdrhistogram_c//:hdrhistogram_c'

--- a/modules/hdrhistogram_c/0.11.2/source.json
+++ b/modules/hdrhistogram_c/0.11.2/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/HdrHistogram/HdrHistogram_c/archive/refs/tags/0.11.2.tar.gz",
+    "integrity": "sha256-Y38otfZN4uJoEx5ONObu8Lkc9f+ZFn20R9mygl6ua60=",
+    "strip_prefix": "HdrHistogram_c-0.11.2",
+    "patches": {
+        "add_build_file.patch": "sha256-3oOur+YN9ttwuII6klYpndhMGf1WNdgcp/c3ybpvWYw=",
+        "module_dot_bazel.patch": "sha256-N833h2a0gYMTx877/Qrs4Yx0LkKjwVi649g9PyzMCb4="
+    },
+    "patch_strip": 0
+}

--- a/modules/hdrhistogram_c/metadata.json
+++ b/modules/hdrhistogram_c/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/HdrHistogram/HdrHistogram_c",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:HdrHistogram/HdrHistogram_c"
+    ],
+    "versions": [
+        "0.11.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/HdrHistogram/HdrHistogram_c/releases/tag/0.11.2

Used by:
* https://github.com/envoyproxy/nighthawk