### PR TITLE
Add "github:bazel-contrib/rules_jvm_external" as a source repo to `rules_jvm_external`'s metadata

### DIFF
--- a/modules/rules_jvm_external/metadata.json
+++ b/modules/rules_jvm_external/metadata.json
@@ -18,6 +18,7 @@
         }
     ],
     "repository": [
+        "github:bazel-contrib/rules_jvm_external",
         "github:bazelbuild/rules_jvm_external"
     ],
     "versions": [


### PR DESCRIPTION
The old domain redirects to the new one, so I think it's okay to leave it in place.