### PR TITLE
dd-trace-cpp@0.2.0

### DIFF
--- a/modules/dd-trace-cpp/0.2.0/MODULE.bazel
+++ b/modules/dd-trace-cpp/0.2.0/MODULE.bazel
@@ -1,0 +1,21 @@
+module(
+    name = "dd-trace-cpp",
+    version = "0.2.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.2.1",
+)
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.9",
+)
+# -- bazel_dep definitions -- #
+
+non_module_dependencies = use_extension("//:extensions.bzl", "non_module_dependencies")
+use_repo(
+    non_module_dependencies,
+    "com_google_absl",
+)

--- a/modules/dd-trace-cpp/0.2.0/patches/module_dot_bazel.patch
+++ b/modules/dd-trace-cpp/0.2.0/patches/module_dot_bazel.patch
@@ -1,0 +1,11 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,6 +1,7 @@
+ module(
+     name = "dd-trace-cpp",
+-    version = "",
++    version = "0.2.0",
++    compatibility_level = 1,
+ )
+ 
+ bazel_dep(

--- a/modules/dd-trace-cpp/0.2.0/presubmit.yml
+++ b/modules/dd-trace-cpp/0.2.0/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform:
+  - ubuntu2004
+  - macos
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@dd-trace-cpp//:dd_trace_cpp'

--- a/modules/dd-trace-cpp/0.2.0/source.json
+++ b/modules/dd-trace-cpp/0.2.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/DataDog/dd-trace-cpp/archive/refs/tags/v0.2.0.tar.gz",
+    "integrity": "sha256-RGLwiT+gjkraLrqo+cAjrhbN3lSdd7uMdSJjKCIfAmw=",
+    "strip_prefix": "dd-trace-cpp-0.2.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-bqAzB3Uw7A7hIoBsIFfnJIKGJoYVRaPo5nu+O6ScbOk="
+    }
+}

--- a/modules/dd-trace-cpp/metadata.json
+++ b/modules/dd-trace-cpp/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/DataDog/dd-trace-cpp",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:DataDog/dd-trace-cpp"
+    ],
+    "versions": [
+        "0.2.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/DataDog/dd-trace-cpp/releases/tag/v0.2.0

Used by:
* https://github.com/envoyproxy/envoy