### PR TITLE
Ruff format the BCR tooling

### DIFF
--- a/tools/add_module.py
+++ b/tools/add_module.py
@@ -150,7 +150,10 @@ def from_user_input():
 def get_maintainers_from_input():
     maintainers = []
     prefix = "a"
-    explain = " (See https://github.com/bazelbuild/bazel-central-registry/tree/main/docs/bcr-policies.md#become-a-module-maintainer)"
+    explain = (
+        " (See https://github.com/bazelbuild/bazel-central-registry/tree/main"
+        "/docs/bcr-policies.md#become-a-module-maintainer)"
+    )
     while yes_or_no(f"Do you want to add {prefix} maintainer for this module?{explain}", False):
         maintainer = {}
         name = ask_input("Please enter maintainer name: ")

--- a/tools/add_module.py
+++ b/tools/add_module.py
@@ -53,168 +53,171 @@ RESET = "\x1b[0m"
 
 
 def yes_or_no(question, default):
-  if default:
-    question += " [Y/n]: "
-  else:
-    question += " [y/N]: "
-
-  var = None
-  while var is None:
-    user_input = ask_input(question).strip().lower()
-    if user_input == "y":
-      var = True
-    elif user_input == "n":
-      var = False
-    elif not user_input:
-      var = default
+    if default:
+        question += " [Y/n]: "
     else:
-      print("Invalid selection: {}".format(user_input))
-  return var
+        question += " [y/N]: "
+
+    var = None
+    while var is None:
+        user_input = ask_input(question).strip().lower()
+        if user_input == "y":
+            var = True
+        elif user_input == "n":
+            var = False
+        elif not user_input:
+            var = default
+        else:
+            print("Invalid selection: {}".format(user_input))
+    return var
 
 
 def ask_input(msg):
-  return input(f"{YELLOW}ACTION: {RESET}{msg}")
+    return input(f"{YELLOW}ACTION: {RESET}{msg}")
 
 
 def from_user_input():
-  name = ask_input("Please enter the module name: ")
-  version = ask_input("Please enter the module version: ")
-  compatibility = ask_input(
-      "Please enter the compatibility level [default is 0]: ") or "0"
-  module = Module(name, version, compatibility)
+    name = ask_input("Please enter the module name: ")
+    version = ask_input("Please enter the module version: ")
+    compatibility = ask_input("Please enter the compatibility level [default is 0]: ") or "0"
+    module = Module(name, version, compatibility)
 
-  url = ask_input("Please enter the URL of the source archive: ")
-  strip_prefix = ask_input(
-      "Please enter the strip_prefix value of the archive [default None]: ") or None
-  module.set_source(url, strip_prefix)
+    url = ask_input("Please enter the URL of the source archive: ")
+    strip_prefix = ask_input("Please enter the strip_prefix value of the archive [default None]: ") or None
+    module.set_source(url, strip_prefix)
 
-  if yes_or_no("Do you want to add patch files?", False):
-    patches = ask_input("Please enter patch file paths, separated by `,`: ")
-    for patch in patches.strip().split(","):
-      module.add_patch(patch.strip())
-    patch_strip = ask_input("Please enter the patch strip number [Default is 1, compatible with git generated "
-                            "patches]: ") or "1"
-    module.set_patch_strip(int(patch_strip.strip()))
+    if yes_or_no("Do you want to add patch files?", False):
+        patches = ask_input("Please enter patch file paths, separated by `,`: ")
+        for patch in patches.strip().split(","):
+            module.add_patch(patch.strip())
+        patch_strip = (
+            ask_input("Please enter the patch strip number [Default is 1, compatible with git generated " "patches]: ")
+            or "1"
+        )
+        module.set_patch_strip(int(patch_strip.strip()))
 
-  if yes_or_no("Do you want to add a BUILD file?", False):
-    build_file = ask_input(
-        "Please enter the path of the BUILD file to be added: ")
-    module.set_build_file(build_file.strip())
+    if yes_or_no("Do you want to add a BUILD file?", False):
+        build_file = ask_input("Please enter the path of the BUILD file to be added: ")
+        module.set_build_file(build_file.strip())
 
-  if yes_or_no("Do you want to specify a MODULE.bazel file?", False):
-    path = ask_input("Please enter the MODULE.bazel file path: ").strip()
-    module.set_module_dot_bazel(path)
-  else:
-    if yes_or_no("Do you want to specify dependencies for this module?", False):
-      deps = ask_input(
-          "Please enter dependencies in the form of <name>@<version>, separated by `,`: ")
-      for dep in deps.strip().split(","):
-        name, version = dep.split("@")
-        module.add_dep(name, version)
+    if yes_or_no("Do you want to specify a MODULE.bazel file?", False):
+        path = ask_input("Please enter the MODULE.bazel file path: ").strip()
+        module.set_module_dot_bazel(path)
+    else:
+        if yes_or_no("Do you want to specify dependencies for this module?", False):
+            deps = ask_input("Please enter dependencies in the form of <name>@<version>, separated by `,`: ")
+            for dep in deps.strip().split(","):
+                name, version = dep.split("@")
+                module.add_dep(name, version)
 
-  presubmit_url = "https://github.com/bazelbuild/bazel-central-registry/tree/main/docs#presubmit"
-  if yes_or_no(f"Do you want to specify an existing presubmit.yml file? (See {presubmit_url})", False):
-    path = ask_input("Please enter the presubmit.yml file path: ").strip()
-    module.set_presubmit_yml(path)
-  else:
-    first = True
-    while not module.build_targets:
-      if not first:
-        print("Build targets cannot be empty, please re-enter!")
-      first = False
-      build_targets = ask_input(
-          "Please enter a list of build targets you want to expose to downstream users, separated by `,`: ")
-      for target in build_targets.strip().split(","):
-        if target:
-          module.add_build_target(target)
+    presubmit_url = "https://github.com/bazelbuild/bazel-central-registry/tree/main/docs#presubmit"
+    if yes_or_no(f"Do you want to specify an existing presubmit.yml file? (See {presubmit_url})", False):
+        path = ask_input("Please enter the presubmit.yml file path: ").strip()
+        module.set_presubmit_yml(path)
+    else:
+        first = True
+        while not module.build_targets:
+            if not first:
+                print("Build targets cannot be empty, please re-enter!")
+            first = False
+            build_targets = ask_input(
+                "Please enter a list of build targets you want to expose to downstream users, separated by `,`: "
+            )
+            for target in build_targets.strip().split(","):
+                if target:
+                    module.add_build_target(target)
 
-    if yes_or_no("Do you have a test module in your source archive?", True):
-      module.test_module_path = ask_input(
-          "Please enter the test module path in your source archive: ")
-      first = True
-      while not (module.test_module_build_targets or module.test_module_test_targets):
-        if not first:
-          print("Build targets and test targets cannot both be empty, please re-enter!")
-        first = False
-        build_targets = ask_input(
-            "Please enter a list of build targets for the test module, separated by `,`: ")
-        for target in build_targets.strip().split(","):
-          if target:
-            module.add_test_module_build_target(target)
-        test_targets = ask_input(
-            "Please enter a list of test targets for the test module, separated by `,`: ")
-        for target in test_targets.strip().split(","):
-          if target:
-            module.add_test_module_test_target(target)
-  return module
+        if yes_or_no("Do you have a test module in your source archive?", True):
+            module.test_module_path = ask_input("Please enter the test module path in your source archive: ")
+            first = True
+            while not (module.test_module_build_targets or module.test_module_test_targets):
+                if not first:
+                    print("Build targets and test targets cannot both be empty, please re-enter!")
+                first = False
+                build_targets = ask_input(
+                    "Please enter a list of build targets for the test module, separated by `,`: "
+                )
+                for target in build_targets.strip().split(","):
+                    if target:
+                        module.add_test_module_build_target(target)
+                test_targets = ask_input("Please enter a list of test targets for the test module, separated by `,`: ")
+                for target in test_targets.strip().split(","):
+                    if target:
+                        module.add_test_module_test_target(target)
+    return module
 
 
 def get_maintainers_from_input():
-  maintainers = []
-  prefix = "a"
-  explain = " (See https://github.com/bazelbuild/bazel-central-registry/tree/main/docs/bcr-policies.md#become-a-module-maintainer)"
-  while yes_or_no(f"Do you want to add {prefix} maintainer for this module?{explain}", False):
-    maintainer = {}
-    name = ask_input("Please enter maintainer name: ")
-    maintainer["name"] = name
-    email = ask_input("Please enter the maintainer's email address: ")
-    maintainer["email"] = email
-    username = ask_input(
-        "(Optional) Please enter the maintainer's github username: ")
-    if username:
-      maintainer["github"] = username
-    maintainers.append(maintainer)
-    prefix = "another"
-    explain = ""
-  return maintainers
+    maintainers = []
+    prefix = "a"
+    explain = " (See https://github.com/bazelbuild/bazel-central-registry/tree/main/docs/bcr-policies.md#become-a-module-maintainer)"
+    while yes_or_no(f"Do you want to add {prefix} maintainer for this module?{explain}", False):
+        maintainer = {}
+        name = ask_input("Please enter maintainer name: ")
+        maintainer["name"] = name
+        email = ask_input("Please enter the maintainer's email address: ")
+        maintainer["email"] = email
+        username = ask_input("(Optional) Please enter the maintainer's github username: ")
+        if username:
+            maintainer["github"] = username
+        maintainers.append(maintainer)
+        prefix = "another"
+        explain = ""
+    return maintainers
 
 
 def main(argv=None):
-  if argv is None:
-    argv = sys.argv[1:]
+    if argv is None:
+        argv = sys.argv[1:]
 
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--registry", type=str, default=".",
-                      help="Specify the root path of the registry (default: the current working directory).")
-  parser.add_argument(
-      "--input", type=str, help="Take module information from a json file, which can be generated from previous input.")
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--registry",
+        type=str,
+        default=".",
+        help="Specify the root path of the registry (default: the current working directory).",
+    )
+    parser.add_argument(
+        "--input",
+        type=str,
+        help="Take module information from a json file, which can be generated from previous input.",
+    )
 
-  args = parser.parse_args(argv)
+    args = parser.parse_args(argv)
 
-  if args.input:
-    log(f"Getting module information from {args.input}...")
-    module = Module()
-    module.from_json(args.input)
-  else:
-    log("Getting module information from user input...")
-    module = from_user_input()
-    timestamp = time.strftime("%Y%m%d-%H%M%S")
-    log(f"Saving module information to {module.name}.{timestamp}.json")
-    log(f"You can use it via --input={module.name}.{timestamp}.json")
-    module.dump(f"{module.name}.{timestamp}.json")
+    if args.input:
+        log(f"Getting module information from {args.input}...")
+        module = Module()
+        module.from_json(args.input)
+    else:
+        log("Getting module information from user input...")
+        module = from_user_input()
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        log(f"Saving module information to {module.name}.{timestamp}.json")
+        log(f"You can use it via --input={module.name}.{timestamp}.json")
+        module.dump(f"{module.name}.{timestamp}.json")
 
-  client = RegistryClient(args.registry)
+    client = RegistryClient(args.registry)
 
-  if not client.contains(module.name):
-    log(f"{module.name} is a new Bazel module...")
-    homepage = ask_input(
-        "Please enter the homepage url for this module: ").strip()
-    maintainers = get_maintainers_from_input()
-    source_repository = ""
-    if module.url.startswith("https://github.com/"):
-      parts = module.url.split("/")
-      source_repository = "github:" + parts[3] + "/" + parts[4]
-    client.init_module(module.name, maintainers, homepage, source_repository)
+    if not client.contains(module.name):
+        log(f"{module.name} is a new Bazel module...")
+        homepage = ask_input("Please enter the homepage url for this module: ").strip()
+        maintainers = get_maintainers_from_input()
+        source_repository = ""
+        if module.url.startswith("https://github.com/"):
+            parts = module.url.split("/")
+            source_repository = "github:" + parts[3] + "/" + parts[4]
+        client.init_module(module.name, maintainers, homepage, source_repository)
 
-  client.add(module, override=True)
-  log(f"{module.name} {module.version} is added into the registry.")
+    client.add(module, override=True)
+    log(f"{module.name} {module.version} is added into the registry.")
 
-  log(f"Running ./tools/bcr_validation.py --check={module.name}@{module.version} --fix")
-  bcr_validation.main([f"--check={module.name}@{module.version}", "--fix"])
+    log(f"Running ./tools/bcr_validation.py --check={module.name}@{module.version} --fix")
+    bcr_validation.main([f"--check={module.name}@{module.version}", "--fix"])
 
 
 if __name__ == "__main__":
