### PR TITLE
feat: add `rules_squashfs@1.0.0-alpha.2`

### DIFF
--- a/modules/rules_squashfs/1.0.0-alpha.2/presubmit.yml
+++ b/modules/rules_squashfs/1.0.0-alpha.2/presubmit.yml
@@ -14,7 +14,7 @@ bcr_test_module:
       # - macos
       # - macos_arm64
   tasks:
-    run_tests:
+    e2e_tests:
       name: Run end-to-end Tests
       bazel: ${{ bazel }}
       platform: ${{ platform }}

--- a/modules/rules_squashfs/metadata.json
+++ b/modules/rules_squashfs/metadata.json
@@ -5,6 +5,7 @@
   ],
   "versions": [
     "1.0.0-alpha.1",
+    "1.0.0-alpha.2",
     "1.0.0-alpha.2"
   ],
   "maintainers": [


### PR DESCRIPTION
Bumps to remote execution compatible `toolchain_utils`.