### PR TITLE
Add grpc-web@1.5.0.bcr.

### DIFF
--- a/modules/grpc-web/1.5.0.bcr/MODULE.bazel
+++ b/modules/grpc-web/1.5.0.bcr/MODULE.bazel
@@ -1,0 +1,17 @@
+module(
+    name = "grpc-web",
+    version = "1.5.0.bcr",  # This isn't exactly version 1.5.0, so add a .bcr suffix
+    compatibility_level = 1,
+    repo_name = "com_github_grpc_grpc_web",
+)
+
+bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "grpc", version = "1.65.0", repo_name = "com_github_grpc_grpc")
+bazel_dep(name = "rules_cc", version = "0.0.2")
+bazel_dep(name = "rules_proto", version = "6.0.2")
+
+# Needed to resolve https://github.com/bazelbuild/bazel-central-registry/issues/2538.
+single_version_override(
+    module_name = "grpc-java",
+    version = "1.64.0",
+)

--- a/modules/grpc-web/1.5.0.bcr/patches/bzlmod-support.patch
+++ b/modules/grpc-web/1.5.0.bcr/patches/bzlmod-support.patch
@@ -1,0 +1,84 @@
+diff --git .bazelrc .bazelrc
+new file mode 100644
+index 0000000..6a4d040
+--- /dev/null
++++ .bazelrc
+@@ -0,0 +1,11 @@
++# Required until this is the default; expected in Bazel 7
++common --enable_bzlmod
++
++# Load any settings specific to the current user.
++# .bazelrc.user should appear in .gitignore so that settings are not shared with team members
++# This needs to be last statement in this
++# config, as the user configuration should be able to overwrite flags from this file.
++# See https://docs.bazel.build/versions/master/best-practices.html#bazelrc
++# (Note that we use .bazelrc.user so the file appears next to .bazelrc in directory listing,
++# rather than user.bazelrc as suggested in the Bazel docs)
++try-import %workspace%/.bazelrc.user
+diff --git MODULE.bazel MODULE.bazel
+new file mode 100644
+index 0000000..6ec2d21
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,17 @@
++module(
++    name = "grpc-web",
++    version = "1.5.0.bcr",  # This isn't exactly version 1.5.0, so add a .bcr suffix
++    compatibility_level = 1,
++    repo_name = "com_github_grpc_grpc_web",
++)
++
++bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
++bazel_dep(name = "grpc", version = "1.65.0", repo_name = "com_github_grpc_grpc")
++bazel_dep(name = "rules_cc", version = "0.0.2")
++bazel_dep(name = "rules_proto", version = "6.0.2")
++
++# Needed to resolve https://github.com/bazelbuild/bazel-central-registry/issues/2538.
++single_version_override(
++    module_name = "grpc-java",
++    version = "1.64.0",
++)
+diff --git WORKSPACE WORKSPACE
+deleted file mode 100644
+index 526fc0d..0000000
+--- WORKSPACE
++++ /dev/null
+@@ -1,38 +0,0 @@
+-workspace(name = "com_github_grpc_grpc_web")
+-
+-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+-
+-http_archive(
+-    name = "bazel_skylib",
+-    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+-    urls = [
+-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+-    ],
+-)
+-
+-http_archive(
+-    name = "com_google_protobuf",
+-    sha256 = "ba0650be1b169d24908eeddbe6107f011d8df0da5b1a5a4449a913b10e578faf",
+-    strip_prefix = "protobuf-3.19.4",
+-    urls = [
+-        "https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protobuf-all-3.19.4.tar.gz",
+-    ],
+-)
+-
+-http_archive(
+-    name = "com_github_grpc_grpc",
+-    sha256 = "de2d3168e77e5ffb27758b07e87f6066fd0d8087fe272f278771e7780e6aaacb",
+-    strip_prefix = "grpc-1.44.0",
+-    urls = [
+-        "https://github.com/grpc/grpc/archive/v1.44.0.zip",
+-    ],
+-)
+-
+-load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+-
+-grpc_deps()
+-
+-load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+-
+-grpc_extra_deps()

--- a/modules/grpc-web/1.5.0.bcr/presubmit.yml
+++ b/modules/grpc-web/1.5.0.bcr/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@grpc-web//javascript/net/grpc/web/generator:protoc-gen-grpc-web'
+    - '@grpc-web//net/grpc/gateway/examples/echo:server'

--- a/modules/grpc-web/1.5.0.bcr/source.json
+++ b/modules/grpc-web/1.5.0.bcr/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/gonzojive/grpc-web/releases/download/1.5.0/grpc-web-1.5.0.zip",
+    "integrity": "sha256-30dmQwuMjjpx/bWmfrGvxl5AUxsHHeLmp3mq25syVaU=",
+    "strip_prefix": "grpc-web-1.5.0",
+    "patch_strip": 0,
+    "patches": {
+        "bzlmod-support.patch": "sha256-+SLnPRcMPpiJy8Y0lWYV3H19ADf6wtdXANIBvJ6Vy7s="
+    }
+}

--- a/modules/grpc-web/metadata.json
+++ b/modules/grpc-web/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/grpc/grpc-web",
+    "maintainers": [
+        {
+            "email": "reddaly@gmail.com",
+            "github": "gonzojive",
+            "name": "Red Daly"
+        }
+    ],
+    "repository": [
+        "github:grpc/grpc-web",
+        "github:gonzojive/grpc-web"
+    ],
+    "versions": [
+        "1.5.0.bcr"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
The module is based on changes at
https://github.com/gonzojive/grpc-web/tree/bzlmod-1.5.0.bcr.

The release archive is hosted in the fork of the repository because the [official 1.5.0 release](https://github.com/grpc/grpc-web/releases/tag/1.5.0) has [no stable source
archive](https://blog.bazel.build/2023/02/15/github-archive-checksum.html).