### PR TITLE
Restore minimal Python support in Protobuf v25+

### DIFF
--- a/modules/protobuf/26.0.bcr.2/MODULE.bazel
+++ b/modules/protobuf/26.0.bcr.2/MODULE.bazel
@@ -1,0 +1,51 @@
+module(
+    name = "protobuf",
+    version = "26.0.bcr.2",
+    compatibility_level = 1,
+    repo_name = "com_google_protobuf",
+)
+
+# LOWER BOUND dependency versions.
+# Bzlmod follows MVS:
+# https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
+# Thus the highest version in their module graph is resolved.
+bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "jsoncpp", version = "1.9.5")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_java", version = "4.0.0")
+bazel_dep(name = "rules_jvm_external", version = "5.1")
+bazel_dep(name = "rules_pkg", version = "0.7.0")
+bazel_dep(name = "rules_python", version = "0.28.0")
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "zlib", version = "1.2.11")
+
+# TODO: remove after toolchain types are moved to protobuf
+bazel_dep(name = "rules_proto", version = "4.0.0")
+
+SUPPORTED_PYTHON_VERSIONS = [
+    "3.8",
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+]
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+[
+    python.toolchain(
+        is_default = python_version == SUPPORTED_PYTHON_VERSIONS[-1],
+        python_version = python_version,
+    )
+    for python_version in SUPPORTED_PYTHON_VERSIONS
+]
+use_repo(python, system_python = "python_{}".format(SUPPORTED_PYTHON_VERSIONS[-1].replace(".", "_")))
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+[
+    pip.parse(
+        hub_name = "pip_deps",
+        python_version = python_version,
+        requirements_lock = "//python:requirements.txt",
+    )
+    for python_version in SUPPORTED_PYTHON_VERSIONS
+]
+use_repo(pip, "pip_deps")

