### PR TITLE
Boost.exeception@1.83.0

### DIFF
--- a/modules/boost.exception/1.83.0/MODULE.bazel
+++ b/modules/boost.exception/1.83.0/MODULE.bazel
@@ -1,0 +1,15 @@
+module(
+    name = "boost.exception",
+    version = "1.83.0",
+    compatibility_level = 108300,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "boost.assert", version = "1.83.0")
+bazel_dep(name = "boost.config", version = "1.83.0")
+bazel_dep(name = "boost.core", version = "1.83.0")
+bazel_dep(name = "boost.smart_ptr", version = "1.83.0")
+bazel_dep(name = "boost.throw_exception", version = "1.83.0")
+bazel_dep(name = "boost.tuple", version = "1.83.0")
+bazel_dep(name = "boost.type_traits", version = "1.83.0")
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/boost.exception/1.83.0/MODULE.bazel
+++ b/modules/boost.exception/1.83.0/MODULE.bazel
@@ -1,8 +1,8 @@
 module(
     name = "boost.exception",
     version = "1.83.0",
-    compatibility_level = 108300,
     bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 108300,
 )
 
 bazel_dep(name = "boost.assert", version = "1.83.0")

--- a/modules/boost.exception/1.83.0/overlay/BUILD.bazel
+++ b/modules/boost.exception/1.83.0/overlay/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "boost.exception",
+    hdrs = glob(
+        [
+            "include/**/*.hpp",
+            "include/**/*.h",
+        ],
+        exclude = [
+            #"include/boost/bind/bind_cc.hpp",
+            #"include/boost/bind/bind_mf_cc.hpp",
+            #"include/boost/bind/bind_mf2_cc.hpp",
+            #"include/boost/bind/bind_template.hpp",
+            #"include/boost/bind/mem_fn_cc.hpp",
+            #"include/boost/bind/mem_fn_template.hpp",
+            #"include/boost/bind/mem_fn_vw.hpp",
+        ],
+    ),
+    features = [
+        "parse_headers",
+    ],
+    includes = ["include"],
+    textual_hdrs = glob(
+        [
+            #"include/boost/bind/bind_cc.hpp",
+            #"include/boost/bind/bind_mf_cc.hpp",
+            #"include/boost/bind/bind_mf2_cc.hpp",
+            #"include/boost/bind/bind_template.hpp",
+            #"include/boost/bind/mem_fn_cc.hpp",
+            #"include/boost/bind/mem_fn_template.hpp",
+            #"include/boost/bind/mem_fn_vw.hpp",
+        ],
+    ),
+    deps = [
+        "boost.assert",
+        "boost.config",
+        "boost.core",
+        "boost.smart_ptr",
+        "boost.throw_exception",
+        "boost.tuple",
+        "boost.type_traits",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/modules/boost.exception/1.83.0/overlay/BUILD.bazel
+++ b/modules/boost.exception/1.83.0/overlay/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
     name = "boost.exception",
@@ -7,39 +7,19 @@ cc_library(
             "include/**/*.hpp",
             "include/**/*.h",
         ],
-        exclude = [
-            #"include/boost/bind/bind_cc.hpp",
-            #"include/boost/bind/bind_mf_cc.hpp",
-            #"include/boost/bind/bind_mf2_cc.hpp",
-            #"include/boost/bind/bind_template.hpp",
-            #"include/boost/bind/mem_fn_cc.hpp",
-            #"include/boost/bind/mem_fn_template.hpp",
-            #"include/boost/bind/mem_fn_vw.hpp",
-        ],
     ),
     features = [
         "parse_headers",
     ],
     includes = ["include"],
-    textual_hdrs = glob(
-        [
-            #"include/boost/bind/bind_cc.hpp",
-            #"include/boost/bind/bind_mf_cc.hpp",
-            #"include/boost/bind/bind_mf2_cc.hpp",
-            #"include/boost/bind/bind_template.hpp",
-            #"include/boost/bind/mem_fn_cc.hpp",
-            #"include/boost/bind/mem_fn_template.hpp",
-            #"include/boost/bind/mem_fn_vw.hpp",
-        ],
-    ),
-    deps = [
-        "boost.assert",
-        "boost.config",
-        "boost.core",
-        "boost.smart_ptr",
-        "boost.throw_exception",
-        "boost.tuple",
-        "boost.type_traits",
-    ],
     visibility = ["//visibility:public"],
