### PR TITLE
Revert "Recognize github.com source URLs rehosted on the Bazel mirror…

### DIFF
--- a/tools/add_module.py
+++ b/tools/add_module.py
@@ -207,9 +207,8 @@ def main(argv=None):
         homepage = ask_input("Please enter the homepage url for this module: ").strip()
         maintainers = get_maintainers_from_input()
         source_repository = ""
-        source_url = bcr_validation.normalize_bazel_mirror_source_url(module.url)
-        if source_url.startswith("https://github.com/"):
-            parts = source_url.split("/")
+        if module.url.startswith("https://github.com/"):
+            parts = module.url.split("/")
             source_repository = "github:" + parts[3] + "/" + parts[4]
         client.init_module(module.name, maintainers, homepage, source_repository)
 

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -108,23 +108,6 @@ def fix_line_endings(lines):
     return [line.rstrip() + "\n" for line in lines]
 
 
-def normalize_bazel_mirror_source_url(source_url):
-    # The canonical domain of the Bazel Mirror is `mirror.bazel.build`.
-    #
-    # https://bazel.googlesource.com/continuous-integration/+/refs/heads/master/docs/mirror.md
-    mirror_prefix = "https://mirror.bazel.build/"
-    if not source_url.startswith(mirror_prefix):
-        return source_url
-
-    # Normalize mirrored GitHub URLs, such as auto-generated source archives.
-    #
-    # "https://mirror.bazel.build/github.com/a/b" -> "https://github.com/a/b"
-    if source_url.startswith(mirror_prefix + "github.com/"):
-        return "https://" + source_url[len(mirror_prefix) :]
-
-    return source_url
-
-
 class BcrValidationException(Exception):
     """
     Raised whenever we should stop the validation immediately.
@@ -158,7 +141,7 @@ class BcrValidator:
 
     def verify_source_archive_url_match_github_repo(self, module_name, version):
         """Verify the source archive URL matches the github repo. For now, we only support github repositories check."""
-        source_url = normalize_bazel_mirror_source_url(self.registry.get_source(module_name, version)["url"])
+        source_url = self.registry.get_source(module_name, version)["url"]
         source_repositories = self.registry.get_metadata(module_name).get("repository", [])
         matched = not source_repositories
         for source_repository in source_repositories:


### PR DESCRIPTION
…. (#2745)"

This reverts commit 216ebb57930ff4e646240bef5f0fc4a19c22fafb.

We should not accept bazel mirror URLs as source urls. See https://github.com/bazelbuild/bazel-central-registry/pull/2753#discussion_r1751961847