### PR TITLE
cel-spec@0.15.0

### DIFF
--- a/modules/cel-spec/0.15.0/MODULE.bazel
+++ b/modules/cel-spec/0.15.0/MODULE.bazel
@@ -1,0 +1,80 @@
+module(
+    name = "cel-spec",
+    version = "0.15.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "abseil-cpp",
+    version = "20230802.1",
+    repo_name = "com_google_absl",
+)
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.4.1",
+)
+bazel_dep(
+    name = "gazelle",
+    version = "0.34.0",
+    repo_name = "bazel_gazelle",
+)
+bazel_dep(
+    name = "protobuf",
+    version = "21.7",
+    repo_name = "com_google_protobuf",
+)
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.9",
+)
+bazel_dep(
+    name = "rules_go",
+    version = "0.45.1",
+    repo_name = "io_bazel_rules_go",
+)
+bazel_dep(
+    name = "rules_java",
+    version = "6.0.0",
+)
+bazel_dep(
+    name = "rules_pkg",
+    version = "0.7.0",
+)
+bazel_dep(
+    name = "rules_proto",
+    version = "5.3.0-21.7",
+)
+bazel_dep(
+    name = "rules_python",
+    version = "0.22.1",
+)
+# -- bazel_dep definitions -- #
+
+non_module_dependencies = use_extension("//:extensions.bzl", "non_module_dependencies")
+use_repo(
+    non_module_dependencies,
+    "com_google_googleapis",
+)
+
+googleapis_ext = use_extension("//:googleapis_ext.bzl", "googleapis_ext")
+use_repo(
+    googleapis_ext,
+    "com_google_googleapis_imports",
+)
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.19.1")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+go_deps.module(
+    path = "google.golang.org/genproto/googleapis/api",
+    sum = "h1:RFiFrvy37/mpSpdySBDrUdipW/dHwsRwh3J3+A9VgT4=",
+    version = "v0.0.0-20240318140521-94a12d6c2237",
+)
+use_repo(
+    go_deps,
+    "org_golang_google_genproto_googleapis_api",
+    "org_golang_google_genproto_googleapis_rpc",
+    "org_golang_google_protobuf",
+)

--- a/modules/cel-spec/0.15.0/patches/cel-spec.patch
+++ b/modules/cel-spec/0.15.0/patches/cel-spec.patch
@@ -1,0 +1,33 @@
+diff --git a/extensions.bzl b/extensions.bzl
+new file mode 100644
+index 0000000..c7e96b3
+--- /dev/null
++++ b/extensions.bzl
+@@ -0,0 +1,15 @@
++load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
++
++def _non_module_dependencies_impl(_ctx):
++    http_archive(
++        name = "com_google_googleapis",
++        sha256 = "bd8e735d881fb829751ecb1a77038dda4a8d274c45490cb9fcf004583ee10571",
++        strip_prefix = "googleapis-07c27163ac591955d736f3057b1619ece66f5b99",
++        urls = [
++            "https://github.com/googleapis/googleapis/archive/07c27163ac591955d736f3057b1619ece66f5b99.tar.gz",
++        ],
++    )
++
++non_module_dependencies = module_extension(
++    implementation = _non_module_dependencies_impl,
++)
+diff --git a/googleapis_ext.bzl b/googleapis_ext.bzl
+new file mode 100644
+index 0000000..f3c1e15
+--- /dev/null
++++ b/googleapis_ext.bzl
+@@ -0,0 +1,6 @@
++load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
++
++googleapis_ext = module_extension(implementation = lambda x: switched_rules_by_language(
++    name = "com_google_googleapis_imports",
++    cc = True,
++))

