### PR TITLE
Fix `xz 5.4.5.bcr.4`'s MODULE.bazel symlink

### DIFF
--- a/modules/xz/5.4.5.bcr.4/MODULE.bazel
+++ b/modules/xz/5.4.5.bcr.4/MODULE.bazel
@@ -1,1 +1,7 @@
-overlay/MODULE.bazel
+module(
+    name = "xz",
+    version = "5.4.5.bcr.4",
+)
+
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")

--- a/modules/xz/5.4.5.bcr.4/overlay/MODULE.bazel
+++ b/modules/xz/5.4.5.bcr.4/overlay/MODULE.bazel
@@ -1,7 +1,1 @@
-module(
-    name = "xz",
-    version = "5.4.5.bcr.4",
-)
-
-bazel_dep(name = "platforms", version = "0.0.8")
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
+../MODULE.bazel


### PR DESCRIPTION
After upgrading to `bazel_dep(name = "xz", version = "5.4.5.bcr.4")` (https://github.com/bazelbuild/bazel-central-registry/pull/2508) I get:
```
❯ bazel build @rules_boost//...
INFO: Invocation ID: f34d950c-698f-4f51-841f-15e1d26b36cb
ERROR: https:/raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/modules/xz/5.4.5.bcr.4/MODULE.bazel:1:1: name 'overlay' is not defined
ERROR: https:/raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/modules/xz/5.4.5.bcr.4/MODULE.bazel:1:9: name 'MODULE' is not defined (did you mean 'module'?)
ERROR: Error computing the main repository mapping: in module dependency chain <root> -> xz@5.4.5.bcr.4: syntax error in MODULE.bazel file for xz@5.4.5.bcr.4
Computing main repo mapping:

```

... woops. Looks like the MODULE.bazel symlink has to be the other way around. Should add a BCR Validation check for this.

I think it's ok to fix this directly instead of creating a .bcr.5 because there are no integrity changes and this actually makes the otherwise defunct .bcr.4 version work.