### PR TITLE
feat: add `rules_curl@1.0.0-alpha.8`

### DIFF
--- a/modules/rules_curl/1.0.0-alpha.8/MODULE.bazel
+++ b/modules/rules_curl/1.0.0-alpha.8/MODULE.bazel
@@ -1,0 +1,28 @@
+module(
+    name = "rules_curl",
+    version = "1.0.0-alpha.8",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.9")
+bazel_dep(name = "ape", version = "1.0.0-beta.6")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+use_repo(export, "ape-curl")
+export.symlink(
+    name = "curl",
+    target = "@ape-curl",
+)
+use_repo(export, "curl")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+resolved(
+    name = "resolved-curl",
+    toolchain_type = "//curl/toolchain/curl:type",
+)
+
+register_toolchains("//curl/toolchain/...")

--- a/modules/rules_curl/1.0.0-alpha.8/presubmit.yml
+++ b/modules/rules_curl/1.0.0-alpha.8/presubmit.yml
@@ -1,0 +1,24 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2004_arm64
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      # TODO: enable this once `curl_upload_file` has a Batch script to work on Windows
+      # - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_curl/1.0.0-alpha.8/source.json
+++ b/modules/rules_curl/1.0.0-alpha.8/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_curl/-/releases/v1.0.0-alpha.8/downloads/src.tar.gz",
+  "integrity": "sha512-YE9OKkT2Y5UPlchNy0+nQiHbq10XFLqBfwOBynVWGuOZyvr4WA95OvhvVYT2RRHRUVdXOVvGKQVHgAwgMvE2GA==",
+  "strip_prefix": "rules_curl-v1.0.0-alpha.8"
+}

--- a/modules/rules_curl/metadata.json
+++ b/modules/rules_curl/metadata.json
@@ -5,7 +5,8 @@
   ],
   "versions": [
     "1.0.0-alpha.6",
-    "1.0.0-alpha.7"
+    "1.0.0-alpha.7",
+    "1.0.0-alpha.8"
   ],
   "maintainers": [
     {


### PR DESCRIPTION
Fixes runfile propagation to correct remote execution support.