### PR TITLE
Add protobuf 27.0 with fixed java support

### DIFF
--- a/modules/protobuf/27.0.bcr.1/MODULE.bazel
+++ b/modules/protobuf/27.0.bcr.1/MODULE.bazel
@@ -1,0 +1,49 @@
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/protocolbuffers/protobuf/issues/14313
+module(
+    name = "protobuf",
+    version = "27.0.bcr.1",  # Automatically updated on release
+    compatibility_level = 1,
+    repo_name = "com_google_protobuf",
+)
+
+# LOWER BOUND dependency versions.
+# Bzlmod follows MVS:
+# https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
+# Thus the highest version in their module graph is resolved.
+bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "jsoncpp", version = "1.9.5")
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_java", version = "6.0.0")
+bazel_dep(name = "rules_jvm_external", version = "6.0")
+bazel_dep(name = "rules_pkg", version = "0.7.0")
+bazel_dep(name = "rules_python", version = "0.10.2")
+bazel_dep(name = "zlib", version = "1.2.11")
+
+# TODO: remove after toolchain types are moved to protobuf
+bazel_dep(name = "rules_proto", version = "4.0.0")
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.install(
+    artifacts = [
+        "biz.aQute.bnd:biz.aQute.bndlib:6.4.0",
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.code.gson:gson:2.8.9",
+        "com.google.errorprone:error_prone_annotations:2.18.0",
+        "com.google.guava:guava:32.0.1-jre",
+        "com.google.j2objc:j2objc-annotations:2.8",
+        "info.picocli:picocli:4.6.3",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://repo.maven.apache.org/maven2",
+    ],
+)
+use_repo(
+    maven,
+    "maven",
+)
+
+# -- bazel_dep definitions -- #

