### PR TITLE
fix bzlib header include

### DIFF
--- a/modules/bzip2/1.0.8.bcr.1/MODULE.bazel
+++ b/modules/bzip2/1.0.8.bcr.1/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "bzip2",
+    version = "1.0.8.bcr.1",
+    compatibility_level = 1,
+)

--- a/modules/bzip2/1.0.8.bcr.1/patches/add_build_file.patch
+++ b/modules/bzip2/1.0.8.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,37 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,33 @@
++cc_binary(
++    name = "bzip2",
++    srcs = ["bzip2.c"],
++    defines = [
++        "_FILE_OFFSET_BITS=64",
++    ],
++    deps = [
++        ":bz2",
++    ],
++    visibility = ["//visibility:public"],
++)
++
++cc_library(
++    name = "bz2",
++    srcs = [
++        "blocksort.c",
++        "bzlib.c",
++        "bzlib_private.h",
++        "compress.c",
++        "crctable.c",
++        "decompress.c",
++        "huffman.c",
++        "randtable.c",
++    ],
++    hdrs = [
++        "bzlib.h",
++    ],
++    defines = [
++        "_FILE_OFFSET_BITS=64",
++    ],
++    includes = ["."],
++    strip_include_prefix = "",
++    visibility = ["//visibility:public"],
++)

--- a/modules/bzip2/1.0.8.bcr.1/patches/add_build_file.patch
+++ b/modules/bzip2/1.0.8.bcr.1/patches/add_build_file.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ BUILD.bazel
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,34 @@
 +cc_binary(
 +    name = "bzip2",
 +    srcs = ["bzip2.c"],

--- a/modules/bzip2/1.0.8.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/bzip2/1.0.8.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "bzip2",
++    version = "1.0.8.bcr.1",
++    compatibility_level = 1,
++)

--- a/modules/bzip2/1.0.8.bcr.1/presubmit.yml
+++ b/modules/bzip2/1.0.8.bcr.1/presubmit.yml
@@ -5,6 +5,7 @@ matrix:
   - ubuntu2004
   - macos
   - windows
+  bazel: [6.x, 7.x]
 tasks:
   verify_targets:
     name: Verify build targets

--- a/modules/bzip2/1.0.8.bcr.1/presubmit.yml
+++ b/modules/bzip2/1.0.8.bcr.1/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@bzip2//:bzip2'
+    - '@bzip2//:bz2'

--- a/modules/bzip2/1.0.8.bcr.1/presubmit.yml
+++ b/modules/bzip2/1.0.8.bcr.1/presubmit.yml
@@ -10,6 +10,7 @@ tasks:
   verify_targets:
     name: Verify build targets
     platform: ${{ platform }}
+    bazel: ${{ bazel }}
     build_targets:
     - '@bzip2//:bzip2'
     - '@bzip2//:bz2'

--- a/modules/bzip2/1.0.8.bcr.1/source.json
+++ b/modules/bzip2/1.0.8.bcr.1/source.json
@@ -2,7 +2,7 @@
     "integrity": "sha256-q1oDF27hBtPw+pDjgdpHjdrkBZGBU8yiSOaCzQxKImk=",
     "patch_strip": 0,
     "patches": {
-        "add_build_file.patch": "sha256-mtwAfvUOf3GQzAbtj9rL1b7SFnn8meTWI9N8UvhWF9M=",
+        "add_build_file.patch": "sha256-QPcAoslzyuAkL4VQgb18uhZaUu8A30/LUrD8wHaKZHY=",
         "module_dot_bazel.patch": "sha256-lfm8AQkGepyTCT/UQrNpojSPcuu9TnCpPEWykSew7r8="
     },
     "strip_prefix": "bzip2-1.0.8",

--- a/modules/bzip2/1.0.8.bcr.1/source.json
+++ b/modules/bzip2/1.0.8.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-q1oDF27hBtPw+pDjgdpHjdrkBZGBU8yiSOaCzQxKImk=",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-mtwAfvUOf3GQzAbtj9rL1b7SFnn8meTWI9N8UvhWF9M=",
+        "module_dot_bazel.patch": "sha256-lfm8AQkGepyTCT/UQrNpojSPcuu9TnCpPEWykSew7r8="
+    },
+    "strip_prefix": "bzip2-1.0.8",
+    "url": "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
+}

--- a/modules/bzip2/1.0.8/presubmit.yml
+++ b/modules/bzip2/1.0.8/presubmit.yml
@@ -5,6 +5,7 @@ matrix:
   - ubuntu2004
   - macos
   - windows
+  bazel: [6.x, 7.x]
 tasks:
   verify_targets:
     name: Verify build targets

--- a/modules/bzip2/1.0.8/presubmit.yml
+++ b/modules/bzip2/1.0.8/presubmit.yml
@@ -10,6 +10,7 @@ tasks:
   verify_targets:
     name: Verify build targets
     platform: ${{ platform }}
+    bazel: ${{ bazel }}
     build_targets:
     - '@bzip2//:bzip2'
     - '@bzip2//:bz2'

--- a/modules/bzip2/metadata.json
+++ b/modules/bzip2/metadata.json
@@ -7,7 +7,8 @@
     }
   ],
   "versions": [
-    "1.0.8"
+    "1.0.8",
+    "1.0.8.bcr.1"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
it is expected that including bzip2 header included with angle brackets

```cpp
#include <bzlib.h>
```

without this change and more modules get added to the bcr there will be a lot of theses kinds of patches https://github.com/bazelbuild/bazel-central-registry/pull/1846/files#diff-3d0ec8cf226f2e480a40e8c6126f6ed456555c147c2f4e1b3557fd81f4db4ab5

unfortunately I think this breaks `libarchive` with clang/gcc due to the patch linked above