+    deps = [
+        "@boost.assert",
+        "@boost.config",
+        "@boost.core",
+        "@boost.smart_ptr",
+        "@boost.throw_exception",
+        "@boost.tuple",
+        "@boost.type_traits",
+    ],
 )

--- a/modules/boost.exception/1.83.0/overlay/MODULE.bazel
+++ b/modules/boost.exception/1.83.0/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/boost.exception/1.83.0/overlay/test/BUILD.bazel
+++ b/modules/boost.exception/1.83.0/overlay/test/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_test(
+    name = "1-throw_exception_test",
+    srcs = ["1-throw_exception_test.cpp"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boost.exception",
+    ],
+)
+
+cc_test(
+    name = "cloning_test",
+    srcs = ["cloning_test.cpp"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boost.exception",
+    ],
+)

--- a/modules/boost.exception/1.83.0/overlay/test/BUILD.bazel
+++ b/modules/boost.exception/1.83.0/overlay/test/BUILD.bazel
@@ -1,7 +1,6 @@
 cc_test(
     name = "1-throw_exception_test",
     srcs = ["1-throw_exception_test.cpp"],
-    visibility = ["//visibility:public"],
     deps = [
         "@boost.exception",
     ],
@@ -10,7 +9,6 @@ cc_test(
 cc_test(
     name = "cloning_test",
     srcs = ["cloning_test.cpp"],
-    visibility = ["//visibility:public"],
     deps = [
         "@boost.exception",
     ],

--- a/modules/boost.exception/1.83.0/overlay/test/MODULE.bazel
+++ b/modules/boost.exception/1.83.0/overlay/test/MODULE.bazel
@@ -1,0 +1,5 @@
+bazel_dep(name = "boost.exception")
+local_path_override(
+    module_name = "boost.exception",
+    path = "..",
+)

--- a/modules/boost.exception/1.83.0/presubmit.yml
+++ b/modules/boost.exception/1.83.0/presubmit.yml
@@ -17,3 +17,26 @@ tasks:
       - '--process_headers_in_dependencies'
     build_targets:
       - '@boost.bind//:boost.exception'
+bcr_test_module:
+  module_path: test
+  matrix:
+    platform:
+      - debian10
+      - debian11
+      - macos
+      - macos_arm64
+      - ubuntu2004
+      - ubuntu2204
+      - windows
+    bazel: [7.x]
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - '--process_headers_in_dependencies'
+      build_targets:
+        - //...
+      test_targets:
+        - //...

--- a/modules/boost.exception/1.83.0/presubmit.yml
+++ b/modules/boost.exception/1.83.0/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - windows
+  bazel: [7.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.bind//:boost.exception'

--- a/modules/boost.exception/1.83.0/presubmit.yml
+++ b/modules/boost.exception/1.83.0/presubmit.yml
@@ -16,7 +16,7 @@ tasks:
     build_flags:
       - '--process_headers_in_dependencies'
     build_targets:
-      - '@boost.bind//:boost.exception'
+      - '@boost.exception//:boost.exception'
 bcr_test_module:
   module_path: test
   matrix:

--- a/modules/boost.exception/1.83.0/source.json
+++ b/modules/boost.exception/1.83.0/source.json
@@ -6,6 +6,7 @@
     "overlay": {
         "BUILD.bazel": "sha256-WIGbgzbNTB5cThsIOfWngtq1m4/C8MKA60fujvgphGE=",
         "MODULE.bazel": "sha256-PMLgaZXLkuMpRJeT44kFEDXsNRYYCq7Au/0278bJDXs=",
-        "test/BUILD.bazel": "sha256-bfwJGTC0+8jGiCFFIJTEqz3lfjBGMKhG70ETSD8vyMc="
+        "test/BUILD.bazel": "sha256-bfwJGTC0+8jGiCFFIJTEqz3lfjBGMKhG70ETSD8vyMc=",
+        "test/MODULE.bazel": "sha256-Mv4cyjNsxQYH/PB1nkXQp02bV0oC634sMgsalpvlxvE="
     }
 }

--- a/modules/boost.exception/1.83.0/source.json
+++ b/modules/boost.exception/1.83.0/source.json
@@ -6,7 +6,7 @@
     "overlay": {
         "BUILD.bazel": "sha256-WIGbgzbNTB5cThsIOfWngtq1m4/C8MKA60fujvgphGE=",
         "MODULE.bazel": "sha256-PMLgaZXLkuMpRJeT44kFEDXsNRYYCq7Au/0278bJDXs=",
-        "test/BUILD.bazel": "sha256-bfwJGTC0+8jGiCFFIJTEqz3lfjBGMKhG70ETSD8vyMc=",
+        "test/BUILD.bazel": "sha256-P3jQlT3yvOIZEs9MDS2QVGvIFshjpgelvlpPgfkkN0Q=",
         "test/MODULE.bazel": "sha256-Mv4cyjNsxQYH/PB1nkXQp02bV0oC634sMgsalpvlxvE="
     }
 }

--- a/modules/boost.exception/1.83.0/source.json
+++ b/modules/boost.exception/1.83.0/source.json
@@ -1,10 +1,10 @@
 {
-    "integrity": "sha256-U+HLqJ68bQ4dATYDq47bCPiy+792BrkeurgxCsSqwa8=",
+    "integrity": "sha256-SYJ8+mfZ7RtL1a6Ay05y7EQOYxxWSV7zyiBJYWqnfJE=",
     "strip_prefix": "exception-boost-1.83.0",
     "url": "https://github.com/boostorg/exception/archive/refs/tags/boost-1.83.0.tar.gz",
     "patch_strip": 0,
     "overlay": {
-        "MODULE.bazel": "sha256-EeXbR/kX60oCOOibwO2itBqXloLGecwhIJ29NHw/RyM=",
-        "BUILD.bazel": "sha256-tGcsmQc0glQgLxJ3lPnfqq4YA4ad5G76kEAPs2K6J7I="
+        "BUILD.bazel": "sha256-35/7PFWGH4eWslhGt59+81TvLSZPl6deU0L2cE1q5jU=",
+        "MODULE.bazel": "sha256-UscOJ7aS00y8NkmbbjnhaIaUZbPGg+1oSwPRUWQTt0I="
     }
 }

--- a/modules/boost.exception/1.83.0/source.json
+++ b/modules/boost.exception/1.83.0/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-U+HLqJ68bQ4dATYDq47bCPiy+792BrkeurgxCsSqwa8=",
+    "strip_prefix": "exception-boost-1.83.0",
+    "url": "https://github.com/boostorg/exception/archive/refs/tags/boost-1.83.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "MODULE.bazel": "sha256-EeXbR/kX60oCOOibwO2itBqXloLGecwhIJ29NHw/RyM=",
+        "BUILD.bazel": "sha256-tGcsmQc0glQgLxJ3lPnfqq4YA4ad5G76kEAPs2K6J7I="
+    }
+}

