### PR TITLE
feat: add `libarmgpuinfo@1.1.0+11140bec96`

### DIFF
--- a/modules/libarmgpuinfo/1.1.0+11140bec96/MODULE.bazel
+++ b/modules/libarmgpuinfo/1.1.0+11140bec96/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "libarmgpuinfo",
+    version = "1.1.0+11140bec96",
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.9")
+
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0", dev_dependency = True)

--- a/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0001-chore-ignore-Bazel-build-symlinks.patch
+++ b/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0001-chore-ignore-Bazel-build-symlinks.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Clarkson <matthew.clarkson@arm.com>
+Date: Fri, 16 Aug 2024 14:16:40 +0100
+Subject: [PATCH] chore: ignore Bazel build symlinks
+
+---
+ .gitignore | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/.gitignore b/.gitignore
+index 5af55a1..c32d031 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -8,3 +8,4 @@
+ /build*
+ /log*
+ /scratch*
++/bazel-*

--- a/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0002-build-add-bzlmod-files.patch
+++ b/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0002-build-add-bzlmod-files.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Clarkson <matthew.clarkson@arm.com>
+Date: Fri, 16 Aug 2024 14:17:57 +0100
+Subject: [PATCH] build: add `bzlmod` files
+
+---
+ MODULE.bazel | 7 +++++++
+ WORKSPACE    | 0
+ 2 files changed, 7 insertions(+)
+ create mode 100644 MODULE.bazel
+ create mode 100644 WORKSPACE
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..a9eb7be
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "libarmgpuinfo",
++)
++
++bazel_dep(name = "rules_cc", version = "0.0.9")
++
++bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0", dev_dependency = True)
+diff --git a/WORKSPACE b/WORKSPACE
+new file mode 100644
+index 0000000..e69de29

--- a/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0003-build-add-source-Bazel-build.patch
+++ b/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0003-build-add-source-Bazel-build.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Clarkson <matthew.clarkson@arm.com>
+Date: Fri, 16 Aug 2024 14:18:08 +0100
+Subject: [PATCH] build: add `source` Bazel build
+
+---
+ source/BUILD.bazel | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+ create mode 100644 source/BUILD.bazel
+
+diff --git a/source/BUILD.bazel b/source/BUILD.bazel
+new file mode 100644
+index 0000000..9f60b32
+--- /dev/null
++++ b/source/BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "libarmgpuinfo",
++    srcs = ["libgpuinfo.cpp"],
++    hdrs = ["libgpuinfo.hpp"],
++    visibility = ["//:__subpackages__"],
++)
++
++cc_binary(
++    name = "arm-gpu-info",
++    srcs = ["arm_gpuinfo.cpp"],
++    visibility = ["//:__subpackages__"],
++    deps = [":libarmgpuinfo"],
++)

--- a/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0004-build-add-top-level-Bazel-aliases.patch
+++ b/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0004-build-add-top-level-Bazel-aliases.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Clarkson <matthew.clarkson@arm.com>
+Date: Fri, 16 Aug 2024 14:18:19 +0100
+Subject: [PATCH] build: add top-level Bazel aliases
+
+---
+ BUILD.bazel | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+ create mode 100644 BUILD.bazel
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 0000000..5f4fc9d
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,11 @@
++alias(
++    name = "libarmgpuinfo",
++    actual = "//source:libarmgpuinfo",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "arm-gpu-info",
++    actual = "//source:arm-gpu-info",
++    visibility = ["//visibility:public"],
++)

