### PR TITLE
libcircllhist@0.3.2

### DIFF
--- a/modules/libcircllhist/0.3.2/MODULE.bazel
+++ b/modules/libcircllhist/0.3.2/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "libcircllhist",
+    version = "0.3.2",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.9",
+)

--- a/modules/libcircllhist/0.3.2/patches/add_build_file.patch
+++ b/modules/libcircllhist/0.3.2/patches/add_build_file.patch
@@ -1,0 +1,32 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,29 @@
++licenses(["notice"])  # Apache 2
++
++config_setting(
++    name = "windows_x86_64",
++    constraint_values = [
++        "@platforms//os:windows",
++        "@platforms//cpu:x86_64",
++    ],
++)
++
++cc_library(
++    name = "circlhist",
++    srcs = ["src/circllhist.c"],
++    hdrs = [
++        "src/circllhist.h",
++    ],
++    copts = select({
++        "//:windows_x86_64": ["-DWIN32"],
++        "//conditions:default": [],
++    }),
++    includes = ["src"],
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "libcirclhist",
++    actual = "//:circlhist",
++    visibility = ["//visibility:public"],
++)

--- a/modules/libcircllhist/0.3.2/patches/module_dot_bazel.patch
+++ b/modules/libcircllhist/0.3.2/patches/module_dot_bazel.patch
@@ -1,0 +1,13 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,10 @@
++module(
++    name = "libcircllhist",
++    version = "0.3.2",
++    compatibility_level = 1,
++)
++
++bazel_dep(
++    name = "platforms",
++    version = "0.0.9",
++)

--- a/modules/libcircllhist/0.3.2/presubmit.yml
+++ b/modules/libcircllhist/0.3.2/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@libcircllhist//:circlhist'

--- a/modules/libcircllhist/0.3.2/source.json
+++ b/modules/libcircllhist/0.3.2/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/openhistogram/libcircllhist/archive/refs/tags/py-0.3.2.tar.gz",
+    "integrity": "sha256-bfvWSf3jgPeiJW3vQ7nGN0xtb+doF4sJ457t+HSxOfQ=",
+    "strip_prefix": "libcircllhist-py-0.3.2",
+    "patches": {
+        "add_build_file.patch": "sha256-wPHohNg+WtTFG3P20tz5XFvUIIky91m+rcTBAPQRp68=",
+        "module_dot_bazel.patch": "sha256-vDWOqnn32u7V2xvbuIqMabjVLu6oejZtcLAjxFCJQTo="
+    },
+    "patch_strip": 0
+}

--- a/modules/libcircllhist/metadata.json
+++ b/modules/libcircllhist/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/openhistogram/libcircllhist",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:openhistogram/libcircllhist"
+    ],
+    "versions": [
+        "0.3.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/openhistogram/libcircllhist/releases/tag/py-0.3.2

Used by:
* https://github.com/envoyproxy/envoy