### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Revisions specified in this file are hidden from the blame view using Gits git blame --ignore-revs-file configuration.
+# https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
+
+# Formatted all Python tooling with `ruff`
+b208c2be96da9a36b9baac69230a9142bd014f79


### PR DESCRIPTION
Add [.git-blame-ignore-revs](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)

This hides https://github.com/bazelbuild/bazel-central-registry/commit/b208c2be96da9a36b9baac69230a9142bd014f79 from GitHub's line blame.

This is step 3 of https://github.com/bazelbuild/bazel-central-registry/discussions/2317

This is entirely optional. If maintainers think it would be better to have the formatting change be more visible we can just close this PR.