### PR TITLE
Improve opentelemetry-cpp

### DIFF
--- a/modules/opentelemetry-cpp/1.14.2.bcr.1/MODULE.bazel
+++ b/modules/opentelemetry-cpp/1.14.2.bcr.1/MODULE.bazel
@@ -1,0 +1,21 @@
+module(
+    name = "opentelemetry-cpp",
+    version = "1.14.2.bcr.1",
+    compatibility_level = 0,
+    repo_name = "io_opentelemetry_cpp",
+)
+
+bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "curl", version = "8.4.0")
+bazel_dep(name = "grpc", version = "1.56.3.bcr.1", repo_name = "com_github_grpc_grpc")
+bazel_dep(name = "nlohmann_json", version = "3.11.3", repo_name = "github_nlohmann_json")
+bazel_dep(name = "opentelemetry-proto", version = "1.1.0", repo_name = "com_github_opentelemetry_proto")
+bazel_dep(name = "opentracing-cpp", version = "1.6.0", repo_name = "com_github_opentracing")
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "prometheus-cpp", version = "1.2.4", repo_name = "com_github_jupp0r_prometheus_cpp")
+bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
+
+bazel_dep(name = "google_benchmark", version = "1.8.3", dev_dependency = True, repo_name = "com_github_google_benchmark")
+bazel_dep(name = "googletest", version = "1.14.0.bcr.1", dev_dependency = True, repo_name = "com_google_googletest")

--- a/modules/opentelemetry-cpp/1.14.2.bcr.1/patches/0001-Add-MODULE.bazel.patch
+++ b/modules/opentelemetry-cpp/1.14.2.bcr.1/patches/0001-Add-MODULE.bazel.patch
@@ -1,0 +1,24 @@
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,21 @@
++module(
++    name = "opentelemetry-cpp",
++    version = "1.14.2.bcr.1",
++    compatibility_level = 0,
++    repo_name = "io_opentelemetry_cpp",
++)
++
++bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
++bazel_dep(name = "bazel_skylib", version = "1.5.0")
++bazel_dep(name = "curl", version = "8.4.0")
++bazel_dep(name = "grpc", version = "1.56.3.bcr.1", repo_name = "com_github_grpc_grpc")
++bazel_dep(name = "nlohmann_json", version = "3.11.3", repo_name = "github_nlohmann_json")
++bazel_dep(name = "opentelemetry-proto", version = "1.1.0", repo_name = "com_github_opentelemetry_proto")
++bazel_dep(name = "opentracing-cpp", version = "1.6.0", repo_name = "com_github_opentracing")
++bazel_dep(name = "platforms", version = "0.0.8")
++bazel_dep(name = "prometheus-cpp", version = "1.2.4", repo_name = "com_github_jupp0r_prometheus_cpp")
++bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
++bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
++
++bazel_dep(name = "google_benchmark", version = "1.8.3", dev_dependency = True, repo_name = "com_github_google_benchmark")
++bazel_dep(name = "googletest", version = "1.14.0.bcr.1", dev_dependency = True, repo_name = "com_google_googletest")

--- a/modules/opentelemetry-cpp/1.14.2.bcr.1/presubmit.yml
+++ b/modules/opentelemetry-cpp/1.14.2.bcr.1/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  bazel: ["6.x", "7.x"]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++14'
+    - '--host_cxxopt=-std=c++14'
+    - '--@opentelemetry-cpp//api:with_abseil=true'
+    build_targets:
+    - '@opentelemetry-cpp//api'

--- a/modules/opentelemetry-cpp/1.14.2.bcr.1/source.json
+++ b/modules/opentelemetry-cpp/1.14.2.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-x+eAHJ9iKHUc253Uck0PBHd+1T9STIgo5zv0yfiU4L0=",
+    "strip_prefix": "opentelemetry-cpp-1.14.2",
+    "url": "https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.14.2.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "0001-Add-MODULE.bazel.patch": "sha256-URD4W7cT7CkyghBZOt+SM70775L0u+WUCTkvySXS5Ho="
+    }
+}

--- a/modules/opentelemetry-cpp/metadata.json
+++ b/modules/opentelemetry-cpp/metadata.json
@@ -1,17 +1,18 @@
 {
-  "homepage": "https://github.com/open-telemetry/opentelemetry-cpp",
-  "maintainers": [
+    "homepage": "https://github.com/open-telemetry/opentelemetry-cpp",
+    "maintainers": [
         {
             "email": "keithbsmiley@gmail.com",
             "github": "keith",
             "name": "Keith Smiley"
         }
-  ],
-  "repository": [
-    "github:open-telemetry/opentelemetry-cpp"
-  ],
-  "versions": [
-    "1.14.2"
-  ],
-  "yanked_versions": {}
+    ],
+    "repository": [
+        "github:open-telemetry/opentelemetry-cpp"
+    ],
+    "versions": [
+        "1.14.2",
+        "1.14.2.bcr.1"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
- Remove `single_version_override()` which has no effect for foreign modules
- Remove transitive dependencies `upb` and `zlib`