### PR TITLE
antlr4-cpp-runtime@4.12.0

### DIFF
--- a/modules/antlr4-cpp-runtime/4.12.0/MODULE.bazel
+++ b/modules/antlr4-cpp-runtime/4.12.0/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "antlr4-cpp-runtime",
+    version = "4.12.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "abseil-cpp",
+    version = "20240116.0",
+    repo_name = "com_google_absl",
+)

--- a/modules/antlr4-cpp-runtime/4.12.0/patches/add_build_file.patch
+++ b/modules/antlr4-cpp-runtime/4.12.0/patches/add_build_file.patch
@@ -1,0 +1,40 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,37 @@
++# Copyright 2023 Google LLC
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#      http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++licenses(["notice"])
++
++cc_library(
++    name = "antlr4-cpp-runtime",
++    srcs = glob(["runtime/src/**/*.cpp"]),
++    hdrs = ["runtime/src/antlr4-runtime.h"],
++    copts = ["-fexceptions"],
++    defines = ["ANTLR4CPP_USING_ABSEIL"],
++    features = ["-use_header_modules"],
++    includes = ["runtime/src"],
++    textual_hdrs = glob(
++        ["runtime/src/**/*.h"],
++        exclude = ["runtime/src/antlr4-runtime.h"],
++    ),
++    visibility = ["//visibility:public"],
++    deps = [
++        "@com_google_absl//absl/base",
++        "@com_google_absl//absl/base:core_headers",
++        "@com_google_absl//absl/container:flat_hash_map",
++        "@com_google_absl//absl/container:flat_hash_set",
++        "@com_google_absl//absl/synchronization",
++    ],
++)

--- a/modules/antlr4-cpp-runtime/4.12.0/patches/module_dot_bazel.patch
+++ b/modules/antlr4-cpp-runtime/4.12.0/patches/module_dot_bazel.patch
@@ -1,0 +1,14 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,11 @@
++module(
++    name = "antlr4-cpp-runtime",
++    version = "4.12.0",
++    compatibility_level = 1,
++)
++
++bazel_dep(
++    name = "abseil-cpp",
++    version = "20240116.0",
++    repo_name = "com_google_absl",
++)

--- a/modules/antlr4-cpp-runtime/4.12.0/presubmit.yml
+++ b/modules/antlr4-cpp-runtime/4.12.0/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@antlr4-cpp-runtime//:antlr4-cpp-runtime'

--- a/modules/antlr4-cpp-runtime/4.12.0/source.json
+++ b/modules/antlr4-cpp-runtime/4.12.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/antlr/antlr4/archive/refs/tags/4.12.0.tar.gz",
+    "integrity": "sha256-i2BQohEaa7ZAXMXp57yoDBNlSKyTDkssJ1ZtHrMviu0=",
+    "strip_prefix": "antlr4-4.12.0/runtime/Cpp",
+    "patches": {
+        "add_build_file.patch": "sha256-duEX0yg+Uj2SApjAY+y3eqUmQZezBovypV4orucvFx4=",
+        "module_dot_bazel.patch": "sha256-wNE6Cu+mPW8uIssUDWVnpdwbpH4rQFR9ppD3OPk0vnc="
+    },
+    "patch_strip": 0
+}

--- a/modules/antlr4-cpp-runtime/metadata.json
+++ b/modules/antlr4-cpp-runtime/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://www.antlr.org",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:antlr/antlr4"
+    ],
+    "versions": [
+        "4.12.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/antlr/antlr4/releases/tag/4.12.0

Used by:
* https://github.com/google/fuzztest