### PR TITLE
libxml2@2.13.5 (#2511)

### DIFF
--- a/modules/libxml2/2.13.5/MODULE.bazel
+++ b/modules/libxml2/2.13.5/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "libxml2",
+    version = "2.13.5",
+    compatibility_level = 1,
+)
+bazel_dep(name = "rules_foreign_cc", version = "0.13.0")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/libxml2/2.13.5/patches/add_build_file.patch
+++ b/modules/libxml2/2.13.5/patches/add_build_file.patch
@@ -1,0 +1,41 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,38 @@
++""" Builds libxml2.
++"""
++
++load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
++
++filegroup(
++    name = "srcs",
++    srcs = glob(["**"]),
++)
++
++cache_entries = {
++    "CMAKE_INSTALL_LIBDIR": "lib",
++    "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
++    "BUILD_SHARED_LIBS": "OFF",
++    #libxml2 specific options.
++    "LIBXML2_WITH_PYTHON": "OFF",
++    "LIBXML2_WITH_LZMA": "OFF",
++    "LIBXML2_WITH_ICONV": "OFF",
++    "LIBXML2_WITH_TESTS": "OFF",
++    "LIBXML2_WITH_PROGRAMS": "OFF",
++}
++
++cmake(
++    name = "libxml2",
++    env = {"CMAKE_BUILD_TYPE": "Release"},
++    lib_source = ":srcs",
++    cache_entries = cache_entries,
++    out_static_libs = select({
++        "@platforms//os:windows": [
++            "libxml2s.lib",
++        ],
++        "//conditions:default": [
++            "libxml2.a",
++        ],
++    }),
++    out_include_dir = "include/libxml2",
++    visibility = ["//visibility:public"],
++)

--- a/modules/libxml2/2.13.5/patches/module_dot_bazel.patch
+++ b/modules/libxml2/2.13.5/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "libxml2",
++    version = "2.13.5",
++    compatibility_level = 1,
++)
++bazel_dep(name = "rules_foreign_cc", version = "0.13.0")
++bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/libxml2/2.13.5/presubmit.yml
+++ b/modules/libxml2/2.13.5/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@libxml2//:libxml2'

--- a/modules/libxml2/2.13.5/source.json
+++ b/modules/libxml2/2.13.5/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.5.tar.xz",
+    "integrity": "sha256-dPwWMhejlkJX0745r5Q+CIYSY8QjH571tJa29tTHsrY=",
+    "strip_prefix": "libxml2-2.13.5",
+    "patches": {
+        "add_build_file.patch": "sha256-up7y9h92pFRePlMeUPgtT5LfXjk3IUqZrHgXyEJ+mjE=",
+        "module_dot_bazel.patch": "sha256-M4LQp+uhFlKRQDma/x1YhoHftrvtKfEgQkFMH6/0Ud4="
+    },
+    "patch_strip": 0
+}

--- a/modules/libxml2/metadata.json
+++ b/modules/libxml2/metadata.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
+    "maintainers": [
+        {
+            "email": "tectep@gmail.com",
+            "github": "dmitry-j-mikhin",
+            "name": "Dmitry Mikhin"
+        }
+    ],
+    "repository": [],
+    "versions": [
+        "2.13.5"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Closes #2511

Release: https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.5

Previous stale PR #282