### PR TITLE
Add rules_contest module

### DIFF
--- a/modules/rules_contest/0.9.0/MODULE.bazel
+++ b/modules/rules_contest/0.9.0/MODULE.bazel
@@ -1,0 +1,27 @@
+module(
+    name = "rules_contest",
+    version = "0.9.0",
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_python", version = "0.31.0")
+
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+http_file(
+    name = "buildifier_prebuilt_linux_amd64",
+    sha256 = "069a03fc1fa46135e3f71e075696e09389344710ccee798b2722c50a2d92d55a",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/4.0.1/buildifier-linux-amd64"],
+)
+
+http_file(
+    name = "buildifier_prebuilt_darwin_amd64",
+    sha256 = "f4d0ede5af04b32671b9a086ae061df8f621f48ea139b01b3715bfa068219e4a",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/4.0.1/buildifier-darwin-amd64"],
+)
+
+http_file(
+    name = "buildifier_prebuilt_windows_amd64",
+    sha256 = "cde962f8a76739a01f637a16f019253a1f22166f91ed78d38ad66d1d3ca13ea9",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/4.0.1/buildifier-windows-amd64.exe"],
+)

--- a/modules/rules_contest/0.9.0/presubmit.yml
+++ b/modules/rules_contest/0.9.0/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - "@rules_contest//..."

--- a/modules/rules_contest/0.9.0/source.json
+++ b/modules/rules_contest/0.9.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/nya3jp/rules_contest/releases/download/v0.9.0/rules_contest-0.9.0.tar.gz",
+    "integrity": "sha256-2uuI+pqWX+MdAd0JNGKLvt3oT9dSeePp1Z2MxrxVY4M=",
+    "strip_prefix": "rules_contest-0.9.0"
+}

--- a/modules/rules_contest/metadata.json
+++ b/modules/rules_contest/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/nya3jp/rules_contest",
+    "maintainers": [
+        {
+            "email": "takahashi.shuhei@gmail.com",
+            "github": "nya3jp",
+            "name": "Shuhei Takahashi"
+        }
+    ],
+    "repository": [
+        "github:nya3jp/rules_contest"
+    ],
+    "versions": [
+        "0.9.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
`rules_contest` is a collection of Bazel rules for maintaining programming contest problems. `rules_contest` helps you automate tasks to prepare programming contest problems, such as:

- Building and testing datasets
- Building and testing reference solutions
- Building problem statements
- Building a progress tracker

Repository: https://github.com/nya3jp/rules_contest
