### PR TITLE
Add rules_jsonnet 0.6.0

### DIFF
--- a/modules/rules_jsonnet/0.6.0/MODULE.bazel
+++ b/modules/rules_jsonnet/0.6.0/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "rules_jsonnet",
+    version = "0.6.0",
+    repo_name = "io_bazel_rules_jsonnet",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "jsonnet", version = "0.20.0")
+bazel_dep(name = "jsonnet_go", version = "0.20.0", repo_name = "google_jsonnet_go")

--- a/modules/rules_jsonnet/0.6.0/presubmit.yml
+++ b/modules/rules_jsonnet/0.6.0/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: examples
+  matrix:
+    platform: ["centos7", "debian10", "macos", "ubuntu2004"]
+    bazel: ["7.x"]
+  tasks:
+    run_tests:
+      name: "Run example test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_jsonnet/0.6.0/source.json
+++ b/modules/rules_jsonnet/0.6.0/source.json
@@ -1,0 +1,6 @@
+{
+    "url": "https://github.com/bazelbuild/rules_jsonnet/releases/download/0.6.0/rules_jsonnet-0.6.0.tar.gz",
+    "integrity": "sha256-4Js8CG7po47gztv/lnGXAL0BIdeITQGTZkr/XqMgEo0=",
+    "strip_prefix": "rules_jsonnet-0.6.0",
+    "patch_strip": 0
+}

--- a/modules/rules_jsonnet/metadata.json
+++ b/modules/rules_jsonnet/metadata.json
@@ -3,7 +3,7 @@
     "maintainers": [
         {
             "email": "ed@nuxi.nl",
-            "github": "@EdSchouten",
+            "github": "EdSchouten",
             "name": "Ed Schouten"
         }
     ],

--- a/modules/rules_jsonnet/metadata.json
+++ b/modules/rules_jsonnet/metadata.json
@@ -11,7 +11,8 @@
         "github:bazelbuild/rules_jsonnet"
     ],
     "versions": [
-        "0.5.0"
+        "0.5.0",
+        "0.6.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This release no longer needs any local patching on the BCR side, as upstream includes a MODULE.bazel. Furthermore, this release addresses some known issues in the area of import path handling.