### PR TITLE
bcr_validation: Validate at least one task is specified

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -250,6 +250,9 @@ class BcrValidator:
     shutil.rmtree(tmp_dir)
 
   def check_if_bazel_version_is_set(self, tasks):
+    if not tasks:
+      self.report(BcrValidationResult.FAILED, "At least one task should be specified in the presubmit.yml file.")
+      return
     for task_name, task_config in tasks.items():
       if "bazel" not in task_config:
         self.report(BcrValidationResult.FAILED, "Missing bazel version for task '%s' in the presubmit.yml file." % task_name)


### PR DESCRIPTION
This would prevent using outdated presubmit.yml format for BCR modules.

Context: https://github.com/bazelbuild/bazel-central-registry/pull/1861/files#diff-12d94d573f23b0e6beb29366322c6b4d459839255f9cf227e54051fd28c6e308R1