### PR TITLE
Add nanobind-bazel v2.0.0

### DIFF
--- a/modules/nanobind_bazel/2.0.0/MODULE.bazel
+++ b/modules/nanobind_bazel/2.0.0/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "nanobind_bazel",
+    version = "2.0.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_python", version = "0.32.2")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
+
+# Creates a `http_archive` for nanobind and robin-map.
+internal_configure = use_extension("//:internal_configure.bzl", "internal_configure_extension")
+use_repo(internal_configure, "nanobind")

--- a/modules/nanobind_bazel/2.0.0/presubmit.yml
+++ b/modules/nanobind_bazel/2.0.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  bazel:
+    - 6.x
+    - 7.x
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    - windows
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@nanobind_bazel//...'

--- a/modules/nanobind_bazel/2.0.0/source.json
+++ b/modules/nanobind_bazel/2.0.0/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/nicholasjng/nanobind-bazel/releases/download/v2.0.0/nanobind-bazel-2.0.0.tar.gz",
+  "integrity": "sha256-6AVN2rDlPl8Ijs9eCO1NwnHdWXhXgiCFppfdmUj5zKs=",
+  "strip_prefix": "nanobind-bazel-2.0.0"
+}

--- a/modules/nanobind_bazel/metadata.json
+++ b/modules/nanobind_bazel/metadata.json
@@ -1,17 +1,13 @@
 {
-    "homepage": "https://github.com/nicholasjng/nanobind-bazel",
-    "maintainers": [
-        {
-            "email": "nicho.junge@gmail.com",
-            "github": "nicholasjng",
-            "name": "Nicholas Junge"
-        }
-    ],
-    "repository": [
-        "github:nicholasjng/nanobind-bazel"
-    ],
-    "versions": [
-        "1.0.0"
-    ],
-    "yanked_versions": {}
+  "homepage": "https://github.com/nicholasjng/nanobind-bazel",
+  "maintainers": [
+    {
+      "email": "nicho.junge@gmail.com",
+      "github": "nicholasjng",
+      "name": "Nicholas Junge"
+    }
+  ],
+  "repository": ["github:nicholasjng/nanobind-bazel"],
+  "versions": ["1.0.0", "2.0.0"],
+  "yanked_versions": {}
 }


### PR DESCRIPTION
Provides capabilities for building Python bindings with Bazel using nanobind v2.0.0, which was released recently.