### PR TITLE
Add blake3@1.5.1

### DIFF
--- a/modules/blake3/1.5.1/MODULE.bazel
+++ b/modules/blake3/1.5.1/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "blake3",
+    version = "1.5.1",
+    compatibility_level = 1,
+)
+bazel_dep(name = "rules_cc", version = "0.0.6")

--- a/modules/blake3/1.5.1/patches/add_build_file.patch
+++ b/modules/blake3/1.5.1/patches/add_build_file.patch
@@ -1,0 +1,61 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,58 @@
++load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
++
++cc_library(
++    name = "blake3",
++    srcs = [
++        "c/blake3.c",
++        "c/blake3_dispatch.c",
++        "c/blake3_portable.c",
++    ] + select({
++        "@bazel_tools//src/conditions:linux_x86_64": [
++            "c/blake3_avx2_x86-64_unix.S",
++            "c/blake3_avx512_x86-64_unix.S",
++            "c/blake3_sse2_x86-64_unix.S",
++            "c/blake3_sse41_x86-64_unix.S",
++        ],
++        "@bazel_tools//src/conditions:linux_aarch64": [
++            "c/blake3_neon.c",
++        ],
++        "@bazel_tools//src/conditions:windows_x64": [
++            "c/blake3_avx2_x86-64_windows_msvc.asm",
++            "c/blake3_avx512_x86-64_windows_msvc.asm",
++            "c/blake3_sse2_x86-64_windows_msvc.asm",
++            "c/blake3_sse41_x86-64_windows_msvc.asm",
++        ],
++        "@bazel_tools//src/conditions:windows_arm64": [
++            "c/blake3_neon.c",
++        ],
++        "@bazel_tools//src/conditions:darwin_arm64": [
++            "c/blake3_neon.c",
++        ],
++        "//conditions:default": [],
++    }),
++    hdrs = [
++        "c/blake3.h",
++        "c/blake3_impl.h",
++    ],
++    copts = select({
++        "@bazel_tools//src/conditions:linux_x86_64": [],
++        "@bazel_tools//src/conditions:linux_aarch64": [
++            "-DBLAKE3_USE_NEON=1",
++        ],
++        "@bazel_tools//src/conditions:windows_x64": [],
++        "@bazel_tools//src/conditions:windows_arm64": [
++            "-DBLAKE3_USE_NEON=1",
++        ],
++        "@bazel_tools//src/conditions:darwin_arm64": [
++            "-DBLAKE3_USE_NEON=1",
++        ],
++        "//conditions:default": [
++            "-DBLAKE3_NO_SSE2",
++            "-DBLAKE3_NO_SSE41",
++            "-DBLAKE3_NO_AVX2",
++            "-DBLAKE3_NO_AVX512",
++        ],
++    }),
++    includes = ["."],
++    visibility = ["//visibility:public"],
++)

--- a/modules/blake3/1.5.1/patches/module_dot_bazel.patch
+++ b/modules/blake3/1.5.1/patches/module_dot_bazel.patch
@@ -1,0 +1,9 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,6 @@
++module(
++    name = "blake3",
++    version = "1.5.1",
++    compatibility_level = 1,
++)
++bazel_dep(name = "rules_cc", version = "0.0.6")

--- a/modules/blake3/1.5.1/presubmit.yml
+++ b/modules/blake3/1.5.1/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - fedora39
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  - windows_arm64
+  bazel:
+  - 6.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@blake3//:blake3'

--- a/modules/blake3/1.5.1/source.json
+++ b/modules/blake3/1.5.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/1.5.1.tar.gz",
+    "integrity": "sha256-gizTf3AVLlmFQz0sUMj2suyDqvEaoxvp/nFIapF0Tzc=",
+    "strip_prefix": "BLAKE3-1.5.1",
+    "patches": {
+        "add_build_file.patch": "sha256-VfKMxf9Ob1ZSmRRAd6slnDmuIucajQJFGUjfM5C1VMQ=",
+        "module_dot_bazel.patch": "sha256-6CEtNE6MyaIyEw8l+hzU5MM6HlBDepCWUDLrrB9BMKM="
+    },
+    "patch_strip": 0
+}

--- a/modules/blake3/metadata.json
+++ b/modules/blake3/metadata.json
@@ -1,17 +1,18 @@
 {
-  "homepage": "https://github.com/BLAKE3-team/BLAKE3",
-  "maintainers": [
-    {
-      "email": "bcr-maintainers@bazel.build",
-      "name": "No Maintainer Specified"
-    }
-  ],
-  "repository": [
-    "github:BLAKE3-team/BLAKE3"
-  ],
-  "versions": [
-    "1.3.3",
-    "1.3.3.bcr.1"
-  ],
-  "yanked_versions": {}
+    "homepage": "https://github.com/BLAKE3-team/BLAKE3",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:BLAKE3-team/BLAKE3"
+    ],
+    "versions": [
+        "1.3.3",
+        "1.3.3.bcr.1",
+        "1.5.1"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Adds AVX-512 support for Linux x86_64 and tests more platforms compared to previous BCR versions.