### PR TITLE
boringssl@0.0.0-20240530-2db0eb3

### DIFF
--- a/modules/boringssl/0.0.0-20240530-2db0eb3/MODULE.bazel
+++ b/modules/boringssl/0.0.0-20240530-2db0eb3/MODULE.bazel
@@ -1,0 +1,32 @@
+# Copyright (c) 2024, Google Inc.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+# OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+# When publishing to BCR, replace the version field below with
+# 0.0.0-YYYYMMDD-HASH, e.g. "0.0.0-20240126-22d349c".
+module(
+    name = "boringssl",
+    version = "0.0.0-20240530-2db0eb3",
+    compatibility_level = 2,
+)
+
+# In principle, googletest is only needed for tests and could be a
+# dev_dependency. But it would then be impossible for downstream modules to run
+# BoringSSL's tests. The downstream module provides the toolchain, so we may
+# need to request they run tests when triaging issues. If
+# https://github.com/bazelbuild/bazel/issues/22187 is ever fixed, we can change
+# this.
+bazel_dep(name = "googletest", version = "1.14.0.bcr.1")
+
+bazel_dep(name = "platforms", version = "0.0.9")
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/boringssl/0.0.0-20240530-2db0eb3/patches/module_dot_bazel.patch
+++ b/modules/boringssl/0.0.0-20240530-2db0eb3/patches/module_dot_bazel.patch
@@ -1,0 +1,11 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -16,7 +16,7 @@
+ # 0.0.0-YYYYMMDD-HASH, e.g. "0.0.0-20240126-22d349c".
+ module(
+     name = "boringssl",
+-    version = "0.0.0-dev",
++    version = "0.0.0-20240530-2db0eb3",
+     compatibility_level = 2,
+ )
+ 

--- a/modules/boringssl/0.0.0-20240530-2db0eb3/presubmit.yml
+++ b/modules/boringssl/0.0.0-20240530-2db0eb3/presubmit.yml
@@ -1,0 +1,33 @@
+build_targets: &build_targets
+  - "@boringssl//:crypto"
+  - "@boringssl//:ssl"
+
+matrix:
+  platform:
+    - centos7_java11_devtoolset10
+    - debian11
+    - ubuntu2204
+    - windows
+  bazel: [6.x, 7.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets: *build_targets
+  # Work around https://github.com/bazelbuild/bazel/issues/10472
+  verify_targets_on_macos:
+    name: Verify build targets on macOS
+    platform: macos
+    bazel: ${{ bazel }}
+    build_targets: *build_targets
+    build_flags:
+      - '--cxxopt=-std=c++14'
+      - '--sandbox_block_path=/usr/local'
+  run_test_module:
+    name: Run test module
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    module_path: util/bazel-example
+    build_targets:
+      - //...

--- a/modules/boringssl/0.0.0-20240530-2db0eb3/source.json
+++ b/modules/boringssl/0.0.0-20240530-2db0eb3/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/google/boringssl/archive/2db0eb3f96a5756298dcd7f9319e56a98585bd10.tar.gz",
+    "integrity": "sha256-zSQL8nRQ91zV9BxRKgYpfABkbNusn4e2BOkxJ3HbFaY=",
+    "strip_prefix": "boringssl-2db0eb3f96a5756298dcd7f9319e56a98585bd10",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-ROmpGIa6bWfDTV1c02V7xp0uScaKaRWYJKoz0uAhaoA="
+    }
+}

--- a/modules/boringssl/metadata.json
+++ b/modules/boringssl/metadata.json
@@ -1,18 +1,30 @@
 {
-  "homepage": "https://github.com/google/boringssl",
-  "maintainers": [
-    {
-      "email": "bcr-maintainers@bazel.build",
-      "name": "No Maintainer Specified"
-    }
-  ],
-  "repository": [
-    "github:google/boringssl"
-  ],
-  "versions": [
-    "0.0.0-20211025-d4f1ab9",
-    "0.0.0-20230215-5c22014",
-    "0.0.0-20240126-22d349c"
-  ],
-  "yanked_versions": {}
+    "homepage": "https://boringssl.googlesource.com/boringssl/",
+    "maintainers": [
+        {
+            "email": "agl@google.com",
+            "github": "agl",
+            "name": "Adam Langley"
+        },
+        {
+            "email": "bbe@google.com",
+            "github": "bob-beck",
+            "name": "Bob Beck"
+        },
+        {
+            "email": "davidben@google.com",
+            "github": "davidben",
+            "name": "David Benjamin"
+        }
+    ],
+    "repository": [
+        "github:google/boringssl"
+    ],
+    "versions": [
+        "0.0.0-20211025-d4f1ab9",
+        "0.0.0-20230215-5c22014",
+        "0.0.0-20240126-22d349c",
+        "0.0.0-20240530-2db0eb3"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/google/boringssl/archive/1b6fe250a3b8b66aa4990a6ec59f20f5bf52df5d.tar.gz

Used by:
* https://github.com/google/riegeli