### PR TITLE
feat: add `rules_tar@1.0.0-beta.1`

### DIFF
--- a/modules/rules_tar/1.0.0-beta.1/MODULE.bazel
+++ b/modules/rules_tar/1.0.0-beta.1/MODULE.bazel
@@ -1,0 +1,32 @@
+module(
+    name = "rules_tar",
+    version = "1.0.0-beta.1",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_gzip", version = "1.0.0-beta.1")
+bazel_dep(name = "rules_bzip2", version = "1.0.0-beta.1")
+bazel_dep(name = "rules_zstd", version = "1.0.0-beta.1")
+bazel_dep(name = "rules_xz", version = "1.0.0-beta.1")
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.9")
+bazel_dep(name = "ape", version = "1.0.0-beta.11")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+use_repo(export, "ape-tar")
+export.symlink(
+    name = "tar",
+    target = "@ape-tar",
+)
+use_repo(export, "tar")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+resolved(
+    name = "resolved-tar",
+    toolchain_type = "//tar/toolchain/tar:type",
+)
+
+register_toolchains("//tar/toolchain/...")

--- a/modules/rules_tar/1.0.0-beta.1/presubmit.yml
+++ b/modules/rules_tar/1.0.0-beta.1/presubmit.yml
@@ -1,0 +1,22 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_tar/1.0.0-beta.1/source.json
+++ b/modules/rules_tar/1.0.0-beta.1/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_tar/-/releases/v1.0.0-beta.1/downloads/src.tar.gz",
+  "integrity": "sha512-KReF/K/Kz/8+HfbuOYPGg9afu7/tvZjrjlFUQ8ucU7ndGWwtYjkEF2LBsA8yS71KZNkyoaShovq/7UMnUumMdg==",
+  "strip_prefix": "rules_tar-v1.0.0-beta.1"
+}

--- a/modules/rules_tar/metadata.json
+++ b/modules/rules_tar/metadata.json
@@ -1,0 +1,16 @@
+{
+  "homepage": "https://gitlab.arm.com/bazel/rules_tar",
+  "repository": [
+    "https://gitlab.arm.com/bazel/rules_tar"
+  ],
+  "versions": [
+    "1.0.0-beta.1"
+  ],
+  "maintainers": [
+    {
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson",
+      "github": "mattyclarkson"
+    }
+  ]
+}


### PR DESCRIPTION
```py
load("@rules_tar//tar/unpack:defs.bzl", "tar_unpack")
load("@rules_tar//tar/extract:defs.bzl", "tar_extract")

tar_unpack(
    name = "unpack",
    src = "some.tar.bz2",
)

tar_extract(
    name = "extract",
    src = "some.tar.zst",
    outs = [
        "a/specific/member.txt",
        "another/member.txt",
    ]
)
```

Does not perform any ceation: `rules_pkg` for that (at least for the foreseeable future)