### PR TITLE
enable dependabot for github-actions, npm and pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: /tools
+    schedule:
+      interval: weekly
+  - package-ecosystem: pip
+    directory: /tools
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This will allow to check weekly if there are updates for github-actions, npm and pip dependencies for the BCR. It will then create one PR for each dependency to update and will need to be validated individually.
This will help reduce the risk of vulnerabilities and technical debt.