### PR TITLE
Compression ruleset updates

### DIFF
--- a/modules/rules_bzip2/1.0.0-beta.2/MODULE.bazel
+++ b/modules/rules_bzip2/1.0.0-beta.2/MODULE.bazel
@@ -1,0 +1,29 @@
+module(
+    name = "rules_bzip2",
+    version = "1.0.0-beta.2",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_coreutils", version = "1.0.0-beta.1")
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.12")
+bazel_dep(name = "ape", version = "1.0.0-beta.12")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+use_repo(export, "ape-bzip2")
+export.symlink(
+    name = "bzip2",
+    target = "@ape-bzip2",
+)
+use_repo(export, "bzip2")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+resolved(
+    name = "resolved-bzip2",
+    toolchain_type = "//bzip2/toolchain/bzip2:type",
+)
+
+register_toolchains("//bzip2/toolchain/...")

--- a/modules/rules_bzip2/1.0.0-beta.2/presubmit.yml
+++ b/modules/rules_bzip2/1.0.0-beta.2/presubmit.yml
@@ -1,0 +1,22 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_bzip2/1.0.0-beta.2/source.json
+++ b/modules/rules_bzip2/1.0.0-beta.2/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_bzip2/-/releases/v1.0.0-beta.2/downloads/src.tar.gz",
+  "integrity": "sha512-10AOTvRsQdd8wpf20exrQKSUVVJB3nU0GEl+aCourgM/trZiPd+VKoWalUm2nZwEUaxyOGYm+Cne/+19n/POhw==",
+  "strip_prefix": "rules_bzip2-v1.0.0-beta.2"
+}

