### PR TITLE
zipkin-api@1.0.0

### DIFF
--- a/modules/zipkin-api/1.0.0/MODULE.bazel
+++ b/modules/zipkin-api/1.0.0/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "zipkin-api",
+    version = "1.0.0",
+    compatibility_level = 1,
+)

--- a/modules/zipkin-api/1.0.0/patches/add_build_file.patch
+++ b/modules/zipkin-api/1.0.0/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++proto_library(
++    name = "zipkin_proto",
++    srcs = [
++        "zipkin.proto",
++    ],
++    visibility = ["//visibility:public"],
++)
++
++proto_library(
++    name = "zipkin_jsonv2_proto",
++    srcs = [
++        "zipkin-jsonv2.proto",
++    ],
++    visibility = ["//visibility:public"],
++)

--- a/modules/zipkin-api/1.0.0/patches/module_dot_bazel.patch
+++ b/modules/zipkin-api/1.0.0/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "zipkin-api",
++    version = "1.0.0",
++    compatibility_level = 1,
++)

--- a/modules/zipkin-api/1.0.0/presubmit.yml
+++ b/modules/zipkin-api/1.0.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@zipkin-api//:zipkin_proto'
+    - '@zipkin-api//:zipkin_jsonv2_proto'

--- a/modules/zipkin-api/1.0.0/source.json
+++ b/modules/zipkin-api/1.0.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/openzipkin/zipkin-api/archive/refs/tags/1.0.0.tar.gz",
+    "integrity": "sha256-bI7iAUzwdGukUuXywB8DjfYOhestkQsib5qifdwORM8=",
+    "strip_prefix": "zipkin-api-1.0.0",
+    "patches": {
+        "add_build_file.patch": "sha256-dArUcsY31vXF/WickIO6wJL1dhb/UdBdwLlcExZnVZk=",
+        "module_dot_bazel.patch": "sha256-HM0FvHWvQnsi5aVL5/9F99AfTHc4wzLYxYVjY1DIsek="
+    },
+    "patch_strip": 0
+}

--- a/modules/zipkin-api/metadata.json
+++ b/modules/zipkin-api/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/openzipkin/zipkin-api",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:openzipkin/zipkin-api"
+    ],
+    "versions": [
+        "1.0.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/openzipkin/zipkin-api/releases/tag/1.0.0

Used by:
* https://github.com/envoyproxy/envoy