### PR TITLE
snappy@1.1.8

### DIFF
--- a/modules/snappy/1.1.8/MODULE.bazel
+++ b/modules/snappy/1.1.8/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "snappy",
+    version = "1.1.8",
+    compatibility_level = 1,
+)

--- a/modules/snappy/1.1.8/patches/add_build_file.patch
+++ b/modules/snappy/1.1.8/patches/add_build_file.patch
@@ -1,0 +1,95 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,92 @@
++package(
++    default_visibility = ["//visibility:public"],
++    features = ["header_modules"],
++)
++
++licenses(["notice"])
++
++cc_library(
++    name = "snappy",
++    srcs = [
++        "config.h",
++        "snappy.cc",
++        "snappy-internal.h",
++        "snappy-sinksource.cc",
++        "snappy-stubs-internal.cc",
++        "snappy-stubs-internal.h",
++        "snappy-stubs-public.h",
++    ],
++    hdrs = [
++        "snappy.h",
++        "snappy-sinksource.h",
++    ],
++    copts = [
++        "-DHAVE_CONFIG_H",
++        "-Wno-sign-compare",
++    ],
++)
++
++genrule(
++    name = "config_h",
++    outs = ["config.h"],
++    cmd = "\n".join([
++        "cat <<'EOF' >$@",
++        "#define HAVE_STDDEF_H 1",
++        "#define HAVE_STDINT_H 1",
++        "",
++        "#ifdef __has_builtin",
++        "#  if !defined(HAVE_BUILTIN_EXPECT) && __has_builtin(__builtin_expect)",
++        "#    define HAVE_BUILTIN_EXPECT 1",
++        "#  endif",
++        "#  if !defined(HAVE_BUILTIN_CTZ) && __has_builtin(__builtin_ctzll)",
++        "#    define HAVE_BUILTIN_CTZ 1",
++        "#  endif",
++        "#elif defined(__GNUC__) && (__GNUC__ > 3 || __GNUC__ == 3 && __GNUC_MINOR__ >= 4)",
++        "#  ifndef HAVE_BUILTIN_EXPECT",
++        "#    define HAVE_BUILTIN_EXPECT 1",
++        "#  endif",
++        "#  ifndef HAVE_BUILTIN_CTZ",
++        "#    define HAVE_BUILTIN_CTZ 1",
++        "#  endif",
++        "#endif",
++        "",
++        "#ifdef __has_include",
++        "#  if !defined(HAVE_BYTESWAP_H) && __has_include(<byteswap.h>)",
++        "#    define HAVE_BYTESWAP_H 1",
++        "#  endif",
++        "#  if !defined(HAVE_UNISTD_H) && __has_include(<unistd.h>)",
++        "#    define HAVE_UNISTD_H 1",
++        "#  endif",
++        "#  if !defined(HAVE_SYS_ENDIAN_H) && __has_include(<sys/endian.h>)",
++        "#    define HAVE_SYS_ENDIAN_H 1",
++        "#  endif",
++        "#  if !defined(HAVE_SYS_MMAN_H) && __has_include(<sys/mman.h>)",
++        "#    define HAVE_SYS_MMAN_H 1",
++        "#  endif",
++        "#  if !defined(HAVE_SYS_UIO_H) && __has_include(<sys/uio.h>)",
++        "#    define HAVE_SYS_UIO_H 1",
++        "#  endif",
++        "#endif",
++        "",
++        "#ifndef SNAPPY_IS_BIG_ENDIAN",
++        "#  ifdef __s390x__",
++        "#    define SNAPPY_IS_BIG_ENDIAN 1",
++        "#  elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__",
++        "#    define SNAPPY_IS_BIG_ENDIAN 1",
++        "#  endif",
++        "#endif",
++        "EOF",
++    ]),
++)
++
++genrule(
++    name = "snappy_stubs_public_h",
++    srcs = ["snappy-stubs-public.h.in"],
++    outs = ["snappy-stubs-public.h"],
++    cmd = ("sed " +
++           "-e 's/$${\\(.*\\)_01}/\\1/g' " +
++           "-e 's/$${SNAPPY_MAJOR}/1/g' " +
++           "-e 's/$${SNAPPY_MINOR}/1/g' " +
++           "-e 's/$${SNAPPY_PATCHLEVEL}/4/g' " +
++           "$< >$@"),
++)

--- a/modules/snappy/1.1.8/patches/module_dot_bazel.patch
+++ b/modules/snappy/1.1.8/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "snappy",
++    version = "1.1.8",
++    compatibility_level = 1,
++)

--- a/modules/snappy/1.1.8/presubmit.yml
+++ b/modules/snappy/1.1.8/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@snappy//...'

--- a/modules/snappy/1.1.8/source.json
+++ b/modules/snappy/1.1.8/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/google/snappy/archive/refs/tags/1.1.8.tar.gz",
+    "integrity": "sha256-FrZ38HgyphKwg2F42383TkFPlGV8E45pk8v8XcxYZR8=",
+    "strip_prefix": "snappy-1.1.8",
+    "patches": {
+        "add_build_file.patch": "sha256-DmKamYCCHDTyEhnmwsYqRFIhXcbmUcXhxG3qYONIaGQ=",
+        "module_dot_bazel.patch": "sha256-vVCIcqnQ9mQec3Bg/YLcY+SWwXXaAKWnt2eWJjIxWtU="
+    },
+    "patch_strip": 0
+}

--- a/modules/snappy/metadata.json
+++ b/modules/snappy/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/google/snappy",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:google/snappy"
+    ],
+    "versions": [
+        "1.1.8"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/google/snappy/releases/tag/1.1.8

Use by:
* https://github.com/google/riegeli