--- a/modules/rules_bzip2/metadata.json
+++ b/modules/rules_bzip2/metadata.json
@@ -4,7 +4,8 @@
     "https://gitlab.arm.com/bazel/rules_bzip2"
   ],
   "versions": [
-    "1.0.0-beta.1"
+    "1.0.0-beta.1",
+    "1.0.0-beta.2"
   ],
   "maintainers": [
     {

--- a/modules/rules_gzip/1.0.0-beta.2/MODULE.bazel
+++ b/modules/rules_gzip/1.0.0-beta.2/MODULE.bazel
@@ -1,0 +1,29 @@
+module(
+    name = "rules_gzip",
+    version = "1.0.0-beta.2",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.12")
+bazel_dep(name = "rules_coreutils", version = "1.0.0-beta.1")
+bazel_dep(name = "ape", version = "1.0.0-beta.12")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+use_repo(export, "ape-pigz")
+export.symlink(
+    name = "pigz",
+    target = "@ape-pigz",
+)
+use_repo(export, "pigz")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+resolved(
+    name = "resolved-pigz",
+    toolchain_type = "//gzip/toolchain/pigz:type",
+)
+
+register_toolchains("//gzip/toolchain/...")

--- a/modules/rules_gzip/1.0.0-beta.2/presubmit.yml
+++ b/modules/rules_gzip/1.0.0-beta.2/presubmit.yml
@@ -1,0 +1,22 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_gzip/1.0.0-beta.2/source.json
+++ b/modules/rules_gzip/1.0.0-beta.2/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_gzip/-/releases/v1.0.0-beta.2/downloads/src.tar.gz",
+  "integrity": "sha512-nDoXCHM/LekNYj1xkLF+7z0zaoC9htyZBXStkApDPIohRxGGJGkP0mes8oB2X0xv+wc4dYHda0K6PXL10wHlaQ==",
+  "strip_prefix": "rules_gzip-v1.0.0-beta.2"
+}

--- a/modules/rules_gzip/metadata.json
+++ b/modules/rules_gzip/metadata.json
@@ -4,7 +4,8 @@
     "https://gitlab.arm.com/bazel/rules_gzip"
   ],
   "versions": [
-    "1.0.0-beta.1"
+    "1.0.0-beta.1",
+    "1.0.0-beta.2"
   ],
   "maintainers": [
     {

--- a/modules/rules_xz/1.0.0-beta.2/MODULE.bazel
+++ b/modules/rules_xz/1.0.0-beta.2/MODULE.bazel
@@ -1,0 +1,29 @@
+module(
+    name = "rules_xz",
+    version = "1.0.0-beta.2",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_coreutils", version = "1.0.0-beta.1")
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.12")
+bazel_dep(name = "ape", version = "1.0.0-beta.12")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+use_repo(export, "ape-xz")
+export.symlink(
+    name = "xz",
+    target = "@ape-xz",
+)
+use_repo(export, "xz")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+resolved(
+    name = "resolved-xz",
+    toolchain_type = "//xz/toolchain/xz:type",
+)
+
+register_toolchains("//xz/toolchain/...")

--- a/modules/rules_xz/1.0.0-beta.2/presubmit.yml
+++ b/modules/rules_xz/1.0.0-beta.2/presubmit.yml
@@ -1,0 +1,22 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_xz/1.0.0-beta.2/source.json
+++ b/modules/rules_xz/1.0.0-beta.2/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_xz/-/releases/v1.0.0-beta.2/downloads/src.tar.gz",
+  "integrity": "sha512-KL1PnM3wuTF/XV+s5q7jK+mXrVN5GjulHMp5ojS2/c8m7+UY6DQJBMJM/5MXg/RGsIW86ZpVMXkOnaN5vJFdoA==",
+  "strip_prefix": "rules_xz-v1.0.0-beta.2"
+}

--- a/modules/rules_xz/metadata.json
+++ b/modules/rules_xz/metadata.json
@@ -4,7 +4,8 @@
     "https://gitlab.arm.com/bazel/rules_xz"
   ],
   "versions": [
-    "1.0.0-beta.1"
+    "1.0.0-beta.1",
+    "1.0.0-beta.2"
   ],
   "maintainers": [
     {

--- a/modules/rules_zstd/1.0.0-beta.2/MODULE.bazel
+++ b/modules/rules_zstd/1.0.0-beta.2/MODULE.bazel
@@ -1,0 +1,30 @@
+module(
+    name = "rules_zstd",
+    version = "1.0.0-beta.2",
+    bazel_compatibility = [
+        ">=7.0.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.0")
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.12")
+bazel_dep(name = "ape", version = "1.0.0-beta.12")
+
+export = use_extension("@toolchain_utils//toolchain/export:defs.bzl", "toolchain_export")
+use_repo(export, "ape-zstd")
+export.symlink(
+    name = "zstd",
+    target = "@ape-zstd",
+)
+use_repo(export, "zstd")
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+resolved(
+    name = "resolved-zstd",
+    toolchain_type = "//zstd/toolchain/zstd:type",
+)
+
+register_toolchains("//zstd/toolchain/...")

--- a/modules/rules_zstd/1.0.0-beta.2/presubmit.yml
+++ b/modules/rules_zstd/1.0.0-beta.2/presubmit.yml
@@ -1,0 +1,22 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_zstd/1.0.0-beta.2/presubmit.yml
+++ b/modules/rules_zstd/1.0.0-beta.2/presubmit.yml
@@ -10,7 +10,8 @@ bcr_test_module:
       - ubuntu2004
       - ubuntu2204
       - fedora39
-      - macos
+      # FIXME: timefn::clock_gettime(CLOCK_MONOTONIC): Invalid argument
+      # - macos
       - macos_arm64
       - windows
   tasks:

--- a/modules/rules_zstd/1.0.0-beta.2/source.json
+++ b/modules/rules_zstd/1.0.0-beta.2/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_zstd/-/releases/v1.0.0-beta.2/downloads/src.tar.gz",
+  "integrity": "sha512-5mss6bMEGyELCOqEKRrCln1I/fIKIjv/PLAXAKGpD7Xkqg3avCzxPGFmUKkNjmfzKORp0UTSjWP/NbBUfNPPCA==",
+  "strip_prefix": "rules_zstd-v1.0.0-beta.2"
+}

--- a/modules/rules_zstd/metadata.json
+++ b/modules/rules_zstd/metadata.json
@@ -4,7 +4,8 @@
     "https://gitlab.arm.com/bazel/rules_zstd"
   ],
   "versions": [
-    "1.0.0-beta.1"
+    "1.0.0-beta.1",
+    "1.0.0-beta.2"
   ],
   "maintainers": [
     {


### PR DESCRIPTION
Upgrades `gzip`, `bzip2`, `xz`, `zstd` to use the new `@ape//ape/toolchain/info:*` targets removing the deprecated `@ape//:*` targets.