### PR TITLE
Remove `mirror.bazel.build` URLs.

### DIFF
--- a/modules/javacc/7.0.13/source.json
+++ b/modules/javacc/7.0.13/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://mirror.bazel.build/github.com/javacc/javacc/archive/refs/tags/javacc-7.0.13.tar.gz",
+    "url": "https://github.com/javacc/javacc/archive/refs/tags/javacc-7.0.13.tar.gz",
     "integrity": "sha256-0b/rtMqSYcXDsWsAKAsyeKQbGTyoUD8ph/ct5FO/mcY=",
     "strip_prefix": "javacc-javacc-7.0.13",
     "patch_strip": 0,

--- a/modules/javaparser/3.26.2/source.json
+++ b/modules/javaparser/3.26.2/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://mirror.bazel.build/github.com/javaparser/javaparser/archive/refs/tags/javaparser-parent-3.26.2.tar.gz",
+    "url": "https://github.com/javaparser/javaparser/archive/refs/tags/javaparser-parent-3.26.2.tar.gz",
     "integrity": "sha256-alKR8wQMNu3n8/icelY2cMoZFKsgBuKPFYwHrFT6ZOU=",
     "strip_prefix": "javaparser-javaparser-parent-3.26.2",
     "patch_strip": 0,

--- a/modules/ninja/1.12.1.bcr.1/source.json
+++ b/modules/ninja/1.12.1.bcr.1/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://mirror.bazel.build/github.com/ninja-build/ninja/archive/refs/tags/v1.12.1.tar.gz",
+    "url": "https://github.com/ninja-build/ninja/archive/refs/tags/v1.12.1.tar.gz",
     "integrity": "sha256-ghvf9Io/aDvEuztvC1/nstZHz2XVKutjMoyRpsbfKFo=",
     "strip_prefix": "ninja-1.12.1",
     "patches": {

--- a/modules/ninja/1.12.1/source.json
+++ b/modules/ninja/1.12.1/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://mirror.bazel.build/github.com/ninja-build/ninja/archive/refs/tags/v1.12.1.tar.gz",
+    "url": "https://github.com/ninja-build/ninja/archive/refs/tags/v1.12.1.tar.gz",
     "integrity": "sha256-ghvf9Io/aDvEuztvC1/nstZHz2XVKutjMoyRpsbfKFo=",
     "strip_prefix": "ninja-1.12.1",
     "patches": {


### PR DESCRIPTION
Per discussion on https://github.com/bazelbuild/bazel-central-registry/pull/2753

r? @meteorcloudy 