### PR TITLE
Add pybind11_protobuf

### DIFF
--- a/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/MODULE.bazel
+++ b/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/MODULE.bazel
@@ -1,0 +1,85 @@
+module(
+  name = "pybind11_protobuf",
+  version = "0.0.0-20240524-1d7a729",
+)
+
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.5.0",
+)
+
+bazel_dep(
+    name = "abseil-cpp",
+    version = "20230802.0.bcr.1",
+    repo_name = "com_google_absl",
+)
+
+bazel_dep(
+    name = "abseil-py",
+    version = "2.1.0",
+    repo_name = "com_google_absl_py",
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.8"
+)
+
+bazel_dep(
+    name = "pybind11_bazel",
+    version = "2.11.1.bzl.2",
+)
+
+bazel_dep(
+    name = "protobuf",
+    version = "23.1",
+    repo_name = "com_google_protobuf"
+)
+
+bazel_dep(
+  name = "grpc",
+  version = "1.56.3.bcr.1",
+  repo_name = "com_github_grpc_grpc",
+)
+
+bazel_dep(
+    name = "rules_python",
+    version = "0.31.0",
+)
+
+SUPPORTED_PYTHON_VERSIONS = [
+  "3.12",
+  "3.11",
+  "3.10",
+  "3.9",
+  "3.8"
+]
+
+DEFAULT_PYTHON = "3.11"
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+[
+  python.toolchain(
+    python_version = version,
+    is_default = version == DEFAULT_PYTHON,
+  )
+  for version in SUPPORTED_PYTHON_VERSIONS
+]
+
+use_repo(
+    python,
+    python = "python_versions",
+)
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+[
+  pip.parse(
+    hub_name = "pybind11_protobuf_py_deps",
+    python_version = version,
+    requirements_lock = "//pybind11_protobuf/requirements:requirements_lock_" + version.replace('.','_') + ".txt",
+  )
+  for version in SUPPORTED_PYTHON_VERSIONS
+
+]
+
+use_repo(pip, "pybind11_protobuf_py_deps")

--- a/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/patches/module-dot-bazel-dev-dependency.patch
+++ b/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/patches/module-dot-bazel-dev-dependency.patch
@@ -1,0 +1,13 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index f0b1190..c774abb 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -73,7 +73,5 @@ use_repo(
+ 
+-#### DEV ONLY DEPENDENCIES BELOW HERE ####
+-
+-pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency=True)
++pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+ [
+   pip.parse(
+     hub_name = "pypi",

--- a/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/patches/module-dot-bazel-pypi-hub-name.patch
+++ b/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/patches/module-dot-bazel-pypi-hub-name.patch
@@ -1,0 +1,32 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 7e8f183..9526e70 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -74,7 +74,7 @@ use_repo(
+ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+ [
+   pip.parse(
+-    hub_name = "pypi",
++    hub_name = "pybind11_protobuf_py_deps",
+     python_version = version,
+     requirements_lock = "//pybind11_protobuf/requirements:requirements_lock_" + version.replace('.','_') + ".txt",
+   )
+@@ -82,4 +82,4 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+ 
+ ]
+ 
+-use_repo(pip, "pypi")
++use_repo(pip, "pybind11_protobuf_py_deps")
+diff --git a/pybind11_protobuf/tests/BUILD b/pybind11_protobuf/tests/BUILD
+index 5166c82..ae20022 100644
+--- a/pybind11_protobuf/tests/BUILD
++++ b/pybind11_protobuf/tests/BUILD
+@@ -7,7 +7,7 @@ load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_proto_library")
+ load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
+ 
+ # [internal] load cc_proto_library.bzl
+-load("@pypi//:requirements.bzl", "requirement")
++load("@pybind11_protobuf_py_deps//:requirements.bzl", "requirement")
+ 
+ licenses(["notice"])
+ 

--- a/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/patches/module-dot-bazel-version.patch
+++ b/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/patches/module-dot-bazel-version.patch
@@ -1,0 +1,12 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index c774abb..829f00c 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+   name = "pybind11_protobuf",
+-  version = "head",
++  version = "0.0.0-20240524-1d7a729",
+ )
+ 
+ bazel_dep(

--- a/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/presubmit.yml
+++ b/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  bazel:
+  - 6.x
+  - 7.x
+tasks:
+  build:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    build_targets:
+    - '@pybind11_protobuf//...'

--- a/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/source.json
+++ b/modules/pybind11_protobuf/0.0.0-20240524-1d7a729/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/pybind/pybind11_protobuf/archive/1d7a7296604537db5f6ace2ddafd1d08c967ec63.tar.gz",
+    "integrity": "sha256-IRiavQmFKP05htzsNJ72GuVQbSnQxRx6E9b538wXxnY=",
+    "strip_prefix": "pybind11_protobuf-1d7a7296604537db5f6ace2ddafd1d08c967ec63",
+    "patch_strip": 1,
+    "patches": {
+        "module-dot-bazel-version.patch": "sha256-kKZgynxCHUB1jjbeOcxxyG4y8aZwNRff2qjMJIphXHo=",
+        "module-dot-bazel-dev-dependency.patch": "sha256-hkNfR1/Jym4B/fgVc+aIiOBtqzBHx6SLFWOfhtR/0+o=",
+        "module-dot-bazel-pypi-hub-name.patch": "sha256-52REsI8aEwfjEQTd8Ei22ndvw2a5FaJBIp+gJbPx3BM="
+    }
+}

--- a/modules/pybind11_protobuf/metadata.json
+++ b/modules/pybind11_protobuf/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/pybind/pybind11_protobuf",
+    "maintainers": [
+        {
+            "email": "jankuehle@google.com",
+            "github": "frigus02",
+            "name": "Jan Kühle"
+        }
+    ],
+    "repository": [
+        "github:pybind/pybind11_protobuf"
+    ],
+    "versions": [
+        "0.0.0-20240524-1d7a729"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This is using the same patches as in #2031.

As there is no release process, we are using a version string including the commit sha like it's done for `boringssl` as well.