### PR TITLE
bazel_ci_rules@1.0.0

### DIFF
--- a/modules/bazel_ci_rules/1.0.0/MODULE.bazel
+++ b/modules/bazel_ci_rules/1.0.0/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "bazel_ci_rules",
+    version = "1.0.0",
+)

--- a/modules/bazel_ci_rules/1.0.0/patches/module_dot_bazel.patch
+++ b/modules/bazel_ci_rules/1.0.0/patches/module_dot_bazel.patch
@@ -1,0 +1,7 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,4 @@
++module(
++    name = "bazel_ci_rules",
++    version = "1.0.0",
++)

--- a/modules/bazel_ci_rules/1.0.0/presubmit.yml
+++ b/modules/bazel_ci_rules/1.0.0/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@bazel_ci_rules//...'

--- a/modules/bazel_ci_rules/1.0.0/source.json
+++ b/modules/bazel_ci_rules/1.0.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
+    "integrity": "sha256-7KIYhOb2aojDWOWA/WemsUjTCrV7FoD2KpbAD5vGoH4=",
+    "strip_prefix": "bazelci_rules-1.0.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-7+y6zT4ZrnkI5+oTjCn7RU49mEm+Cofu+lvejkt83Ow="
+    }
+}

--- a/modules/bazel_ci_rules/metadata.json
+++ b/modules/bazel_ci_rules/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/bazelbuild/continuous-integration",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:bazelbuild/continuous-integration"
+    ],
+    "versions": [
+        "1.0.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/bazelbuild/continuous-integration/releases/tag/rules-1.0.0

Used by:
* https://github.com/bazelbuild/rules_rust