### PR TITLE
Fail BcrValidator on incorrect overlay MODULE.bazel symlinks

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -258,6 +258,10 @@ class BcrValidator:
         download_file(source_url, archive_file)
         shutil.unpack_archive(str(archive_file), output_dir)
 
+        module_file = self.registry.get_module_dot_bazel_path(module_name, version)
+        if module_file.is_symlink():
+            self.report(BcrValidationResult.FAILED, f"{module_file} must not be a symlink.")
+
         # Apply patch files if there are any, also verify their integrity values
         source_root = output_dir.joinpath(source["strip_prefix"] if "strip_prefix" in source else "")
         if "patches" in source:
@@ -273,6 +277,12 @@ class BcrValidator:
                 apply_patch(source_root, source["patch_strip"], str(patch_file.resolve()))
         if "overlay" in source:
             overlay_dir = self.registry.get_overlay_dir(module_name, version)
+            module_file = overlay_dir / "MODULE.bazel"
+            if module_file.exists() and (
+                not module_file.is_symlink() or module_file.readlink().as_posix() != "../MODULE.bazel"
+            ):
+                self.report(BcrValidationResult.FAILED, f"{module_file} should be a symlink to `../MODULE.bazel`.")
+
             for overlay_file, expected_integrity in source["overlay"].items():
                 overlay_src = overlay_dir / overlay_file
                 overlay_dst = source_root / overlay_file


### PR DESCRIPTION
Testing `❯ bazel run //tools:bcr_validation -- --check xz` on this branch which includes the oopsie fixed in https://github.com/bazelbuild/bazel-central-registry/pull/2533:
```
(...)
BcrValidationResult.GOOD: The presubmit.yml file is valid.

BcrValidationResult.FAILED: modules/xz/5.4.5.bcr.4/MODULE.bazel must not be a symlink.

patching file tests/test_bcj_exact_size.c
patching file tests/test_check.c
patching file tests/test_lzip_decoder.c
patching file tests/test_memlimit.c
BcrValidationResult.FAILED: modules/xz/5.4.5.bcr.4/overlay/MODULE.bazel should be a symlink to `../MODULE.bazel`.

BcrValidationResult.GOOD: Checked in MODULE.bazel matches the sources.
(...)
```

There isn't currently a requirement for overlay/MODULE.bazel files to be ../MODULE.bazel symlinks but I think it would make sense, curious to hear opinions.
If people disagree we could only add the first check.