--- a/modules/protobuf/26.0.bcr.2/patches/0003-Update-rules_python-to-0.28.0.patch
+++ b/modules/protobuf/26.0.bcr.2/patches/0003-Update-rules_python-to-0.28.0.patch
@@ -1,0 +1,64 @@
+From 854ccc71064ffc979abd3a1d2a35e2ffb7f9d3fb Mon Sep 17 00:00:00 2001
+From: Protobuf Team Bot <protobuf-github-bot@google.com>
+Date: Wed, 5 Jun 2024 13:36:57 -0700
+Subject: [PATCH 3/4] Update rules_python to 0.28.0
+
+Closes #15849
+
+PiperOrigin-RevId: 640633756
+---
+ MODULE.bazel            |  2 +-
+ bazel/system_python.bzl | 12 ++++--------
+ 4 files changed, 9 insertions(+), 13 deletions(-)
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+index b50917142..c69ea951b 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -15,7 +15,7 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
+ bazel_dep(name = "rules_java", version = "4.0.0")
+ bazel_dep(name = "rules_jvm_external", version = "5.1")
+ bazel_dep(name = "rules_pkg", version = "0.7.0")
+-bazel_dep(name = "rules_python", version = "0.10.2")
++bazel_dep(name = "rules_python", version = "0.28.0")
+ bazel_dep(name = "platforms", version = "0.0.8")
+ bazel_dep(name = "zlib", version = "1.2.11")
+ 
+diff --git a/bazel/system_python.bzl b/bazel/system_python.bzl
+index 29400be22..db5b30e0b 100644
+--- a/bazel/system_python.bzl
++++ b/bazel/system_python.bzl
+@@ -36,7 +36,7 @@ pip_parse = pip_install
+ 
+ # Alias rules_python's pip.bzl for cases where a system python is found.
+ _alias_pip = """
+-load("@rules_python//python:pip.bzl", _pip_install = "pip_install", _pip_parse = "pip_parse")
++load("@rules_python//python:pip.bzl", _pip_parse = "pip_parse")
+ 
+ def _get_requirements(requirements, requirements_overrides):
+     for version, override in requirements_overrides.items():
+@@ -45,18 +45,14 @@ def _get_requirements(requirements, requirements_overrides):
+             break
+     return requirements
+ 
+-def pip_install(requirements, requirements_overrides={{}}, **kwargs):
+-    _pip_install(
+-        python_interpreter_target = "@{repo}//:interpreter",
+-        requirements = _get_requirements(requirements, requirements_overrides),
+-        **kwargs,
+-    )
+ def pip_parse(requirements, requirements_overrides={{}}, **kwargs):
+     _pip_parse(
+         python_interpreter_target = "@{repo}//:interpreter",
+-        requirements = _get_requirements(requirements, requirements_overrides),
++        requirements_lock = _get_requirements(requirements, requirements_overrides),
+         **kwargs,
+     )
++
++pip_install = pip_parse
+ """
+ 
+ _mock_fuzzing_py = """
+-- 
+2.45.2.505.gda0bf45e8d-goog
+

--- a/modules/protobuf/26.0.bcr.2/patches/0004-Add-minimal-Python-support-to-MODULE.bazel.patch
+++ b/modules/protobuf/26.0.bcr.2/patches/0004-Add-minimal-Python-support-to-MODULE.bazel.patch
@@ -1,0 +1,48 @@
+From 93e5b71e81b76f05b10dfefca2a494057d383eae Mon Sep 17 00:00:00 2001
+From: Protobuf Team Bot <protobuf-github-bot@google.com>
+Date: Wed, 12 Jun 2024 22:55:27 -0700
+Subject: [PATCH 4/4] Add minimal Python support to MODULE.bazel
+
+PiperOrigin-RevId: 642857334
+---
+ MODULE.bazel | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+index c69ea951b..ae31876bb 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -21,3 +21,30 @@ bazel_dep(name = "zlib", version = "1.2.11")
+ 
+ # TODO: remove after toolchain types are moved to protobuf
+ bazel_dep(name = "rules_proto", version = "4.0.0")
++
++SUPPORTED_PYTHON_VERSIONS = [
++    "3.8",
++    "3.9",
++    "3.10",
++    "3.11",
++    "3.12",
++]
++python = use_extension("@rules_python//python/extensions:python.bzl", "python")
++[
++    python.toolchain(
++        is_default = python_version == SUPPORTED_PYTHON_VERSIONS[-1],
++        python_version = python_version,
++    )
++    for python_version in SUPPORTED_PYTHON_VERSIONS
++]
++use_repo(python, system_python = "python_{}".format(SUPPORTED_PYTHON_VERSIONS[-1].replace(".", "_")))
++pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
++[
++    pip.parse(
++        hub_name = "pip_deps",
++        python_version = python_version,
++        requirements_lock = "//python:requirements.txt",
++    )
++    for python_version in SUPPORTED_PYTHON_VERSIONS
++]
++use_repo(pip, "pip_deps")
+-- 
+2.45.2.505.gda0bf45e8d-goog
+

--- a/modules/protobuf/26.0.bcr.2/patches/0005-Update-MODULE.bazel.patch
+++ b/modules/protobuf/26.0.bcr.2/patches/0005-Update-MODULE.bazel.patch
@@ -1,0 +1,12 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 2d43e46df..b50917142 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "protobuf",
+-    version = "26.0.bcr.1",
++    version = "26.0.bcr.2",
+     compatibility_level = 1,
+     repo_name = "com_google_protobuf",
+ )

--- a/modules/protobuf/26.0.bcr.2/presubmit.yml
+++ b/modules/protobuf/26.0.bcr.2/presubmit.yml
@@ -1,0 +1,40 @@
+matrix:
+  platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  bazel:
+  - 7.x
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--host_cxxopt=-std=c++14'
+    - '--cxxopt=-std=c++14'
+    build_targets:
+    - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_lite'
+    - '@protobuf//:protobuf_python'
+    - '@protobuf//:protoc'
+    - '@protobuf//:test_messages_proto2_cc_proto'
+    - '@protobuf//:test_messages_proto3_cc_proto'
+    - '@protobuf//upb_generator:all'
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel:
+    - 7.x
+    - 6.x
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+      - '--host_cxxopt=-std=c++14'
+      - '--cxxopt=-std=c++14'
+      - '--nocheck_visibility'
+      build_targets:
+      - "//..."

--- a/modules/protobuf/26.0.bcr.2/source.json
+++ b/modules/protobuf/26.0.bcr.2/source.json
@@ -1,0 +1,13 @@
+{
+    "integrity": "sha256-4yEAqAE4cNJP/Dfa1ngaYeXQyZUBvLBNOcNAocRKjmM=",
+    "patch_strip": 1,
+    "patches": {
+        "../../26.0.bcr.1/patches/0001-Add-MODULE.bazel.patch": "sha256-rv+t+/L4C2BgRFhLYncji4yGODTLvcMjZIrSM1RcA54=",
+        "../../26.0.bcr.1/patches/0002-relative-labels.patch": "sha256-NvicAuuDJLFNLEi9pvGj7PPj/GbpYYYoVdihRosZgSA=",
+        "0003-Update-rules_python-to-0.28.0.patch": "sha256-7x6pIpHxIqNPNM/TYlmlCvTj23U/pwKyRCt0PHNu75o=",
+        "0004-Add-minimal-Python-support-to-MODULE.bazel.patch": "sha256-1z4oM41SvBGzX4UpRuoRR4n4FKb+UhIUHZGfw5X6lYw=",
+        "0005-Update-MODULE.bazel.patch": "sha256-tu+6kxVEXf8mZ0+ljWBNHGIuQfdDy3ZhEbyrwu5iZ4c="
+    },
+    "strip_prefix": "protobuf-26.0",
+    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v26.0/protobuf-26.0.tar.gz"
+}

--- a/modules/protobuf/27.0.bcr.1/MODULE.bazel
+++ b/modules/protobuf/27.0.bcr.1/MODULE.bazel
@@ -1,0 +1,51 @@
+module(
+    name = "protobuf",
+    version = "27.0.bcr.1",
+    compatibility_level = 1,
+    repo_name = "com_google_protobuf",
+)
+
+# LOWER BOUND dependency versions.
+# Bzlmod follows MVS:
+# https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
+# Thus the highest version in their module graph is resolved.
+bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "jsoncpp", version = "1.9.5")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_java", version = "5.3.5")
+bazel_dep(name = "rules_jvm_external", version = "5.1")
+bazel_dep(name = "rules_pkg", version = "0.7.0")
+bazel_dep(name = "rules_python", version = "0.28.0")
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "zlib", version = "1.2.11")
+
+# TODO: remove after toolchain types are moved to protobuf
+bazel_dep(name = "rules_proto", version = "4.0.0")
+
+SUPPORTED_PYTHON_VERSIONS = [
+    "3.8",
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+]
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+[
+    python.toolchain(
+        is_default = python_version == SUPPORTED_PYTHON_VERSIONS[-1],
+        python_version = python_version,
+    )
+    for python_version in SUPPORTED_PYTHON_VERSIONS
+]
+use_repo(python, system_python = "python_{}".format(SUPPORTED_PYTHON_VERSIONS[-1].replace(".", "_")))
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+[
+    pip.parse(
+        hub_name = "pip_deps",
+        python_version = python_version,
+        requirements_lock = "//python:requirements.txt",
+    )
+    for python_version in SUPPORTED_PYTHON_VERSIONS
+]
+use_repo(pip, "pip_deps")

--- a/modules/protobuf/27.0.bcr.1/patches/0001-Update-rules_python-to-0.28.0.patch
+++ b/modules/protobuf/27.0.bcr.1/patches/0001-Update-rules_python-to-0.28.0.patch
@@ -1,0 +1,64 @@
+From ba6e8aa8430277380aaf67a5c25d07911c5c322f Mon Sep 17 00:00:00 2001
+From: Protobuf Team Bot <protobuf-github-bot@google.com>
+Date: Wed, 5 Jun 2024 13:36:57 -0700
+Subject: [PATCH 1/2] Update rules_python to 0.28.0
+
+Closes #15849
+
+PiperOrigin-RevId: 640633756
+---
+ MODULE.bazel                  |  2 +-
+ python/dist/system_python.bzl | 12 ++++--------
+ 4 files changed, 10 insertions(+), 14 deletions(-)
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 842953b43..71d29efcb 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -18,7 +18,7 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
+ bazel_dep(name = "rules_java", version = "5.3.5")
+ bazel_dep(name = "rules_jvm_external", version = "5.1")
+ bazel_dep(name = "rules_pkg", version = "0.7.0")
+-bazel_dep(name = "rules_python", version = "0.10.2")
++bazel_dep(name = "rules_python", version = "0.28.0")
+ bazel_dep(name = "platforms", version = "0.0.8")
+ bazel_dep(name = "zlib", version = "1.2.11")
+ 
+diff --git a/python/dist/system_python.bzl b/python/dist/system_python.bzl
+index 29400be22..db5b30e0b 100644
+--- a/python/dist/system_python.bzl
++++ b/python/dist/system_python.bzl
+@@ -36,7 +36,7 @@ pip_parse = pip_install
+ 
+ # Alias rules_python's pip.bzl for cases where a system python is found.
+ _alias_pip = """
+-load("@rules_python//python:pip.bzl", _pip_install = "pip_install", _pip_parse = "pip_parse")
++load("@rules_python//python:pip.bzl", _pip_parse = "pip_parse")
+ 
+ def _get_requirements(requirements, requirements_overrides):
+     for version, override in requirements_overrides.items():
+@@ -45,18 +45,14 @@ def _get_requirements(requirements, requirements_overrides):
+             break
+     return requirements
+ 
+-def pip_install(requirements, requirements_overrides={{}}, **kwargs):
+-    _pip_install(
+-        python_interpreter_target = "@{repo}//:interpreter",
+-        requirements = _get_requirements(requirements, requirements_overrides),
+-        **kwargs,
+-    )
+ def pip_parse(requirements, requirements_overrides={{}}, **kwargs):
+     _pip_parse(
+         python_interpreter_target = "@{repo}//:interpreter",
+-        requirements = _get_requirements(requirements, requirements_overrides),
++        requirements_lock = _get_requirements(requirements, requirements_overrides),
+         **kwargs,
+     )
++
++pip_install = pip_parse
+ """
+ 
+ _mock_fuzzing_py = """
+-- 
+2.45.2.505.gda0bf45e8d-goog
+

