### PR TITLE
Add argparse 3.0

### DIFF
--- a/modules/argparse/3.0.0/MODULE.bazel
+++ b/modules/argparse/3.0.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "argparse",
+    version = "3.0.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/argparse/3.0.0/patches/add_build_file.patch
+++ b/modules/argparse/3.0.0/patches/add_build_file.patch
@@ -1,0 +1,15 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,12 @@
++"""argparse header library for Bazel"""
++
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++licenses(["notice"])  # MIT
++
++cc_library(
++    name = "argparse",
++    hdrs = ["//:include/argparse/argparse.hpp"],
++    strip_include_prefix = "include",
++    visibility = ["//visibility:public"],
++)

--- a/modules/argparse/3.0.0/patches/module_dot_bazel.patch
+++ b/modules/argparse/3.0.0/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "argparse",
++    version = "3.0.0",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/argparse/3.0.0/presubmit.yml
+++ b/modules/argparse/3.0.0/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@argparse//:argparse'

--- a/modules/argparse/3.0.0/source.json
+++ b/modules/argparse/3.0.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/p-ranav/argparse/archive/refs/tags/v3.0.tar.gz",
+    "integrity": "sha256-untGV1m7AQadVzAoVer00ffWd/Ia17CwC5KTlkXDD0c=",
+    "strip_prefix": "argparse-3.0",
+    "patches": {
+        "add_build_file.patch": "sha256-Ap6xahEoXu+dFGsJsX5UH1nxOZV/tsAUYJIVrg076LQ=",
+        "module_dot_bazel.patch": "sha256-W6TT3LEXWFcgF/5e52ti8YIOhZ3JmXe4ehcCxzBf9N4="
+    },
+    "patch_strip": 0
+}

--- a/modules/argparse/metadata.json
+++ b/modules/argparse/metadata.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://github.com/p-ranav/argparse",
+    "maintainers": [],
+    "repository": [
+        "github:p-ranav/argparse"
+    ],
+    "versions": [
+        "3.0.0"
+    ],
+    "yanked_versions": {}
+}

--- a/modules/argparse/metadata.json
+++ b/modules/argparse/metadata.json
@@ -1,6 +1,12 @@
 {
     "homepage": "https://github.com/p-ranav/argparse",
-    "maintainers": [],
+    "maintainers": [
+        {
+            "email": "casablancaernesto@gmail.com",
+            "github": "TendTo",
+            "name": "Ernesto Casablanca"
+        }
+    ],
     "repository": [
         "github:p-ranav/argparse"
     ],


### PR DESCRIPTION
Adding the lightweight header only library [argparse](https://github.com/p-ranav/argparse) to the BCR

[ closes #1796 ]