--- a/modules/protobuf/27.0.bcr.1/patches/module.patch
+++ b/modules/protobuf/27.0.bcr.1/patches/module.patch
@@ -1,0 +1,53 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 842953b43..2fc0304be 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -2,7 +2,7 @@
+ # https://github.com/protocolbuffers/protobuf/issues/14313
+ module(
+     name = "protobuf",
+-    version = "27.0", # Automatically updated on release
++    version = "27.0.bcr.1",  # Automatically updated on release
+     compatibility_level = 1,
+     repo_name = "com_google_protobuf",
+ )
+@@ -14,13 +14,36 @@ module(
+ bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
+ bazel_dep(name = "bazel_skylib", version = "1.4.1")
+ bazel_dep(name = "jsoncpp", version = "1.9.5")
++bazel_dep(name = "platforms", version = "0.0.8")
+ bazel_dep(name = "rules_cc", version = "0.0.9")
+-bazel_dep(name = "rules_java", version = "5.3.5")
+-bazel_dep(name = "rules_jvm_external", version = "5.1")
++bazel_dep(name = "rules_java", version = "6.0.0")
++bazel_dep(name = "rules_jvm_external", version = "6.0")
+ bazel_dep(name = "rules_pkg", version = "0.7.0")
+ bazel_dep(name = "rules_python", version = "0.10.2")
+-bazel_dep(name = "platforms", version = "0.0.8")
+ bazel_dep(name = "zlib", version = "1.2.11")
+ 
+ # TODO: remove after toolchain types are moved to protobuf
+ bazel_dep(name = "rules_proto", version = "4.0.0")
++
++maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
++maven.install(
++    artifacts = [
++        "biz.aQute.bnd:biz.aQute.bndlib:6.4.0",
++        "com.google.code.findbugs:jsr305:3.0.2",
++        "com.google.code.gson:gson:2.8.9",
++        "com.google.errorprone:error_prone_annotations:2.18.0",
++        "com.google.guava:guava:32.0.1-jre",
++        "com.google.j2objc:j2objc-annotations:2.8",
++        "info.picocli:picocli:4.6.3",
++    ],
++    repositories = [
++        "https://repo1.maven.org/maven2",
++        "https://repo.maven.apache.org/maven2",
++    ],
++)
++use_repo(
++    maven,
++    "maven",
++)
++
++# -- bazel_dep definitions -- #

--- a/modules/protobuf/27.0.bcr.1/presubmit.yml
+++ b/modules/protobuf/27.0.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform: ["debian11", "macos", "ubuntu2004"]
-  bazel: [6.x, 7.x]
+  bazel: [7.x]
 
 tasks:
   verify_targets:
@@ -43,7 +43,7 @@ bcr_test_module:
   module_path: "examples"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004"]
-    bazel: [6.x, 7.x]
+    bazel: [7.x]
   tasks:
     run_test_module:
       name: "Run test module"
@@ -60,7 +60,7 @@ bcr_test_module:
 bcr_test_module_windows:
   module_path: "examples"
   matrix:
-    bazel: [6.x, 7.x]
+    bazel: [7.x]
   tasks:
     run_test_module:
       name: "Run test module"

--- a/modules/protobuf/27.0.bcr.1/presubmit.yml
+++ b/modules/protobuf/27.0.bcr.1/presubmit.yml
@@ -1,0 +1,73 @@
+matrix:
+  platform: ["debian11", "macos", "ubuntu2004"]
+  bazel: [6.x, 7.x]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--host_cxxopt=-std=c++14'
+    - '--cxxopt=-std=c++14'
+    - '--host_copt=-Wno-deprecated-declarations'
+    - '--copt=-Wno-deprecated-declarations'
+    build_targets:
+    - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_java'
+    - '@protobuf//:protobuf_java_util'
+    - '@protobuf//:protobuf_javalite'
+    - '@protobuf//:protobuf_lite'
+    - '@protobuf//:protoc'
+    - '@protobuf//:test_messages_proto2_cc_proto'
+    - '@protobuf//:test_messages_proto3_cc_proto'
+
+  verify_targets_windows:
+    name: "Verify build targets"
+    platform: windows
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--host_cxxopt=-std=c++14'
+    - '--cxxopt=-std=c++14'
+    build_targets:
+    - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_java'
+    - '@protobuf//:protobuf_java_util'
+    - '@protobuf//:protobuf_javalite'
+    - '@protobuf//:protobuf_lite'
+    - '@protobuf//:protoc'
+    - '@protobuf//:test_messages_proto2_cc_proto'
+    - '@protobuf//:test_messages_proto3_cc_proto'
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2004"]
+    bazel: [6.x, 7.x]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+      - '--host_cxxopt=-std=c++14'
+      - '--cxxopt=-std=c++14'
+      - '--host_copt=-Wno-deprecated-declarations'
+      - '--copt=-Wno-deprecated-declarations'
+      build_targets:
+      - "//..."
+
+bcr_test_module_windows:
+  module_path: "examples"
+  matrix:
+    bazel: [6.x, 7.x]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: windows
+      bazel: ${{ bazel }}
+      build_flags:
+      - '--host_cxxopt=-std=c++14'
+      - '--cxxopt=-std=c++14'
+      build_targets:
+      - "//..."

--- a/modules/protobuf/27.0.bcr.1/source.json
+++ b/modules/protobuf/27.0.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-PhFI2wkP8hImwYiO85+nvHeQBCviH/Qon9Ic4XNfNFU=",
+    "strip_prefix": "protobuf-27.0",
+    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.zip",
+    "patch_strip": 1,
+    "patches": {
+        "module.patch": "sha256-KLaf9+2uckxc7OHW6J+kmj0NZlTaK8C6hNlMbxdgc6U="
+    }
+}

--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -30,7 +30,8 @@
         "26.0",
         "26.0.bcr.1",
         "27.0-rc2",
-        "27.0"
+        "27.0",
+        "27.0.bcr.1"
     ],
     "yanked_versions": {
         "3.19.0": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)",


### PR DESCRIPTION
This is the same as 27.0 but with
https://github.com/protocolbuffers/protobuf/pull/16884 to make java
targets work for grpc-java and others.