--- a/modules/protobuf/27.0.bcr.1/patches/0002-Add-minimal-Python-support-to-MODULE.bazel.patch
+++ b/modules/protobuf/27.0.bcr.1/patches/0002-Add-minimal-Python-support-to-MODULE.bazel.patch
@@ -1,0 +1,48 @@
+From 2b966a05925ba5b436876e33eab85e3638f192b3 Mon Sep 17 00:00:00 2001
+From: Protobuf Team Bot <protobuf-github-bot@google.com>
+Date: Wed, 12 Jun 2024 22:55:27 -0700
+Subject: [PATCH 2/2] Add minimal Python support to MODULE.bazel
+
+PiperOrigin-RevId: 642857334
+---
+ MODULE.bazel       | 27 +++++++++++++++++++++++++++
+ 2 files changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 71d29efcb..661636eac 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -24,3 +24,30 @@ bazel_dep(name = "zlib", version = "1.2.11")
+ 
+ # TODO: remove after toolchain types are moved to protobuf
+ bazel_dep(name = "rules_proto", version = "4.0.0")
++
++SUPPORTED_PYTHON_VERSIONS = [
++    "3.8",
++    "3.9",
++    "3.10",
++    "3.11",
++    "3.12",
++]
++python = use_extension("@rules_python//python/extensions:python.bzl", "python")
++[
++    python.toolchain(
++        is_default = python_version == SUPPORTED_PYTHON_VERSIONS[-1],
++        python_version = python_version,
++    )
++    for python_version in SUPPORTED_PYTHON_VERSIONS
++]
++use_repo(python, system_python = "python_{}".format(SUPPORTED_PYTHON_VERSIONS[-1].replace(".", "_")))
++pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
++[
++    pip.parse(
++        hub_name = "pip_deps",
++        python_version = python_version,
++        requirements_lock = "//python:requirements.txt",
++    )
++    for python_version in SUPPORTED_PYTHON_VERSIONS
++]
++use_repo(pip, "pip_deps")
+-- 
+2.45.2.505.gda0bf45e8d-goog
+

