### PR TITLE
feat: add `rules_gzip@1.0.0-beta.1`

### DIFF
--- a/modules/rules_gzip/1.0.0-beta.1/MODULE.bazel
+++ b/modules/rules_gzip/1.0.0-beta.1/MODULE.bazel
@@ -1,0 +1,29 @@
+module(
+    name = "rules_gzip",
+    version = "1.0.0-beta.1",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.9")
+bazel_dep(name = "rules_coreutils", version = "1.0.0-beta.1")
+bazel_dep(name = "ape", version = "1.0.0-beta.7")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+use_repo(export, "ape-pigz")
+export.symlink(
+    name = "pigz",
+    target = "@ape-pigz",
+)
+use_repo(export, "pigz")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+resolved(
+    name = "resolved-pigz",
+    toolchain_type = "//gzip/toolchain/pigz:type",
+)
+
+register_toolchains("//gzip/toolchain/...")

--- a/modules/rules_gzip/1.0.0-beta.1/presubmit.yml
+++ b/modules/rules_gzip/1.0.0-beta.1/presubmit.yml
@@ -1,0 +1,23 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2004_arm64
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_gzip/1.0.0-beta.1/source.json
+++ b/modules/rules_gzip/1.0.0-beta.1/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_gzip/-/releases/v1.0.0-beta.1/downloads/src.tar.gz",
+  "integrity": "sha512-d608JvMhu4oVc3oQp3bs1OE45IuPiSz8LTQ0oHXZ6+dy6TkDaK+AGo7r1u4UqnRrix7im4WD4EK4YmTq5Yb+xw==",
+  "strip_prefix": "rules_gzip-v1.0.0-beta.1"
+}

--- a/modules/rules_gzip/metadata.json
+++ b/modules/rules_gzip/metadata.json
@@ -1,0 +1,16 @@
+{
+  "homepage": "https://gitlab.arm.com/bazel/rules_gzip",
+  "repository": [
+    "https://gitlab.arm.com/bazel/rules_gzip"
+  ],
+  "versions": [
+    "1.0.0-beta.1"
+  ],
+  "maintainers": [
+    {
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson",
+      "github": "mattyclarkson"
+    }
+  ]
+}


### PR DESCRIPTION
Brings simple compression and decompression rules:

```py
load("@rules_gzip//gzip/compress:defs.bzl", "gzip_compress")
load("@rules_gzip//gzip/decompress:defs.bzl", "gzip_decompress")

gzip_compress(
    name = "compress",
    src = "//fixture:hello-world.txt",
)

gzip_decompress(
    name = "decompress",
    src = ":compress",
)
```