### PR TITLE
Add tree-sitter-bazel 0.22.5.

### DIFF
--- a/modules/tree-sitter-bazel/0.22.5/MODULE.bazel
+++ b/modules/tree-sitter-bazel/0.22.5/MODULE.bazel
@@ -1,0 +1,27 @@
+# Copyright 2024 github.com/zadlg
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"zadlg/tree-sitter-bazel"
+
+module(
+    name = "tree-sitter-bazel",
+    version = "0.22.5",
+    compatibility_level = 1,
+    repo_name = "tree-sitter-bazel",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+
+tree_sitter_source_code = use_extension(":extensions.bzl", "tree_sitter_source_code")
+use_repo(tree_sitter_source_code, "tree-sitter-raw")

--- a/modules/tree-sitter-bazel/0.22.5/presubmit.yml
+++ b/modules/tree-sitter-bazel/0.22.5/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - macos
+  - macos_arm64
+  - ubuntu2004
+  bazel:
+  - 7.x
+  - 6.x
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@tree-sitter-bazel//:tree-sitter'

--- a/modules/tree-sitter-bazel/0.22.5/source.json
+++ b/modules/tree-sitter-bazel/0.22.5/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/zadlg/tree-sitter-bazel/releases/download/v0.22.5/tree-sitter.tar.gz",
+    "integrity": "sha384-630xAIInHTaA4EjLjNePCHYeAvL5dP/0pOdgu8rrGNz7RzJjkvjjX2BlkD6ZAO+M",
+    "strip_prefix": "tree-sitter-bazel-0.22.5"
+}

--- a/modules/tree-sitter-bazel/metadata.json
+++ b/modules/tree-sitter-bazel/metadata.json
@@ -1,0 +1,12 @@
+{
+  "homepage": "https://github.com/zadlg/tree-sitter-bazel",
+  "maintainers": [
+    {
+      "github": "zadlg",
+      "name": "zadig"
+    }
+  ],
+  "repository": ["github:zadlg/tree-sitter-bazel"],
+  "versions": ["0.22.5"],
+  "yanked_versions": {}
+}


### PR DESCRIPTION
Add tree-sitter-bazel 0.22.5.

See [`tree-sitter-bazel`] and [`tree-sitter-bazel` v0.22.5].

I attempted to integrate Bazel into the original repo (see https://github.com/tree-sitter/tree-sitter/pull/3312),
but tree-sitter maintainers are not willing to do so, so I decided to create
my own repo for this purpose.

[`tree-sitter-bazel`]: https://github.com/zadlg/tree-sitter-bazel
[`tree-sitter-bazel` v0.22.5]: https://github.com/zadlg/tree-sitter-bazel/releases/tag/v0.22.5
