### PR TITLE
.bazelignore the modules/ dir.

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+modules/


### PR DESCRIPTION
With the addition of overlays (#1566) it now can make sense to have BUILD and .bzl files inside the module version directories. However they don't necessarily make sense on their own. They are only supposed to work in the context of the source archive they overlay.

To prevent issues like not being able to load() from a //:def.bzl that does not exist in the registry repo, let's just .bazelignore the modules/ dir.