### PR TITLE
Add rules_nixpkgs_nodejs version 0.12.0

### DIFF
--- a/modules/rules_nixpkgs_nodejs/0.12.0/MODULE.bazel
+++ b/modules/rules_nixpkgs_nodejs/0.12.0/MODULE.bazel
@@ -1,0 +1,17 @@
+module(
+    name = "rules_nixpkgs_nodejs",
+    version = "0.12.0",
+)
+
+bazel_dep(name = "rules_nixpkgs_core", version = "0.12.0")
+bazel_dep(name = "platforms", version = "0.0.4")
+bazel_dep(name = "rules_nodejs", version = "5.5.3")
+bazel_dep(name = "bazel_skylib", version = "1.0.3")
+
+nix_repo = use_extension("@rules_nixpkgs_core//extensions:repository.bzl", "nix_repo")
+nix_repo.default(name = "nixpkgs")
+use_repo(nix_repo, "nixpkgs")
+
+nix_nodejs = use_extension("//extensions:toolchain.bzl", "nix_nodejs")
+use_repo(nix_nodejs, "nixpkgs_nodejs_toolchains")
+register_toolchains("@nixpkgs_nodejs_toolchains//:all")

--- a/modules/rules_nixpkgs_nodejs/0.12.0/presubmit.yml
+++ b/modules/rules_nixpkgs_nodejs/0.12.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  # XXX not fully supported yet
+  #- macos_arm64
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@rules_nixpkgs_nodejs//:nodejs'
+    - '@rules_nixpkgs_nodejs//extensions:toolchain'

--- a/modules/rules_nixpkgs_nodejs/0.12.0/source.json
+++ b/modules/rules_nixpkgs_nodejs/0.12.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/tweag/rules_nixpkgs/releases/download/v0.12.0/rules_nixpkgs-0.12.0.tar.gz",
+    "integrity": "sha256-GtsE3AQWkV/vQndX9CcsT32s7+zu78UPaDrsf36beHo=",
+    "strip_prefix": "rules_nixpkgs-0.12.0/toolchains/nodejs"
+}

--- a/modules/rules_nixpkgs_nodejs/metadata.json
+++ b/modules/rules_nixpkgs_nodejs/metadata.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://nix-bazel.build",
+    "maintainers": [
+        {
+            "email": "benjamin.radford@tweag.io ",
+            "github": "benradf",
+            "name": "Benjamin Radford"
+        },
+        {
+            "email": "andreas.herrmann@tweag.io",
+            "github": "aherrmann",
+            "name": "Andreas Herrmann"
+        }
+    ],
+    "repository": [
+        "github:tweag/rules_nixpkgs"
+    ],
+    "versions": [
+        "0.12.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This is the first toolchain that we added a proper module extension for. More to come in the future.

Unfortunately, there's no testing module yet since this depends on the cc and java rules_nixpkgs modules which are still being worked on.