### PR TITLE
fix: fix foonathan_memory include path

### DIFF
--- a/modules/foonathan_memory/0.7.3.bcr.1/MODULE.bazel
+++ b/modules/foonathan_memory/0.7.3.bcr.1/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "foonathan_memory",
+    version = "0.7.3.bcr.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "rules_foreign_cc",
+    version = "0.10.1",
+)

--- a/modules/foonathan_memory/0.7.3.bcr.1/patches/add_build_file.patch
+++ b/modules/foonathan_memory/0.7.3.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,36 @@
+diff --git BUILD.bazel BUILD.bazel
+new file mode 100644
+index 0000000..45721ac
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,30 @@
++""" Builds foonathan_memory.
++"""
++
++load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
++
++filegroup(
++    name = "all_srcs",
++    srcs = glob(["**"]),
++)
++
++cache_entries = {
++    "CMAKE_POSITION_INDEPENDENT_CODE": "ON",  # Must be set!
++    "BUILD_SHARED_LIBS": "OFF",
++    # foonathan_memory specific options.
++    "FOONATHAN_MEMORY_BUILD_EXAMPLES": "OFF",
++    "FOONATHAN_MEMORY_BUILD_TESTS": "OFF",
++}
++
++cmake(
++    name = "foonathan_memory",
++    build_args = [
++        "--",
++        "-j4",
++    ],
++    cache_entries = cache_entries,
++    lib_source = ":all_srcs",
++    lib_name = "libfoonathan_memory-0.7.3",
++    out_include_dir = "include/foonathan_memory",
++    visibility = ["//visibility:public"]
++)

--- a/modules/foonathan_memory/0.7.3.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/foonathan_memory/0.7.3.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,16 @@
+diff --git MODULE.bazel MODULE.bazel
+new file mode 100644
+index 0000000..362cdcd
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,10 @@
++module(
++    name = "foonathan_memory",
++    version = "0.7.3.bcr.1",
++    compatibility_level = 1,
++)
++
++bazel_dep(
++    name = "rules_foreign_cc",
++    version = "0.10.1",
++)

--- a/modules/foonathan_memory/0.7.3.bcr.1/presubmit.yml
+++ b/modules/foonathan_memory/0.7.3.bcr.1/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  bazel: [6.x, 7.x]
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@foonathan_memory//:foonathan_memory'

--- a/modules/foonathan_memory/0.7.3.bcr.1/source.json
+++ b/modules/foonathan_memory/0.7.3.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/foonathan/memory/archive/refs/tags/v0.7-3.tar.gz",
+    "integrity": "sha256-QgPRXbIqlKOXjusa+1mjfTXFfA8UhzPw8aU6YoHLdN0=",
+    "strip_prefix": "memory-0.7-3",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-SETra+qT0FnuOI6uoRe8BeZVpBXnTgnnQyp5EGHsPZM=",
+        "module_dot_bazel.patch": "sha256-Vil9DymRxv47rWW3FJSFkyjwEDJ39kALv/Tf78S/4iM="
+    }
+}

--- a/modules/foonathan_memory/metadata.json
+++ b/modules/foonathan_memory/metadata.json
@@ -10,7 +10,8 @@
     "github:foonathan/memory"
   ],
   "versions": [
-    "0.7.3"
+    "0.7.3",
+    "0.7.3.bcr.1"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
add "include/foonathan_memory" include path instead of "include"

In Fast-DDS which use below include path
```c++
#include <foonathan/memory/container.hpp>
#include <foonathan/memory/memory_pool.hpp>
```

If so, then we need to add `out_include_dir = "include/foonathan_memory",`, I don't know why bazel add `foonathan_memory` in external path?

- source path `include/foonathan/memory`
- bazel external path `include/foonathan_memory/foonathan/memory`