-  # Under 'bazel run' we want to run within the source folder instead of the execroot.
-  if os.getenv("BUILD_WORKSPACE_DIRECTORY"):
-    os.chdir(os.getenv("BUILD_WORKSPACE_DIRECTORY"))
-  sys.exit(main())
+    # Under 'bazel run' we want to run within the source folder instead of the execroot.
+    if os.getenv("BUILD_WORKSPACE_DIRECTORY"):
+        os.chdir(os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+    sys.exit(main())

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -52,9 +52,10 @@ from verify_stable_archives import verify_stable_archive
 
 
 class BcrValidationResult(Enum):
-  GOOD = 1
-  NEED_BCR_MAINTAINER_REVIEW = 2
-  FAILED = 3
+    GOOD = 1
+    NEED_BCR_MAINTAINER_REVIEW = 2
+    FAILED = 3
+
 
 RED = "\x1b[31m"
 GREEN = "\x1b[32m"
@@ -62,365 +63,432 @@ YELLOW = "\x1b[33m"
 RESET = "\x1b[0m"
 
 COLOR = {
-  BcrValidationResult.GOOD: GREEN,
-  BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW: YELLOW,
-  BcrValidationResult.FAILED: RED,
+    BcrValidationResult.GOOD: GREEN,
+    BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW: YELLOW,
+    BcrValidationResult.FAILED: RED,
 }
+
 
 def print_collapsed_group(name):
     print("\n\n--- {0}\n\n".format(name))
 
+
 def print_expanded_group(name):
     print("\n\n+++ {0}\n\n".format(name))
 
+
 def parse_module_versions(registry, check_all, inputs):
-  """Parse module versions to be validated from input."""
-  if check_all:
-    return registry.get_all_module_versions()
-  if not inputs:
-    return []
-  result = []
-  for s in inputs:
-    if "@" in s:
-      name, version = s.split("@")
-      result.append((name, version))
-    else:
-      result.extend(registry.get_module_versions(s))
-  return result
+    """Parse module versions to be validated from input."""
+    if check_all:
+        return registry.get_all_module_versions()
+    if not inputs:
+        return []
+    result = []
+    for s in inputs:
+        if "@" in s:
+            name, version = s.split("@")
+            result.append((name, version))
+        else:
+            result.extend(registry.get_module_versions(s))
+    return result
+
 
 def apply_patch(work_dir, patch_strip, patch_file):
-  # Requires patch to be installed
-  subprocess.run(
-      ["patch", "-p%d" % patch_strip, "-f", "-l", "-i", patch_file], shell=False, check=True, env=os.environ, cwd=work_dir
-  )
+    # Requires patch to be installed
+    subprocess.run(
+        ["patch", "-p%d" % patch_strip, "-f", "-l", "-i", patch_file],
+        shell=False,
+        check=True,
+        env=os.environ,
+        cwd=work_dir,
+    )
+
 
 def fix_line_endings(lines):
-  return [line.rstrip() + "\n" for line in lines]
+    return [line.rstrip() + "\n" for line in lines]
+
 
 class BcrValidationException(Exception):
-  """
-  Raised whenever we should stop the validation immediately.
-  """
+    """
+    Raised whenever we should stop the validation immediately.
+    """
+
 
 class BcrValidator:
+    def __init__(self, registry, should_fix):
+        self.validation_results = []
+        self.registry = registry
+        # Whether the validator should try to fix the detected error.
+        self.should_fix = should_fix
 
-  def __init__(self, registry, should_fix):
-    self.validation_results = []
-    self.registry = registry
-    # Whether the validator should try to fix the detected error.
-    self.should_fix = should_fix
+    def report(self, type, message):
+        color = COLOR[type]
+        print(f"{color}{type}{RESET}: {message}\n")
+        self.validation_results.append((type, message))
 
-  def report(self, type, message):
-    color = COLOR[type]
-    print(f"{color}{type}{RESET}: {message}\n")
-    self.validation_results.append((type, message))
-
-  def verify_module_existence(self, module_name, version):
-    """Verify the directory exists and the version is recorded in metadata.json."""
-    if not self.registry.contains(module_name, version):
-      self.report(BcrValidationResult.FAILED, f"{module_name}@{version} doesn't exist.")
-      raise BcrValidationException("The module to be validated doesn't exist!")
-    versions = self.registry.get_metadata(module_name)["versions"]
-    if version not in versions:
-      self.report(BcrValidationResult.FAILED, f"Version {version} is not recorded in {module_name}'s metadata.json file.")
-    else:
-      self.report(BcrValidationResult.GOOD, "The module exists and is recorded in metadata.json.")
-
-  def verify_source_archive_url_match_github_repo(self, module_name, version):
-    """Verify the source archive URL matches the github repo. For now, we only support github repositories check."""
-    source_url = self.registry.get_source(module_name, version)["url"]
-    source_repositories = self.registry.get_metadata(module_name).get("repository", [])
-    matched = not source_repositories
-    for source_repository in source_repositories:
-      if matched:
-        break
-      repo_type, repo_path = source_repository.split(":")
-      if repo_type == "github":
-        parts = urlparse(source_url)
-        matched = parts.scheme == "https" and parts.netloc == "github.com" and os.path.abspath(parts.path).startswith(f"/{repo_path}/")
-      elif repo_type == "https":
-        repo = urlparse(source_repository)
-        parts = urlparse(source_url)
-        matched = parts.scheme == repo.scheme and parts.netloc == repo.netloc and os.path.abspath(parts.path).startswith(f"{repo.path}/")
-    if not matched:
-      self.report(BcrValidationResult.FAILED, f"The source URL of {module_name}@{version} ({source_url}) doesn't match any of the module's source repositories {source_repositories}.")
-    else:
-      self.report(BcrValidationResult.GOOD, "The source URL matches one of the source repositories.")
-
-
-  def verify_source_archive_url_stability(self, module_name, version):
-    """Verify source archive URL is stable"""
-    source_url = self.registry.get_source(module_name, version)["url"]
-    if verify_stable_archive(source_url) == UrlStability.UNSTABLE:
-      self.report(BcrValidationResult.FAILED,
-                  f"{module_name}@{version} is using an unstable source url: `{source_url}`.\n"
-                  + "You should use a release archive URL in the format of `https://github.com/<ORGANIZATION>/<REPO>/releases/download/<version>/<name>.tar.gz` to ensure the archive checksum stability.\n"
-                  + "See https://blog.bazel.build/2023/02/15/github-archive-checksum.html for more context.")
-    else:
-      self.report(BcrValidationResult.GOOD, "The source URL doesn't look unstable.")
-
-
-  def verify_source_archive_url_integrity(self, module_name, version):
-    """Verify the integrity value of the URL is correct."""
-    source_url = self.registry.get_source(module_name, version)["url"]
-    expected_integrity = self.registry.get_source(module_name, version)["integrity"]
-    algorithm, _ = expected_integrity.split("-", 1)
-    real_integrity = integrity(download(source_url), algorithm)
-    if real_integrity != expected_integrity:
-      self.report(BcrValidationResult.FAILED, f"{module_name}@{version}'s source archive `{source_url}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{real_integrity}`!")
-    else:
-      self.report(BcrValidationResult.GOOD, "The source archive's integrity value matches.")
-
-
-  def verify_presubmit_yml_change(self, module_name, version):
-    """Verify if the presubmit.yml is the same as the previous version."""
-    versions = self.registry.get_metadata(module_name)["versions"]
-    versions.sort(key=Version)
-    index = versions.index(version)
-    if index == 0:
-      self.report(BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW, f"Module version {module_name}@{version} is new, the presubmit.yml file should be reviewed by a BCR maintainer.")
-    elif index > 0:
-      pre_version = versions[index - 1]
-      previous_presubmit_yml = self.registry.get_presubmit_yml_path(module_name, pre_version)
-      previous_presubmit_content = open(previous_presubmit_yml, "r").readlines()
-      current_presubmit_yml = self.registry.get_presubmit_yml_path(module_name, version)
-      current_presubmit_content = open(current_presubmit_yml, "r").readlines()
-      diff = list(unified_diff(previous_presubmit_content, current_presubmit_content, fromfile=str(previous_presubmit_yml), tofile = str(current_presubmit_yml)))
-      if diff:
-        self.report(BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW,
-                    f"The presubmit.yml file of {module_name}@{version} doesn't match its previous version {module_name}@{pre_version}, the following presubmit.yml file change should be reviewed by a BCR maintainer.\n"
-                    + "    " + "    ".join(diff))
-      else:
-        self.report(BcrValidationResult.GOOD, "The presubmit.yml file matches the previous version.")
-
-  def add_module_dot_bazel_patch(self, diff, module_name, version):
-    """Adding a patch file for MODULE.bazel according to the diff result."""
-    source = self.registry.get_source(module_name, version)
-    patch_file = self.registry.get_patch_file_path(module_name, version, "module_dot_bazel.patch")
-    patch_file.parent.mkdir(parents=True, exist_ok=True)
-    open(patch_file, "w").writelines(diff)
-    source["patch_strip"] = int(source.get("patch_strip", 0))
-    patches = source.get("patches", {})
-    patches["module_dot_bazel.patch"] = integrity(read(patch_file))
-    source["patches"] = patches
-    source_json_content = json.dumps(source, indent=4) + "\n"
-    self.registry.get_source_json_path(module_name, version).write_text(source_json_content)
-
-  def verify_module_dot_bazel(self, module_name, version):
-    source = self.registry.get_source(module_name, version)
-    source_url = source["url"]
-    tmp_dir = Path(tempfile.mkdtemp())
-    archive_file = tmp_dir.joinpath(source_url.split("/")[-1].split("?")[0])
-    output_dir = tmp_dir.joinpath("source_root")
-    download_file(source_url, archive_file)
-    shutil.unpack_archive(str(archive_file), output_dir)
-
-    # Apply patch files if there are any, also verify their integrity values
-    source_root = output_dir.joinpath(source["strip_prefix"] if "strip_prefix" in source else "")
-    if "patches" in source:
-        for patch_name, expected_integrity in source["patches"].items():
-            patch_file = self.registry.get_patch_file_path(module_name, version, patch_name)
-            actual_integrity = integrity(read(patch_file))
-            if actual_integrity != expected_integrity:
-              self.report(BcrValidationResult.FAILED, f"The patch file `{patch_file}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{actual_integrity}`.")
-            apply_patch(source_root, source["patch_strip"], str(patch_file.resolve()))
-    if "overlay" in source:
-      overlay_dir = self.registry.get_overlay_dir(module_name, version)
-      for overlay_file, expected_integrity in source["overlay"].items():
-        overlay_src = overlay_dir / overlay_file
-        overlay_dst = source_root / overlay_file
-        try:
-          overlay_dst.resolve().relative_to(source_root)
-        except ValueError:
-          self.report(BcrValidationResult.FAILED, f"The overlay file path `{overlay_file}` must point inside the source archive.")
-          continue
-        try:
-          actual_integrity = integrity(read(overlay_src))
-        except FileNotFoundError:
-          self.report(BcrValidationResult.FAILED, f"The overlay file `{overlay_file}` does not exist")
-          continue
-        if actual_integrity != expected_integrity:
-          self.report(BcrValidationResult.FAILED, f"The overlay file `{overlay_file}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{actual_integrity}`.")
-          continue
-        overlay_dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(overlay_src, overlay_dst)
-
-    source_module_dot_bazel = source_root.joinpath("MODULE.bazel")
-    if source_module_dot_bazel.exists():
-      source_module_dot_bazel_content = open(source_module_dot_bazel, "r").readlines()
-    else:
-      source_module_dot_bazel_content = []
-    bcr_module_dot_bazel_content = open(self.registry.get_module_dot_bazel_path(module_name, version), "r").readlines()
-    source_module_dot_bazel_content = fix_line_endings(source_module_dot_bazel_content)
-    bcr_module_dot_bazel_content = fix_line_endings(bcr_module_dot_bazel_content)
-    file_name = "a/" * int(source.get("patch_strip", 0)) + "MODULE.bazel"
-    diff = list(unified_diff(source_module_dot_bazel_content, bcr_module_dot_bazel_content, fromfile=file_name, tofile=file_name))
-
-    if diff:
-      self.report(BcrValidationResult.FAILED,
-                  "Checked in MODULE.bazel file doesn't match the one in the extracted and patched sources.\n"
-                  + f"Please fix the MODULE.bazel file or you can add the following patch to {module_name}@{version}:\n"
-                  + "    " + "    ".join(diff))
-      if self.should_fix:
-        self.add_module_dot_bazel_patch(diff, module_name, version)
-    else:
-      self.report(BcrValidationResult.GOOD, "Checked in MODULE.bazel matches the sources.")
-
-    shutil.rmtree(tmp_dir)
-
-  def check_if_bazel_version_is_set(self, tasks):
-    for task_name, task_config in tasks.items():
-      if "bazel" not in task_config:
-        self.report(BcrValidationResult.FAILED, "Missing bazel version for task '%s' in the presubmit.yml file." % task_name)
-
-  def validate_presubmit_yml(self, module_name, version):
-    presubmit_yml = self.registry.get_presubmit_yml_path(module_name, version)
-    presubmit = yaml.safe_load(open(presubmit_yml, "r"))
-    report_num_old = len(self.validation_results)
-    tasks = presubmit.get("tasks", {})
-    self.check_if_bazel_version_is_set(tasks)
-    test_module_tasks = {}
-    if "bcr_test_module" in presubmit:
-      test_module_tasks = presubmit["bcr_test_module"].get("tasks", {})
-      self.check_if_bazel_version_is_set(test_module_tasks)
-    if not tasks and not test_module_tasks:
-      self.report(BcrValidationResult.FAILED, "At least one task should be specified in the presubmit.yml file.")
-    report_num_new = len(self.validation_results)
-    if report_num_new == report_num_old:
-      self.report(BcrValidationResult.GOOD, "The presubmit.yml file is valid.")
-
-  def verify_module_name_conflict(self):
-    """Verify no module name conflict when ignoring case sensitivity."""
-    module_names = self.registry.get_all_modules()
-    conflict_found = False
-    module_group = {}
-    for name in module_names:
-      module_group.setdefault(name.lower(), []).append(name)
-
-    for name, modules in module_group.items():
-      if len(modules) > 1:
-        conflict_found = True
-        self.report(BcrValidationResult.FAILED, f"Module name conflict found: {', '.join(modules)}")
-
-    if not conflict_found:
-      self.report(BcrValidationResult.GOOD, "No module name conflict found.")
-
-  def validate_module(self, module_name, version, skipped_validations):
-    print_expanded_group(f"Validating {module_name}@{version}")
-    self.verify_module_name_conflict()
-    self.verify_module_existence(module_name, version)
-    if "source_repo" not in skipped_validations:
-      self.verify_source_archive_url_match_github_repo(module_name, version)
-    if "url_stability" not in skipped_validations:
-      self.verify_source_archive_url_stability(module_name, version)
-    self.verify_source_archive_url_integrity(module_name, version)
-    if "presubmit_yml" not in skipped_validations:
-      self.verify_presubmit_yml_change(module_name, version)
-    self.validate_presubmit_yml(module_name, version)
-    self.verify_module_dot_bazel(module_name, version)
-
-  def validate_all_metadata(self):
-    print_expanded_group("Validating all metadata.json files")
-    has_error = False
-    for module_name in self.registry.get_all_modules():
-      try:
-        metadata = self.registry.get_metadata(module_name)
-      except json.JSONDecodeError as e:
-        self.report(BcrValidationResult.FAILED, f"Failed to load {module_name}'s metadata.json file: " + str(e))
-        has_error = True
-        continue
-
-      sorted_versions = sorted(metadata["versions"], key=Version)
-      if sorted_versions != metadata["versions"]:
-        self.report(BcrValidationResult.FAILED, f"{module_name}'s metadata.json file is not sorted by version.\n Sorted versions: {sorted_versions}.\n Original versions: {metadata['versions']}")
-        has_error = True
-
-      for version in metadata["versions"]:
+    def verify_module_existence(self, module_name, version):
+        """Verify the directory exists and the version is recorded in metadata.json."""
         if not self.registry.contains(module_name, version):
-          self.report(BcrValidationResult.FAILED, f"{module_name}@{version} doesn't exist, but it's recorded in {module_name}'s metadata.json file.")
-          has_error = True
-    if not has_error:
-      self.report(BcrValidationResult.GOOD, "All metadata.json files are valid.")
+            self.report(BcrValidationResult.FAILED, f"{module_name}@{version} doesn't exist.")
+            raise BcrValidationException("The module to be validated doesn't exist!")
+        versions = self.registry.get_metadata(module_name)["versions"]
+        if version not in versions:
+            self.report(
+                BcrValidationResult.FAILED, f"Version {version} is not recorded in {module_name}'s metadata.json file."
+            )
+        else:
+            self.report(BcrValidationResult.GOOD, "The module exists and is recorded in metadata.json.")
 
-  def getValidationReturnCode(self):
-    # Calculate the overall return code
-    # 0: All good
-    # 1: BCR validation failed
-    # 42: BCR validation passes, but some changes need BCR maintainer review before trigging follow up BCR presubmit jobs.
-    result_codes = [code for code, _ in self.validation_results]
-    if BcrValidationResult.FAILED in result_codes:
-      return 1
-    if BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW in result_codes:
-      # Use a special return code to avoid conflict with other error code
-      return 42
-    return 0
+    def verify_source_archive_url_match_github_repo(self, module_name, version):
+        """Verify the source archive URL matches the github repo. For now, we only support github repositories check."""
+        source_url = self.registry.get_source(module_name, version)["url"]
+        source_repositories = self.registry.get_metadata(module_name).get("repository", [])
+        matched = not source_repositories
+        for source_repository in source_repositories:
+            if matched:
+                break
+            repo_type, repo_path = source_repository.split(":")
+            if repo_type == "github":
+                parts = urlparse(source_url)
+                matched = (
+                    parts.scheme == "https"
+                    and parts.netloc == "github.com"
+                    and os.path.abspath(parts.path).startswith(f"/{repo_path}/")
+                )
+            elif repo_type == "https":
+                repo = urlparse(source_repository)
+                parts = urlparse(source_url)
+                matched = (
+                    parts.scheme == repo.scheme
+                    and parts.netloc == repo.netloc
+                    and os.path.abspath(parts.path).startswith(f"{repo.path}/")
+                )
+        if not matched:
+            self.report(
+                BcrValidationResult.FAILED,
+                f"The source URL of {module_name}@{version} ({source_url}) doesn't match any of the module's source repositories {source_repositories}.",
+            )
+        else:
+            self.report(BcrValidationResult.GOOD, "The source URL matches one of the source repositories.")
+
+    def verify_source_archive_url_stability(self, module_name, version):
+        """Verify source archive URL is stable"""
+        source_url = self.registry.get_source(module_name, version)["url"]
+        if verify_stable_archive(source_url) == UrlStability.UNSTABLE:
+            self.report(
+                BcrValidationResult.FAILED,
+                f"{module_name}@{version} is using an unstable source url: `{source_url}`.\n"
+                + "You should use a release archive URL in the format of `https://github.com/<ORGANIZATION>/<REPO>/releases/download/<version>/<name>.tar.gz` to ensure the archive checksum stability.\n"
+                + "See https://blog.bazel.build/2023/02/15/github-archive-checksum.html for more context.",
+            )
+        else:
+            self.report(BcrValidationResult.GOOD, "The source URL doesn't look unstable.")
+
+    def verify_source_archive_url_integrity(self, module_name, version):
+        """Verify the integrity value of the URL is correct."""
+        source_url = self.registry.get_source(module_name, version)["url"]
+        expected_integrity = self.registry.get_source(module_name, version)["integrity"]
+        algorithm, _ = expected_integrity.split("-", 1)
+        real_integrity = integrity(download(source_url), algorithm)
+        if real_integrity != expected_integrity:
+            self.report(
+                BcrValidationResult.FAILED,
+                f"{module_name}@{version}'s source archive `{source_url}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{real_integrity}`!",
+            )
+        else:
+            self.report(BcrValidationResult.GOOD, "The source archive's integrity value matches.")
+
+    def verify_presubmit_yml_change(self, module_name, version):
+        """Verify if the presubmit.yml is the same as the previous version."""
+        versions = self.registry.get_metadata(module_name)["versions"]
+        versions.sort(key=Version)
+        index = versions.index(version)
+        if index == 0:
+            self.report(
+                BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW,
+                f"Module version {module_name}@{version} is new, the presubmit.yml file should be reviewed by a BCR maintainer.",
+            )
+        elif index > 0:
+            pre_version = versions[index - 1]
+            previous_presubmit_yml = self.registry.get_presubmit_yml_path(module_name, pre_version)
+            previous_presubmit_content = open(previous_presubmit_yml, "r").readlines()
+            current_presubmit_yml = self.registry.get_presubmit_yml_path(module_name, version)
+            current_presubmit_content = open(current_presubmit_yml, "r").readlines()
+            diff = list(
+                unified_diff(
+                    previous_presubmit_content,
+                    current_presubmit_content,
+                    fromfile=str(previous_presubmit_yml),
+                    tofile=str(current_presubmit_yml),
+                )
+            )
+            if diff:
+                self.report(
+                    BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW,
+                    f"The presubmit.yml file of {module_name}@{version} doesn't match its previous version {module_name}@{pre_version}, the following presubmit.yml file change should be reviewed by a BCR maintainer.\n"
+                    + "    "
+                    + "    ".join(diff),
+                )
+            else:
+                self.report(BcrValidationResult.GOOD, "The presubmit.yml file matches the previous version.")
+
+    def add_module_dot_bazel_patch(self, diff, module_name, version):
+        """Adding a patch file for MODULE.bazel according to the diff result."""
+        source = self.registry.get_source(module_name, version)
+        patch_file = self.registry.get_patch_file_path(module_name, version, "module_dot_bazel.patch")
+        patch_file.parent.mkdir(parents=True, exist_ok=True)
+        open(patch_file, "w").writelines(diff)
+        source["patch_strip"] = int(source.get("patch_strip", 0))
+        patches = source.get("patches", {})
+        patches["module_dot_bazel.patch"] = integrity(read(patch_file))
+        source["patches"] = patches
+        source_json_content = json.dumps(source, indent=4) + "\n"
+        self.registry.get_source_json_path(module_name, version).write_text(source_json_content)
+
+    def verify_module_dot_bazel(self, module_name, version):
+        source = self.registry.get_source(module_name, version)
+        source_url = source["url"]
+        tmp_dir = Path(tempfile.mkdtemp())
+        archive_file = tmp_dir.joinpath(source_url.split("/")[-1].split("?")[0])
+        output_dir = tmp_dir.joinpath("source_root")
+        download_file(source_url, archive_file)
+        shutil.unpack_archive(str(archive_file), output_dir)
+
+        # Apply patch files if there are any, also verify their integrity values
+        source_root = output_dir.joinpath(source["strip_prefix"] if "strip_prefix" in source else "")
+        if "patches" in source:
+            for patch_name, expected_integrity in source["patches"].items():
+                patch_file = self.registry.get_patch_file_path(module_name, version, patch_name)
+                actual_integrity = integrity(read(patch_file))
+                if actual_integrity != expected_integrity:
+                    self.report(
+                        BcrValidationResult.FAILED,
+                        f"The patch file `{patch_file}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{actual_integrity}`.",
+                    )
+                apply_patch(source_root, source["patch_strip"], str(patch_file.resolve()))
+        if "overlay" in source:
+            overlay_dir = self.registry.get_overlay_dir(module_name, version)
+            for overlay_file, expected_integrity in source["overlay"].items():
+                overlay_src = overlay_dir / overlay_file
+                overlay_dst = source_root / overlay_file
+                try:
+                    overlay_dst.resolve().relative_to(source_root)
+                except ValueError:
+                    self.report(
+                        BcrValidationResult.FAILED,
+                        f"The overlay file path `{overlay_file}` must point inside the source archive.",
+                    )
+                    continue
+                try:
+                    actual_integrity = integrity(read(overlay_src))
+                except FileNotFoundError:
+                    self.report(BcrValidationResult.FAILED, f"The overlay file `{overlay_file}` does not exist")
+                    continue
+                if actual_integrity != expected_integrity:
+                    self.report(
+                        BcrValidationResult.FAILED,
+                        f"The overlay file `{overlay_file}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{actual_integrity}`.",
+                    )
+                    continue
+                overlay_dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(overlay_src, overlay_dst)
+
+        source_module_dot_bazel = source_root.joinpath("MODULE.bazel")
+        if source_module_dot_bazel.exists():
+            source_module_dot_bazel_content = open(source_module_dot_bazel, "r").readlines()
+        else:
+            source_module_dot_bazel_content = []
+        bcr_module_dot_bazel_content = open(
+            self.registry.get_module_dot_bazel_path(module_name, version), "r"
+        ).readlines()
+        source_module_dot_bazel_content = fix_line_endings(source_module_dot_bazel_content)
+        bcr_module_dot_bazel_content = fix_line_endings(bcr_module_dot_bazel_content)
+        file_name = "a/" * int(source.get("patch_strip", 0)) + "MODULE.bazel"
+        diff = list(
+            unified_diff(
+                source_module_dot_bazel_content, bcr_module_dot_bazel_content, fromfile=file_name, tofile=file_name
+            )
+        )
+
+        if diff:
+            self.report(
+                BcrValidationResult.FAILED,
+                "Checked in MODULE.bazel file doesn't match the one in the extracted and patched sources.\n"
+                + f"Please fix the MODULE.bazel file or you can add the following patch to {module_name}@{version}:\n"
+                + "    "
+                + "    ".join(diff),
+            )
+            if self.should_fix:
+                self.add_module_dot_bazel_patch(diff, module_name, version)
+        else:
+            self.report(BcrValidationResult.GOOD, "Checked in MODULE.bazel matches the sources.")
+
+        shutil.rmtree(tmp_dir)
+
+    def check_if_bazel_version_is_set(self, tasks):
+        for task_name, task_config in tasks.items():
+            if "bazel" not in task_config:
+                self.report(
+                    BcrValidationResult.FAILED,
+                    "Missing bazel version for task '%s' in the presubmit.yml file." % task_name,
+                )
+
+    def validate_presubmit_yml(self, module_name, version):
+        presubmit_yml = self.registry.get_presubmit_yml_path(module_name, version)
+        presubmit = yaml.safe_load(open(presubmit_yml, "r"))
+        report_num_old = len(self.validation_results)
+        tasks = presubmit.get("tasks", {})
+        self.check_if_bazel_version_is_set(tasks)
+        test_module_tasks = {}
+        if "bcr_test_module" in presubmit:
+            test_module_tasks = presubmit["bcr_test_module"].get("tasks", {})
+            self.check_if_bazel_version_is_set(test_module_tasks)
+        if not tasks and not test_module_tasks:
+            self.report(BcrValidationResult.FAILED, "At least one task should be specified in the presubmit.yml file.")
+        report_num_new = len(self.validation_results)
+        if report_num_new == report_num_old:
+            self.report(BcrValidationResult.GOOD, "The presubmit.yml file is valid.")
+
+    def verify_module_name_conflict(self):
+        """Verify no module name conflict when ignoring case sensitivity."""
+        module_names = self.registry.get_all_modules()
+        conflict_found = False
+        module_group = {}
+        for name in module_names:
+            module_group.setdefault(name.lower(), []).append(name)
+
+        for name, modules in module_group.items():
+            if len(modules) > 1:
+                conflict_found = True
+                self.report(BcrValidationResult.FAILED, f"Module name conflict found: {', '.join(modules)}")
+
+        if not conflict_found:
+            self.report(BcrValidationResult.GOOD, "No module name conflict found.")
+
+    def validate_module(self, module_name, version, skipped_validations):
+        print_expanded_group(f"Validating {module_name}@{version}")
+        self.verify_module_name_conflict()
+        self.verify_module_existence(module_name, version)
+        if "source_repo" not in skipped_validations:
+            self.verify_source_archive_url_match_github_repo(module_name, version)
+        if "url_stability" not in skipped_validations:
+            self.verify_source_archive_url_stability(module_name, version)
+        self.verify_source_archive_url_integrity(module_name, version)
+        if "presubmit_yml" not in skipped_validations:
+            self.verify_presubmit_yml_change(module_name, version)
+        self.validate_presubmit_yml(module_name, version)
+        self.verify_module_dot_bazel(module_name, version)
+
+    def validate_all_metadata(self):
+        print_expanded_group("Validating all metadata.json files")
+        has_error = False
+        for module_name in self.registry.get_all_modules():
+            try:
+                metadata = self.registry.get_metadata(module_name)
+            except json.JSONDecodeError as e:
+                self.report(BcrValidationResult.FAILED, f"Failed to load {module_name}'s metadata.json file: " + str(e))
+                has_error = True
+                continue
+
+            sorted_versions = sorted(metadata["versions"], key=Version)
+            if sorted_versions != metadata["versions"]:
+                self.report(
+                    BcrValidationResult.FAILED,
+                    f"{module_name}'s metadata.json file is not sorted by version.\n Sorted versions: {sorted_versions}.\n Original versions: {metadata['versions']}",
+                )
+                has_error = True
+
+            for version in metadata["versions"]:
+                if not self.registry.contains(module_name, version):
+                    self.report(
+                        BcrValidationResult.FAILED,
+                        f"{module_name}@{version} doesn't exist, but it's recorded in {module_name}'s metadata.json file.",
+                    )
+                    has_error = True
+        if not has_error:
+            self.report(BcrValidationResult.GOOD, "All metadata.json files are valid.")
+
+    def getValidationReturnCode(self):
+        # Calculate the overall return code
+        # 0: All good
+        # 1: BCR validation failed
+        # 42: BCR validation passes, but some changes need BCR maintainer review before trigging follow up BCR presubmit jobs.
+        result_codes = [code for code, _ in self.validation_results]
+        if BcrValidationResult.FAILED in result_codes:
+            return 1
+        if BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW in result_codes:
+            # Use a special return code to avoid conflict with other error code
+            return 42
+        return 0
+
 
 def main(argv=None):
-  if argv is None:
-    argv = sys.argv[1:]
+    if argv is None:
+        argv = sys.argv[1:]
 
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-    "--registry",
-    type=str,
-    default=".",
-    help="Specify the root path of the registry (default: the current working directory).")
-  parser.add_argument(
-    "--check",
-    type=str,
-    action = "append",
-    help="Specify a Bazel module version you want to perform the BCR check on."
-    + " (e.g. bazel_skylib@1.3.0). If no version is specified, all versions of that module are checked."
-    + " This flag can be repeated to accept multiple module versions.")
-  parser.add_argument(
-    "--check_all",
-    action="store_true",
-    help="Check all Bazel modules in the registry, ignore other --check flags.")
-  parser.add_argument(
-    "--check_all_metadata",
-    action="store_true",
-    help="Check all Bazel module metadata in the registry.")
-  parser.add_argument(
-    "--fix",
-    action="store_true",
-    help="Should the script try to fix the detected validation errors.")
-  parser.add_argument(
-    "--skip_validation",
-    type=str,
-    default=[],
-    action = "append",
-    help="Bypass the given step for validating modules. Supported values are: \"url_stability\", "
-    + "to bypass the URL stability check; \"presubmit_yml\", to bypass the presubmit.yml check; "
-    + "\"source_repo\", to bypass the source repo verification; "
-    + "This flag can be repeated to skip multiple validations.")
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--registry",
+        type=str,
+        default=".",
+        help="Specify the root path of the registry (default: the current working directory).",
+    )
+    parser.add_argument(
+        "--check",
+        type=str,
+        action="append",
+        help="Specify a Bazel module version you want to perform the BCR check on."
+        + " (e.g. bazel_skylib@1.3.0). If no version is specified, all versions of that module are checked."
+        + " This flag can be repeated to accept multiple module versions.",
+    )
+    parser.add_argument(
+        "--check_all", action="store_true", help="Check all Bazel modules in the registry, ignore other --check flags."
+    )
+    parser.add_argument(
+        "--check_all_metadata", action="store_true", help="Check all Bazel module metadata in the registry."
+    )
+    parser.add_argument(
+        "--fix", action="store_true", help="Should the script try to fix the detected validation errors."
+    )
+    parser.add_argument(
+        "--skip_validation",
+        type=str,
+        default=[],
+        action="append",
+        help='Bypass the given step for validating modules. Supported values are: "url_stability", '
+        + 'to bypass the URL stability check; "presubmit_yml", to bypass the presubmit.yml check; '
+        + '"source_repo", to bypass the source repo verification; '
+        + "This flag can be repeated to skip multiple validations.",
+    )
 