--- a/modules/boost.exception/1.83.0/source.json
+++ b/modules/boost.exception/1.83.0/source.json
@@ -4,7 +4,8 @@
     "url": "https://github.com/boostorg/exception/archive/refs/tags/boost-1.83.0.tar.gz",
     "patch_strip": 0,
     "overlay": {
-        "BUILD.bazel": "sha256-35/7PFWGH4eWslhGt59+81TvLSZPl6deU0L2cE1q5jU=",
-        "MODULE.bazel": "sha256-UscOJ7aS00y8NkmbbjnhaIaUZbPGg+1oSwPRUWQTt0I="
+        "BUILD.bazel": "sha256-WIGbgzbNTB5cThsIOfWngtq1m4/C8MKA60fujvgphGE=",
+        "MODULE.bazel": "sha256-PMLgaZXLkuMpRJeT44kFEDXsNRYYCq7Au/0278bJDXs=",
+        "test/BUILD.bazel": "sha256-bfwJGTC0+8jGiCFFIJTEqz3lfjBGMKhG70ETSD8vyMc="
     }
 }

--- a/modules/boost.exception/metadata.json
+++ b/modules/boost.exception/metadata.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "http://boost.org/libs/exception",
+    "maintainers": [
+        {
+            "email": "daisuke.nishimatsu1021@gmail.com",
+            "github": "wep21",
+            "name": "Daisuke Nishimatsu"
+        },
+        {
+            "email": "julian.amann@tum.de",
+            "github": "Vertexwahn",
+            "name": "Julian Amann"
+        }
+    ],
+    "repository": [
+        "github:boostorg/exception"
+    ],
+    "versions": [
+        "1.83.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Boost.exeception@1.83.0

Could not add all test since boost.threads is currently missing, which is a dev dependency for the test. There for only two tests - but this is more testing that most of the boost modules have currently