### PR TITLE
grpc-java@1.64.0

### DIFF
--- a/modules/grpc-java/1.64.0/MODULE.bazel
+++ b/modules/grpc-java/1.64.0/MODULE.bazel
@@ -1,0 +1,206 @@
+module(
+    name = "grpc-java",
+    compatibility_level = 0,
+    repo_name = "io_grpc_grpc_java",
+    version = "1.64.0",
+)
+
+# GRPC_DEPS_START
+IO_GRPC_GRPC_JAVA_ARTIFACTS = [
+    "com.google.android:annotations:4.1.1.4",
+    "com.google.api.grpc:proto-google-common-protos:2.29.0",
+    "com.google.auth:google-auth-library-credentials:1.22.0",
+    "com.google.auth:google-auth-library-oauth2-http:1.22.0",
+    "com.google.auto.value:auto-value-annotations:1.10.4",
+    "com.google.auto.value:auto-value:1.10.4",
+    "com.google.code.findbugs:jsr305:3.0.2",
+    "com.google.code.gson:gson:2.10.1",
+    "com.google.errorprone:error_prone_annotations:2.23.0",
+    "com.google.guava:failureaccess:1.0.1",
+    "com.google.guava:guava:32.1.3-android",
+    "com.google.re2j:re2j:1.7",
+    "com.google.truth:truth:1.1.5",
+    "com.squareup.okhttp:okhttp:2.7.5",
+    "com.squareup.okio:okio:2.10.0",  # 3.0+ needs swapping to -jvm; need work to avoid flag-day
+    "io.netty:netty-buffer:4.1.100.Final",
+    "io.netty:netty-codec-http2:4.1.100.Final",
+    "io.netty:netty-codec-http:4.1.100.Final",
+    "io.netty:netty-codec-socks:4.1.100.Final",
+    "io.netty:netty-codec:4.1.100.Final",
+    "io.netty:netty-common:4.1.100.Final",
+    "io.netty:netty-handler-proxy:4.1.100.Final",
+    "io.netty:netty-handler:4.1.100.Final",
+    "io.netty:netty-resolver:4.1.100.Final",
+    "io.netty:netty-tcnative-boringssl-static:2.0.61.Final",
+    "io.netty:netty-tcnative-classes:2.0.61.Final",
+    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.100.Final",
+    "io.netty:netty-transport-native-unix-common:4.1.100.Final",
+    "io.netty:netty-transport:4.1.100.Final",
+    "io.opencensus:opencensus-api:0.31.0",
+    "io.opencensus:opencensus-contrib-grpc-metrics:0.31.0",
+    "io.perfmark:perfmark-api:0.26.0",
+    "junit:junit:4.13.2",
+    "org.apache.tomcat:annotations-api:6.0.53",
+    "org.codehaus.mojo:animal-sniffer-annotations:1.23",
+]
+# GRPC_DEPS_END
+
+bazel_dep(name = "googleapis", repo_name = "com_google_googleapis", version = "0.0.0-20240326-1c8d509c5")
+bazel_dep(name = "grpc", repo_name = "com_github_grpc_grpc", version = "1.56.3.bcr.1")
+bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "23.1")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_java", version = "5.3.5")
+bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.46.0")
+bazel_dep(name = "rules_jvm_external", version = "6.0")
+bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
+
+non_module_deps = use_extension("//:repositories.bzl", "grpc_java_repositories_extension")
+
+use_repo(
+    non_module_deps,
+    "com_github_cncf_xds",
+    "envoy_api",
+    "io_grpc_grpc_proto",
+)
+
+grpc_repo_deps_ext = use_extension("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")
+
+use_repo(
+    grpc_repo_deps_ext,
+    "com_envoyproxy_protoc_gen_validate",
+    "com_github_cncf_udpa",
+    "opencensus_proto",
+)
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+
+maven.install(
+    artifacts = IO_GRPC_GRPC_JAVA_ARTIFACTS,
+    repositories = [
+        "https://repo.maven.apache.org/maven2/",
+    ],
+    strict_visibility = True,
+)
+
+use_repo(maven, "maven")
+
+maven.override(
+    coordinates = "com.google.protobuf:protobuf-java",
+    target = "@com_google_protobuf//:protobuf_java",
+)
+
+maven.override(
+    coordinates = "com.google.protobuf:protobuf-java-util",
+    target = "@com_google_protobuf//:protobuf_java_util",
+)
+
+maven.override(
+    coordinates = "com.google.protobuf:protobuf-javalite",
+    target = "@com_google_protobuf//:protobuf_javalite",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-alts",
+    target = "@io_grpc_grpc_java//alts",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-api",
+    target = "@io_grpc_grpc_java//api",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-auth",
+    target = "@io_grpc_grpc_java//auth",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-census",
+    target = "@io_grpc_grpc_java//census",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-context",
+    target = "@io_grpc_grpc_java//context",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-core",
+    target = "@io_grpc_grpc_java//core:core_maven",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-googleapis",
+    target = "@io_grpc_grpc_java//googleapis",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-grpclb",
+    target = "@io_grpc_grpc_java//grpclb",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-inprocess",
+    target = "@io_grpc_grpc_java//inprocess",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-netty",
+    target = "@io_grpc_grpc_java//netty",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-netty-shaded",
+    target = "@io_grpc_grpc_java//netty:shaded_maven",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-okhttp",
+    target = "@io_grpc_grpc_java//okhttp",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-protobuf",
+    target = "@io_grpc_grpc_java//protobuf",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-protobuf-lite",
+    target = "@io_grpc_grpc_java//protobuf-lite",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-rls",
+    target = "@io_grpc_grpc_java//rls",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-services",
+    target = "@io_grpc_grpc_java//services:services_maven",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-stub",
+    target = "@io_grpc_grpc_java//stub",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-testing",
+    target = "@io_grpc_grpc_java//testing",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-xds",
+    target = "@io_grpc_grpc_java//xds:xds_maven",
+)
+
+maven.override(
+    coordinates = "io.grpc:grpc-util",
+    target = "@io_grpc_grpc_java//util",
+)
+
+switched_rules = use_extension("@com_google_googleapis//:extensions.bzl", "switched_rules")
+
+switched_rules.use_languages(java = True)
+
+use_repo(switched_rules, "com_google_googleapis_imports")

