### PR TITLE
Add `repository` metadata for modules with mirrored GitHub archives.

### DIFF
--- a/modules/javacc/metadata.json
+++ b/modules/javacc/metadata.json
@@ -7,6 +7,9 @@
             "name": "John Millikin"
         }
     ],
+    "repository": [
+        "github:javacc/javacc"
+    ],
     "versions": [
         "7.0.13"
     ],

--- a/modules/javaparser/metadata.json
+++ b/modules/javaparser/metadata.json
@@ -7,6 +7,9 @@
             "name": "John Millikin"
         }
     ],
+    "repository": [
+        "github:javaparser/javaparser"
+    ],
     "versions": [
         "3.26.2"
     ],

--- a/modules/ninja/metadata.json
+++ b/modules/ninja/metadata.json
@@ -6,6 +6,9 @@
             "name": "No Maintainer Specified"
         }
     ],
+    "repository": [
+        "github:ninja-build/ninja"
+    ],
     "versions": [
         "1.12.1",
         "1.12.1.bcr.1"


### PR DESCRIPTION
Enabled by the fix to https://github.com/bazelbuild/bazel-central-registry/issues/2720