### PR TITLE
Add pre-commit workflow with ruff format

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.5.0
+  hooks:
+  - id: ruff-format

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,1 @@
+line-length = 120


### PR DESCRIPTION
Step 2 of https://github.com/bazelbuild/bazel-central-registry/discussions/2317

Adds a GitHub Actions workflow that runs on each PR as well as on main.
Note that depending on repo settings an admin may have to configure this to become "required".

Uses https://github.com/pre-commit/action to run [pre-commit](https://pre-commit.com/).

pre-commit is configured to run the [official ruff-format hook](https://github.com/astral-sh/ruff-pre-commit)
I will add the lint hook in a follow-up PR as the lint is still failing.

Added a [ruff config file](https://docs.astral.sh/ruff/configuration/) as well to configure the line length to the same number the current formatting was done with.

The workflow already ran on this PR :) https://github.com/bazelbuild/bazel-central-registry/actions/runs/9717570688/job/26823514964?pr=2327#step:4:67