### PR TITLE
tinyformat: Fix homepage attribute

### DIFF
--- a/modules/tinyformat/metadata.json
+++ b/modules/tinyformat/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "//tools:update_integrity_test",
+    "homepage": "https://github.com/c42f/tinyformat",
     "maintainers": [
         {
             "email": "julian.amann@tum.de",


### PR DESCRIPTION
`homepage` attribute in metadata is incorrect - maybe a URL check in the CI could fetch such errors