--- a/modules/protobuf/27.0.bcr.1/patches/0003-Update-MODULE.bazel.patch
+++ b/modules/protobuf/27.0.bcr.1/patches/0003-Update-MODULE.bazel.patch
@@ -1,0 +1,14 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 2d43e46df..b50917142 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,8 +1,6 @@
+-# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+-# https://github.com/protocolbuffers/protobuf/issues/14313
+ module(
+     name = "protobuf",
+-    version = "27.0", # Automatically updated on release
++    version = "27.0.bcr.1",
+     compatibility_level = 1,
+     repo_name = "com_google_protobuf",
+ )

--- a/modules/protobuf/27.0.bcr.1/presubmit.yml
+++ b/modules/protobuf/27.0.bcr.1/presubmit.yml
@@ -1,0 +1,68 @@
+matrix:
+  platform: ["debian11", "macos", "ubuntu2004"]
+  bazel: [6.x, 7.x]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--host_cxxopt=-std=c++14'
+    - '--cxxopt=-std=c++14'
+    - '--host_copt=-Wno-deprecated-declarations'
+    - '--copt=-Wno-deprecated-declarations'
+    build_targets:
+    - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_lite'
+    - '@protobuf//:protobuf_python'
+    - '@protobuf//:protoc'
+    - '@protobuf//:test_messages_proto2_cc_proto'
+    - '@protobuf//:test_messages_proto3_cc_proto'
+
+  verify_targets_windows:
+    name: "Verify build targets"
+    platform: windows
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--host_cxxopt=-std=c++14'
+    - '--cxxopt=-std=c++14'
+    build_targets:
+    - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_lite'
+    - '@protobuf//:protoc'
+    - '@protobuf//:test_messages_proto2_cc_proto'
+    - '@protobuf//:test_messages_proto3_cc_proto'
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2004"]
+    bazel: [6.x, 7.x]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+      - '--host_cxxopt=-std=c++14'
+      - '--cxxopt=-std=c++14'
+      - '--host_copt=-Wno-deprecated-declarations'
+      - '--copt=-Wno-deprecated-declarations'
+      build_targets:
+      - "//..."
+
+bcr_test_module_windows:
+  module_path: "examples"
+  matrix:
+    bazel: [6.x, 7.x]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: windows
+      bazel: ${{ bazel }}
+      build_flags:
+      - '--host_cxxopt=-std=c++14'
+      - '--cxxopt=-std=c++14'
+      build_targets:
+      - "//..."

