### PR TITLE
Fix protobuf release issue

### DIFF
--- a/modules/protobuf/26.0.bcr.1/MODULE.bazel
+++ b/modules/protobuf/26.0.bcr.1/MODULE.bazel
@@ -1,0 +1,24 @@
+module(
+    name = "protobuf",
+    version = "26.0.bcr.1",
+    compatibility_level = 1,
+    repo_name = "com_google_protobuf",
+)
+
+# LOWER BOUND dependency versions.
+# Bzlmod follows MVS:
+# https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
+# Thus the highest version in their module graph is resolved.
+bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "jsoncpp", version = "1.9.5")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_jvm_external", version = "5.1")
+bazel_dep(name = "rules_pkg", version = "0.7.0")
+bazel_dep(name = "rules_python", version = "0.10.2")
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "zlib", version = "1.2.11")
+
+# TODO: remove after toolchain types are moved to protobuf
+bazel_dep(name = "rules_proto", version = "4.0.0")

--- a/modules/protobuf/26.0.bcr.1/patches/0001-Add-MODULE.bazel.patch
+++ b/modules/protobuf/26.0.bcr.1/patches/0001-Add-MODULE.bazel.patch
@@ -1,0 +1,67 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 2d43e46df..b50917142 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,2 +1,24 @@
+-# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+-# https://github.com/protocolbuffers/protobuf/issues/14313
++module(
++    name = "protobuf",
++    version = "26.0.bcr.1",
++    compatibility_level = 1,
++    repo_name = "com_google_protobuf",
++)
++
++# LOWER BOUND dependency versions.
++# Bzlmod follows MVS:
++# https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
++# Thus the highest version in their module graph is resolved.
++bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
++bazel_dep(name = "bazel_skylib", version = "1.4.1")
++bazel_dep(name = "jsoncpp", version = "1.9.5")
++bazel_dep(name = "rules_cc", version = "0.0.9")
++bazel_dep(name = "rules_java", version = "4.0.0")
++bazel_dep(name = "rules_jvm_external", version = "5.1")
++bazel_dep(name = "rules_pkg", version = "0.7.0")
++bazel_dep(name = "rules_python", version = "0.10.2")
++bazel_dep(name = "platforms", version = "0.0.8")
++bazel_dep(name = "zlib", version = "1.2.11")
++
++# TODO: remove after toolchain types are moved to protobuf
++bazel_dep(name = "rules_proto", version = "4.0.0")
+diff --git a/WORKSPACE.bzlmod b/WORKSPACE.bzlmod
+new file mode 100644
+index 000000000..e7bc5752e
+--- /dev/null
++++ b/WORKSPACE.bzlmod
+@@ -0,0 +1 @@
++# Disables default WORKSPACE for bzlmod
+diff --git a/examples/MODULE.bazel b/examples/MODULE.bazel
+new file mode 100644
+index 000000000..6bd5977c0
+--- /dev/null
++++ b/examples/MODULE.bazel
+@@ -0,0 +1,16 @@
++"""Bazel module dependencies"""
++
++module(name = "com_google_protobuf_examples")
++
++bazel_dep(name = "protobuf", version = "0.0.0", dev_dependency = True, repo_name = "com_google_protobuf")
++local_path_override(
++    module_name = "protobuf",
++    path = "..",
++)
++
++bazel_dep(name = "bazel_skylib", version = "1.0.3")
++bazel_dep(name = "rules_cc", version = "0.0.1")
++bazel_dep(name = "rules_java", version = "7.3.0")
++bazel_dep(name = "rules_pkg", version = "0.7.0")
++bazel_dep(name = "rules_python", version = "0.25.0")
++bazel_dep(name = "rules_proto", version = "4.0.0")
+diff --git a/examples/WORKSPACE.bzlmod b/examples/WORKSPACE.bzlmod
+new file mode 100644
+index 000000000..e7bc5752e
+--- /dev/null
++++ b/examples/WORKSPACE.bzlmod
+@@ -0,0 +1 @@
++# Disables default WORKSPACE for bzlmod

--- a/modules/protobuf/26.0.bcr.1/patches/0002-relative-labels.patch
+++ b/modules/protobuf/26.0.bcr.1/patches/0002-relative-labels.patch
@@ -1,0 +1,15 @@
+diff --git a/protobuf.bzl b/protobuf.bzl
+index 3c8afcc17..a5a125944 100644
+--- a/protobuf.bzl
++++ b/protobuf.bzl
+@@ -501,8 +501,8 @@ def internal_ruby_proto_library(
+         srcs = [],
+         deps = [],
+         includes = ["."],
+-        default_runtime = "@com_google_protobuf//ruby:protobuf",
+-        protoc = "@com_google_protobuf//:protoc",
++        default_runtime = Label("//ruby:protobuf"),
++        protoc = Label("//:protoc"),
+         testonly = None,
+         visibility = ["//visibility:public"],
+         **kwargs):

--- a/modules/protobuf/26.0.bcr.1/presubmit.yml
+++ b/modules/protobuf/26.0.bcr.1/presubmit.yml
@@ -2,7 +2,6 @@ matrix:
   platform: ["debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
-  - 6.x
 
 tasks:
   verify_targets:

--- a/modules/protobuf/26.0.bcr.1/presubmit.yml
+++ b/modules/protobuf/26.0.bcr.1/presubmit.yml
@@ -1,0 +1,40 @@
+matrix:
+  platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  bazel:
+  - 7.x
+  - 6.x
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--host_cxxopt=-std=c++14'
+    - '--cxxopt=-std=c++14'
+    build_targets:
+    - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_lite'
+    - '@protobuf//:protoc'
+    - '@protobuf//:test_messages_proto2_cc_proto'
+    - '@protobuf//:test_messages_proto3_cc_proto'
+    - '@protobuf//upb_generator:all'
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel:
+    - 7.x
+    - 6.x
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+      - '--host_cxxopt=-std=c++14'
+      - '--cxxopt=-std=c++14'
+      - '--nocheck_visibility'
+      build_targets:
+      - "//..."

--- a/modules/protobuf/26.0.bcr.1/source.json
+++ b/modules/protobuf/26.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-wscevJCvl5bog09lCT8vq4iwqCsqPoBbNIQmRaKvxLA=",
+    "patch_strip": 1,
+    "patches": {
+        "0001-Add-MODULE.bazel.patch": "sha256-rv+t+/L4C2BgRFhLYncji4yGODTLvcMjZIrSM1RcA54=",
+        "0002-relative-labels.patch": "sha256-NvicAuuDJLFNLEi9pvGj7PPj/GbpYYYoVdihRosZgSA="
+    },
+    "strip_prefix": "protobuf-26.0",
+    "url": "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v26.0.zip"
+}

--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -15,7 +15,8 @@
     "3.19.6",
     "21.7",
     "23.1",
-    "26.0"
+    "26.0",
+    "26.0.bcr.1"
   ],
   "yanked_versions": {
     "3.19.0": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)",


### PR DESCRIPTION
My 26.0 PR didn't have the repo_name attribute set which causes some
failures when built outside of this repo. This new version fixes that
and introduces a test for it in the presubmit config.
