### PR TITLE
Add rules_antlr 0.5.0.bcr.1

### DIFF
--- a/modules/rules_antlr/0.5.0.bcr.1/MODULE.bazel
+++ b/modules/rules_antlr/0.5.0.bcr.1/MODULE.bazel
@@ -1,0 +1,40 @@
+module(
+    name = "rules_antlr",
+    version = "0.5.0.bcr.1",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_java", version = "7.5.0")
+bazel_dep(name = "stardoc", version = "0.7.0", repo_name = "io_bazel_stardoc")
+
+antlr = use_extension("//antlr:extensions.bzl", "antlr")
+antlr.download(version = "4.8")
+use_repo(
+    antlr,
+    "antlr3_runtime",
+    "antlr4_runtime",
+    "antlr4_tool",
+    "javax_json",
+    "stringtemplate4",
+)
+
+http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+
+http_jar(
+    name = "junit",
+    sha256 = "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
+    url = "https://jcenter.bintray.com/junit/junit/4.12/junit-4.12.jar",
+)
+
+http_jar(
+    name = "jimfs",
+    sha256 = "c4828e28d7c0a930af9387510b3bada7daa5c04d7c25a75c7b8b081f1c257ddd",
+    url = "https://jcenter.bintray.com/com/google/jimfs/jimfs/1.1/jimfs-1.1.jar",
+)
+
+http_jar(
+    name = "guava",
+    sha256 = "4a5aa70cc968a4d137e599ad37553e5cfeed2265e8c193476d7119036c536fe7",
+    url = "https://jcenter.bintray.com/com/google/guava/guava/27.1-jre/guava-27.1-jre.jar",
+)
+

--- a/modules/rules_antlr/0.5.0.bcr.1/patches/antlr_4.10.patch
+++ b/modules/rules_antlr/0.5.0.bcr.1/patches/antlr_4.10.patch
@@ -1,0 +1,78 @@
+diff --git antlr/repositories.bzl antlr/repositories.bzl
+index e2525ab..12f79f0 100644
+--- antlr/repositories.bzl
++++ antlr/repositories.bzl
+@@ -3,13 +3,18 @@
+ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
+ load(":lang.bzl", "C", "CPP", "GO", "JAVA", "OBJC", "PYTHON", "PYTHON2", "PYTHON3", supportedLanguages = "supported")
+ 
+-v4 = [4, "4.7.1", "4.7.2", "4.8"]
++v4 = [4, "4.7.1", "4.7.2", "4.8", "4.10"]
+ v4_opt = [4, "4.7.1", "4.7.2", "4.7.3", "4.7.4"]
+ v3 = [3, "3.5.2"]
+ v2 = [2, "2.7.7"]
+ 
+ PACKAGES = {
+     "antlr": {
++        "4.10": {
++            "url": "https://github.com/antlr/antlr4/archive/4.10.tar.gz",
++            "prefix": "antlr4-4.10",
++            "sha256": "39b2604fc75fa77323bd7046f2fb750c818cf11fcce2cd6cca06b6697f60ffbb",
++        },
+         "4.8": {
+             "url": "https://github.com/antlr/antlr4/archive/4.8.tar.gz",
+             "prefix": "antlr4-4.8",
+@@ -38,6 +43,10 @@ PACKAGES = {
+         },
+     },
+     "antlr4_runtime": {
++        "4.10": {
++            "path": "org/antlr/antlr4-runtime/4.10/antlr4-runtime-4.10.jar",
++            "sha256": "4663a38f88e1935ea612336cbf34f702f10bd0af8e62715a9e959629f141654e",
++        },
+         "4.8": {
+             "path": "org/antlr/antlr4-runtime/4.8/antlr4-runtime-4.8.jar",
+             "sha256": "2337df5d81e715b39aeea07aac46ad47e4f1f9e9cd7c899f124f425913efdcf8",
+@@ -68,6 +77,10 @@ PACKAGES = {
+         },
+     },
+     "antlr4_tool": {
++        "4.10": {
++            "path": "org/antlr/antlr4/4.10/antlr4-4.10.jar",
++            "sha256": "f32485cfdf114295a58cd2005af9463706c5fd43d900118126eb3a9ac36bfec3",
++        },
+         "4.8": {
+             "path": "org/antlr/antlr4/4.8/antlr4-4.8.jar",
+             "sha256": "6e4477689371f237d4d8aa40642badbb209d4628ccdd81234d90f829a743bac8",
+@@ -179,7 +192,9 @@ def rules_antlr_dependencies(*versionsAndLanguages):
+             languages = [JAVA]
+ 
+         for version in sorted(versions, key = _toString):
+-            if version == 4 or version == "4.8":
++            if version == 4 or version == "4.10":
++                _antlr410_dependencies(languages)
++            elif version == "4.8":
+                 _antlr48_dependencies(languages)
+             elif version == "4.7.2":
+                 _antlr472_dependencies(languages)
+@@ -217,6 +232,19 @@ def rules_antlr_optimized_dependencies(version):
+     else:
+         fail('Unsupported ANTLR version provided: "{0}". Currently supported are: {1}'.format(version, v4_opt), attr = "version")
+ 
++def _antlr410_dependencies(languages):
++    _antlr4_dependencies(
++        "4.10",
++        languages,
++        {
++            "antlr4_runtime": "4.10",
++            "antlr4_tool": "4.10",
++            "antlr3_runtime": "3.5.2",
++            "stringtemplate4": "4.3",
++            "javax_json": "1.0.4",
++        },
++    )
++
+ def _antlr48_dependencies(languages):
+     _antlr4_dependencies(
+         "4.8",
+

--- a/modules/rules_antlr/0.5.0.bcr.1/patches/bzlmod.patch
+++ b/modules/rules_antlr/0.5.0.bcr.1/patches/bzlmod.patch
@@ -1,0 +1,85 @@
+diff --git MODULE.bazel MODULE.bazel
+new file mode 100644
+index 0000000..9a9368e
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,40 @@
++module(
++    name = "rules_antlr",
++    version = "0.5.0.bcr.1",
++)
++
++bazel_dep(name = "bazel_skylib", version = "1.7.1")
++bazel_dep(name = "rules_java", version = "7.5.0")
++bazel_dep(name = "stardoc", version = "0.7.0", repo_name = "io_bazel_stardoc")
++
++antlr = use_extension("//antlr:extensions.bzl", "antlr")
++antlr.download(version = "4.8")
++use_repo(
++    antlr,
++    "antlr3_runtime",
++    "antlr4_runtime",
++    "antlr4_tool",
++    "javax_json",
++    "stringtemplate4",
++)
++
++http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
++
++http_jar(
++    name = "junit",
++    sha256 = "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
++    url = "https://jcenter.bintray.com/junit/junit/4.12/junit-4.12.jar",
++)
++
++http_jar(
++    name = "jimfs",
++    sha256 = "c4828e28d7c0a930af9387510b3bada7daa5c04d7c25a75c7b8b081f1c257ddd",
++    url = "https://jcenter.bintray.com/com/google/jimfs/jimfs/1.1/jimfs-1.1.jar",
++)
++
++http_jar(
++    name = "guava",
++    sha256 = "4a5aa70cc968a4d137e599ad37553e5cfeed2265e8c193476d7119036c536fe7",
++    url = "https://jcenter.bintray.com/com/google/guava/guava/27.1-jre/guava-27.1-jre.jar",
++)
++
+diff --git antlr/extensions.bzl antlr/extensions.bzl
+new file mode 100644
+index 0000000..3151e01
+--- /dev/null
++++ antlr/extensions.bzl
+@@ -0,0 +1,17 @@
++load("//antlr:repositories.bzl", "rules_antlr_dependencies")
++
++download = tag_class(attrs = {"version": attr.string()})
++
++def _antlr(module_ctx):
++    rules_antlr_dependencies(
++        max([
++            ([int(part) for part in download.version.split(".")], download.version)
++            for mod in module_ctx.modules
++            for download in mod.tags.download
++        ])[1],
++    )
++
++antlr = module_extension(
++    implementation = _antlr,
++    tag_classes = {"download": download},
++)
+diff --git examples/MODULE.bazel examples/MODULE.bazel
+new file mode 100644
+index 0000000..a05ec91
+--- /dev/null
++++ examples/MODULE.bazel
+@@ -0,0 +1,9 @@
++module(name = "examples")
++
++bazel_dep(name = "rules_antlr")
++
++local_path_override(
++    module_name = "rules_antlr",
++    path = "..",
++)
++
+

--- a/modules/rules_antlr/0.5.0.bcr.1/patches/stardoc.patch
+++ b/modules/rules_antlr/0.5.0.bcr.1/patches/stardoc.patch
@@ -1,0 +1,30 @@
+diff --git antlr/BUILD antlr/BUILD
+index 2d6696f..248cb80 100644
+--- antlr/BUILD
++++ antlr/BUILD
+@@ -19,9 +19,7 @@ bzl_library(
+ stardoc(
+     name = "antlr4",
+     out = "antlr4.md",
+-    func_template = "@stardoc_templates//:func.vm",
+     input = "antlr4.bzl",
+-    rule_template = "@stardoc_templates//:rule.vm",
+     deps = [":shared"],
+ )
+ 
+@@ -29,7 +27,6 @@ stardoc(
+     name = "antlr3",
+     out = "antlr3.md",
+     input = "antlr3.bzl",
+-    rule_template = "@stardoc_templates//:rule.vm",
+     deps = [":shared"],
+ )
+ 
+@@ -37,6 +34,5 @@ stardoc(
+     name = "antlr2",
+     out = "antlr2.md",
+     input = "antlr2.bzl",
+-    rule_template = "@stardoc_templates//:rule.vm",
+     deps = [":shared"],
+ )
+

--- a/modules/rules_antlr/0.5.0.bcr.1/presubmit.yml
+++ b/modules/rules_antlr/0.5.0.bcr.1/presubmit.yml
@@ -1,0 +1,24 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+matrix:
+  platform: ["debian11", "macos", "ubuntu2004"]
+  bazel: [7.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@rules_antlr//src/...'

--- a/modules/rules_antlr/0.5.0.bcr.1/source.json
+++ b/modules/rules_antlr/0.5.0.bcr.1/source.json
@@ -1,0 +1,11 @@
+{
+    "integrity": "sha256-JuaoPGZc9sEJO2KLOnSQcTIvD3AwXRLt4wkJaV7YVZE=",
+    "strip_prefix": "rules_antlr-0.5.0",
+    "url": "https://github.com/marcohu/rules_antlr/archive/refs/tags/0.5.0.tar.gz",
+    "patches": {
+        "bzlmod.patch": "sha256-VB/6XuqAmlNnDB61qX77ZNI+4W+ggq1g2dBMg94bAqc=",
+        "antlr_4.10.patch": "sha256-Jirx7sQZY8ud2w1o6M7adBk5UbX6mFQAUuPWjtMzitI=",
+        "stardoc.patch": "sha256-KxEZTt3BzQZgt3pdtJOja8dL/iBYlphzqlKSF2kudkQ="
+    },
+    "patch_strip": 0
+}

--- a/modules/rules_antlr/metadata.json
+++ b/modules/rules_antlr/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/marcohu/rules_antlr",
+    "maintainers": [
+        {
+            "github": "mortenmj",
+            "name": "Morten Mjelva"
+        }
+    ],
+    "repository": [
+        "github:marcohu/rules_antlr"
+    ],
+    "versions": [
+        "0.5.0.bcr.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This upstreams the work to add bzlmod support for rules_antlr, done in https://github.com/buildbarn/go-xdr
Support is somewhat minimal, but enough to support the current usecase.

There's no published archive for rules_antlr, requiring override to use an unstable archive. As the project is unmaintained, I don't see that changing.