### PR TITLE
Recognize github.com source URLs rehosted on the Bazel mirror.

### DIFF
--- a/tools/add_module.py
+++ b/tools/add_module.py
@@ -207,8 +207,15 @@ def main(argv=None):
         homepage = ask_input("Please enter the homepage url for this module: ").strip()
         maintainers = get_maintainers_from_input()
         source_repository = ""
-        if module.url.startswith("https://github.com/"):
-            parts = module.url.split("/")
+        source_url = module.url
+        if source_url.startswith("https://mirror.bazel.build/github.com/"):
+            source_url = source_url.replace(
+                "https://mirror.bazel.build/github.com/",
+                "https://github.com/",
+                1,
+            )
+        if source_url.startswith("https://github.com/"):
+            parts = source_url.split("/")
             source_repository = "github:" + parts[3] + "/" + parts[4]
         client.init_module(module.name, maintainers, homepage, source_repository)
 

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -142,6 +142,12 @@ class BcrValidator:
     def verify_source_archive_url_match_github_repo(self, module_name, version):
         """Verify the source archive URL matches the github repo. For now, we only support github repositories check."""
         source_url = self.registry.get_source(module_name, version)["url"]
+        if source_url.startswith("https://mirror.bazel.build/github.com/"):
+            source_url = source_url.replace(
+                "https://mirror.bazel.build/github.com/",
+                "https://github.com/",
+                1,
+            )
         source_repositories = self.registry.get_metadata(module_name).get("repository", [])
         matched = not source_repositories
         for source_repository in source_repositories:


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel-central-registry/issues/2720