### PR TITLE
Update BCR tooling to support 7.2.1 style overlay

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -225,9 +225,9 @@ class BcrValidator:
               self.report(BcrValidationResult.FAILED, f"The patch file `{patch_file}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{actual_integrity}`.")
             apply_patch(source_root, source["patch_strip"], str(patch_file.resolve()))
     if "overlay" in source:
-      version_dir = self.registry.get_version_dir(module_name, version)
+      overlay_dir = self.registry.get_overlay_dir(module_name, version)
       for overlay_file, expected_integrity in source["overlay"].items():
-        overlay_src = version_dir / overlay_file
+        overlay_src = overlay_dir / overlay_file
         overlay_dst = source_root / overlay_file
         try:
           overlay_dst.resolve().relative_to(source_root)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -249,6 +249,9 @@ module(
   def get_version_dir(self, module_name, version):
     return self.get_module_dir(module_name) / version
 
+  def get_overlay_dir(self, module_name, version):
+    return self.get_version_dir(module_name, version) / "overlay"
+
   def get_source(self, module_name, version):
     return json.loads(self.get_source_json_path(module_name, version).read_text())
 
@@ -468,13 +471,14 @@ module(
     else:
       source.pop("patches", None)
 
+    overlay_dir = self.get_overlay_dir(module_name, version)
     overlay_files = {
       file
       for file in source.get("overlay", {}).keys()
-      if (source_path.parent / file).is_file()
+      if (overlay_dir / file).is_file()
     }
     overlay_integrities = {
-      file: integrity(read(source_path.parent / file)) for file in overlay_files
+      file: integrity(read(overlay_dir / file)) for file in overlay_files
     }
     if overlay_files:
       source["overlay"] = overlay_integrities

--- a/tools/update_integrity_test.sh
+++ b/tools/update_integrity_test.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # Set up a registry that needs some update_integrity treatment
 foomod="${TEST_TMPDIR}/registry/modules/foomod"
 mkdir -p "${foomod}/1.2.3/patches"
+mkdir -p "${foomod}/1.2.3/overlay"
 cat <<"EOF" >"${foomod}/metadata.json"
 {
   "homepage": "https://example.com/",
@@ -15,7 +16,7 @@ cat <<"EOF" >"${foomod}/metadata.json"
 }
 EOF
 echo 'module(name = "foomod", version = "1.2.3")' >"${foomod}/1.2.3/MODULE.bazel"
-echo hello >"${foomod}//1.2.3/overlay.file"
+echo hello >"${foomod}/1.2.3/overlay/overlay.file"
 echo old >"${foomod}/1.2.3/patches/preexisting-1.patch"
 echo old >"${foomod}/1.2.3/patches/preexisting-2.patch"
 echo new >"${foomod}/1.2.3/patches/a-newly-added.patch"


### PR DESCRIPTION
To enable using the new overlay format (https://github.com/bazelbuild/bazel-central-registry/issues/1566) with the Bazel 7.2.1 fix that requires the overlay files to be in an `overlay` dir (https://github.com/bazelbuild/bazel/pull/22811)

Tested locally on https://github.com/bazelbuild/bazel-central-registry/pull/2240