### PR TITLE
Add rules_jsonnet

### DIFF
--- a/modules/rules_jsonnet/0.5.0/MODULE.bazel
+++ b/modules/rules_jsonnet/0.5.0/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "rules_jsonnet",
+    repo_name = "io_bazel_rules_jsonnet",
+    version = "0.5.0",
+)
+
+bazel_dep(name = "jsonnet", version = "0.20.0")
+bazel_dep(name = "jsonnet_go", version = "0.20.0", repo_name = "google_jsonnet_go")

--- a/modules/rules_jsonnet/0.5.0/patches/add_examples_module_dot_bazel.patch
+++ b/modules/rules_jsonnet/0.5.0/patches/add_examples_module_dot_bazel.patch
@@ -1,0 +1,37 @@
+diff --git examples/.bazelrc examples/.bazelrc
+new file mode 100644
+index 0000000..c39c658
+--- /dev/null
++++ examples/.bazelrc
+@@ -0,0 +1,2 @@
++import %workspace%/../tools/bazel.rc
++build --workspace_status_command=../tools/stamping/workspace_status.sh
+diff --git examples/MODULE.bazel examples/MODULE.bazel
+new file mode 100644
+index 0000000..c2990d2
+--- /dev/null
++++ examples/MODULE.bazel
+@@ -0,0 +1,14 @@
++module(
++    name = "examples",
++    version = "0.0.0",
++)
++
++bazel_dep(
++    name = "rules_jsonnet",
++    version = "0.0.0",
++    repo_name = "io_bazel_rules_jsonnet",
++)
++local_path_override(
++    module_name = "rules_jsonnet",
++    path = "..",
++)
+diff --git examples/invalid.out examples/invalid.out
+index f449612..d8e6fb8 100644
+--- examples/invalid.out
++++ examples/invalid.out
+@@ -1,3 +1,3 @@
+ ^RUNTIME ERROR: Foo\.
+-	../examples/invalid\.jsonnet:15:1-13	($|\$
++	.*invalid\.jsonnet:15:1-13	($|\$
+ 	During evaluation	)

--- a/modules/rules_jsonnet/0.5.0/patches/add_module_dot_bazel.patch
+++ b/modules/rules_jsonnet/0.5.0/patches/add_module_dot_bazel.patch
@@ -1,0 +1,11 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,8 @@
++module(
++    name = "rules_jsonnet",
++    repo_name = "io_bazel_rules_jsonnet",
++    version = "0.5.0",
++)
++
++bazel_dep(name = "jsonnet", version = "0.20.0")
++bazel_dep(name = "jsonnet_go", version = "0.20.0", repo_name = "google_jsonnet_go")

--- a/modules/rules_jsonnet/0.5.0/presubmit.yml
+++ b/modules/rules_jsonnet/0.5.0/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: examples
+  matrix:
+    platform: ["centos7", "debian10", "macos", "ubuntu2004"]
+    bazel: ["7.x"]
+  tasks:
+    run_tests:
+      name: "Run example test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_jsonnet/0.5.0/source.json
+++ b/modules/rules_jsonnet/0.5.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/bazelbuild/rules_jsonnet/archive/refs/tags/0.5.0.tar.gz",
+    "integrity": "sha256-xRug26QdZn+lxk5W4lK6VL4JPlrnZK9kcNq8qQHzc+s=",
+    "strip_prefix": "rules_jsonnet-0.5.0",
+    "patches": {
+        "add_module_dot_bazel.patch": "sha256-qkrjrjVpcuo+ykWoNtrUr6yZDbTcMJC+48/rgeAVfNM=",
+        "add_examples_module_dot_bazel.patch": "sha256-AikVRYmO8oFBEnvZCO1Dk0Er7KYhMDl2b3Zo+M9VVyg="
+    },
+    "patch_strip": 0
+}

--- a/modules/rules_jsonnet/metadata.json
+++ b/modules/rules_jsonnet/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/bazelbuild/rules_jsonnet",
+    "maintainers": [
+        {
+            "email": "ed@nuxi.nl",
+            "github": "@EdSchouten",
+            "name": "Ed Schouten"
+        }
+    ],
+    "repository": [
+        "github:bazelbuild/rules_jsonnet"
+    ],
+    "versions": [
+        "0.5.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Even though we haven't performed a release of rules_jsonnet in ages, it's still seeing some active use. Adding it to BCR is relatively easy, because it mostly just depends on jsonnet and jsonnet_go. The documentation parts depend on skydoc and rules_sass, but those aren't necessary to use the rules themselves.