### PR TITLE
snappy@1.2.0

### DIFF
--- a/modules/snappy/1.2.0/MODULE.bazel
+++ b/modules/snappy/1.2.0/MODULE.bazel
@@ -1,0 +1,23 @@
+module(
+    name = "snappy",
+    version = "1.2.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "googletest",
+    version = "1.14.0.bcr.1",
+    dev_dependency = True,
+    repo_name = "com_google_googletest",
+)
+bazel_dep(
+    name = "google_benchmark",
+    version = "1.8.3",
+    dev_dependency = True,
+    repo_name = "com_google_benchmark",
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.9",
+)

--- a/modules/snappy/1.2.0/patches/build_dot_bazel.patch
+++ b/modules/snappy/1.2.0/patches/build_dot_bazel.patch
@@ -1,0 +1,22 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 97c9f3a..4dc23aa 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -114,7 +114,7 @@ cc_test(
+     deps = [
+         ":snappy",
+         ":snappy-test",
+-        "//third_party/benchmark:benchmark_main",
++        "@com_google_benchmark//:benchmark_main",
+     ],
+ )
+ 
+@@ -127,7 +127,7 @@ cc_test(
+     deps = [
+         ":snappy",
+         ":snappy-test",
+-        "//third_party/googletest:gtest_main",
++        "@com_google_googletest//:gtest_main",
+     ],
+ )
+ 

--- a/modules/snappy/1.2.0/patches/module_dot_bazel.patch
+++ b/modules/snappy/1.2.0/patches/module_dot_bazel.patch
@@ -1,0 +1,26 @@
+--- a/MODULE.bazel
++++ a/MODULE.bazel
+@@ -0,0 +1,23 @@
++module(
++    name = "snappy",
++    version = "1.2.0",
++    compatibility_level = 1,
++)
++
++bazel_dep(
++    name = "googletest",
++    version = "1.14.0.bcr.1",
++    dev_dependency = True,
++    repo_name = "com_google_googletest",
++)
++bazel_dep(
++    name = "google_benchmark",
++    version = "1.8.3",
++    dev_dependency = True,
++    repo_name = "com_google_benchmark",
++)
++
++bazel_dep(
++    name = "platforms",
++    version = "0.0.9",
++)

--- a/modules/snappy/1.2.0/presubmit.yml
+++ b/modules/snappy/1.2.0/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@snappy//:snappy'

--- a/modules/snappy/1.2.0/source.json
+++ b/modules/snappy/1.2.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/google/snappy/archive/refs/tags/1.2.0.tar.gz",
+    "integrity": "sha256-m48Q+7XjvBEvLl5k+BPLc/rqQuycUzpQI7WuCK7e9C4=",
+    "strip_prefix": "snappy-1.2.0",
+    "patches": {
+        "build_dot_bazel.patch": "sha256-T3IPEcrNi0zqdVXpKowy8fm5Mmc/30O2aU6AqJc/FXU=",
+        "module_dot_bazel.patch": "sha256-UBIVAWj4oSYWMurXcXU79Fu5W44yJggHEFH+EssrcfI="
+    },
+    "patch_strip": 1
+}

--- a/modules/snappy/metadata.json
+++ b/modules/snappy/metadata.json
@@ -10,7 +10,8 @@
         "github:google/snappy"
     ],
     "versions": [
-        "1.1.8"
+        "1.1.8",
+        "1.2.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/google/snappy/releases/tag/1.2.0

Used by:
* https://github.com/google/riegeli