### PR TITLE
protobuf@28.0

### DIFF
--- a/modules/protobuf/28.0/MODULE.bazel
+++ b/modules/protobuf/28.0/MODULE.bazel
@@ -1,0 +1,72 @@
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/protocolbuffers/protobuf/issues/14313
+
+module(
+    name = "protobuf",
+    version = "28.0", # Automatically updated on release
+    compatibility_level = 1,
+    repo_name = "com_google_protobuf",
+)
+
+# LOWER BOUND dependency versions.
+# Bzlmod follows MVS:
+# https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
+# Thus the highest version in their module graph is resolved.
+bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "jsoncpp", version = "1.9.5")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_fuzzing", version = "0.5.2")
+bazel_dep(name = "rules_java", version = "5.3.5")
+bazel_dep(name = "rules_jvm_external", version = "5.1")
+bazel_dep(name = "rules_pkg", version = "0.7.0")
+bazel_dep(name = "rules_python", version = "0.28.0")
+bazel_dep(name = "rules_rust", version = "0.45.1")
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "zlib", version = "1.3.1")
+
+# TODO: remove after toolchain types are moved to protobuf
+bazel_dep(name = "rules_proto", version = "4.0.0")
+
+SUPPORTED_PYTHON_VERSIONS = [
+    "3.8",
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+]
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+[
+    python.toolchain(
+        is_default = python_version == SUPPORTED_PYTHON_VERSIONS[-1],
+        python_version = python_version,
+    )
+    for python_version in SUPPORTED_PYTHON_VERSIONS
+]
+use_repo(python, system_python = "python_{}".format(SUPPORTED_PYTHON_VERSIONS[-1].replace(".", "_")))
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+[
+    pip.parse(
+        hub_name = "pip_deps",
+        python_version = python_version,
+        requirements_lock = "//python:requirements.txt",
+    )
+    for python_version in SUPPORTED_PYTHON_VERSIONS
+]
+use_repo(pip, "pip_deps")
+
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust.toolchain(edition = "2021")
+use_repo(rust, "rust_toolchains")
+register_toolchains("@rust_toolchains//:all")
+crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")
+crate.spec(
+    package = "googletest",
+    version = ">0.0.0",
+)
+crate.spec(
+    package = "paste",
+    version = ">=1",
+)
+crate.from_specs()
+use_repo(crate, crate_index = "crates")

--- a/modules/protobuf/28.0/presubmit.yml
+++ b/modules/protobuf/28.0/presubmit.yml
@@ -1,0 +1,35 @@
+matrix:
+  platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  bazel: [6.x, 7.x]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--host_cxxopt=-std=c++14'
+    - '--cxxopt=-std=c++14'
+    build_targets:
+    - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_lite'
+    - '@protobuf//:protobuf_python'
+    - '@protobuf//:protoc'
+    - '@protobuf//:test_messages_proto2_cc_proto'
+    - '@protobuf//:test_messages_proto3_cc_proto'
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+      - '--host_cxxopt=-std=c++14'
+      - '--cxxopt=-std=c++14'
+      build_targets:
+      - "//..."

--- a/modules/protobuf/28.0/source.json
+++ b/modules/protobuf/28.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-l5AnIzg33Or5J0AueJJh5G1P+HzkWz44vosVxKH2lqM=",
+    "strip_prefix": "protobuf-28.0",
+    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v28.0/protobuf-28.0.zip"
+}

--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -38,7 +38,8 @@
         "27.2",
         "27.3",
         "28.0-rc1",
-        "28.0-rc2"
+        "28.0-rc2",
+        "28.0"
     ],
     "yanked_versions": {
         "3.19.0": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)",


### PR DESCRIPTION
Release: https://github.com/protocolbuffers/protobuf/releases/tag/v28.0

*Manual BCR release **NOT** automated by [Publish to BCR](https://github.com/apps/publish-to-bcr) due to misconfiguration at time of v28.0 release.* 