### PR TITLE
Fix crash in verify_stable_archive if source URL has too few path segments

### DIFF
--- a/tools/verify_stable_archives.py
+++ b/tools/verify_stable_archives.py
@@ -34,7 +34,7 @@ def verify_stable_archive(url):
 
     path_parts = parsed.path.split("/")
 
-    if path_parts[3] == "releases" and path_parts[4] == "download":
+    if len(path_parts) > 3 and path_parts[3] == "releases" and path_parts[4] == "download":
         return UrlStability.STABLE
 
     return UrlStability.UNSTABLE


### PR DESCRIPTION
a source URL like "https://github.com/foo/bar" will just make the script crash.