--- a/modules/cel-spec/0.15.0/patches/module_dot_bazel.patch
+++ b/modules/cel-spec/0.15.0/patches/module_dot_bazel.patch
@@ -1,0 +1,83 @@
+--- a/MODULE.bazel
++++ a/MODULE.bazel
+@@ -0,0 +1,80 @@
++module(
++    name = "cel-spec",
++    version = "0.15.0",
++    compatibility_level = 1,
++)
++
++bazel_dep(
++    name = "abseil-cpp",
++    version = "20230802.1",
++    repo_name = "com_google_absl",
++)
++bazel_dep(
++    name = "bazel_skylib",
++    version = "1.4.1",
++)
++bazel_dep(
++    name = "gazelle",
++    version = "0.34.0",
++    repo_name = "bazel_gazelle",
++)
++bazel_dep(
++    name = "protobuf",
++    version = "21.7",
++    repo_name = "com_google_protobuf",
++)
++bazel_dep(
++    name = "rules_cc",
++    version = "0.0.9",
++)
++bazel_dep(
++    name = "rules_go",
++    version = "0.45.1",
++    repo_name = "io_bazel_rules_go",
++)
++bazel_dep(
++    name = "rules_java",
++    version = "6.0.0",
++)
++bazel_dep(
++    name = "rules_pkg",
++    version = "0.7.0",
++)
++bazel_dep(
++    name = "rules_proto",
++    version = "5.3.0-21.7",
++)
++bazel_dep(
++    name = "rules_python",
++    version = "0.22.1",
++)
++# -- bazel_dep definitions -- #
++
++non_module_dependencies = use_extension("//:extensions.bzl", "non_module_dependencies")
++use_repo(
++    non_module_dependencies,
++    "com_google_googleapis",
++)
++
++googleapis_ext = use_extension("//:googleapis_ext.bzl", "googleapis_ext")
++use_repo(
++    googleapis_ext,
++    "com_google_googleapis_imports",
++)
++
++go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
++go_sdk.download(version = "1.19.1")
++
++go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
++go_deps.from_file(go_mod = "//:go.mod")
++go_deps.module(
++    path = "google.golang.org/genproto/googleapis/api",
++    sum = "h1:RFiFrvy37/mpSpdySBDrUdipW/dHwsRwh3J3+A9VgT4=",
++    version = "v0.0.0-20240318140521-94a12d6c2237",
++)
++use_repo(
++    go_deps,
++    "org_golang_google_genproto_googleapis_api",
++    "org_golang_google_genproto_googleapis_rpc",
++    "org_golang_google_protobuf",
++)

--- a/modules/cel-spec/0.15.0/presubmit.yml
+++ b/modules/cel-spec/0.15.0/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@cel-spec//proto/...'

--- a/modules/cel-spec/0.15.0/presubmit.yml
+++ b/modules/cel-spec/0.15.0/presubmit.yml
@@ -14,4 +14,5 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_targets:
-    - '@cel-spec//proto/...'
+    - '@cel-spec//proto/cel/expr:checked_proto'
+    - '@cel-spec//proto/cel/expr:syntax_proto'

--- a/modules/cel-spec/0.15.0/source.json
+++ b/modules/cel-spec/0.15.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/google/cel-spec/archive/refs/tags/v0.15.0.tar.gz",
+    "integrity": "sha256-PuCetp2+d3Iune4j3EjcLNn3ZYafz1/7EiZYfIF5Ggs=",
+    "strip_prefix": "cel-spec-0.15.0",
+    "patches": {
+        "cel-spec.patch": "sha256-ETGVTIU6n5yA3RRtJi24uoO2/qOkoo80qFu+N2TKo5U=",
+        "module_dot_bazel.patch": "sha256-X5fgxo3K9m6UmvEU6a5I8vCfF2CtWbVLn2rb8qC55U4="
+    },
+    "patch_strip": 1
+}

--- a/modules/cel-spec/metadata.json
+++ b/modules/cel-spec/metadata.json
@@ -10,7 +10,8 @@
         "github:google/cel-spec"
     ],
     "versions": [
-        "0.14.0"
+        "0.14.0",
+        "0.15.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/google/cel-spec/releases/tag/v0.15.0

Used by:
* https://github.com/cncf/xds