### PR TITLE
fix: freertos@10.5.1: Add missing CM33_NTZ header

### DIFF
--- a/modules/freertos/10.5.1/patches/bazel.patch
+++ b/modules/freertos/10.5.1/patches/bazel.patch
@@ -80,10 +80,7 @@ index 000000000..c7ba810ee
 +    ] + select({
 +        ":port_ARM_CM0": ["portable/GCC/ARM_CM0/port.c"],
 +        ":port_ARM_CM3": ["portable/GCC/ARM_CM3/port.c"],
-+        ":port_ARM_CM33_NTZ": [
-+            "portable/GCC/ARM_CM33_NTZ/non_secure/port.c",
-+            "portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c",
-+        ],
++        ":port_ARM_CM33_NTZ": glob(["portable/GCC/ARM_CM33_NTZ/non_secure/*.h"]),
 +        ":port_ARM_CM4F": ["portable/GCC/ARM_CM4F/port.c"],
 +        ":port_ARM_CM7": ["portable/GCC/ARM_CM7/r0p1/port.c"],
 +        ":port_Xtensa": [


### PR DESCRIPTION
Based on http://pwrev.dev/222574.