### PR TITLE
Add tree-sitter-c-bazel 0.20.7.

### DIFF
--- a/modules/tree-sitter-c-bazel/0.20.7/MODULE.bazel
+++ b/modules/tree-sitter-c-bazel/0.20.7/MODULE.bazel
@@ -1,0 +1,27 @@
+# Copyright 2024 github.com/zadlg
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+"zadlg/tree-sitter-c-bazel"
+
+module(
+    name = "tree-sitter-c-bazel",
+    version = "0.20.7",
+    compatibility_level = 1,
+    repo_name = "tree-sitter-c-bazel",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "tree-sitter-bazel", version = "0.22.5")
+
+tree_sitter_c_source_code = use_extension(":extensions.bzl", "tree_sitter_c_source_code")
+use_repo(tree_sitter_c_source_code, "tree-sitter-c-raw")

--- a/modules/tree-sitter-c-bazel/0.20.7/presubmit.yml
+++ b/modules/tree-sitter-c-bazel/0.20.7/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - macos
+  - macos_arm64
+  - ubuntu2004
+  bazel:
+  - 7.x
+  - 6.x
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@tree-sitter-c-bazel//:tree-sitter-c'

--- a/modules/tree-sitter-c-bazel/0.20.7/source.json
+++ b/modules/tree-sitter-c-bazel/0.20.7/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/zadlg/tree-sitter-c-bazel/releases/download/v0.20.7/tree-sitter-c.tar.gz",
+    "integrity": "sha384-WqzeDAxp67zDtVdxcZ7VtXcgL3zOEzb+tGO/HysK40RAYZk6aLeo0jjNNyXAhUA1",
+    "strip_prefix": "tree-sitter-c-bazel-0.20.7"
+}

--- a/modules/tree-sitter-c-bazel/metadata.json
+++ b/modules/tree-sitter-c-bazel/metadata.json
@@ -1,0 +1,12 @@
+{
+  "homepage": "https://github.com/zadlg/tree-sitter-c-bazel",
+  "maintainers": [
+    {
+      "github": "zadlg",
+      "name": "zadig"
+    }
+  ],
+  "repository": ["github:zadlg/tree-sitter-c-bazel"],
+  "versions": ["0.20.7"],
+  "yanked_versions": {}
+}


### PR DESCRIPTION
Add tree-sitter-c-bazel 0.20.7.

See [`tree-sitter-c-bazel`] and [`tree-sitter-c-bazel` v0.20.7].

This module allows Bazel users to use the [tree-sitter C parser] in their
Bazel project.

[`tree-sitter-c-bazel`]: https://github.com/zadlg/tree-sitter-c-bazel
[`tree-sitter-c-bazel` v0.20.7]:
https://github.com/zadlg/tree-sitter-c-bazel/releases/tag/v0.20.7
[tree-sitter C parser]: https://github.com/tree-sitter/tree-sitter-c