--- a/modules/grpc-java/1.64.0/patches/module_dot_bazel_version.patch
+++ b/modules/grpc-java/1.64.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+diff --git MODULE.bazel MODULE.bazel
+index 1d79e362e..b116abed0 100644
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -2,7 +2,7 @@ module(
+     name = "grpc-java",
+     compatibility_level = 0,
+     repo_name = "io_grpc_grpc_java",
+-    version = "0",
++    version = "1.64.0",
+ )
+ 
+ # GRPC_DEPS_START

--- a/modules/grpc-java/1.64.0/presubmit.yml
+++ b/modules/grpc-java/1.64.0/presubmit.yml
@@ -1,0 +1,9 @@
+matrix:
+  platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  bazel: ["7.x"]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@grpc-java//:java_grpc_library__external_repo_test'

--- a/modules/grpc-java/1.64.0/source.json
+++ b/modules/grpc-java/1.64.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-hiaqXiASPlVBCDb6k5u3k4RZTv3UW5eeiDZC2szK36E=",
+    "strip_prefix": "grpc-java-1.64.0",
+    "url": "https://github.com/grpc/grpc-java/archive/refs/tags/v1.64.0.tar.gz",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-DwMImFR9xKzB52qlWeQ3+2zrh6aOkM6l8HFyZGTQbIA="
+    }
+}

--- a/modules/grpc-java/metadata.json
+++ b/modules/grpc-java/metadata.json
@@ -10,7 +10,8 @@
     "github:grpc/grpc-java"
   ],
   "versions": [
-    "1.62.2"
+    "1.62.2",
+    "1.64.0"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
Add grpc-java@1.64.0

Less patching is necessary than v1.62.2 since Bzlmod support was integrated upstream (https://github.com/grpc/grpc-java/pull/11046).