### PR TITLE
Added fremtind_rules_vitest 0.1.0

### DIFF
--- a/modules/fremtind_rules_vitest/0.1.0/MODULE.bazel
+++ b/modules/fremtind_rules_vitest/0.1.0/MODULE.bazel
@@ -1,0 +1,17 @@
+"aspect-build/rules_vitest"
+
+module(
+    name = "fremtind_rules_vitest",
+    version = "0.1.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "aspect_bazel_lib", version = "1.32.1")
+bazel_dep(name = "aspect_rules_js", version = "1.29.2")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "rules_nodejs", version = "5.8.2")
+bazel_dep(name = "bazel_features", version = "1.9.0")
+
+bazel_dep(name = "gazelle", version = "0.29.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "6.3.3", dev_dependency = True)

--- a/modules/fremtind_rules_vitest/0.1.0/patches/module_dot_bazel_version.patch
+++ b/modules/fremtind_rules_vitest/0.1.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -2,7 +2,7 @@
+
+ module(
+     name = "fremtind_rules_vitest",
+-    version = "0.0.0",
++    version = "0.1.0",
+     compatibility_level = 1,
+ )

--- a/modules/fremtind_rules_vitest/0.1.0/patches/module_dot_bazel_version.patch
+++ b/modules/fremtind_rules_vitest/0.1.0/patches/module_dot_bazel_version.patch
@@ -1,5 +1,5 @@
---- MODULE.bazel
-+++ MODULE.bazel
+--- a/MODULE.bazel
++++ b/MODULE.bazel
 @@ -2,7 +2,7 @@
 
  module(

--- a/modules/fremtind_rules_vitest/0.1.0/presubmit.yml
+++ b/modules/fremtind_rules_vitest/0.1.0/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    bazel: ["7.x", "6.x"]
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/fremtind_rules_vitest/0.1.0/source.json
+++ b/modules/fremtind_rules_vitest/0.1.0/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-tM9E7HNbPcFHaoPHv+7IQQ4PLhNG8BQ8yI+LP54+v/g=",
     "strip_prefix": "rules_vitest-0.1.0",
     "patches": {
-        "module_dot_bazel_version.patch": "sha256-sUiRaUEaBKxY5boKV/7M8pA+cYEXQVMQk8Q5KzatDgs="
+        "module_dot_bazel_version.patch": "sha256-iJTm8o3rWcKBd/73oYHXWrszuDKDvyImz+KmiTHQ1pk="
     },
     "patch_strip": 1
 }

--- a/modules/fremtind_rules_vitest/0.1.0/source.json
+++ b/modules/fremtind_rules_vitest/0.1.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/fremtind/rules_vitest/releases/download/v0.1.0/rules_vitest-v0.1.0.tar.gz",
+    "integrity": "sha256-tM9E7HNbPcFHaoPHv+7IQQ4PLhNG8BQ8yI+LP54+v/g=",
+    "strip_prefix": "rules_vitest-0.1.0",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-sUiRaUEaBKxY5boKV/7M8pA+cYEXQVMQk8Q5KzatDgs="
+    },
+    "patch_strip": 1
+}

--- a/modules/fremtind_rules_vitest/metadata.json
+++ b/modules/fremtind_rules_vitest/metadata.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://github.com/fremtind/rules_vitest",
+    "maintainers": [
+        {
+            "email": "knut.hjelle@fremtind.no",
+            "github": "hjellek",
+            "name": "Knut Eirik Leira Hjelle"
+        },
+        {
+            "email": "magnus.raaum@fremtind.no",
+            "github": "tempacc21",
+            "name": "Magnus Raaum"
+        }
+    ],
+    "repository": [
+        "github:fremtind/rules_vitest"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This is the initial release of rules_vitest, making testing with [vitest](https://vitest.dev) under Bazel work with code coverage, test sharding and snapshots

release: https://github.com/fremtind/rules_vitest/releases/tag/v0.1.0