### PR TITLE
highs@1.7.0

### DIFF
--- a/modules/highs/1.7.0/MODULE.bazel
+++ b/modules/highs/1.7.0/MODULE.bazel
@@ -1,0 +1,18 @@
+module(
+    name = "highs",
+    version = "1.7.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.3.0",
+)
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.9",
+)
+bazel_dep(
+    name = "zlib",
+    version = "1.2.11",
+)

--- a/modules/highs/1.7.0/patches/highs.patch
+++ b/modules/highs/1.7.0/patches/highs.patch
@@ -1,0 +1,12 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 438a8286f..07f40ff65 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -62,6 +62,7 @@ cc_library(
+         # "src/test",
+         # "src/util",
+         "bazel-bin"],
++    linkopts = ["-lpthread"],
+     visibility = ["//visibility:public"],
+         deps = [
+         "//:config",

--- a/modules/highs/1.7.0/patches/module_dot_bazel.patch
+++ b/modules/highs/1.7.0/patches/module_dot_bazel.patch
@@ -1,0 +1,21 @@
+--- a/MODULE.bazel
++++ a/MODULE.bazel
+@@ -0,0 +1,18 @@
++module(
++    name = "highs",
++    version = "1.7.0",
++    compatibility_level = 1,
++)
++
++bazel_dep(
++    name = "bazel_skylib",
++    version = "1.3.0",
++)
++bazel_dep(
++    name = "rules_cc",
++    version = "0.0.9",
++)
++bazel_dep(
++    name = "zlib",
++    version = "1.2.11",
++)

--- a/modules/highs/1.7.0/presubmit.yml
+++ b/modules/highs/1.7.0/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--cxxopt=-Wno-sign-compare'
+    - '--host_cxxopt=-std=c++17'
+    - '--host_cxxopt=-Wno-sign-compare'
+    build_targets:
+    - '@highs//...'

--- a/modules/highs/1.7.0/source.json
+++ b/modules/highs/1.7.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/ERGO-Code/HiGHS/archive/refs/tags/v1.7.0.tar.gz",
+    "integrity": "sha256-0QF1rWbn8ROsXcAMnWZQpiBmOmiE+/KULW63o9hUYE8=",
+    "strip_prefix": "HiGHS-1.7.0",
+    "patches": {
+        "highs.patch": "sha256-dJ/S88Tpfi88heov9GTBtGFWLbXQzz1CH26FvzefTcw=",
+        "module_dot_bazel.patch": "sha256-DUcnXSBiv36uLvvjXvDpbGCj8CuH0VoNLfEZY29FaF8="
+    },
+    "patch_strip": 1
+}

--- a/modules/highs/metadata.json
+++ b/modules/highs/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/ERGO-Code/HiGHS",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:ERGO-Code/HiGHS"
+    ],
+    "versions": [
+        "1.7.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/ERGO-Code/HiGHS/tree/v1.7.0

Used by:
* https://github.com/google/or-tools