### PR TITLE
Mark bcr_validation as py_bianary()

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -45,7 +45,7 @@ py_binary(
     ],
 )
 
-py_library(
+py_binary(
     name = "bcr_validation",
     srcs = ["bcr_validation.py"],
     deps = [


### PR DESCRIPTION
This allows execution via `bazel run`.

It is still possible to depend on it from other `py_binary()` like `:add_module`.