### PR TITLE
Unyank older version of osqp-cpp

### DIFF
--- a/modules/osqp-cpp/metadata.json
+++ b/modules/osqp-cpp/metadata.json
@@ -14,7 +14,5 @@
         "0.0.0-20231004-4343373",
         "0.0.0-20231004-4343373.bcr.1"
     ],
-    "yanked_versions": {
-        "0.0.0-20231004-4343373": "Fails while linking due to dependency SuiteSparse and osqp not having appropriate defines. Use 0.0.0-20231004-4343373.bcr.1 instead."
-    }
+    "yanked_versions": {}
 }


### PR DESCRIPTION
I yanked the previous version by mistake. That broke our internal CI systems. As that version didn't have any security vulnerabilities, and just was broken, unyanking to recover our CI.