### PR TITLE
add wheelos_common_msgs

### DIFF
--- a/modules/wheelos_common_msgs/0.1.2/MODULE.bazel
+++ b/modules/wheelos_common_msgs/0.1.2/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "wheelos_common_msgs",
+    version = "0.1.2",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_pkg", version = "0.10.1")
+bazel_dep(name = "rules_proto", version = "6.0.0")
+bazel_dep(name = "protobuf", version = "27.1", repo_name = "com_google_protobuf")

--- a/modules/wheelos_common_msgs/0.1.2/presubmit.yml
+++ b/modules/wheelos_common_msgs/0.1.2/presubmit.yml
@@ -1,0 +1,27 @@
+matrix:
+  platform:
+  - ubuntu2204
+  - ubuntu2004
+  - windows
+  bazel: [6.x, 7.x]
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@wheelos_common_msgs//common_msgs/basic_msgs:all'
+    - '@wheelos_common_msgs//common_msgs/chassis_msgs:all'
+    - '@wheelos_common_msgs//common_msgs/config_msgs:all'
+    - '@wheelos_common_msgs//common_msgs/sensor_msgs:all'
+
+  verify_targets_macos:
+    name: Verify build targets on MacOS
+    platform: macos_arm64
+    bazel: "7.x"
+    build_targets:
+    - '@wheelos_common_msgs//common_msgs/basic_msgs:all'
+    - '@wheelos_common_msgs//common_msgs/chassis_msgs:all'
+    - '@wheelos_common_msgs//common_msgs/config_msgs:all'
+    - '@wheelos_common_msgs//common_msgs/sensor_msgs:all'

--- a/modules/wheelos_common_msgs/0.1.2/source.json
+++ b/modules/wheelos_common_msgs/0.1.2/source.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "sha256-FbtvVwDzulg3NcLrjcI3FaRnQs+BDDZtwQXA2yUkLxA=",
+  "strip_prefix": "common_msgs-0.1.2",
+  "url": "https://github.com/wheelos/common_msgs/releases/download/0.1.2/common_msgs-0.1.2.zip"
+}

--- a/modules/wheelos_common_msgs/metadata.json
+++ b/modules/wheelos_common_msgs/metadata.json
@@ -1,0 +1,17 @@
+{
+  "homepage": "https://github.com/wheelos/common_msgs",
+  "maintainers": [
+      {
+          "email": "daohu527@google.com",
+          "github": "daohu527",
+          "name": "daohu527"
+      }
+  ],
+  "repository": [
+      "github:wheelos/common_msgs"
+  ],
+  "versions": [
+      "0.1.2"
+  ],
+  "yanked_versions": {}
+}


### PR DESCRIPTION
Added the common_msg library, which mainly uses protobuf to define the message format of the autonomous driving system.