-  args = parser.parse_args(argv)
+    args = parser.parse_args(argv)
 
-  if not args.check_all and not args.check and not args.check_all_metadata:
-    parser.print_help()
-    return -1
+    if not args.check_all and not args.check and not args.check_all_metadata:
+        parser.print_help()
+        return -1
 
-  registry = RegistryClient(args.registry)
+    registry = RegistryClient(args.registry)
 
-  # Parse what module versions we should validate
-  module_versions = parse_module_versions(registry, args.check_all, args.check)
-  if module_versions:
-    print_expanded_group("Module versions to be validated:")
+    # Parse what module versions we should validate
+    module_versions = parse_module_versions(registry, args.check_all, args.check)
+    if module_versions:
+        print_expanded_group("Module versions to be validated:")
+        for name, version in module_versions:
+            print(f"{name}@{version}")
+
+    # Validate given module version.
+    validator = BcrValidator(registry, args.fix)
     for name, version in module_versions:
-      print(f"{name}@{version}")
+        validator.validate_module(name, version, args.skip_validation)
 
-  # Validate given module version.
-  validator = BcrValidator(registry, args.fix)
-  for name, version in module_versions:
-    validator.validate_module(name, version, args.skip_validation)
+    if args.check_all_metadata:
+        validator.validate_all_metadata()
 
-  if args.check_all_metadata:
-    validator.validate_all_metadata()
+    return validator.getValidationReturnCode()
 
-  return validator.getValidationReturnCode()
 
 if __name__ == "__main__":
