### PR TITLE
sdl@2.0.8

### DIFF
--- a/modules/sdl/2.0.8/MODULE.bazel
+++ b/modules/sdl/2.0.8/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "sdl",
+    version = "2.0.8",
+    compatibility_level = 2,
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.9",
+)

--- a/modules/sdl/2.0.8/patches/add_build_file.patch
+++ b/modules/sdl/2.0.8/patches/add_build_file.patch
@@ -1,0 +1,86 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,83 @@
++# Copyright 2018 Google LLC
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     https://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++licenses(["notice"])
++
++# Common include paths
++sdl_includes = [
++    "include",
++    "src/video/khronos",
++]
++
++objc_library(
++    name = "sdl_objc",
++    srcs = glob([
++        "src/**/*.h",
++        "include/*.h",
++    ]),
++    includes = sdl_includes,
++    non_arc_srcs = glob([
++        "src/audio/coreaudio/*.m",
++        "src/file/cocoa/*.m",
++        "src/filesystem/cocoa/*.m",
++        "src/render/metal/*.m",
++        "src/video/cocoa/*.m",
++    ]),
++    sdk_frameworks = [
++        "AudioToolbox",
++        "Carbon",
++        "CoreAudio",
++        "CoreVideo",
++        "Cocoa",
++        "ForceFeedback",
++        "IOKit",
++        "OpenGL",
++        "Metal",
++    ],
++    alwayslink = 1,
++)
++
++sdl_srcs = glob(
++    include = [
++        "src/**/*.c",
++        "src/**/*.h",
++    ],
++    exclude = [
++        "src/video/qnx/**",
++        "src/haptic/windows/**",
++        "src/test/*.c",
++        "src/thread/generic/*.c",
++        "src/core/linux/*.c",
++    ],
++)
++
++cc_library(
++    name = "sdl",
++    srcs = select({
++        "@platforms//os:osx": sdl_srcs,
++        "//conditions:default": [],
++    }),
++    hdrs = glob(["include/*.h"]),
++    includes = sdl_includes,
++    linkopts = select({
++        "@platforms//os:linux": ["-lSDL2"],
++        "//conditions:default": [],
++    }),
++    textual_hdrs = glob(["src/thread/generic/*.c"]),
++    visibility = ["//visibility:public"],
++    deps = select({
++        "@platforms//os:osx": [":sdl_objc"],
++        "//conditions:default": [],
++    }),
++)

--- a/modules/sdl/2.0.8/patches/module_dot_bazel.patch
+++ b/modules/sdl/2.0.8/patches/module_dot_bazel.patch
@@ -1,0 +1,13 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,10 @@
++module(
++    name = "sdl",
++    version = "2.0.8",
++    compatibility_level = 2,
++)
++
++bazel_dep(
++    name = "platforms",
++    version = "0.0.9",
++)

--- a/modules/sdl/2.0.8/presubmit.yml
+++ b/modules/sdl/2.0.8/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    build_targets:
+    - '@sdl//:sdl'

--- a/modules/sdl/2.0.8/source.json
+++ b/modules/sdl/2.0.8/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/libsdl-org/SDL/releases/download/release-2.0.8/SDL2-2.0.8.tar.gz",
+    "integrity": "sha256-7cd8VzCGYdV26EM0TYY44CWngYv/c/j7+rCcPF/Qkuw=",
+    "strip_prefix": "SDL2-2.0.8",
+    "patches": {
+        "add_build_file.patch": "sha256-9qD9d3uS90dqccRMlXVBabVhPy355CimBReyfbHRJEc=",
+        "module_dot_bazel.patch": "sha256-TBsEb7lT0rV0zJGX8yerguvCyjlm9tZSxm6S9VHeWF0="
+    },
+    "patch_strip": 0
+}

--- a/modules/sdl/metadata.json
+++ b/modules/sdl/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://www.libsdl.org",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:libsdl-org/SDL"
+    ],
+    "versions": [
+        "2.0.8"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/libsdl-org/SDL/releases/tag/release-2.0.8

Used by:
* https://github.com/google/quic-trace