### PR TITLE
feat: add `rules_zstd@1.0.0-beta.1`

### DIFF
--- a/modules/rules_zstd/1.0.0-beta.1/MODULE.bazel
+++ b/modules/rules_zstd/1.0.0-beta.1/MODULE.bazel
@@ -1,0 +1,30 @@
+module(
+    name = "rules_zstd",
+    version = "1.0.0-beta.1",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.0")
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.9")
+bazel_dep(name = "ape", version = "1.0.0-beta.6")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+use_repo(export, "ape-zstd")
+export.symlink(
+    name = "zstd",
+    target = "@ape-zstd",
+)
+use_repo(export, "zstd")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+resolved(
+    name = "resolved-zstd",
+    toolchain_type = "//zstd/toolchain/zstd:type",
+)
+
+register_toolchains("//zstd/toolchain/...")

--- a/modules/rules_zstd/1.0.0-beta.1/presubmit.yml
+++ b/modules/rules_zstd/1.0.0-beta.1/presubmit.yml
@@ -1,0 +1,23 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2004_arm64
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_zstd/1.0.0-beta.1/source.json
+++ b/modules/rules_zstd/1.0.0-beta.1/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_zstd/-/releases/v1.0.0-beta.1/downloads/src.tar.gz",
+  "integrity": "sha512-dwkIQ5WKxbfCpNDiP7wd9cO+AvXXxf00v1IKbcXE6v/9fquTfggVUgEdPS1WTbC95HKRUaal8/5j0cCF17Z4EQ==",
+  "strip_prefix": "rules_zstd-v1.0.0-beta.1"
+}

--- a/modules/rules_zstd/metadata.json
+++ b/modules/rules_zstd/metadata.json
@@ -1,0 +1,16 @@
+{
+  "homepage": "https://gitlab.arm.com/bazel/rules_zstd",
+  "repository": [
+    "https://gitlab.arm.com/bazel/rules_zstd"
+  ],
+  "versions": [
+    "1.0.0-beta.1"
+  ],
+  "maintainers": [
+    {
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson",
+      "github": "mattyclarkson"
+    }
+  ]
+}


### PR DESCRIPTION
Uses `@ape//:zstd` to get hermetic compress/decompress:

```py
load("@rules_zstd//zstd/compress:defs.bzl", "zstd_compress")
load("@rules_zstd//zstd/decompress:defs.bzl", "zstd_decompress")

zstd_compress(
    name = "compress",
    src = "//fixture:hello-world.txt",
)

zstd_decompress(
    name = "decompress",
    src = ":compress",
)
```