--- a/modules/protobuf/27.0.bcr.1/source.json
+++ b/modules/protobuf/27.0.bcr.1/source.json
@@ -1,0 +1,11 @@
+{
+    "integrity": "sha256-PhFI2wkP8hImwYiO85+nvHeQBCviH/Qon9Ic4XNfNFU=",
+    "patch_strip": 1,
+    "patches": {
+        "0001-Update-rules_python-to-0.28.0.patch": "sha256-Way1+ExlpTYA0alOYm6vZ18qx8iMksHwA/84USEVzJY=",
+        "0002-Add-minimal-Python-support-to-MODULE.bazel.patch": "sha256-4y0A7IArROGqMTrO14NHaroKJEjWI4NjfpOaEZzT9Vc=",
+        "0003-Update-MODULE.bazel.patch": "sha256-iVa4c+CidZAYG+b5XHN+Vsatmm2S41hvHIPoHLie6Yo="
+    },
+    "strip_prefix": "protobuf-27.0",
+    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.zip"
+}

--- a/modules/protobuf/27.1.bcr.1/MODULE.bazel
+++ b/modules/protobuf/27.1.bcr.1/MODULE.bazel
@@ -1,0 +1,51 @@
+module(
+    name = "protobuf",
+    version = "27.1.bcr.1",
+    compatibility_level = 1,
+    repo_name = "com_google_protobuf",
+)
+
+# LOWER BOUND dependency versions.
+# Bzlmod follows MVS:
+# https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
+# Thus the highest version in their module graph is resolved.
+bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "jsoncpp", version = "1.9.5")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_java", version = "5.3.5")
+bazel_dep(name = "rules_jvm_external", version = "5.1")
+bazel_dep(name = "rules_pkg", version = "0.7.0")
+bazel_dep(name = "rules_python", version = "0.28.0")
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "zlib", version = "1.2.11")
+
+# TODO: remove after toolchain types are moved to protobuf
+bazel_dep(name = "rules_proto", version = "4.0.0")
+
+SUPPORTED_PYTHON_VERSIONS = [
+    "3.8",
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+]
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+[
+    python.toolchain(
+        is_default = python_version == SUPPORTED_PYTHON_VERSIONS[-1],
+        python_version = python_version,
+    )
+    for python_version in SUPPORTED_PYTHON_VERSIONS
+]
+use_repo(python, system_python = "python_{}".format(SUPPORTED_PYTHON_VERSIONS[-1].replace(".", "_")))
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+[
+    pip.parse(
+        hub_name = "pip_deps",
+        python_version = python_version,
+        requirements_lock = "//python:requirements.txt",
+    )
+    for python_version in SUPPORTED_PYTHON_VERSIONS
+]
+use_repo(pip, "pip_deps")

