### PR TITLE
Add rules_platform

### DIFF
--- a/modules/rules_platform/0.1.0/MODULE.bazel
+++ b/modules/rules_platform/0.1.0/MODULE.bazel
@@ -1,0 +1,14 @@
+"""Bazel build and test dependencies."""
+
+# NOTE: When editing this file, also update the lockfile.
+#   bazel mod deps --lockfile_mode=update
+
+module(
+    name = "rules_platform",
+    version = "0.1.0",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+
+# Dev dependencies
+bazel_dep(name = "rules_pkg", version = "0.10.1", dev_dependency = True)

--- a/modules/rules_platform/0.1.0/presubmit.yml
+++ b/modules/rules_platform/0.1.0/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@rules_platform//platform_data:srcs'

--- a/modules/rules_platform/0.1.0/source.json
+++ b/modules/rules_platform/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/bazelbuild/rules_platform/releases/download/0.1.0/rules_platform-0.1.0.tar.gz",
+    "integrity": "sha256-Cq3RvTUAkaofm28vvKyM2YIBR2KJRU5HWyiAHs+F0/0=",
+    "patch_strip": 0
+}

--- a/modules/rules_platform/metadata.json
+++ b/modules/rules_platform/metadata.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://github.com/bazelbuild/rules_platform",
+    "maintainers": [
+        {
+            "email": "aranguyen@google.com",
+            "github": "aranguyen",
+            "name": "Ara Nguyen"
+        },
+        {
+            "email": "gregce@google.com",
+            "github": "gregestren",
+            "name": "Greg Estren"
+        }
+    ],
+    "repository": [
+        "github:bazelbuild/rules_platform"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Created using `bazel run //tools:add_module`.

Fixes https://github.com/bazelbuild/rules_platform/issues/13