### PR TITLE
Update to new versor version - old version unusable (yanked)

### DIFF
--- a/modules/versor/0.1.0/MODULE.bazel
+++ b/modules/versor/0.1.0/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "versor",
+    version = "0.1.0",
+)
+
+bazel_dep(name = "rules_license", version = "0.0.8")

--- a/modules/versor/0.1.0/patches/add_build_file.patch
+++ b/modules/versor/0.1.0/patches/add_build_file.patch
@@ -1,0 +1,43 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 0000000..23d04a9
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,37 @@
++load("@rules_license//rules:license.bzl", "license")
++
++package(
++    default_applicable_licenses = [":license"],
++    default_visibility = ["//visibility:public"],
++)
++
++license(
++    name = "license",
++    package_name = "versor",
++    license_kinds = [
++      "@rules_license//licenses/spdx:BSD-2-Clause-FreeBSD",
++    ],
++    license_text = "copyrights/COPYRIGHT",
++)
++
++exports_files(["copyrights/COPYRIGHT"])
++
++cc_library(
++    name = "vsr",
++    srcs = glob(["src/space/*.cpp"]),
++    hdrs = glob([
++        "include/vsr/**/*.h",
++    ]),
++    copts = [
++        "-Wno-reorder",
++        "-Wno-unused-variable",
++    ],
++    features = [
++        "-parse_headers",
++    ],
++    includes = [
++        "include",
++        "include/vsr",
++        "include/vsr/detail",
++    ],
++)

--- a/modules/versor/0.1.0/patches/module_dot_bazel.patch
+++ b/modules/versor/0.1.0/patches/module_dot_bazel.patch
@@ -1,0 +1,9 @@
+--- a/MODULE.bazel
++++ a/MODULE.bazel
+@@ -0,0 +1,6 @@
++module(
++    name = "versor",
++    version = "0.1.0",
++)
++
++bazel_dep(name = "rules_license", version = "0.0.8")

--- a/modules/versor/0.1.0/presubmit.yml
+++ b/modules/versor/0.1.0/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@versor//:*'

--- a/modules/versor/0.1.0/presubmit.yml
+++ b/modules/versor/0.1.0/presubmit.yml
@@ -4,7 +4,6 @@ matrix:
   - ubuntu2004
   - macos
   - macos_arm64
-  - windows
   bazel:
   - 7.x
   - 6.x

--- a/modules/versor/0.1.0/source.json
+++ b/modules/versor/0.1.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/wolftype/versor/archive/refs/tags/v0.1.0.tar.gz",
+    "integrity": "sha256-0JPnJb4SI5P71Xf7RB6bdYbDEyVoEf2JidbQXuQ0fKM=",
+    "strip_prefix": "versor-0.1.0",
+    "patches": {
+        "add_build_file.patch": "sha256-RTeGfsp+eeKX6SmRIKW1RUrKVaXXewjs7uI6O3WSYmE=",
+        "module_dot_bazel.patch": "sha256-n0AZG9H+xYdTJpdrN/xef5CUt1PhEdQdpqlgUiCwUUA="
+    },
+    "patch_strip": 1
+}

--- a/modules/versor/metadata.json
+++ b/modules/versor/metadata.json
@@ -11,7 +11,10 @@
         "github:wolftype/versor"
     ],
     "versions": [
-        "0.0.1"
+        "0.0.1",
+        "0.1.0"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "0.0.1": "wrong include paths, unusable library, upgrade to 0.1.0"
+    }
 }


### PR DESCRIPTION
The BUILD file of the old version assumed different file paths like `include`, `include/vsr` and `include/vsr/detail`. They are not present in the old version.

This PR updates to a new version of versor and yanks the old. There are no dependents yet. So, this should be safe.