### PR TITLE
Add Ignas as rule_python BCR maintainer

### DIFF
--- a/modules/rules_python/metadata.json
+++ b/modules/rules_python/metadata.json
@@ -10,6 +10,11 @@
             "name": "Thulio Ferraz Assis",
             "email": "thulio@aspect.dev",
             "github": "f0rmiga"
+        },
+        {
+            "name": "Ignas Anikevicius",
+            "email": "anikevicius@gmail.com",
+            "github": "aignas"
         }
     ],
     "repository": [


### PR DESCRIPTION
Ignas has been doing about half the maintenance on rules_python, including initiating releases and following up on BCR PRs for it