### PR TITLE
BCR PR reviewer: Add support for a "do_not_notify" field

### DIFF
--- a/.github/workflows/dismiss_approvals.yml
+++ b/.github/workflows/dismiss_approvals.yml
@@ -15,7 +15,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@ecb81a9f161e6a560633222436406e41b93f6991 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@2997e589af56c74eeccaf79640f20a6b40e1b0b6 # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/notify_maintainers.yml
+++ b/.github/workflows/notify_maintainers.yml
@@ -16,7 +16,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@ecb81a9f161e6a560633222436406e41b93f6991 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@2997e589af56c74eeccaf79640f20a6b40e1b0b6 # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/review_prs.yml
+++ b/.github/workflows/review_prs.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Run BCR PR Reviewer
         if: github.repository_owner == 'bazelbuild'
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@ecb81a9f161e6a560633222436406e41b93f6991 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@2997e589af56c74eeccaf79640f20a6b40e1b0b6 # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/metadata.schema.json
+++ b/metadata.schema.json
@@ -24,6 +24,10 @@
             "name": {
               "type": "string",
               "description": "maintainer's name"
+            },
+            "do_not_notify": {
+              "type": "boolean",
+              "description": "when set to true, this maintainer won't be notified by new PRs, but still has approver rights"
             }
           }
         }


### PR DESCRIPTION
See https://github.com/bazelbuild/continuous-integration/pull/2037. This PR updates the workflows to include that change, and the schema of metadata.json to add the new "do_not_notify" field.

cc @zhangskz 