### PR TITLE
Add nanobind_bazel v2.1.0

### DIFF
--- a/modules/nanobind_bazel/2.1.0/MODULE.bazel
+++ b/modules/nanobind_bazel/2.1.0/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "nanobind_bazel",
+    version = "2.1.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_python", version = "0.32.2")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
+
+# Creates a `http_archive` for nanobind and robin-map.
+internal_configure = use_extension("//:internal_configure.bzl", "internal_configure_extension")
+use_repo(internal_configure, "nanobind", "pypi__typing_extensions")

--- a/modules/nanobind_bazel/2.1.0/presubmit.yml
+++ b/modules/nanobind_bazel/2.1.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  bazel:
+    - 6.x
+    - 7.x
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    - windows
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@nanobind_bazel//...'

--- a/modules/nanobind_bazel/2.1.0/source.json
+++ b/modules/nanobind_bazel/2.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/nicholasjng/nanobind-bazel/releases/download/v2.1.0/nanobind-bazel-2.1.0.tar.gz",
+    "integrity": "sha256-XsK8YfcStwnTns75NPoCyt3VVJFbpLPPIx+cYyhcxoA=",
+    "strip_prefix": "nanobind-bazel-2.1.0"
+}

--- a/modules/nanobind_bazel/metadata.json
+++ b/modules/nanobind_bazel/metadata.json
@@ -1,13 +1,19 @@
 {
-  "homepage": "https://github.com/nicholasjng/nanobind-bazel",
-  "maintainers": [
-    {
-      "email": "nicho.junge@gmail.com",
-      "github": "nicholasjng",
-      "name": "Nicholas Junge"
-    }
-  ],
-  "repository": ["github:nicholasjng/nanobind-bazel"],
-  "versions": ["1.0.0", "2.0.0"],
-  "yanked_versions": {}
+    "homepage": "https://github.com/nicholasjng/nanobind-bazel",
+    "maintainers": [
+        {
+            "email": "nicho.junge@gmail.com",
+            "github": "nicholasjng",
+            "name": "Nicholas Junge"
+        }
+    ],
+    "repository": [
+        "github:nicholasjng/nanobind-bazel"
+    ],
+    "versions": [
+        "1.0.0",
+        "2.0.0",
+        "2.1.0"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Contains new `nanobind_shared_library` and `nanobind_stubgen` rules to leverage nanobind v2's full capabilities.

Sorry about the `metadata.json` reformat, I think my editor screwed it up the last time - this one is taken exactly as it came out of `//tools:add_module`.