-  # Under 'bazel run' we want to run within the source folder instead of the execroot.
-  if os.getenv("BUILD_WORKSPACE_DIRECTORY"):
-    os.chdir(os.getenv("BUILD_WORKSPACE_DIRECTORY"))
-  sys.exit(main())
+    # Under 'bazel run' we want to run within the source folder instead of the execroot.
+    if os.getenv("BUILD_WORKSPACE_DIRECTORY"):
+        os.chdir(os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+    sys.exit(main())

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -178,7 +178,9 @@ class BcrValidator:
             self.report(
                 BcrValidationResult.FAILED,
                 f"{module_name}@{version} is using an unstable source url: `{source_url}`.\n"
-                + "You should use a release archive URL in the format of `https://github.com/<ORGANIZATION>/<REPO>/releases/download/<version>/<name>.tar.gz` to ensure the archive checksum stability.\n"
+                + "You should use a release archive URL in the format of "
+                + "`https://github.com/<ORGANIZATION>/<REPO>/releases/download/<version>/<name>.tar.gz` "
+                + "to ensure the archive checksum stability.\n"
                 + "See https://blog.bazel.build/2023/02/15/github-archive-checksum.html for more context.",
             )
         else:
@@ -193,7 +195,8 @@ class BcrValidator:
         if real_integrity != expected_integrity:
             self.report(
                 BcrValidationResult.FAILED,
-                f"{module_name}@{version}'s source archive `{source_url}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{real_integrity}`!",
+                f"{module_name}@{version}'s source archive `{source_url}` has expected integrity value "
+                f"`{expected_integrity}`, but the real integrity value is `{real_integrity}`!",
             )
         else:
             self.report(BcrValidationResult.GOOD, "The source archive's integrity value matches.")
@@ -206,7 +209,8 @@ class BcrValidator:
         if index == 0:
             self.report(
                 BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW,
-                f"Module version {module_name}@{version} is new, the presubmit.yml file should be reviewed by a BCR maintainer.",
+                f"Module version {module_name}@{version} is new, the presubmit.yml file "
+                "should be reviewed by a BCR maintainer.",
             )
         elif index > 0:
             pre_version = versions[index - 1]
@@ -225,9 +229,9 @@ class BcrValidator:
             if diff:
                 self.report(
                     BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW,
-                    f"The presubmit.yml file of {module_name}@{version} doesn't match its previous version {module_name}@{pre_version}, the following presubmit.yml file change should be reviewed by a BCR maintainer.\n"
-                    + "    "
-                    + "    ".join(diff),
+                    f"The presubmit.yml file of {module_name}@{version} doesn't match its previous version "
+                    f"{module_name}@{pre_version}, the following presubmit.yml file change "
+                    "should be reviewed by a BCR maintainer.\n    " + "    ".join(diff),
                 )
             else:
                 self.report(BcrValidationResult.GOOD, "The presubmit.yml file matches the previous version.")
@@ -263,7 +267,8 @@ class BcrValidator:
                 if actual_integrity != expected_integrity:
                     self.report(
                         BcrValidationResult.FAILED,
-                        f"The patch file `{patch_file}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{actual_integrity}`.",
+                        f"The patch file `{patch_file}` has expected integrity value `{expected_integrity}`, "
+                        f"but the real integrity value is `{actual_integrity}`.",
                     )
                 apply_patch(source_root, source["patch_strip"], str(patch_file.resolve()))
         if "overlay" in source:
@@ -287,7 +292,8 @@ class BcrValidator:
                 if actual_integrity != expected_integrity:
                     self.report(
                         BcrValidationResult.FAILED,
-                        f"The overlay file `{overlay_file}` has expected integrity value `{expected_integrity}`, but the real integrity value is `{actual_integrity}`.",
+                        f"The overlay file `{overlay_file}` has expected integrity value `{expected_integrity}`, "
+                        f"but the real integrity value is `{actual_integrity}`.",
                     )
                     continue
                 overlay_dst.parent.mkdir(parents=True, exist_ok=True)
@@ -394,7 +400,9 @@ class BcrValidator:
             if sorted_versions != metadata["versions"]:
                 self.report(
                     BcrValidationResult.FAILED,
-                    f"{module_name}'s metadata.json file is not sorted by version.\n Sorted versions: {sorted_versions}.\n Original versions: {metadata['versions']}",
+                    f"{module_name}'s metadata.json file is not sorted by version.\n "
+                    f"Sorted versions: {sorted_versions}.\n "
+                    f"Original versions: {metadata['versions']}",
                 )
                 has_error = True
 
@@ -402,7 +410,8 @@ class BcrValidator:
                 if not self.registry.contains(module_name, version):
                     self.report(
                         BcrValidationResult.FAILED,
-                        f"{module_name}@{version} doesn't exist, but it's recorded in {module_name}'s metadata.json file.",
+                        f"{module_name}@{version} doesn't exist, "
+                        f"but it's recorded in {module_name}'s metadata.json file.",
                     )
                     has_error = True
         if not has_error:

--- a/tools/calc_integrity.py
+++ b/tools/calc_integrity.py
@@ -23,10 +23,10 @@ from registry import download
 from registry import integrity
 
 if __name__ == "__main__":
-  # Under 'bazel run' we want to run within the source folder instead of the execroot.
-  if os.getenv("BUILD_WORKSPACE_DIRECTORY"):
-    os.chdir(os.getenv("BUILD_WORKSPACE_DIRECTORY"))
-  if validators.url(sys.argv[1]):
-    print(integrity(download(sys.argv[1])))
-  else:
-    print(integrity(read(sys.argv[1])))
+    # Under 'bazel run' we want to run within the source folder instead of the execroot.
+    if os.getenv("BUILD_WORKSPACE_DIRECTORY"):
+        os.chdir(os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+    if validators.url(sys.argv[1]):
+        print(integrity(download(sys.argv[1])))
+    else:
+        print(integrity(read(sys.argv[1])))

--- a/tools/migrate_to_bzlmod.py
+++ b/tools/migrate_to_bzlmod.py
@@ -50,22 +50,22 @@ BAZEL_DEP_IDENTIFIER = "# -- bazel_dep definitions -- #"
 
 
 def abort_migration():
-  info("Abort migration...")
-  exit(2)
+    info("Abort migration...")
+    exit(2)
 
 
 def assertExitCode(exit_code, expected_exit_code, error_message, stderr):
-  if exit_code != expected_exit_code:
-    error(f"Command exited with {exit_code}, expected {expected_exit_code}:")
-    eprint(stderr)
-    abort_migration()
+    if exit_code != expected_exit_code:
+        error(f"Command exited with {exit_code}, expected {expected_exit_code}:")
+        eprint(stderr)
+        abort_migration()
 
 
 def eprint(*args, **kwargs):
-  """
-  Print to stderr and flush (just in case).
-  """
-  print(*args, flush=True, file=sys.stderr, **kwargs)
+    """
+    Print to stderr and flush (just in case).
+    """
+    print(*args, flush=True, file=sys.stderr, **kwargs)
 
 
 GREEN = "\x1b[32m"
@@ -75,481 +75,484 @@ RESET = "\x1b[0m"
 
 
 def info(msg):
-  eprint(f"{GREEN}INFO: {RESET}{msg}")
+    eprint(f"{GREEN}INFO: {RESET}{msg}")
 
 
 def warning(msg):
-  eprint(f"{YELLOW}WARNING: {RESET}{msg}")
+    eprint(f"{YELLOW}WARNING: {RESET}{msg}")
 
 
 def error(msg):
-  eprint(f"{RED}ERROR: {RESET}{msg}")
+    eprint(f"{RED}ERROR: {RESET}{msg}")
 
 
 def ask_input(msg):
-  return input(f"{YELLOW}ACTION: {RESET}{msg}")
+    return input(f"{YELLOW}ACTION: {RESET}{msg}")
 
 
 def yes_or_no(question, default):
-  if not yes_or_no.enable:
-    return default
+    if not yes_or_no.enable:
+        return default
 
-  if default:
-    question += " [Y/n]: "
-  else:
-    question += " [y/N]: "
-
-  var = None
-  while var is None:
-    user_input = ask_input(question).strip().lower()
-    if user_input == "y":
-      var = True
-    elif user_input == "n":
-      var = False
-    elif not user_input:
-      var = default
+    if default:
+        question += " [Y/n]: "
     else:
-      eprint(f"Invalid selection: {user_input}")
-  return var
+        question += " [y/N]: "
+
+    var = None
+    while var is None:
+        user_input = ask_input(question).strip().lower()
+        if user_input == "y":
+            var = True
+        elif user_input == "n":
+            var = False
+        elif not user_input:
+            var = default
+        else:
+            eprint(f"Invalid selection: {user_input}")
+    return var
 
 
 def scratch_file(file_path, lines=None, mode="w"):
-  """Write lines to a file."""
-  abspath = pathlib.Path(file_path)
-  with open(abspath, mode) as f:
-    if lines:
-      for l in lines:
-        f.write(l)
-        f.write('\n')
-  return abspath
+    """Write lines to a file."""
+    abspath = pathlib.Path(file_path)
+    with open(abspath, mode) as f:
+        if lines:
+            for l in lines:
+                f.write(l)
+                f.write("\n")
+    return abspath
 
 
 def execute_command(args, cwd=None, env=None, shell=False, executable=None):
-  info("Executing command: " + " ".join(args))
-  with tempfile.TemporaryFile() as stdout:
-    with tempfile.TemporaryFile() as stderr:
-      proc = subprocess.Popen(
-          args,
-          executable=executable,
-          stdout=stdout,
-          stderr=stderr,
-          cwd=cwd,
-          env=env,
-          shell=shell)
-      exit_code = proc.wait()
+    info("Executing command: " + " ".join(args))
+    with tempfile.TemporaryFile() as stdout:
+        with tempfile.TemporaryFile() as stderr:
+            proc = subprocess.Popen(
+                args, executable=executable, stdout=stdout, stderr=stderr, cwd=cwd, env=env, shell=shell
+            )
+            exit_code = proc.wait()
 
-      stdout.seek(0)
-      stdout_result = stdout.read().decode(locale.getpreferredencoding())
-      stderr.seek(0)
-      stderr_result = stderr.read().decode(locale.getpreferredencoding())
-      return exit_code, stdout_result, stderr_result
+            stdout.seek(0)
+            stdout_result = stdout.read().decode(locale.getpreferredencoding())
+            stderr.seek(0)
+            stderr_result = stderr.read().decode(locale.getpreferredencoding())
+            return exit_code, stdout_result, stderr_result
 
 
 def print_repo_definition(dep):
-  """Print the repository info to stdout and return the repository definition."""
-  # Parse the repository rule class (rule name, and the label for the bzl file where the rule is defined.)
-  rule_class = dep["original_rule_class"]
-  if rule_class.find("%") != -1:
-    # Starlark rule
-    file_label, rule_name = rule_class.split("%")
-    # If the original macro is not publicly visible, we trace back to fine a visible one.
-    if rule_name.startswith("_"):
-      def_info = dep["definition_information"].split("\n")
-      def_info.reverse()
-      for line in def_info:
-        s = re.match(r"^  (.+):[0-9]+:[0-9]+: in ([^\_<].+)$", line)
-        if s:
-          new_file_name, new_rule_name = s.groups()
-          if new_file_name.endswith(file_label.split("//")[1].replace(":", "/")):
-            rule_name = new_rule_name
-          else:
-            warning(
-                f"A visible macro for {rule_name} is defined in a different bzl file `{new_file_name}` other than `{file_label}`, you have to find out the correct label for `{new_file_name}` manually.")
-          break
-  else:
-    # Native rule
-    file_label = None
-    rule_name = rule_class
+    """Print the repository info to stdout and return the repository definition."""
+    # Parse the repository rule class (rule name, and the label for the bzl file where the rule is defined.)
+    rule_class = dep["original_rule_class"]
+    if rule_class.find("%") != -1:
+        # Starlark rule
+        file_label, rule_name = rule_class.split("%")
+        # If the original macro is not publicly visible, we trace back to fine a visible one.
+        if rule_name.startswith("_"):
+            def_info = dep["definition_information"].split("\n")
+            def_info.reverse()
+            for line in def_info:
+                s = re.match(r"^  (.+):[0-9]+:[0-9]+: in ([^\_<].+)$", line)
+                if s:
+                    new_file_name, new_rule_name = s.groups()
+                    if new_file_name.endswith(file_label.split("//")[1].replace(":", "/")):
+                        rule_name = new_rule_name
+                    else:
+                        warning(
+                            f"A visible macro for {rule_name} is defined in a different bzl file `{new_file_name}` other than `{file_label}`, you have to find out the correct label for `{new_file_name}` manually."
+                        )
+                    break
+    else:
+        # Native rule
+        file_label = None
+        rule_name = rule_class
 
-  # Generate the repository definition lines.
-  repo_def = []
-  if file_label:
-    repo_def.append(f"load(\"{file_label}\", \"{rule_name}\")")
-  repo_def.append(f"{rule_name}(")
-  for key, value in dep["original_attributes"].items():
-    if not key.startswith("generator_"):
-      value_str = json.dumps(value, indent=4)
-      # Fix indentation
-      if value_str.endswith("}") or value_str.endswith("]"):
-        value_str = value_str[:-1] + "  " + value_str[-1]
-      # Fix boolean format
-      if value_str == "false" or value_str == "true":
-        value_str = value_str[0].upper() + value_str[1:]
-      repo_def.append(f"  {key} = {value_str},")
-  repo_def.append(")")
+    # Generate the repository definition lines.
+    repo_def = []
+    if file_label:
+        repo_def.append(f'load("{file_label}", "{rule_name}")')
+    repo_def.append(f"{rule_name}(")
+    for key, value in dep["original_attributes"].items():
+        if not key.startswith("generator_"):
+            value_str = json.dumps(value, indent=4)
+            # Fix indentation
+            if value_str.endswith("}") or value_str.endswith("]"):
+                value_str = value_str[:-1] + "  " + value_str[-1]
+            # Fix boolean format
+            if value_str == "false" or value_str == "true":
+                value_str = value_str[0].upper() + value_str[1:]
+            repo_def.append(f"  {key} = {value_str},")
+    repo_def.append(")")
 
-  header = "----- Repository information for @%s in the WORKSPACE file -----" % dep[
-      "original_attributes"]["name"]
-  eprint(header)
-  if "definition_information" in dep:
-    eprint(dep["definition_information"])
-  eprint("Repository definition:")
-  for line in repo_def:
-    eprint(line)
-  eprint("-" * len(header))
+    header = "----- Repository information for @%s in the WORKSPACE file -----" % dep["original_attributes"]["name"]
+    eprint(header)
+    if "definition_information" in dep:
+        eprint(dep["definition_information"])
+    eprint("Repository definition:")
+    for line in repo_def:
+        eprint(line)
+    eprint("-" * len(header))
 
-  return repo_def
+    return repo_def
 
 
 def detect_unavailable_repo_error(stderr):
-  PATTERNS = [
-      re.compile(r"unknown repo '([A-Za-z0-9_-]+)' requested from"),
-      re.compile(r"The repository '@([A-Za-z0-9_-]+)' could not be resolved"),
-      re.compile(
-          r"No repository visible as '@([A-Za-z0-9_-]+)' from main repository"),
-      re.compile(
-          r"This could either mean you have to add the '@([A-Za-z0-9_-]+)' repository"),
-  ]
+    PATTERNS = [
+        re.compile(r"unknown repo '([A-Za-z0-9_-]+)' requested from"),
+        re.compile(r"The repository '@([A-Za-z0-9_-]+)' could not be resolved"),
+        re.compile(r"No repository visible as '@([A-Za-z0-9_-]+)' from main repository"),
+        re.compile(r"This could either mean you have to add the '@([A-Za-z0-9_-]+)' repository"),
+    ]
 
-  for line in stderr.split("\n"):
-    for p in PATTERNS:
-      m = p.search(line)
-      if m:
-        eprint(line)
-        return m.groups()[0]
+    for line in stderr.split("\n"):
+        for p in PATTERNS:
+            m = p.search(line)
+            if m:
+                eprint(line)
+                return m.groups()[0]
 
-  return None
+    return None
 
 
 def write_at_given_place(filename, new_content, identifier):
-  """Write content to a file at a position marked by the identifier."""
-  file_content = ""
-  with open(filename, "r") as f:
-    file_content = f.read()
-    file_content = file_content.replace(
-        identifier,
-        new_content + "\n" + identifier,
-        1,
-    )
-  with open(filename, "w") as f:
-    f.write(file_content)
+    """Write content to a file at a position marked by the identifier."""
+    file_content = ""
+    with open(filename, "r") as f:
+        file_content = f.read()
+        file_content = file_content.replace(
+            identifier,
+            new_content + "\n" + identifier,
+            1,
+        )
+    with open(filename, "w") as f:
+        f.write(file_content)
 
 
 def add_repo_to_module_extension(repo, repo_def):
-  """Introduce a repository via a module extension."""
-  info(f"Introducing @{repo} via a module extension.")
+    """Introduce a repository via a module extension."""
+    info(f"Introducing @{repo} via a module extension.")
 
-  m = re.search(r'load\(\"@([\w\d-]+)\/\/', repo_def[0])
-  need_separate_module_extension = m and m.group(1) != "bazel_tools"
-  ext_name = f"extension_for_{m.group(1)}".replace(
-      "-", "_") if need_separate_module_extension else "non_module_deps"
-  ext_bzl_name = ext_name + ".bzl"
+    m = re.search(r"load\(\"@([\w\d-]+)\/\/", repo_def[0])
+    need_separate_module_extension = m and m.group(1) != "bazel_tools"
+    ext_name = f"extension_for_{m.group(1)}".replace("-", "_") if need_separate_module_extension else "non_module_deps"
+    ext_bzl_name = ext_name + ".bzl"
 
-  # Generate the initial bzl file for the module extension
-  if not pathlib.Path(ext_bzl_name).is_file():
-    scratch_file(ext_bzl_name, [
-        LOAD_IDENTIFIER,
-        "",
-        f"def _{ext_name}_impl(ctx):",
+    # Generate the initial bzl file for the module extension
+    if not pathlib.Path(ext_bzl_name).is_file():
+        scratch_file(
+            ext_bzl_name,
+            [
+                LOAD_IDENTIFIER,
+                "",
+                f"def _{ext_name}_impl(ctx):",
+                REPO_IDENTIFIER,
+                "",
+                f"{ext_name} = module_extension(implementation = _{ext_name}_impl)",
+            ],
+        )
+
+    # Add repo definition to the module extension's bzl file
+    bzl_content = open(ext_bzl_name, "r").read()
+    if repo_def[0] not in bzl_content:
+        write_at_given_place(ext_bzl_name, repo_def[0], LOAD_IDENTIFIER)
+    write_at_given_place(
+        ext_bzl_name,
+        "\n".join(["  " + line.replace("\n", "\n  ") for line in repo_def[1:]]),
         REPO_IDENTIFIER,
-        "",
-        f"{ext_name} = module_extension(implementation = _{ext_name}_impl)"
-    ])
+    )
 
-  # Add repo definition to the module extension's bzl file
-  bzl_content = open(ext_bzl_name, "r").read()
-  if repo_def[0] not in bzl_content:
-    write_at_given_place(ext_bzl_name, repo_def[0], LOAD_IDENTIFIER)
-  write_at_given_place(
-      ext_bzl_name,
-      "\n".join(["  " + line.replace("\n", "\n  ") for line in repo_def[1:]]),
-      REPO_IDENTIFIER,
-  )
-
-  # Add use_repo statement in the MODULE.bazel file
-  use_ext = f"{ext_name} = use_extension(\"//:{ext_name}.bzl\", \"{ext_name}\")"
-  module_bazel_content = open("MODULE.bazel", "r").read()
-  ext_identifier = f"# End of extension `{ext_name}`"
-  if use_ext not in module_bazel_content:
-    scratch_file("MODULE.bazel", ["", use_ext, ext_identifier], mode="a")
-  write_at_given_place(
-      "MODULE.bazel", f"use_repo({ext_name}, \"{repo}\")", ext_identifier)
+    # Add use_repo statement in the MODULE.bazel file
+    use_ext = f'{ext_name} = use_extension("//:{ext_name}.bzl", "{ext_name}")'
+    module_bazel_content = open("MODULE.bazel", "r").read()
+    ext_identifier = f"# End of extension `{ext_name}`"
+    if use_ext not in module_bazel_content:
+        scratch_file("MODULE.bazel", ["", use_ext, ext_identifier], mode="a")
+    write_at_given_place("MODULE.bazel", f'use_repo({ext_name}, "{repo}")', ext_identifier)
 
 
 def address_unavailable_repo_error(repo, resolved_deps, workspace_name):
-  error(f"@{repo} is not visible in the Bzlmod build.")
+    error(f"@{repo} is not visible in the Bzlmod build.")
 
-  # Check if it's the original main repo name
-  if repo == workspace_name:
-    error(
-        f"Please remove the usages of referring your own repo via `@{repo}//`, targets should be referenced directly with `//`. ")
-    eprint("If it's used in a macro, you can use `Label(\"//foo/bar\")` to make sure it always points to your repo no matter where the macro is used.")
-    eprint("You can temporarily work around this by adding `repo_name` attribute to the `module` directive in your MODULE.bazel file.")
-    abort_migration()
+    # Check if it's the original main repo name
+    if repo == workspace_name:
+        error(
+            f"Please remove the usages of referring your own repo via `@{repo}//`, targets should be referenced directly with `//`. "
+        )
+        eprint(
+            'If it\'s used in a macro, you can use `Label("//foo/bar")` to make sure it always points to your repo no matter where the macro is used.'
+        )
+        eprint(
+            "You can temporarily work around this by adding `repo_name` attribute to the `module` directive in your MODULE.bazel file."
+        )
+        abort_migration()
 
-  # Print the repo definition in the original WORKSPACE file
-  repo_def = []
-  for dep in resolved_deps:
-    if dep["original_attributes"]["name"] == repo:
-      repo_def = print_repo_definition(dep)
-      break
-  if not repo_def:
-    error(
-        f"Repository definition for {repo} isn't found in ./resolved_deps.py file, please add `--force/-f` flag to force update it.")
-    abort_migration()
+    # Print the repo definition in the original WORKSPACE file
+    repo_def = []
+    for dep in resolved_deps:
+        if dep["original_attributes"]["name"] == repo:
+            repo_def = print_repo_definition(dep)
+            break
+    if not repo_def:
+        error(
+            f"Repository definition for {repo} isn't found in ./resolved_deps.py file, please add `--force/-f` flag to force update it."
+        )
+        abort_migration()
 
-  # Check if a module is already available in the registry.
-  found_module = None
-  for module_name in REGISTRY_CLIENT.get_all_modules():
-    # Check if there is matching module name or a well known repo name for a matching module.
-    if repo == module_name or COMMON_REPO_TO_MODULE_MAP.get(repo) == module_name:
-      found_module = module_name
+    # Check if a module is already available in the registry.
+    found_module = None
+    for module_name in REGISTRY_CLIENT.get_all_modules():
+        # Check if there is matching module name or a well known repo name for a matching module.
+        if repo == module_name or COMMON_REPO_TO_MODULE_MAP.get(repo) == module_name:
+            found_module = module_name
 
-  if found_module:
-    metadata = REGISTRY_CLIENT.get_metadata(found_module)
-    version = metadata["versions"][-1]
-    repo_name = "" if repo == found_module else f", repo_name = \"{repo}\""
-    bazel_dep_line = f"bazel_dep(name = \"{found_module}\", version = \"{version}\"{repo_name})"
-    info(f"Found module `{found_module}` in the registry, available versions are " +
-         str(metadata["versions"]))
-    info(f"This can be introudced via a bazel_dep definition:")
-    eprint(f"    {bazel_dep_line}")
+    if found_module:
+        metadata = REGISTRY_CLIENT.get_metadata(found_module)
+        version = metadata["versions"][-1]
+        repo_name = "" if repo == found_module else f', repo_name = "{repo}"'
+        bazel_dep_line = f'bazel_dep(name = "{found_module}", version = "{version}"{repo_name})'
+        info(f"Found module `{found_module}` in the registry, available versions are " + str(metadata["versions"]))
+        info(f"This can be introudced via a bazel_dep definition:")
+        eprint(f"    {bazel_dep_line}")
 
-    if yes_or_no("Do you wish to add the bazel_dep definition to the MODULE.bazel file?", True):
-      info(f"Introducing @{repo} as a Bazel module.")
-      write_at_given_place("MODULE.bazel", bazel_dep_line,
-                           BAZEL_DEP_IDENTIFIER)
-      return True
-  else:
-    info(f"{repo} isn't found in the registry.")
+        if yes_or_no("Do you wish to add the bazel_dep definition to the MODULE.bazel file?", True):
+            info(f"Introducing @{repo} as a Bazel module.")
+            write_at_given_place("MODULE.bazel", bazel_dep_line, BAZEL_DEP_IDENTIFIER)
+            return True
+    else:
+        info(f"{repo} isn't found in the registry.")
 
-  # ask user if the dependency should be introduced via module extension if it looks like a starlark repository rule.
-  if repo_def[0].startswith("load(") and yes_or_no("Do you wish to introduce the repository with a module extension?", True):
-    add_repo_to_module_extension(repo, repo_def)
-  # Ask user if this dep should be added to the WORKSPACE.bzlmod for later migration.
-  elif yes_or_no("Do you wish to add the repo definition to WORKSPACE.bzlmod for later migration?", True):
-    repo_def = ["", "# TODO: Migrated to Bzlmod"] + repo_def
-    info(f"Introducing @{repo} in WORKSPACE.bzlmod file.")
-    scratch_file("WORKSPACE.bzlmod", repo_def, mode="a")
-  else:
-    info("Please manually add this dependency ...")
-    abort_migration()
-  return True
+    # ask user if the dependency should be introduced via module extension if it looks like a starlark repository rule.
+    if repo_def[0].startswith("load(") and yes_or_no(
+        "Do you wish to introduce the repository with a module extension?", True
+    ):
+        add_repo_to_module_extension(repo, repo_def)
+    # Ask user if this dep should be added to the WORKSPACE.bzlmod for later migration.
+    elif yes_or_no("Do you wish to add the repo definition to WORKSPACE.bzlmod for later migration?", True):
+        repo_def = ["", "# TODO: Migrated to Bzlmod"] + repo_def
+        info(f"Introducing @{repo} in WORKSPACE.bzlmod file.")
+        scratch_file("WORKSPACE.bzlmod", repo_def, mode="a")
+    else:
+        info("Please manually add this dependency ...")
+        abort_migration()
+    return True
 
 
 def detect_bind_issue(stderr):
-  """Search for error message that maybe caused by missing bind statements and return the missing target."""
-  for line in stderr.split("\n"):
-    s = re.search(r"no such target '(//external:[A-Za-z0-9_-]+)'", line)
-    if s:
-      eprint(line)
-      return s.groups()[0]
-  return None
+    """Search for error message that maybe caused by missing bind statements and return the missing target."""
+    for line in stderr.split("\n"):
+        s = re.search(r"no such target '(//external:[A-Za-z0-9_-]+)'", line)
+        if s:
+            eprint(line)
+            return s.groups()[0]
+    return None
 
 
 def address_bind_issue(bind_target, resolved_repos):
-  warning(
-      f"A bind target detected: {bind_target}! `bind` is already deprecated, you should reference the actual target directly instead of using //external:<target>.")
-
-  name = bind_target.split(":")[1]
-  bind_def = None
-  for dep in resolved_repos:
-    if dep["original_rule_class"] == "bind" and dep["original_attributes"]["name"] == name:
-      bind_def = print_repo_definition(dep)
-      break
-
-  if bind_def:
-    bind_def = ["", "# TODO: Remove the following bind usage"] + bind_def
-    if yes_or_no("Do you wish to add the bind definition to WORKSPACE.bzlmod for later migration?", True):
-      info(f"Adding bind statement for {bind_target} in WORKSPACE.bzlmod")
-      scratch_file("WORKSPACE.bzlmod", bind_def, mode="a")
-      return True
-  else:
     warning(
-        f"Bind definition for {bind_target} isn't found in ./resolved_deps.py file, please fix manually. "
-        + "You can get more verbose info by rerun the script with --sync/-s and --force/-f flags "
-        + "(but it might take a long time and could fail).")
-    abort_migration()
+        f"A bind target detected: {bind_target}! `bind` is already deprecated, you should reference the actual target directly instead of using //external:<target>."
+    )
+
+    name = bind_target.split(":")[1]
+    bind_def = None
+    for dep in resolved_repos:
+        if dep["original_rule_class"] == "bind" and dep["original_attributes"]["name"] == name:
+            bind_def = print_repo_definition(dep)
+            break
+
+    if bind_def:
+        bind_def = ["", "# TODO: Remove the following bind usage"] + bind_def
+        if yes_or_no("Do you wish to add the bind definition to WORKSPACE.bzlmod for later migration?", True):
+            info(f"Adding bind statement for {bind_target} in WORKSPACE.bzlmod")
+            scratch_file("WORKSPACE.bzlmod", bind_def, mode="a")
+            return True
+    else:
+        warning(
+            f"Bind definition for {bind_target} isn't found in ./resolved_deps.py file, please fix manually. "
+            + "You can get more verbose info by rerun the script with --sync/-s and --force/-f flags "
+            + "(but it might take a long time and could fail)."
+        )
+        abort_migration()
 
 
 def extract_version_number(bazel_version):
-  """Extracts the semantic version number from a version string
-  Args:
-    bazel_version: the version string that begins with the semantic version
-      e.g. "1.2.3rc1 abc1234" where "abc1234" is a commit hash.
-  Returns:
-    The semantic version string, like "1.2.3".
-  """
-  for i in range(len(bazel_version)):
-    c = bazel_version[i]
-    if not (c.isdigit() or c == "."):
-      return bazel_version[:i]
-  return bazel_version
+    """Extracts the semantic version number from a version string
+    Args:
+      bazel_version: the version string that begins with the semantic version
+        e.g. "1.2.3rc1 abc1234" where "abc1234" is a commit hash.
+    Returns:
+      The semantic version string, like "1.2.3".
+    """
+    for i in range(len(bazel_version)):
+        c = bazel_version[i]
+        if not (c.isdigit() or c == "."):
+            return bazel_version[:i]
+    return bazel_version
 
 
 def parse_bazel_version(bazel_version):
-  """Parses a version string into a 3-tuple of ints
-  int tuples can be compared directly using binary operators (<, >).
-  Args:
-    bazel_version: the Bazel version string
-  Returns:
-    An int 3-tuple of a (major, minor, patch) version.
-  """
+    """Parses a version string into a 3-tuple of ints
+    int tuples can be compared directly using binary operators (<, >).
+    Args:
+      bazel_version: the Bazel version string
+    Returns:
+      An int 3-tuple of a (major, minor, patch) version.
+    """
 
-  version = extract_version_number(bazel_version)
-  return tuple([int(n) for n in version.split(".")])
+    version = extract_version_number(bazel_version)
+    return tuple([int(n) for n in version.split(".")])
 
 
 def prepare_migration():
-  """Preparation work before starting the migration."""
-  exit_code, stdout, _ = execute_command(["bazel", "--version"])
-  eprint(stdout.strip())
-  if exit_code != 0 or not stdout:
-    warning("Current bazel is not a release version, please make sure you are running at least bazel 6.0.0")
-  elif parse_bazel_version(stdout.strip().split(" ")[1]) < (6, 0, 0):
-    error("Current Bazel version is older than 6.0.0, please upgrade your Bazel to at least 6.0.0. "
-          + "You can download Bazelisk from https://github.com/bazelbuild/bazelisk/releases and set env var USE_BAZEL_VERSION=6.0.0.")
-    abort_migration()
+    """Preparation work before starting the migration."""
+    exit_code, stdout, _ = execute_command(["bazel", "--version"])
+    eprint(stdout.strip())
+    if exit_code != 0 or not stdout:
+        warning("Current bazel is not a release version, please make sure you are running at least bazel 6.0.0")
+    elif parse_bazel_version(stdout.strip().split(" ")[1]) < (6, 0, 0):
+        error(
+            "Current Bazel version is older than 6.0.0, please upgrade your Bazel to at least 6.0.0. "
+            + "You can download Bazelisk from https://github.com/bazelbuild/bazelisk/releases and set env var USE_BAZEL_VERSION=6.0.0."
+        )
+        abort_migration()
 
-  # Parse the original workspace name from the WORKSPACE file
-  workspace_name = "main"
-  with open("WORKSPACE", "r") as f:
-    for line in f:
-      s = re.search(
-          r"workspace\(name\s+=\s+[\'\"]([A-Za-z0-9_-]+)[\'\"]", line)
-      if s:
-        workspace_name = s.groups()[0]
-        info(f"Detected original workspace name: {workspace_name}")
+    # Parse the original workspace name from the WORKSPACE file
+    workspace_name = "main"
+    with open("WORKSPACE", "r") as f:
+        for line in f:
+            s = re.search(r"workspace\(name\s+=\s+[\'\"]([A-Za-z0-9_-]+)[\'\"]", line)
+            if s:
+                workspace_name = s.groups()[0]
+                info(f"Detected original workspace name: {workspace_name}")
 
-  # Create MODULE.bazel file if it doesn't exist already.
-  if not pathlib.Path("MODULE.bazel").is_file():
-    scratch_file("MODULE.bazel", [
-                 f"module(name = \"{workspace_name}\", version=\"\")", "", BAZEL_DEP_IDENTIFIER])
-  module_bazel_content = open("MODULE.bazel", "r").read()
-  if BAZEL_DEP_IDENTIFIER not in module_bazel_content:
-    scratch_file("MODULE.bazel", ["", BAZEL_DEP_IDENTIFIER], mode="a")
+    # Create MODULE.bazel file if it doesn't exist already.
+    if not pathlib.Path("MODULE.bazel").is_file():
+        scratch_file("MODULE.bazel", [f'module(name = "{workspace_name}", version="")', "", BAZEL_DEP_IDENTIFIER])
+    module_bazel_content = open("MODULE.bazel", "r").read()
+    if BAZEL_DEP_IDENTIFIER not in module_bazel_content:
+        scratch_file("MODULE.bazel", ["", BAZEL_DEP_IDENTIFIER], mode="a")
 
-  # Create WORKSPACE.bzlmod file if it doesn't exist already.
-  scratch_file("WORKSPACE.bzlmod", [], mode="a")
+    # Create WORKSPACE.bzlmod file if it doesn't exist already.
+    scratch_file("WORKSPACE.bzlmod", [], mode="a")
 
-  return workspace_name
+    return workspace_name
 
 
 def generate_resolved_file(targets, use_bazel_sync):
-  exit_code, _, stderr = execute_command(["bazel", "clean", "--expunge"])
-  assertExitCode(exit_code, 0, "Failed to run `bazel clean --expunge`", stderr)
-  bazel_nobuild_command = ["bazel", "build", "--nobuild",
-                           "--experimental_repository_resolved_file=resolved_deps.py"] + targets
-  bazel_sync_comand = ["bazel", "sync",
-                       "--experimental_repository_resolved_file=resolved_deps.py"]
-  bazel_command = bazel_sync_comand if use_bazel_sync else bazel_nobuild_command
-  exit_code, _, stderr = execute_command(bazel_command)
-  assertExitCode(exit_code, 0, "Failed to run `" +
-                 " ".join(bazel_command) + "`", stderr)
+    exit_code, _, stderr = execute_command(["bazel", "clean", "--expunge"])
+    assertExitCode(exit_code, 0, "Failed to run `bazel clean --expunge`", stderr)
+    bazel_nobuild_command = [
+        "bazel",
+        "build",
+        "--nobuild",
+        "--experimental_repository_resolved_file=resolved_deps.py",
+    ] + targets
+    bazel_sync_comand = ["bazel", "sync", "--experimental_repository_resolved_file=resolved_deps.py"]
+    bazel_command = bazel_sync_comand if use_bazel_sync else bazel_nobuild_command
+    exit_code, _, stderr = execute_command(bazel_command)
+    assertExitCode(exit_code, 0, "Failed to run `" + " ".join(bazel_command) + "`", stderr)
 
 
 def load_resolved_deps(targets, use_bazel_sync, force):
-  """Generate and load the resolved file that contains external deps info."""
-  if not pathlib.Path('resolved_deps.py').is_file() or force:
-    info("Generating ./resolved_deps.py file")
-    generate_resolved_file(targets, use_bazel_sync)
-  else:
-    info("Found existing ./resolved_deps.py file, if it's out of date, please add `--force/-f` flag to force update it.")
+    """Generate and load the resolved file that contains external deps info."""
+    if not pathlib.Path("resolved_deps.py").is_file() or force:
+        info("Generating ./resolved_deps.py file")
+        generate_resolved_file(targets, use_bazel_sync)
+    else:
+        info(
+            "Found existing ./resolved_deps.py file, if it's out of date, please add `--force/-f` flag to force update it."
+        )
 
-  spec = importlib.util.spec_from_file_location(
-      "resolved_deps", "./resolved_deps.py")
-  module = importlib.util.module_from_spec(spec)
-  sys.modules["resolved_deps"] = module
-  spec.loader.exec_module(module)
-  resolved_deps = module.resolved
-  info("Found %d external repositories in the ./resolved_deps.py file." %
-       len(resolved_deps))
-  return resolved_deps
+    spec = importlib.util.spec_from_file_location("resolved_deps", "./resolved_deps.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["resolved_deps"] = module
+    spec.loader.exec_module(module)
+    resolved_deps = module.resolved
+    info("Found %d external repositories in the ./resolved_deps.py file." % len(resolved_deps))
+    return resolved_deps
 
 
 def main(argv=None):
-  if argv is None:
-    argv = sys.argv[1:]
+    if argv is None:
+        argv = sys.argv[1:]
 
-  parser = argparse.ArgumentParser(
-      prog="migrate_to_bzlmod",
-      description="A helper script for migrating your external dependencies from WORKSPACE to Bzlmod. "
-      + "For given targets, it first tries to generate a list of external dependencies for building your targets, "
-      + "then tries to detect and add missing dependencies in the Bzlmod build. "
-      + "You may still need to fix some problems manually.",
-      epilog="Example usage: change into your project directory and run `<path to BCR repo>/tools/migrate_to_bzlmod.py --target //foo:bar`")
-  parser.add_argument(
-      "-s",
-      "--sync",
-      action="store_true",
-      help="use `bazel sync` instead of `bazel build --nobuild` to generate the resolved dependencies. "
-      + "`bazel build --nobuild` only fetches dependencies needed for building specified targets, "
-      + "while `bazel sync` resolves and fetches all dependencies defined in your WORKSPACE file, "
-      + "including bind statements and execution platform & toolchain registrations.")
-  parser.add_argument(
-      "-f",
-      "--force",
-      action="store_true",
-      help="ignore previously generated resolved dependencies.")
-  parser.add_argument(
-      "-i",
-      "--interactive",
-      action="store_true",
-      help="ask the user interactively on what to do.")
-  parser.add_argument(
-      "-t",
-      "--target",
-      type=str,
-      action="append",
-      help="specify the targets you want to migrate. This flag is repeatable, and the targets are accumulated.")
+    parser = argparse.ArgumentParser(
+        prog="migrate_to_bzlmod",
+        description="A helper script for migrating your external dependencies from WORKSPACE to Bzlmod. "
+        + "For given targets, it first tries to generate a list of external dependencies for building your targets, "
+        + "then tries to detect and add missing dependencies in the Bzlmod build. "
+        + "You may still need to fix some problems manually.",
+        epilog="Example usage: change into your project directory and run `<path to BCR repo>/tools/migrate_to_bzlmod.py --target //foo:bar`",
+    )
+    parser.add_argument(
+        "-s",
+        "--sync",
+        action="store_true",
+        help="use `bazel sync` instead of `bazel build --nobuild` to generate the resolved dependencies. "
+        + "`bazel build --nobuild` only fetches dependencies needed for building specified targets, "
+        + "while `bazel sync` resolves and fetches all dependencies defined in your WORKSPACE file, "
+        + "including bind statements and execution platform & toolchain registrations.",
+    )
+    parser.add_argument("-f", "--force", action="store_true", help="ignore previously generated resolved dependencies.")
+    parser.add_argument("-i", "--interactive", action="store_true", help="ask the user interactively on what to do.")
+    parser.add_argument(
+        "-t",
+        "--target",
+        type=str,
+        action="append",
+        help="specify the targets you want to migrate. This flag is repeatable, and the targets are accumulated.",
+    )
 
-  args = parser.parse_args(argv)
+    args = parser.parse_args(argv)
 
-  if not args.target:
-    parser.print_help()
-    return 1
+    if not args.target:
+        parser.print_help()
+        return 1
 
-  workspace_name = prepare_migration()
+    workspace_name = prepare_migration()
 
-  resolved_deps = load_resolved_deps(args.target, args.sync, args.force)
+    resolved_deps = load_resolved_deps(args.target, args.sync, args.force)
 
-  yes_or_no.enable = args.interactive
+    yes_or_no.enable = args.interactive
 
-  while True:
-    # Try to build with Bzlmod enabled
-    targets = args.target
-    bazel_command = ["bazel", "build",
-                     "--nobuild", "--enable_bzlmod"] + targets
-    exit_code, _, stderr = execute_command(bazel_command)
-    if exit_code == 0:
-      info("Congratulations! All external repositories needed for building `" +
-           " ".join(targets) + "` are available with Bzlmod (and the WORKSPACE.bzlmod file)!")
-      info("Things you should do next:")
-      info("  - Migrate remaining dependencies in the WORKSPACE.bzlmod file to Bzlmod.")
-      info("  - Run the actual build with Bzlmod enabled (with --enable_bzlmod, but without --nobuild) and fix remaining build time issues.")
-      break
+    while True:
+        # Try to build with Bzlmod enabled
+        targets = args.target
+        bazel_command = ["bazel", "build", "--nobuild", "--enable_bzlmod"] + targets
+        exit_code, _, stderr = execute_command(bazel_command)
+        if exit_code == 0:
+            info(
+                "Congratulations! All external repositories needed for building `"
+                + " ".join(targets)
+                + "` are available with Bzlmod (and the WORKSPACE.bzlmod file)!"
+            )
+            info("Things you should do next:")
+            info("  - Migrate remaining dependencies in the WORKSPACE.bzlmod file to Bzlmod.")
+            info(
+                "  - Run the actual build with Bzlmod enabled (with --enable_bzlmod, but without --nobuild) and fix remaining build time issues."
+            )
+            break
 
-    # 1. Detect build failure caused by unavailable repository
-    repo = detect_unavailable_repo_error(stderr)
-    if repo:
-      if address_unavailable_repo_error(repo, resolved_deps, workspace_name):
-        continue
-      else:
-        abort_migration()
+        # 1. Detect build failure caused by unavailable repository
+        repo = detect_unavailable_repo_error(stderr)
+        if repo:
+            if address_unavailable_repo_error(repo, resolved_deps, workspace_name):
+                continue
+            else:
+                abort_migration()
 
-    # 2. Detect build failure caused by unavailable bind statements
-    bind_target = detect_bind_issue(stderr)
-    if bind_target:
-      if address_bind_issue(bind_target, resolved_deps):
-        continue
-      else:
-        abort_migration()
+        # 2. Detect build failure caused by unavailable bind statements
+        bind_target = detect_bind_issue(stderr)
+        if bind_target:
+            if address_bind_issue(bind_target, resolved_deps):
+                continue
+            else:
+                abort_migration()
 
-    error("Unrecognized error, please fix manually:\n" + stderr)
-    return 1
+        error("Unrecognized error, please fix manually:\n" + stderr)
+        return 1
 
-  return 0
+    return 0
 
 
 if __name__ == "__main__":
-  sys.exit(main())
+    sys.exit(main())

--- a/tools/migrate_to_bzlmod.py
+++ b/tools/migrate_to_bzlmod.py
@@ -159,7 +159,9 @@ def print_repo_definition(dep):
                         rule_name = new_rule_name
                     else:
                         warning(
-                            f"A visible macro for {rule_name} is defined in a different bzl file `{new_file_name}` other than `{file_label}`, you have to find out the correct label for `{new_file_name}` manually."
+                            f"A visible macro for {rule_name} is defined in a different bzl file `{new_file_name}` "
+                            f"other than `{file_label}`, "
+                            f"you have to find out the correct label for `{new_file_name}` manually."
                         )
                     break
     else:
@@ -276,13 +278,16 @@ def address_unavailable_repo_error(repo, resolved_deps, workspace_name):
     # Check if it's the original main repo name
     if repo == workspace_name:
         error(
-            f"Please remove the usages of referring your own repo via `@{repo}//`, targets should be referenced directly with `//`. "
+            f"Please remove the usages of referring your own repo via `@{repo}//`, "
+            "targets should be referenced directly with `//`. "
         )
         eprint(
-            'If it\'s used in a macro, you can use `Label("//foo/bar")` to make sure it always points to your repo no matter where the macro is used.'
+            'If it\'s used in a macro, you can use `Label("//foo/bar")` '
+            "to make sureit always points to your repo no matter where the macro is used."
         )
         eprint(
-            "You can temporarily work around this by adding `repo_name` attribute to the `module` directive in your MODULE.bazel file."
+            "You can temporarily work around this by adding `repo_name` attribute "
+            "to the `module` directive in your MODULE.bazel file."
         )
         abort_migration()
 
@@ -294,7 +299,8 @@ def address_unavailable_repo_error(repo, resolved_deps, workspace_name):
             break
     if not repo_def:
         error(
-            f"Repository definition for {repo} isn't found in ./resolved_deps.py file, please add `--force/-f` flag to force update it."
+            f"Repository definition for {repo} isn't found in ./resolved_deps.py file, "
+            "please add `--force/-f` flag to force update it."
         )
         abort_migration()
 
@@ -349,7 +355,8 @@ def detect_bind_issue(stderr):
 
 def address_bind_issue(bind_target, resolved_repos):
     warning(
-        f"A bind target detected: {bind_target}! `bind` is already deprecated, you should reference the actual target directly instead of using //external:<target>."
+        f"A bind target detected: {bind_target}! `bind` is already deprecated,"
+        " you should reference the actual target directly instead of using //external:<target>."
     )
 
     name = bind_target.split(":")[1]
@@ -411,7 +418,8 @@ def prepare_migration():
     elif parse_bazel_version(stdout.strip().split(" ")[1]) < (6, 0, 0):
         error(
             "Current Bazel version is older than 6.0.0, please upgrade your Bazel to at least 6.0.0. "
-            + "You can download Bazelisk from https://github.com/bazelbuild/bazelisk/releases and set env var USE_BAZEL_VERSION=6.0.0."
+            + "You can download Bazelisk from https://github.com/bazelbuild/bazelisk/releases "
+            + "and set env var USE_BAZEL_VERSION=6.0.0."
         )
         abort_migration()
 
@@ -459,7 +467,8 @@ def load_resolved_deps(targets, use_bazel_sync, force):
         generate_resolved_file(targets, use_bazel_sync)
     else:
         info(
-            "Found existing ./resolved_deps.py file, if it's out of date, please add `--force/-f` flag to force update it."
+            "Found existing ./resolved_deps.py file, "
+            "if it's out of date, please add `--force/-f` flag to force update it."
         )
 
     spec = importlib.util.spec_from_file_location("resolved_deps", "./resolved_deps.py")
@@ -481,7 +490,10 @@ def main(argv=None):
         + "For given targets, it first tries to generate a list of external dependencies for building your targets, "
         + "then tries to detect and add missing dependencies in the Bzlmod build. "
         + "You may still need to fix some problems manually.",
-        epilog="Example usage: change into your project directory and run `<path to BCR repo>/tools/migrate_to_bzlmod.py --target //foo:bar`",
+        epilog=(
+            "Example usage: change into your project directory and run "
+            "`<path to BCR repo>/tools/migrate_to_bzlmod.py --target //foo:bar`"
+        ),
     )
     parser.add_argument(
         "-s",
@@ -528,7 +540,8 @@ def main(argv=None):
             info("Things you should do next:")
             info("  - Migrate remaining dependencies in the WORKSPACE.bzlmod file to Bzlmod.")
             info(
-                "  - Run the actual build with Bzlmod enabled (with --enable_bzlmod, but without --nobuild) and fix remaining build time issues."
+                "  - Run the actual build with Bzlmod enabled (with --enable_bzlmod, but without --nobuild) "
+                "and fix remaining build time issues."
             )
             break
 

--- a/tools/print_all_src_urls.py
+++ b/tools/print_all_src_urls.py
@@ -22,13 +22,15 @@ import sys
 
 from registry import RegistryClient
 
+
 def main():
-  client = RegistryClient(".")
-  for name, version in client.get_all_module_versions(include_yanked=False):
-    print(client.get_source(name, version)["url"])
+    client = RegistryClient(".")
+    for name, version in client.get_all_module_versions(include_yanked=False):
+        print(client.get_source(name, version)["url"])
+
 
 if __name__ == "__main__":
-  # Under 'bazel run' we want to run within the source folder instead of the execroot.
-  if os.getenv("BUILD_WORKSPACE_DIRECTORY"):
-    os.chdir(os.getenv("BUILD_WORKSPACE_DIRECTORY"))
-  sys.exit(main())
+    # Under 'bazel run' we want to run within the source folder instead of the execroot.
+    if os.getenv("BUILD_WORKSPACE_DIRECTORY"):
+        os.chdir(os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+    sys.exit(main())

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -37,178 +37,180 @@ RESET = "\x1b[0m"
 
 
 def log(msg):
-  print(f"{GREEN}INFO: {RESET}{msg}")
+    print(f"{GREEN}INFO: {RESET}{msg}")
 
 
 def download(url):
-  parts = urllib.parse.urlparse(url)
-  headers = {'User-Agent': 'Mozilla/5.0'}  # Set the User-Agent header
-  try:
-    authenticators = netrc.netrc().authenticators(parts.netloc)
-  except FileNotFoundError:
-    authenticators = None
-  if authenticators != None:
-    (login, _, password) = authenticators
-    req = urllib.request.Request(url, headers=headers)
-    creds = base64.b64encode(str.encode('%s:%s' % (login, password))).decode()
-    req.add_header("Authorization", "Basic %s" % creds)
-  else:
-    req = urllib.request.Request(url, headers=headers)
+    parts = urllib.parse.urlparse(url)
+    headers = {"User-Agent": "Mozilla/5.0"}  # Set the User-Agent header
+    try:
+        authenticators = netrc.netrc().authenticators(parts.netloc)
+    except FileNotFoundError:
+        authenticators = None
+    if authenticators != None:
+        (login, _, password) = authenticators
+        req = urllib.request.Request(url, headers=headers)
+        creds = base64.b64encode(str.encode("%s:%s" % (login, password))).decode()
+        req.add_header("Authorization", "Basic %s" % creds)
+    else:
+        req = urllib.request.Request(url, headers=headers)
 
-  with urllib.request.urlopen(req) as response:
-    return response.read()
+    with urllib.request.urlopen(req) as response:
+        return response.read()
+
 
 def download_file(url, file):
-  with open(file, "wb") as f:
-      f.write(download(url))
+    with open(file, "wb") as f:
+        f.write(download(url))
+
 
 def read(path):
-  with open(path, "rb") as file:
-    return file.read()
+    with open(path, "rb") as file:
+        return file.read()
 
 
 def integrity(data, algorithm="sha256"):
-  assert algorithm in {"sha224", "sha256", "sha384", "sha512"}, "Unsupported SRI algorithm"
-  hash = getattr(hashlib, algorithm)(data)
-  encoded = base64.b64encode(hash.digest()).decode()
-  return f"{algorithm}-{encoded}"
+    assert algorithm in {"sha224", "sha256", "sha384", "sha512"}, "Unsupported SRI algorithm"
+    hash = getattr(hashlib, algorithm)(data)
+    encoded = base64.b64encode(hash.digest()).decode()
+    return f"{algorithm}-{encoded}"
 
 
 def json_dump(file, data, sort_keys=True):
-  with open(file, "w") as f:
-    json.dump(data, f, indent=4, sort_keys=sort_keys)
-    f.write("\n")
+    with open(file, "w") as f:
+        json.dump(data, f, indent=4, sort_keys=sort_keys)
+        f.write("\n")
+
 
 # Translated from:
 # https://github.com/bazelbuild/bazel/blob/79a53def2ebbd9358450f739ea37bf70662e8614/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/Version.java#L58
 @functools.total_ordering
 class Version:
+    @functools.total_ordering
+    class Identifier:
+        def __init__(self, s):
+            if not s:
+                raise RegistryException("identifier is empty")
+            self.val = int(s) if s.isnumeric() else s
 
-  @functools.total_ordering
-  class Identifier:
-    def __init__(self, s):
-      if not s:
-        raise RegistryException("identifier is empty")
-      self.val = int(s) if s.isnumeric() else s
+        def __eq__(self, other):
+            if type(self.val) != type(other.val):
+                return False
+            return self.val == other.val
+
+        def __lt__(self, other):
+            if type(self.val) != type(other.val):
+                return type(self.val) == int
+            return self.val < other.val
+
+    @staticmethod
+    def convert_to_identifiers(s):
+        if s == None:
+            return None
+        return [Version.Identifier(i) for i in s.split(".")]
+
+    def __init__(self, version_str):
+        PATTERN = re.compile(r"^([a-zA-Z0-9.]+)(?:-([a-zA-Z0-9.-]+))?(?:\+[a-zA-Z0-9.-]+)?$")
+        m = PATTERN.match(version_str)
+        if not m:
+            raise RegistryException(f"`{version_str}` is not a valid version")
+        self.release = Version.convert_to_identifiers(m.groups()[0])
+        self.prerelease = Version.convert_to_identifiers(m.groups()[1])
 
     def __eq__(self, other):
-      if type(self.val) != type(other.val):
-        return False
-      return self.val == other.val
+        return (self.release, self.prerelease) == (other.release, other.prerelease)
 
     def __lt__(self, other):
-      if type(self.val) != type(other.val):
-        return type(self.val) == int
-      return self.val < other.val
-
-  @staticmethod
-  def convert_to_identifiers(s):
-    if s == None:
-      return None
-    return [Version.Identifier(i) for i in s.split(".")]
-
-  def __init__(self, version_str):
-    PATTERN = re.compile(r"^([a-zA-Z0-9.]+)(?:-([a-zA-Z0-9.-]+))?(?:\+[a-zA-Z0-9.-]+)?$")
-    m = PATTERN.match(version_str)
-    if not m:
-      raise RegistryException(f"`{version_str}` is not a valid version")
-    self.release = Version.convert_to_identifiers(m.groups()[0])
-    self.prerelease = Version.convert_to_identifiers(m.groups()[1])
-
-  def __eq__(self, other):
-    return (self.release, self.prerelease) == (other.release, other.prerelease)
-
-  def __lt__(self, other):
-    if self.release != other.release:
-      return self.release < other.release
-    if self.prerelease == None:
-      return False
-    if other.prerelease == None:
-      return True
-    return self.prerelease < other.prerelease
+        if self.release != other.release:
+            return self.release < other.release
+        if self.prerelease == None:
+            return False
+        if other.prerelease == None:
+            return True
+        return self.prerelease < other.prerelease
 
 
 class Module:
-  """A class to represent all information of a Bazel module."""
+    """A class to represent all information of a Bazel module."""
 
-  def __init__(self, name=None, version=None, compatibility_level=1):
-    self.name = name
-    self.version = version
-    self.compatibility_level = compatibility_level
-    self.module_dot_bazel = None
-    self.url = None
-    self.strip_prefix = None
-    self.deps = []
-    self.patches = []
-    self.patch_strip = 0
-    self.build_file = None
-    self.presubmit_yml = None
-    self.build_targets = []
-    self.test_module_path = None
-    self.test_module_build_targets = []
-    self.test_module_test_targets = []
+    def __init__(self, name=None, version=None, compatibility_level=1):
+        self.name = name
+        self.version = version
+        self.compatibility_level = compatibility_level
+        self.module_dot_bazel = None
+        self.url = None
+        self.strip_prefix = None
+        self.deps = []
+        self.patches = []
+        self.patch_strip = 0
+        self.build_file = None
+        self.presubmit_yml = None
+        self.build_targets = []
+        self.test_module_path = None
+        self.test_module_build_targets = []
+        self.test_module_test_targets = []
 
-  def add_dep(self, module_name, version):
-    self.deps.append((module_name, version))
-    return self
+    def add_dep(self, module_name, version):
+        self.deps.append((module_name, version))
+        return self
 
-  def set_module_dot_bazel(self, module_dot_bazel):
-    self.module_dot_bazel = module_dot_bazel
-    return self
+    def set_module_dot_bazel(self, module_dot_bazel):
+        self.module_dot_bazel = module_dot_bazel
+        return self
 
-  def set_source(self, url, strip_prefix=None):
-    self.url = url
-    self.strip_prefix = strip_prefix
-    return self
+    def set_source(self, url, strip_prefix=None):
+        self.url = url
+        self.strip_prefix = strip_prefix
+        return self
 
-  def add_patch(self, patch_file):
-    self.patches.append(patch_file)
-    return self
+    def add_patch(self, patch_file):
+        self.patches.append(patch_file)
+        return self
 
-  def set_patch_strip(self, patch_strip):
-    self.patch_strip = patch_strip
-    return self
+    def set_patch_strip(self, patch_strip):
+        self.patch_strip = patch_strip
+        return self
 
-  def set_build_file(self, build_file):
-    self.build_file = build_file
-    return self
+    def set_build_file(self, build_file):
+        self.build_file = build_file
+        return self
 
-  def set_presubmit_yml(self, presubmit_yml):
-    self.presubmit_yml = presubmit_yml
-    return self
+    def set_presubmit_yml(self, presubmit_yml):
+        self.presubmit_yml = presubmit_yml
+        return self
 
-  def add_build_target(self, target):
-    if not target.startswith("@" + self.name):
-      target = "@" + self.name + target
-    self.build_targets.append(target)
-    return self
+    def add_build_target(self, target):
+        if not target.startswith("@" + self.name):
+            target = "@" + self.name + target
+        self.build_targets.append(target)
+        return self
 
-  def add_test_module_build_target(self, target):
-    self.test_module_build_targets.append(target)
-    return self
+    def add_test_module_build_target(self, target):
+        self.test_module_build_targets.append(target)
+        return self
 
-  def add_test_module_test_target(self, target):
-    self.test_module_test_targets.append(target)
-    return self
+    def add_test_module_test_target(self, target):
+        self.test_module_test_targets.append(target)
+        return self
 
-  def dump(self, file):
-    json_dump(file, self.__dict__)
+    def dump(self, file):
+        json_dump(file, self.__dict__)
 
-  def from_json(self, file):
-    with open(file) as f:
-      self.__dict__ = json.load(f)
+    def from_json(self, file):
+        with open(file) as f:
+            self.__dict__ = json.load(f)
 
 
 class RegistryException(Exception):
-  """
-  Raised whenever something goes wrong with modifying the registry.
-  """
+    """
+    Raised whenever something goes wrong with modifying the registry.
+    """
 
 
 class RegistryClient:
-  """A class to help create a Bazel registry."""
+    """A class to help create a Bazel registry."""
 
-  _MODULE_BAZEL = """
+    _MODULE_BAZEL = """
 module(
     name = "{0}",
     version = "{1}",
@@ -216,283 +218,264 @@ module(
 )
 """.strip()
 
-  def __init__(self, root):
-    self.root = pathlib.Path(root)
+    def __init__(self, root):
+        self.root = pathlib.Path(root)
 
-  def get_all_modules(self):
-    modules_dir = self.root.joinpath("modules")
-    return [path.name for path in modules_dir.iterdir()]
+    def get_all_modules(self):
+        modules_dir = self.root.joinpath("modules")
+        return [path.name for path in modules_dir.iterdir()]
 
-  def get_module_versions(self, module_name, include_yanked=True):
-    module_versions = []
-    metadata = self.get_metadata(module_name)
-    for version in metadata["versions"]:
-      if include_yanked or version not in metadata.get("yanked_versions", {}):
-        module_versions.append((module_name, version))
-    return module_versions
+    def get_module_versions(self, module_name, include_yanked=True):
+        module_versions = []
+        metadata = self.get_metadata(module_name)
+        for version in metadata["versions"]:
+            if include_yanked or version not in metadata.get("yanked_versions", {}):
+                module_versions.append((module_name, version))
+        return module_versions
 
-  def get_all_module_versions(self, include_yanked=True):
-    module_versions = []
-    for module_name in self.get_all_modules():
-      module_versions.extend(self.get_module_versions(module_name, include_yanked))
-    return module_versions
+    def get_all_module_versions(self, include_yanked=True):
+        module_versions = []
+        for module_name in self.get_all_modules():
+            module_versions.extend(self.get_module_versions(module_name, include_yanked))
+        return module_versions
 
-  def get_metadata(self, module_name):
-    return json.loads(self.get_metadata_path(module_name).read_text())
+    def get_metadata(self, module_name):
+        return json.loads(self.get_metadata_path(module_name).read_text())
 
-  def get_metadata_path(self, module_name):
-    return self.root / "modules" / module_name / "metadata.json"
+    def get_metadata_path(self, module_name):
+        return self.root / "modules" / module_name / "metadata.json"
 
-  def get_module_dir(self, module_name):
-    return self.root / "modules" / module_name
+    def get_module_dir(self, module_name):
+        return self.root / "modules" / module_name
 
-  def get_version_dir(self, module_name, version):
-    return self.get_module_dir(module_name) / version
+    def get_version_dir(self, module_name, version):
+        return self.get_module_dir(module_name) / version
 
-  def get_overlay_dir(self, module_name, version):
-    return self.get_version_dir(module_name, version) / "overlay"
+    def get_overlay_dir(self, module_name, version):
+        return self.get_version_dir(module_name, version) / "overlay"
 
-  def get_source(self, module_name, version):
-    return json.loads(self.get_source_json_path(module_name, version).read_text())
+    def get_source(self, module_name, version):
+        return json.loads(self.get_source_json_path(module_name, version).read_text())
 
-  def get_source_json_path(self, module_name, version):
-    return self.get_version_dir(module_name, version) / "source.json"
+    def get_source_json_path(self, module_name, version):
+        return self.get_version_dir(module_name, version) / "source.json"
 
-  def get_presubmit_yml_path(self, module_name, version):
-    return self.get_version_dir(module_name, version) / "presubmit.yml"
+    def get_presubmit_yml_path(self, module_name, version):
+        return self.get_version_dir(module_name, version) / "presubmit.yml"
 
-  def get_patch_file_path(self, module_name, version, patch_name):
-    return self.get_version_dir(module_name, version) / "patches" / patch_name
+    def get_patch_file_path(self, module_name, version, patch_name):
+        return self.get_version_dir(module_name, version) / "patches" / patch_name
 
-  def get_module_dot_bazel_path(self, module_name, version):
-    return self.get_version_dir(module_name, version) / "MODULE.bazel"
+    def get_module_dot_bazel_path(self, module_name, version):
+        return self.get_version_dir(module_name, version) / "MODULE.bazel"
 
-  def contains(self, module_name, version=None):
-    """
-    Check if the registry contains a module or a specific version of a
-    module by verifying if the directory exists.
-    """
-    dir_path = self.root.joinpath("modules", module_name)
-    if version:
-      dir_path = dir_path.joinpath(version)
-    return dir_path.is_dir()
+    def contains(self, module_name, version=None):
+        """
+        Check if the registry contains a module or a specific version of a
+        module by verifying if the directory exists.
+        """
+        dir_path = self.root.joinpath("modules", module_name)
+        if version:
+            dir_path = dir_path.joinpath(version)
+        return dir_path.is_dir()
 
-  def init_module(self, module_name, maintainers, homepage, source_repository = ""):
-    """
-    Initialize a module, create the directory and metadata.json file.
+    def init_module(self, module_name, maintainers, homepage, source_repository=""):
+        """
+        Initialize a module, create the directory and metadata.json file.
 
-    Parameters
-    ----------
-    module_name : str
-        The module name
-    maintainers : list of maps of string -> string
-        The maintainer information, eg
-         [{"name": "John", "email": "john@guugoo.com"},
-          {"name": "Yun", "github": "meteorcloudy"}]
-    homepage : str
-        A URL to the project's homepage
+        Parameters
+        ----------
+        module_name : str
+            The module name
+        maintainers : list of maps of string -> string
+            The maintainer information, eg
+             [{"name": "John", "email": "john@guugoo.com"},
+              {"name": "Yun", "github": "meteorcloudy"}]
+        homepage : str
+            A URL to the project's homepage
 
-    """
-    p = self.root.joinpath("modules", module_name)
-    p.mkdir(parents=True, exist_ok=True)
+        """
+        p = self.root.joinpath("modules", module_name)
+        p.mkdir(parents=True, exist_ok=True)
 
-    # Create metadata.json file
-    metadata = {
-        "maintainers": maintainers,
-        "homepage": homepage,
-        "repository": [source_repository] if source_repository else [],
-        "versions": [],
-        "yanked_versions": {},
-    }
-    json_dump(p.joinpath("metadata.json"), metadata)
-
-  def add(self, module, override=False):
-    """
-    Add a new module version, the module must be already initialized
-
-    Parameters
-    ----------
-    module : Module
-        A Module instance containing information of the module version to
-        be added
-    override : Whether to override existing module
-    """
-    # Check if the module version already exists
-    if self.contains(module.name, module.version):
-      if override:
-        log("Overriding module '%s' at version '%s'..." %
-            (module.name, module.version))
-        self.delete(module.name, module.version)
-      else:
-        raise RegistryException(
-            f"Version {module.version} for module {module.name} already exists.")
-
-    p = self.root.joinpath("modules", module.name, module.version)
-    p.mkdir()
-
-    # Create MODULE.bazel
-    module_dot_bazel = p.joinpath("MODULE.bazel")
-    if module.module_dot_bazel:
-      # TODO(pcloudy): Sanity check the given MODULE.bazel
-      #   - module name and version should match the specified values
-      #   - no override is used
-      shutil.copy(module.module_dot_bazel, module_dot_bazel)
-    else:
-      deps = "\n".join(
-          f"bazel_dep(name = \"{name}\", version = \"{version}\")"
-          for name, version in module.deps)
-      with module_dot_bazel.open("w") as f:
-        f.write(self._MODULE_BAZEL.format(
-            module.name, module.version,
-            module.compatibility_level))
-        if deps:
-          f.write("\n")
-          f.write(deps)
-        f.write("\n")
-
-    # Create source.json & copy patch files to the registry
-    source = {
-        "url": module.url,
-        "integrity": integrity(download(module.url)),
-    }
-    if module.strip_prefix:
-      source["strip_prefix"] = module.strip_prefix
-
-    patch_dir = p.joinpath("patches")
-    if module.patches or module.build_file:
-      patch_dir.mkdir()
-      source["patches"] = {}
-      source["patch_strip"] = module.patch_strip
-
-    if module.patches:
-      for s in module.patches:
-        patch = pathlib.Path(s)
-        source["patches"][patch.name] = integrity(read(patch))
-        shutil.copy(patch, patch_dir)
-
-    # Turn additional BUILD file into a patch
-    if module.build_file:
-      build_file_content = pathlib.Path(module.build_file).open().readlines()
-      build_file = "a/" * module.patch_strip + "BUILD.bazel"
-      patch_content = difflib.unified_diff(
-          [], build_file_content, "/dev/null", build_file)
-      patch_name = "add_build_file.patch"
-      patch = patch_dir.joinpath(patch_name)
-      with patch.open("w") as f:
-        f.writelines(patch_content)
-      source["patches"][patch_name] = integrity(read(patch))
-
-    json_dump(p.joinpath("source.json"), source, sort_keys=False)
-
-    # Create presubmit.yml file
-    presubmit_yml = p.joinpath("presubmit.yml")
-    if module.presubmit_yml:
-      shutil.copy(module.presubmit_yml, presubmit_yml)
-    else:
-      PLATFORMS = ["debian10", "ubuntu2004", "macos", "macos_arm64", "windows"]
-      BAZEL_VERSIONS = ["7.x", "6.x"]
-      presubmit = {
-          "matrix": {
-              "platform": PLATFORMS.copy(),
-              "bazel": BAZEL_VERSIONS.copy(),
-          },
-          "tasks": {
-              "verify_targets": {
-                  "name": "Verify build targets",
-                  "platform": "${{ platform }}",
-                  "bazel": "${{ bazel }}",
-                  "build_targets": module.build_targets.copy()
-              }
-          }
-      }
-
-      if module.test_module_path:
-        task = {
-            "name": "Run test module",
-            "platform": "${{ platform }}",
-            "bazel": "${{ bazel }}",
+        # Create metadata.json file
+        metadata = {
+            "maintainers": maintainers,
+            "homepage": homepage,
+            "repository": [source_repository] if source_repository else [],
+            "versions": [],
+            "yanked_versions": {},
         }
-        if module.test_module_build_targets:
-          task["build_targets"] = module.test_module_build_targets.copy()
-        if module.test_module_test_targets:
-          task["test_targets"] = module.test_module_test_targets.copy()
-        presubmit["bcr_test_module"] = {
-            "module_path": module.test_module_path,
-            "matrix": {
-                "platform": PLATFORMS.copy(),
-                "bazel": BAZEL_VERSIONS.copy(),
-            },
-            "tasks": {
-                "run_test_module": task
+        json_dump(p.joinpath("metadata.json"), metadata)
+
+    def add(self, module, override=False):
+        """
+        Add a new module version, the module must be already initialized
+
+        Parameters
+        ----------
+        module : Module
+            A Module instance containing information of the module version to
+            be added
+        override : Whether to override existing module
+        """
+        # Check if the module version already exists
+        if self.contains(module.name, module.version):
+            if override:
+                log("Overriding module '%s' at version '%s'..." % (module.name, module.version))
+                self.delete(module.name, module.version)
+            else:
+                raise RegistryException(f"Version {module.version} for module {module.name} already exists.")
+
+        p = self.root.joinpath("modules", module.name, module.version)
+        p.mkdir()
+
+        # Create MODULE.bazel
+        module_dot_bazel = p.joinpath("MODULE.bazel")
+        if module.module_dot_bazel:
+            # TODO(pcloudy): Sanity check the given MODULE.bazel
+            #   - module name and version should match the specified values
+            #   - no override is used
+            shutil.copy(module.module_dot_bazel, module_dot_bazel)
+        else:
+            deps = "\n".join(f'bazel_dep(name = "{name}", version = "{version}")' for name, version in module.deps)
+            with module_dot_bazel.open("w") as f:
+                f.write(self._MODULE_BAZEL.format(module.name, module.version, module.compatibility_level))
+                if deps:
+                    f.write("\n")
+                    f.write(deps)
+                f.write("\n")
+
+        # Create source.json & copy patch files to the registry
+        source = {
+            "url": module.url,
+            "integrity": integrity(download(module.url)),
+        }
+        if module.strip_prefix:
+            source["strip_prefix"] = module.strip_prefix
+
+        patch_dir = p.joinpath("patches")
+        if module.patches or module.build_file:
+            patch_dir.mkdir()
+            source["patches"] = {}
+            source["patch_strip"] = module.patch_strip
+
+        if module.patches:
+            for s in module.patches:
+                patch = pathlib.Path(s)
+                source["patches"][patch.name] = integrity(read(patch))
+                shutil.copy(patch, patch_dir)
+
+        # Turn additional BUILD file into a patch
+        if module.build_file:
+            build_file_content = pathlib.Path(module.build_file).open().readlines()
+            build_file = "a/" * module.patch_strip + "BUILD.bazel"
+            patch_content = difflib.unified_diff([], build_file_content, "/dev/null", build_file)
+            patch_name = "add_build_file.patch"
+            patch = patch_dir.joinpath(patch_name)
+            with patch.open("w") as f:
+                f.writelines(patch_content)
+            source["patches"][patch_name] = integrity(read(patch))
+
+        json_dump(p.joinpath("source.json"), source, sort_keys=False)
+
+        # Create presubmit.yml file
+        presubmit_yml = p.joinpath("presubmit.yml")
+        if module.presubmit_yml:
+            shutil.copy(module.presubmit_yml, presubmit_yml)
+        else:
+            PLATFORMS = ["debian10", "ubuntu2004", "macos", "macos_arm64", "windows"]
+            BAZEL_VERSIONS = ["7.x", "6.x"]
+            presubmit = {
+                "matrix": {
+                    "platform": PLATFORMS.copy(),
+                    "bazel": BAZEL_VERSIONS.copy(),
+                },
+                "tasks": {
+                    "verify_targets": {
+                        "name": "Verify build targets",
+                        "platform": "${{ platform }}",
+                        "bazel": "${{ bazel }}",
+                        "build_targets": module.build_targets.copy(),
+                    }
+                },
             }
-        }
 
-      with presubmit_yml.open("w") as f:
-        yaml.dump(presubmit, f, sort_keys=False)
+            if module.test_module_path:
+                task = {
+                    "name": "Run test module",
+                    "platform": "${{ platform }}",
+                    "bazel": "${{ bazel }}",
+                }
+                if module.test_module_build_targets:
+                    task["build_targets"] = module.test_module_build_targets.copy()
+                if module.test_module_test_targets:
+                    task["test_targets"] = module.test_module_test_targets.copy()
+                presubmit["bcr_test_module"] = {
+                    "module_path": module.test_module_path,
+                    "matrix": {
+                        "platform": PLATFORMS.copy(),
+                        "bazel": BAZEL_VERSIONS.copy(),
+                    },
+                    "tasks": {"run_test_module": task},
+                }
 
-    # Add new version to metadata.json
-    metadata_path = self.root.joinpath("modules", module.name,
-                                       "metadata.json")
-    metadata = json.load(metadata_path.open())
-    metadata["versions"].append(module.version)
-    metadata["versions"] = list(set(metadata["versions"]))
-    metadata["versions"].sort(key=Version)
-    json_dump(metadata_path, metadata)
+            with presubmit_yml.open("w") as f:
+                yaml.dump(presubmit, f, sort_keys=False)
 
-  def update_versions(self, module_name):
-    """Update the list of versions in the metadata.json."""
-    module_path = self.root / "modules" / module_name
-    versions = (v.name for v in module_path.iterdir() if v.is_dir())
-    metadata = self.get_metadata(module_name)
-    metadata["versions"] = sorted(versions, key=Version)
-    metadata_path = self.get_metadata_path(module_name)
-    json_dump(metadata_path, metadata)
+        # Add new version to metadata.json
+        metadata_path = self.root.joinpath("modules", module.name, "metadata.json")
+        metadata = json.load(metadata_path.open())
+        metadata["versions"].append(module.version)
+        metadata["versions"] = list(set(metadata["versions"]))
+        metadata["versions"].sort(key=Version)
+        json_dump(metadata_path, metadata)
 
-  def update_integrity(self, module_name, version):
-    """Update the SRI hashes of the source.json file of module at version."""
-    source = self.get_source(module_name, version)
-    source["integrity"] = integrity(download(source["url"]))
-    source_path = self.get_source_json_path(module_name, version)
+    def update_versions(self, module_name):
+        """Update the list of versions in the metadata.json."""
+        module_path = self.root / "modules" / module_name
+        versions = (v.name for v in module_path.iterdir() if v.is_dir())
+        metadata = self.get_metadata(module_name)
+        metadata["versions"] = sorted(versions, key=Version)
+        metadata_path = self.get_metadata_path(module_name)
+        json_dump(metadata_path, metadata)
 
-    patch_dir = source_path.parent / "patches"
-    if patch_dir.exists():
-      available = sorted(p.name for p in patch_dir.iterdir())
-    else:
-      available = []
-    current = source.get("patches", {}).keys()
-    patch_files = [patch_dir / p for p in current]
-    patch_files.extend(patch_dir / p for p in available if p not in current)
-    patches = {
-      str(patch.relative_to(patch_dir)): integrity(read(patch))
-      for patch in patch_files
-    }
-    if patches:
-      source["patches"] = patches
-    else:
-      source.pop("patches", None)
+    def update_integrity(self, module_name, version):
+        """Update the SRI hashes of the source.json file of module at version."""
+        source = self.get_source(module_name, version)
+        source["integrity"] = integrity(download(source["url"]))
+        source_path = self.get_source_json_path(module_name, version)
 
-    overlay_dir = self.get_overlay_dir(module_name, version)
-    overlay_files = {
-      file
-      for file in source.get("overlay", {}).keys()
-      if (overlay_dir / file).is_file()
-    }
-    overlay_integrities = {
-      file: integrity(read(overlay_dir / file)) for file in overlay_files
-    }
-    if overlay_files:
-      source["overlay"] = overlay_integrities
-    else:
-      source.pop("overlay", None)
+        patch_dir = source_path.parent / "patches"
+        if patch_dir.exists():
+            available = sorted(p.name for p in patch_dir.iterdir())
+        else:
+            available = []
+        current = source.get("patches", {}).keys()
+        patch_files = [patch_dir / p for p in current]
+        patch_files.extend(patch_dir / p for p in available if p not in current)
+        patches = {str(patch.relative_to(patch_dir)): integrity(read(patch)) for patch in patch_files}
+        if patches:
+            source["patches"] = patches
+        else:
+            source.pop("patches", None)
 
-    json_dump(source_path, source, sort_keys=False)
+        overlay_dir = self.get_overlay_dir(module_name, version)
+        overlay_files = {file for file in source.get("overlay", {}).keys() if (overlay_dir / file).is_file()}
+        overlay_integrities = {file: integrity(read(overlay_dir / file)) for file in overlay_files}
+        if overlay_files:
+            source["overlay"] = overlay_integrities
+        else:
+            source.pop("overlay", None)
 
-  def delete(self, module_name, version):
-    """Delete an existing module version."""
-    p = self.root.joinpath("modules", module_name)
-    shutil.rmtree(p.joinpath(version))
-    metadata_path = p.joinpath("metadata.json")
-    metadata = json.load(metadata_path.open())
-    if version in metadata["versions"]:
-      metadata["versions"].remove(version)
-    json_dump(metadata_path, metadata)
+        json_dump(source_path, source, sort_keys=False)
+
+    def delete(self, module_name, version):
+        """Delete an existing module version."""
+        p = self.root.joinpath("modules", module_name)
+        shutil.rmtree(p.joinpath(version))
+        metadata_path = p.joinpath("metadata.json")
+        metadata = json.load(metadata_path.open())
+        if version in metadata["versions"]:
+            metadata["versions"].remove(version)
+        json_dump(metadata_path, metadata)

--- a/tools/update_integrity.py
+++ b/tools/update_integrity.py
@@ -13,13 +13,13 @@ def update_integrity(module, version, registry):
     client = RegistryClient(registry)
     if not client.contains(module):
         raise click.BadParameter(
-            f"{module=} not found in {registry=}. " f"Possible modules: {', '.join(client.get_all_modules())}"
+            f"{module=} not found in {registry=}. Possible modules: {', '.join(client.get_all_modules())}"
         )
     client.update_versions(module)
     versions = [ver for _, ver in client.get_module_versions(module)]
     version = version or versions[-1]
     if not client.contains(module, version):
-        raise click.BadParameter(f"{version=} not found for {module=}. " f"Possible versions: {', '.join(versions)}")
+        raise click.BadParameter(f"{version=} not found for {module=}. Possible versions: {', '.join(versions)}")
     click.echo(f"Updating integrity of {module=} {version=} in {registry=}")
     client.update_integrity(module, version)
 

--- a/tools/update_integrity.py
+++ b/tools/update_integrity.py
@@ -13,17 +13,13 @@ def update_integrity(module, version, registry):
     client = RegistryClient(registry)
     if not client.contains(module):
         raise click.BadParameter(
-            f"{module=} not found in {registry=}. "
-            f"Possible modules: {', '.join(client.get_all_modules())}"
+            f"{module=} not found in {registry=}. " f"Possible modules: {', '.join(client.get_all_modules())}"
         )
     client.update_versions(module)
     versions = [ver for _, ver in client.get_module_versions(module)]
     version = version or versions[-1]
     if not client.contains(module, version):
-        raise click.BadParameter(
-            f"{version=} not found for {module=}. "
-            f"Possible versions: {', '.join(versions)}"
-        )
+        raise click.BadParameter(f"{version=} not found for {module=}. " f"Possible versions: {', '.join(versions)}")
     click.echo(f"Updating integrity of {module=} {version=} in {registry=}")
     client.update_integrity(module, version)
 

--- a/tools/verify_stable_archives.py
+++ b/tools/verify_stable_archives.py
@@ -54,7 +54,9 @@ def main(argv=None):
             has_failure = True
             print(f"Version `{version}` of module `{module_name}` is using an unstable source url: `{source_url}`")
             print(
-                "You should use a release archive URL in the format of `https://github.com/<ORGANIZATION>/<REPO>/releases/download/<version>/<name>.tar.gz` to ensure the archive checksum stability."
+                "You should use a release archive URL in the format of "
+                "`https://github.com/<ORGANIZATION>/<REPO>/releases/download/<version>/<name>.tar.gz` "
+                "to ensure the archive checksum stability."
             )
             print("See https://blog.bazel.build/2023/02/15/github-archive-checksum.html for more context.")
 

--- a/tools/verify_stable_archives.py
+++ b/tools/verify_stable_archives.py
@@ -20,41 +20,47 @@ from enum import Enum
 
 from registry import RegistryClient
 
+
 class UrlStability(Enum):
-  STABLE = 1
-  UNSTABLE = 2
-  UNKNOWN = 3
+    STABLE = 1
+    UNSTABLE = 2
+    UNKNOWN = 3
+
 
 def verify_stable_archive(url):
-  parsed = urlparse(url)
-  if parsed.scheme != "https" or parsed.hostname != "github.com":
-    return UrlStability.UNKNOWN
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.hostname != "github.com":
+        return UrlStability.UNKNOWN
 
-  path_parts = parsed.path.split("/")
+    path_parts = parsed.path.split("/")
 
-  if path_parts[3] == "releases" and path_parts[4] == "download":
-    return UrlStability.STABLE
+    if path_parts[3] == "releases" and path_parts[4] == "download":
+        return UrlStability.STABLE
 
-  return UrlStability.UNSTABLE
+    return UrlStability.UNSTABLE
+
 
 def main(argv=None):
-  if argv is None:
-    argv = sys.argv[1:]
+    if argv is None:
+        argv = sys.argv[1:]
 
-  client = RegistryClient(".")
+    client = RegistryClient(".")
 
-  has_failure = False
-  for module_name, version in client.get_all_module_versions():
-    source_url = client.get_source(module_name, version)["url"]
-    stability = verify_stable_archive(source_url)
-    if stability == UrlStability.UNSTABLE:
-      has_failure = True
-      print(f'Version `{version}` of module `{module_name}` is using an unstable source url: `{source_url}`')
-      print("You should use a release archive URL in the format of `https://github.com/<ORGANIZATION>/<REPO>/releases/download/<version>/<name>.tar.gz` to ensure the archive checksum stability.")
-      print("See https://blog.bazel.build/2023/02/15/github-archive-checksum.html for more context.")
+    has_failure = False
+    for module_name, version in client.get_all_module_versions():
+        source_url = client.get_source(module_name, version)["url"]
+        stability = verify_stable_archive(source_url)
+        if stability == UrlStability.UNSTABLE:
+            has_failure = True
+            print(f"Version `{version}` of module `{module_name}` is using an unstable source url: `{source_url}`")
+            print(
+                "You should use a release archive URL in the format of `https://github.com/<ORGANIZATION>/<REPO>/releases/download/<version>/<name>.tar.gz` to ensure the archive checksum stability."
+            )
+            print("See https://blog.bazel.build/2023/02/15/github-archive-checksum.html for more context.")
 
-  if has_failure:
-    sys.exit(1)
+    if has_failure:
+        sys.exit(1)
+
 
 if __name__ == "__main__":
-  sys.exit(main())
+    sys.exit(main())

--- a/tools/version_test.py
+++ b/tools/version_test.py
@@ -3,38 +3,39 @@ import unittest
 
 from registry import Version
 
+
 # Translated from:
 # https://github.com/bazelbuild/bazel/blob/79a53def2ebbd9358450f739ea37bf70662e8614/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/VersionTest.java#L39
 class TestVersionCompare(unittest.TestCase):
+    def testReleaseVersion(self):
+        self.assertTrue(Version("2.0") > Version("1.0"))
+        self.assertTrue(Version("2.0") > Version("1.9"))
+        self.assertTrue(Version("11.0") > Version("3.0"))
+        self.assertTrue(Version("1.0.1") > Version("1.0"))
+        self.assertTrue(Version("1.0.0") > Version("1.0"))
+        self.assertTrue(Version("1.0+build2") == Version("1.0+build3"))
+        self.assertTrue(Version("1.0") > Version("1.0-pre"))
+        self.assertTrue(Version("1.0") == Version("1.0+build-notpre"))
 
-  def testReleaseVersion(self):
-    self.assertTrue(Version("2.0") > Version("1.0"))
-    self.assertTrue(Version("2.0") > Version("1.9"))
-    self.assertTrue(Version("11.0") > Version("3.0"))
-    self.assertTrue(Version("1.0.1") > Version("1.0"))
-    self.assertTrue(Version("1.0.0") > Version("1.0"))
-    self.assertTrue(Version("1.0+build2") == Version("1.0+build3"))
-    self.assertTrue(Version("1.0") > Version("1.0-pre"))
-    self.assertTrue(Version("1.0") == Version("1.0+build-notpre"))
+    def testReleaseVersionWithLetters(self):
+        self.assertTrue(Version("1.0.patch.3") > Version("1.0"))
+        self.assertTrue(Version("1.0.patch.3") > Version("1.0.patch.2"))
+        self.assertTrue(Version("1.0.patch.3") < Version("1.0.patch.10"))
+        self.assertTrue(Version("1.0.patch3") > Version("1.0.patch10"))
+        self.assertTrue(Version("4") < Version("a"))
+        self.assertTrue(Version("abc") < Version("abd"))
 
-  def testReleaseVersionWithLetters(self):
-    self.assertTrue(Version("1.0.patch.3") > Version("1.0"))
-    self.assertTrue(Version("1.0.patch.3") > Version("1.0.patch.2"))
-    self.assertTrue(Version("1.0.patch.3") < Version("1.0.patch.10"))
-    self.assertTrue(Version("1.0.patch3") > Version("1.0.patch10"))
-    self.assertTrue(Version("4") < Version("a"))
-    self.assertTrue(Version("abc") < Version("abd"))
+    def testPrereleaseVersion(self):
+        self.assertTrue(Version("1.0-pre") > Version("1.0-are"))
+        self.assertTrue(Version("1.0-3") > Version("1.0-2"))
+        self.assertTrue(Version("1.0-pre") < Version("1.0-pre.foo"))
+        self.assertTrue(Version("1.0-pre.3") > Version("1.0-pre.2"))
+        self.assertTrue(Version("1.0-pre.10") > Version("1.0-pre.2"))
+        self.assertTrue(Version("1.0-pre.10a") < Version("1.0-pre.2a"))
+        self.assertTrue(Version("1.0-pre.99") < Version("1.0-pre.2a"))
+        self.assertTrue(Version("1.0-pre.patch.3") < Version("1.0-pre.patch.4"))
+        self.assertTrue(Version("1.0--") < Version("1.0----"))
 
-  def testPrereleaseVersion(self):
-    self.assertTrue(Version("1.0-pre") > Version("1.0-are"))
-    self.assertTrue(Version("1.0-3") > Version("1.0-2"))
-    self.assertTrue(Version("1.0-pre") < Version("1.0-pre.foo"))
-    self.assertTrue(Version("1.0-pre.3") > Version("1.0-pre.2"))
-    self.assertTrue(Version("1.0-pre.10") > Version("1.0-pre.2"))
-    self.assertTrue(Version("1.0-pre.10a") < Version("1.0-pre.2a"))
-    self.assertTrue(Version("1.0-pre.99") < Version("1.0-pre.2a"))
-    self.assertTrue(Version("1.0-pre.patch.3") < Version("1.0-pre.patch.4"))
-    self.assertTrue(Version("1.0--") < Version("1.0----"))
 
-if __name__ == '__main__':
-  unittest.main()
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Step 1 of https://github.com/bazelbuild/bazel-central-registry/discussions/2317.
This is `ruff format --line-length 120` plus some manual line reflowing in the second commit.

This changes the indent to 4 spaces in all files and line length to 120 cols.

After this lands we can take the hash of the squashed and rebased commit and add it to [.git-blame-ignore-revs](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)