--- a/modules/protobuf/27.1.bcr.1/patches/0001-Update-rules_python-to-0.28.0.patch
+++ b/modules/protobuf/27.1.bcr.1/patches/0001-Update-rules_python-to-0.28.0.patch
@@ -1,0 +1,64 @@
+From 5cbb5d48dbf0f93c63bee79b7882b20067669e84 Mon Sep 17 00:00:00 2001
+From: Protobuf Team Bot <protobuf-github-bot@google.com>
+Date: Wed, 5 Jun 2024 13:36:57 -0700
+Subject: [PATCH 1/2] Update rules_python to 0.28.0
+
+Closes #15849
+
+PiperOrigin-RevId: 640633756
+---
+ MODULE.bazel                  |  2 +-
+ python/dist/system_python.bzl | 12 ++++--------
+ 4 files changed, 10 insertions(+), 14 deletions(-)
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 29f61b35c..37e78d867 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -18,7 +18,7 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
+ bazel_dep(name = "rules_java", version = "5.3.5")
+ bazel_dep(name = "rules_jvm_external", version = "5.1")
+ bazel_dep(name = "rules_pkg", version = "0.7.0")
+-bazel_dep(name = "rules_python", version = "0.10.2")
++bazel_dep(name = "rules_python", version = "0.28.0")
+ bazel_dep(name = "platforms", version = "0.0.8")
+ bazel_dep(name = "zlib", version = "1.2.11")
+ 
+diff --git a/python/dist/system_python.bzl b/python/dist/system_python.bzl
+index 29400be22..db5b30e0b 100644
+--- a/python/dist/system_python.bzl
++++ b/python/dist/system_python.bzl
+@@ -36,7 +36,7 @@ pip_parse = pip_install
+ 
+ # Alias rules_python's pip.bzl for cases where a system python is found.
+ _alias_pip = """
+-load("@rules_python//python:pip.bzl", _pip_install = "pip_install", _pip_parse = "pip_parse")
++load("@rules_python//python:pip.bzl", _pip_parse = "pip_parse")
+ 
+ def _get_requirements(requirements, requirements_overrides):
+     for version, override in requirements_overrides.items():
+@@ -45,18 +45,14 @@ def _get_requirements(requirements, requirements_overrides):
+             break
+     return requirements
+ 
+-def pip_install(requirements, requirements_overrides={{}}, **kwargs):
+-    _pip_install(
+-        python_interpreter_target = "@{repo}//:interpreter",
+-        requirements = _get_requirements(requirements, requirements_overrides),
+-        **kwargs,
+-    )
+ def pip_parse(requirements, requirements_overrides={{}}, **kwargs):
+     _pip_parse(
+         python_interpreter_target = "@{repo}//:interpreter",
+-        requirements = _get_requirements(requirements, requirements_overrides),
++        requirements_lock = _get_requirements(requirements, requirements_overrides),
+         **kwargs,
+     )
++
++pip_install = pip_parse
+ """
+ 
+ _mock_fuzzing_py = """
+-- 
+2.45.2.505.gda0bf45e8d-goog
+

--- a/modules/protobuf/27.1.bcr.1/patches/0002-Add-minimal-Python-support-to-MODULE.bazel.patch
+++ b/modules/protobuf/27.1.bcr.1/patches/0002-Add-minimal-Python-support-to-MODULE.bazel.patch
@@ -1,0 +1,48 @@
+From 49eeee66b2066ff2d2ae46a1faa9cc58c2124cc3 Mon Sep 17 00:00:00 2001
+From: Protobuf Team Bot <protobuf-github-bot@google.com>
+Date: Wed, 12 Jun 2024 22:55:27 -0700
+Subject: [PATCH 2/2] Add minimal Python support to MODULE.bazel
+
+PiperOrigin-RevId: 642857334
+---
+ MODULE.bazel       | 27 +++++++++++++++++++++++++++
+ 2 files changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 37e78d867..0f6a47594 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -24,3 +24,30 @@ bazel_dep(name = "zlib", version = "1.2.11")
+ 
+ # TODO: remove after toolchain types are moved to protobuf
+ bazel_dep(name = "rules_proto", version = "4.0.0")
++
++SUPPORTED_PYTHON_VERSIONS = [
++    "3.8",
++    "3.9",
++    "3.10",
++    "3.11",
++    "3.12",
++]
++python = use_extension("@rules_python//python/extensions:python.bzl", "python")
++[
++    python.toolchain(
++        is_default = python_version == SUPPORTED_PYTHON_VERSIONS[-1],
++        python_version = python_version,
++    )
++    for python_version in SUPPORTED_PYTHON_VERSIONS
++]
++use_repo(python, system_python = "python_{}".format(SUPPORTED_PYTHON_VERSIONS[-1].replace(".", "_")))
++pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
++[
++    pip.parse(
++        hub_name = "pip_deps",
++        python_version = python_version,
++        requirements_lock = "//python:requirements.txt",
++    )
++    for python_version in SUPPORTED_PYTHON_VERSIONS
++]
++use_repo(pip, "pip_deps")
+-- 
+2.45.2.505.gda0bf45e8d-goog
+

--- a/modules/protobuf/27.1.bcr.1/patches/0003-Update-MODULE.bazel.patch
+++ b/modules/protobuf/27.1.bcr.1/patches/0003-Update-MODULE.bazel.patch
@@ -1,0 +1,14 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 2d43e46df..b50917142 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,8 +1,6 @@
+-# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+-# https://github.com/protocolbuffers/protobuf/issues/14313
+ module(
+     name = "protobuf",
+-    version = "27.1", # Automatically updated on release
++    version = "27.1.bcr.1",
+     compatibility_level = 1,
+     repo_name = "com_google_protobuf",
+ )

--- a/modules/protobuf/27.1.bcr.1/presubmit.yml
+++ b/modules/protobuf/27.1.bcr.1/presubmit.yml
@@ -1,0 +1,36 @@
+matrix:
+  platform: ["macos", "ubuntu2004", "windows"]
+  bazel: [6.x, 7.x]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--host_cxxopt=-std=c++14'
+    - '--cxxopt=-std=c++14'
+    build_targets:
+    - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_lite'
+    - '@protobuf//:protobuf_python'
+    - '@protobuf//:protoc'
+    - '@protobuf//:test_messages_proto2_cc_proto'
+    - '@protobuf//:test_messages_proto3_cc_proto'
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+
+    platform: ["macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+      - '--host_cxxopt=-std=c++14'
+      - '--cxxopt=-std=c++14'
+      build_targets:
+      - "//..."

--- a/modules/protobuf/27.1.bcr.1/source.json
+++ b/modules/protobuf/27.1.bcr.1/source.json
@@ -1,0 +1,11 @@
+{
+    "integrity": "sha256-fX8t3Mw348HF3+Za1p2Zkj2P6Evqxo7ZzexImQnE2NM=",
+    "patch_strip": 1,
+    "patches": {
+        "0001-Update-rules_python-to-0.28.0.patch": "sha256-R9aWUvQvW+Su08ull1vNavaSp2a21PUaDWMosW6F/wo=",
+        "0002-Add-minimal-Python-support-to-MODULE.bazel.patch": "sha256-ze5v3lXBltTu9u1ZKfvZ2lY7vmWvf870bTPRy+LCGtU=",
+        "0003-Update-MODULE.bazel.patch": "sha256-dqGq2gJ8wBLF5g1ag+YZ5ReTDGG3cENwRislmeW7u0o="
+    },
+    "strip_prefix": "protobuf-27.1",
+    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protobuf-27.1.zip"
+}

--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -29,9 +29,12 @@
         "24.4",
         "26.0",
         "26.0.bcr.1",
+        "26.0.bcr.2",
         "27.0-rc2",
         "27.0",
-        "27.1"
+        "27.0.bcr.1",
+        "27.1",
+        "27.1.bcr.1"
     ],
     "yanked_versions": {
         "3.19.0": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)",


### PR DESCRIPTION
In Protobuf v25 Python support with Bzlmod broke with the introduction of `system_python`. This is a regression compared to previous versions.

This re-adds minimal Python support and adds a target to the presubmit check in order to avoid backsliding in the future.

This backports the following patches:
1. https://github.com/protocolbuffers/protobuf/commit/e1bf1f048e783578bcbdaa4572ce3c93908b6494
2. https://github.com/protocolbuffers/protobuf/commit/2eb4d69ed51c475a77ecd62742ef5064557b531f