--- a/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0005-test-add-Bazel-build-tests.patch
+++ b/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0005-test-add-Bazel-build-tests.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Clarkson <matthew.clarkson@arm.com>
+Date: Fri, 16 Aug 2024 14:18:28 +0100
+Subject: [PATCH] test: add Bazel build tests
+
+---
+ e2e/.gitignore   |  1 +
+ e2e/BUILD.bazel  | 11 +++++++++++
+ e2e/MODULE.bazel | 13 +++++++++++++
+ 3 files changed, 25 insertions(+)
+ create mode 100644 e2e/.gitignore
+ create mode 100644 e2e/BUILD.bazel
+ create mode 100644 e2e/MODULE.bazel
+
+diff --git a/e2e/.gitignore b/e2e/.gitignore
+new file mode 100644
+index 0000000..a6ef824
+--- /dev/null
++++ b/e2e/.gitignore
+@@ -0,0 +1 @@
++/bazel-*
+diff --git a/e2e/BUILD.bazel b/e2e/BUILD.bazel
+new file mode 100644
+index 0000000..2c96d71
+--- /dev/null
++++ b/e2e/BUILD.bazel
+@@ -0,0 +1,11 @@
++load("@bazel_skylib//rules:build_test.bzl", "build_test")
++
++build_test(
++    name = "libarmgpuinfo",
++    targets = ["@libarmgpuinfo"],
++)
++
++build_test(
++    name = "arm-gpu-info",
++    targets = ["@libarmgpuinfo//:arm-gpu-info"],
++)
+diff --git a/e2e/MODULE.bazel b/e2e/MODULE.bazel
+new file mode 100644
+index 0000000..6dc07e7
+--- /dev/null
++++ b/e2e/MODULE.bazel
+@@ -0,0 +1,13 @@
++module(
++    name = "e2e",
++)
++
++bazel_dep(name = "libarmgpuinfo")
++bazel_dep(name = "bazel_skylib", version = "1.7.1")
++
++bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0", dev_dependency = True)
++
++local_path_override(
++    module_name = "libarmgpuinfo",
++    path = "..",
++)

--- a/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0006-build-update-module-version.patch
+++ b/modules/libarmgpuinfo/1.1.0+11140bec96/patches/0006-build-update-module-version.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Clarkson <matthew.clarkson@arm.com>
+Date: Mon, 19 Aug 2024 09:56:36 +0100
+Subject: [PATCH] build: update module version
+
+---
+ MODULE.bazel | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+index a9eb7be..ac9b223 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,5 +1,6 @@
+ module(
+     name = "libarmgpuinfo",
++    version = "1.1.0+11140bec96",
+ )
+ 
+ bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/libarmgpuinfo/1.1.0+11140bec96/presubmit.yml
+++ b/modules/libarmgpuinfo/1.1.0+11140bec96/presubmit.yml
@@ -1,0 +1,14 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+    platform:
+      - debian11
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/libarmgpuinfo/1.1.0+11140bec96/source.json
+++ b/modules/libarmgpuinfo/1.1.0+11140bec96/source.json
@@ -1,0 +1,14 @@
+{
+  "url": "https://github.com/ARM-software/libGPUInfo/archive/11140bec96cc546a4d085aaf0735b38910384349.tar.gz",
+  "integrity": "sha512-E5PecdarWfEQhDfqSCTh3V54goWexrgF1H3AJaI7U3Y32vTH+MDEyvUncZbd4jq754WTr64en/tHJq23kL2JYQ==",
+  "strip_prefix": "libGPUInfo-11140bec96cc546a4d085aaf0735b38910384349",
+  "patch_strip": 1,
+  "patches": {
+    "0001-chore-ignore-Bazel-build-symlinks.patch": "sha256-Vv7uc65mVDBTT4MFhB6gZs6HAP2yOpLc/1GRDjbPd+k=",
+    "0002-build-add-bzlmod-files.patch": "sha256-uGm3I+Pk3XlvvmPO21wpLKEFgaYj9kjdoIyO6dMLVG8=",
+    "0003-build-add-source-Bazel-build.patch": "sha256-GnMDUiVqDgtRR1Czzg80AGRz2bmgMoyNwXoKWd469mg=",
+    "0004-build-add-top-level-Bazel-aliases.patch": "sha256-SuooBys7Z0Ay+8Zzc9qu8AAdeFWBKJfm0OldZeLOaiI=",
+    "0005-test-add-Bazel-build-tests.patch": "sha256-g7wXjSVK5kulvLqmnKDAZowRYgMmYYOaIfAT/ulLtQs=",
+    "0006-build-update-module-version.patch": "sha256-m0QI45p5/+QmwVx5VJLEXtGR7Kr7m9JNF4EayHMy1Qw="
+  }
+}

--- a/modules/libarmgpuinfo/metadata.json
+++ b/modules/libarmgpuinfo/metadata.json
@@ -1,0 +1,16 @@
+{
+  "homepage": "https://github.com/ARM-software/libGPUInfo",
+  "repository": [
+    "https://github.com/ARM-software/libGPUInfo"
+  ],
+  "versions": [
+    "1.1.0+11140bec96"
+  ],
+  "maintainers": [
+    {
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson",
+      "github": "mattyclarkson"
+    }
+  ]
+}


### PR DESCRIPTION
Uses an unstable archive at the moment. Will work with upstream to publish a stable archive for the next release.