### PR TITLE
cctz@2.4

### DIFF
--- a/modules/cctz/2.4/MODULE.bazel
+++ b/modules/cctz/2.4/MODULE.bazel
@@ -1,0 +1,22 @@
+module(
+    name = "cctz",
+    version = "2.4",
+    compatibility_level = 1,
+    repo_name = "com_googlesource_code_cctz",
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.9",
+)
+
+bazel_dep(
+    name = "google_benchmark",
+    version = "1.8.3",
+    repo_name = "com_github_google_benchmark",
+)
+bazel_dep(
+    name = "googletest",
+    version = "1.11.0",
+    repo_name = "com_google_googletest",
+)

--- a/modules/cctz/2.4/patches/module_dot_bazel.patch
+++ b/modules/cctz/2.4/patches/module_dot_bazel.patch
@@ -1,0 +1,25 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,22 @@
++module(
++    name = "cctz",
++    version = "2.4",
++    compatibility_level = 1,
++    repo_name = "com_googlesource_code_cctz",
++)
++
++bazel_dep(
++    name = "platforms",
++    version = "0.0.9",
++)
++
++bazel_dep(
++    name = "google_benchmark",
++    version = "1.8.3",
++    repo_name = "com_github_google_benchmark",
++)
++bazel_dep(
++    name = "googletest",
++    version = "1.11.0",
++    repo_name = "com_google_googletest",
++)

--- a/modules/cctz/2.4/presubmit.yml
+++ b/modules/cctz/2.4/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@cctz//...'

--- a/modules/cctz/2.4/source.json
+++ b/modules/cctz/2.4/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/google/cctz/archive/refs/tags/v2.4.tar.gz",
+    "integrity": "sha256-4aAJV9RyBEgIokom8boCDzbcJpSaacIUVi2Wt0CTrbM=",
+    "strip_prefix": "cctz-2.4",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-CSS39BKI9a8AVhwx2HtXQaYB35vYf44ZR4wmJEI2RzY="
+    }
+}

--- a/modules/cctz/metadata.json
+++ b/modules/cctz/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/google/cctz",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:google/cctz"
+    ],
+    "versions": [
+        "2.4"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/google/cctz/releases/tag/v2.4

Used by:
* https://github.com/google/jwt_verify_lib