### PR TITLE
Add nanobind_bazel repo @v1

### DIFF
--- a/modules/nanobind_bazel/1.0.0/MODULE.bazel
+++ b/modules/nanobind_bazel/1.0.0/MODULE.bazel
@@ -1,0 +1,15 @@
+module(
+    name = "nanobind_bazel",
+    version = "1.0.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_python", version = "0.31.0")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+
+# Parses the configured nanobind version from this file, and creates a `http_archive` for it.
+# Currently, this points to stable tags only.
+internal_configure = use_extension("//:internal_configure.bzl", "internal_configure_extension")
+use_repo(internal_configure, "nanobind")

--- a/modules/nanobind_bazel/1.0.0/presubmit.yml
+++ b/modules/nanobind_bazel/1.0.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  bazel:
+    - 6.x
+    - 7.x
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    - windows
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@nanobind_bazel//...'

--- a/modules/nanobind_bazel/1.0.0/source.json
+++ b/modules/nanobind_bazel/1.0.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/nicholasjng/nanobind-bazel/releases/download/v1.0.0/nanobind-bazel-1.0.0.tar.gz",
+    "integrity": "sha256-zSEmzcJeelI+Bzy+orEblmWwtGWx2RCLFaRGYKDjH6g=",
+    "strip_prefix": "nanobind-bazel-1.0.0"
+}

--- a/modules/nanobind_bazel/metadata.json
+++ b/modules/nanobind_bazel/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/nicholasjng/nanobind-bazel",
+    "maintainers": [
+        {
+            "email": "nicho.junge@gmail.com",
+            "github": "nicholasjng",
+            "name": "Nicholas Junge"
+        }
+    ],
+    "repository": [
+        "github:nicholasjng/nanobind-bazel"
+    ],
+    "versions": [
+        "1.0.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds the nanobind_bazel repo, which is designed to create fast and compact Python bindings for C++ code with nanobind using Bazel.

This release gives the possibility of creating bindings with nanobind@v1 (currently: v1.9.2).