### PR TITLE
feat: add `rules_bzip2@1.0.0-beta.1`

### DIFF
--- a/modules/rules_bzip2/1.0.0-beta.1/MODULE.bazel
+++ b/modules/rules_bzip2/1.0.0-beta.1/MODULE.bazel
@@ -1,0 +1,29 @@
+module(
+    name = "rules_bzip2",
+    version = "1.0.0-beta.1",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_coreutils", version = "1.0.0-beta.1")
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.9")
+bazel_dep(name = "ape", version = "1.0.0-beta.6")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+use_repo(export, "ape-bzip2")
+export.symlink(
+    name = "bzip2",
+    target = "@ape-bzip2",
+)
+use_repo(export, "bzip2")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+resolved(
+    name = "resolved-bzip2",
+    toolchain_type = "//bzip2/toolchain/bzip2:type",
+)
+
+register_toolchains("//bzip2/toolchain/...")

--- a/modules/rules_bzip2/1.0.0-beta.1/presubmit.yml
+++ b/modules/rules_bzip2/1.0.0-beta.1/presubmit.yml
@@ -1,0 +1,23 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2004_arm64
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_bzip2/1.0.0-beta.1/source.json
+++ b/modules/rules_bzip2/1.0.0-beta.1/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_bzip2/-/releases/v1.0.0-beta.1/downloads/src.tar.gz",
+  "integrity": "sha512-LxqJpKipVUyxOxyRq2peyrIv2v8aUiLiDMbhGqKzSjg+tzHMDapOo/mO6RRmh7N/7UvsxXKUlnPqSwzWNi82Gw==",
+  "strip_prefix": "rules_bzip2-v1.0.0-beta.1"
+}

--- a/modules/rules_bzip2/metadata.json
+++ b/modules/rules_bzip2/metadata.json
@@ -1,0 +1,16 @@
+{
+  "homepage": "https://gitlab.arm.com/bazel/rules_bzip2",
+  "repository": [
+    "https://gitlab.arm.com/bazel/rules_bzip2"
+  ],
+  "versions": [
+    "1.0.0-beta.1"
+  ],
+  "maintainers": [
+    {
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson",
+      "github": "mattyclarkson"
+    }
+  ]
+}


### PR DESCRIPTION
Hermetic ruleset (using `ape`) to compress/decompress Burrows-Wheeler files:

```
load("@rules_bzip2//bzip2/compress:defs.bzl", "bzip2_compress")
load("@rules_bzip2//bzip2/decompress:defs.bzl", "bzip2_decompress")

bzip2_compress(
    name = "compress",
    src = "//fixture:hello-world.txt",
)

bzip2_decompress(
    name = "decompress",
    src = ":compress",
)
```