### PR TITLE
Fix "websocketpp" on Mac OS X.

### DIFF
--- a/modules/websocketpp/0.8.2.bcr.1/MODULE.bazel
+++ b/modules/websocketpp/0.8.2.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "websocketpp",
+    version = "0.8.2.bcr.1",
+    compatibility_level = 1,
+)
+bazel_dep(name = "asio", version = "1.28.2")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "zlib", version = "1.3")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/websocketpp/0.8.2.bcr.1/patches/add_build_file.patch
+++ b/modules/websocketpp/0.8.2.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,28 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,25 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "websocketpp",
++    hdrs = glob(["websocketpp/**/*.hpp"]),
++    defines = [
++        "ASIO_STANDALONE",
++        "_WEBSOCKETPP_CPP11_STL_",
++    ],
++    includes = ["."],
++    linkopts = select({
++        "@platforms//os:osx": [
++            "-lpthread",
++        ],
++        "//conditions:default": [
++            "-lpthread",
++            "-lrt",
++        ],
++    }),
++    visibility = ["//visibility:public"],
++    deps = [
++        "@asio",
++        "@zlib",
++    ],
++)

--- a/modules/websocketpp/0.8.2.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/websocketpp/0.8.2.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,12 @@
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,9 @@
++module(
++    name = "websocketpp",
++    version = "0.8.2.bcr.1",
++    compatibility_level = 1,
++)
++bazel_dep(name = "asio", version = "1.28.2")
++bazel_dep(name = "rules_cc", version = "0.0.9")
++bazel_dep(name = "zlib", version = "1.3")
++bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/websocketpp/0.8.2.bcr.1/presubmit.yml
+++ b/modules/websocketpp/0.8.2.bcr.1/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+  bazel: [6.x, 7.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@websocketpp"

--- a/modules/websocketpp/0.8.2.bcr.1/source.json
+++ b/modules/websocketpp/0.8.2.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/zaphoyd/websocketpp/archive/refs/tags/0.8.2.tar.gz",
+    "integrity": "sha256-bOiJ2F7Nwtj6B0CNZ4fnNSUQdQ2qZrWtRKrLR76nZ1U=",
+    "strip_prefix": "websocketpp-0.8.2",
+    "patches": {
+        "add_build_file.patch": "sha256-KhVOfO47POB3xqoHdeOs+dYbn0dp0aAQddYt8ZWZqcI=",
+        "module_dot_bazel.patch": "sha256-Bq9+2iYvtN8TR5zGaKTIdS3vYsx/gEP0pM2xLWuMO2U="
+    },
+    "patch_strip": 0
+}

--- a/modules/websocketpp/0.8.2.bcr.1/source.json
+++ b/modules/websocketpp/0.8.2.bcr.1/source.json
@@ -3,8 +3,8 @@
     "integrity": "sha256-bOiJ2F7Nwtj6B0CNZ4fnNSUQdQ2qZrWtRKrLR76nZ1U=",
     "strip_prefix": "websocketpp-0.8.2",
     "patches": {
-        "add_build_file.patch": "sha256-KhVOfO47POB3xqoHdeOs+dYbn0dp0aAQddYt8ZWZqcI=",
-        "module_dot_bazel.patch": "sha256-Bq9+2iYvtN8TR5zGaKTIdS3vYsx/gEP0pM2xLWuMO2U="
+        "add_build_file.patch": "sha256-95DACIWxqhjix5VgVssEYee5pjCnf/QWL04mQJwQ2uM=",
+        "module_dot_bazel.patch": "sha256-h9esq/BSgla/GaK2cdr7QK71dXvYWj64udsLV06S180="
     },
     "patch_strip": 0
 }

--- a/modules/websocketpp/metadata.json
+++ b/modules/websocketpp/metadata.json
@@ -10,7 +10,8 @@
     "github:zaphoyd/websocketpp"
   ],
   "versions": [
-    "0.8.2"
+    "0.8.2",
+    "0.8.2.bcr.1"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
This change fixes the build on Mac OS X. According to the original CMakeLists.txt, "rt" is not linked on Mac OS X.

        if (NOT APPLE)
            set (WEBSOCKETPP_PLATFORM_LIBS pthread rt)
        else()
            set (WEBSOCKETPP_PLATFORM_LIBS pthread)
        endif()