### PR TITLE
chore: add aignas to rules_python maintainer list

### DIFF
--- a/modules/rules_python/metadata.json
+++ b/modules/rules_python/metadata.json
@@ -10,6 +10,11 @@
             "name": "Thulio Ferraz Assis",
             "email": "thulio@aspect.dev",
             "github": "f0rmiga"
+        },
+        {
+            "name": "Ignas Anikevicius",
+            "email": "bcr-ignas@use.startmail.com",
+            "github": "aignas"
         }
     ],
     "repository": [


### PR DESCRIPTION
I've been doing about half the maintenance on rules_python, including
initiating releases and following up on BCR PRs for it.
