### PR TITLE
libprotobuf-mutator@1.3

### DIFF
--- a/modules/libprotobuf-mutator/1.3/MODULE.bazel
+++ b/modules/libprotobuf-mutator/1.3/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "libprotobuf-mutator",
+    version = "1.3",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "protobuf",
+    version = "26.0.bcr.1",
+    repo_name = "com_google_protobuf",
+)

--- a/modules/libprotobuf-mutator/1.3/patches/add_build_file.patch
+++ b/modules/libprotobuf-mutator/1.3/patches/add_build_file.patch
@@ -1,0 +1,29 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,26 @@
++licenses(["notice"])  # Apache 2
++
++cc_library(
++    name = "protobuf-mutator",
++    srcs = glob(
++        [
++            "src/**/*.cc",
++            "src/**/*.h",
++        ],
++        exclude = ["**/*_test.cc"],
++    ) + ["port/protobuf.h"],
++    hdrs = ["src/libfuzzer/libfuzzer_macro.h"],
++    include_prefix = "libprotobuf_mutator",
++    includes = [
++        "port",
++        "src",
++    ],
++    visibility = ["//visibility:public"],
++    deps = ["@com_google_protobuf//:protobuf"],
++)
++
++alias(
++    name = "libprotobuf-mutator",
++    actual = ":protobuf-mutator",
++    visibility = ["//visibility:public"],
++)

--- a/modules/libprotobuf-mutator/1.3/patches/module_dot_bazel.patch
+++ b/modules/libprotobuf-mutator/1.3/patches/module_dot_bazel.patch
@@ -1,0 +1,14 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,11 @@
++module(
++    name = "libprotobuf-mutator",
++    version = "1.3",
++    compatibility_level = 1,
++)
++
++bazel_dep(
++    name = "protobuf",
++    version = "26.0.bcr.1",
++    repo_name = "com_google_protobuf",
++)

--- a/modules/libprotobuf-mutator/1.3/presubmit.yml
+++ b/modules/libprotobuf-mutator/1.3/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--cxxopt=-std=c++14'
+      - '--host_cxxopt=-std=c++14'
+    build_targets:
+    - '@libprotobuf-mutator//...'

--- a/modules/libprotobuf-mutator/1.3/source.json
+++ b/modules/libprotobuf-mutator/1.3/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/google/libprotobuf-mutator/archive/refs/tags/v1.3.tar.gz",
+    "integrity": "sha256-HuNHOmsCdElPzlmVOWBbsZMFwO+txitY1kWBITLDG6o=",
+    "strip_prefix": "libprotobuf-mutator-1.3",
+    "patches": {
+        "add_build_file.patch": "sha256-xxn0WldoKrThL4zvl8Vl8EO/D1FY342L3qES4krVNHA=",
+        "module_dot_bazel.patch": "sha256-T+jdaKSyBgR16KGCG7ffV/S+pwG6CgogLOncpIERpBo="
+    },
+    "patch_strip": 0
+}

--- a/modules/libprotobuf-mutator/metadata.json
+++ b/modules/libprotobuf-mutator/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/google/libprotobuf-mutator",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:google/libprotobuf-mutator"
+    ],
+    "versions": [
+        "1.3"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/google/libprotobuf-mutator/releases/tag/v1.3

Used by:
* https://github.com/google/jwt_verify_lib
* https://github.com/envoyproxy/envoy