### PR TITLE
Fix fremtind_rules_vitest 0.2.0 patch

### DIFF
--- a/modules/fremtind_rules_vitest/0.2.0/patches/module_dot_bazel_version.patch
+++ b/modules/fremtind_rules_vitest/0.2.0/patches/module_dot_bazel_version.patch
@@ -1,6 +1,8 @@
+===================================================================
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -2,7 +2,7 @@
+@@ -1,9 +1,9 @@
+ "fremtind/rules_vitest"
 
  module(
      name = "fremtind_rules_vitest",
@@ -8,3 +10,5 @@
 +    version = "0.2.0",
      compatibility_level = 1,
  )
+
+ bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")

--- a/modules/fremtind_rules_vitest/0.2.0/source.json
+++ b/modules/fremtind_rules_vitest/0.2.0/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-uXE7NooJ6LLFRssGEr4w6Am9WqUDCTD/f1C5gp45Nfw=",
     "strip_prefix": "rules_vitest-0.2.0",
     "patches": {
-        "module_dot_bazel_version.patch": "sha256-fBKNrLgWtCGSHGYbP1f0ojLhRG6iaXPWNGB0y2zTd0w="
+        "module_dot_bazel_version.patch": "sha256-9WEMHl4jQhfYDiGJQalwgySoJyRv1MhNiEBRBcl8CT0="
     },
     "patch_strip": 1
 }


### PR DESCRIPTION
Apparently there was something wrong with the patch, as downloading the module fails with an error which was not caught with bcr_validation:

```
ERROR: no such package '@@fremtind_rules_vitest~//vitest': Error applying patch /private/var/tmp/.../external/fremtind_rules_vitest~/.tmp_remote_patches/module_dot_bazel_version.patch: Expecting more chunk line at line 11
```

Not sure if fixing the patch, or yanking the version and releasing a new one is the way to move forward here?