### PR TITLE
fix: update boost.detail

### DIFF
--- a/modules/boost.detail/1.83.0.bcr.1/MODULE.bazel
+++ b/modules/boost.detail/1.83.0.bcr.1/MODULE.bazel
@@ -1,0 +1,13 @@
+module(
+    name = "boost.detail",
+    version = "1.83.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 108300,
+)
+
+bazel_dep(name = "boost.config", version = "1.83.0")
+bazel_dep(name = "boost.core", version = "1.83.0")
+bazel_dep(name = "boost.preprocessor", version = "1.83.0")
+bazel_dep(name = "boost.static_assert", version = "1.83.0")
+bazel_dep(name = "boost.type_traits", version = "1.83.0")
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/boost.detail/1.83.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.detail/1.83.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "boost.detail",
+    hdrs = glob(
+        [
+            "include/**/*.hpp",
+            "include/**/*.h",
+            "include/**/*.ipp",
+        ],
+        exclude = [
+            "include/boost/detail/utf8_codecvt_facet.hpp",
+            "include/boost/detail/utf8_codecvt_facet.ipp",
+        ],
+    ),
+    features = [
+        "parse_headers",
+    ],
+    includes = ["include"],
+    textual_hdrs = [
+        "include/boost/detail/utf8_codecvt_facet.hpp",
+        "include/boost/detail/utf8_codecvt_facet.ipp",
+    ],
+    deps = [
+        "@boost.config",
+        "@boost.core",
+        "@boost.preprocessor",
+        "@boost.static_assert",
+        "@boost.type_traits",
+    ],
+)

--- a/modules/boost.detail/1.83.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/boost.detail/1.83.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/boost.detail/1.83.0.bcr.1/overlay/test/BUILD.bazel
+++ b/modules/boost.detail/1.83.0.bcr.1/overlay/test/BUILD.bazel
@@ -1,0 +1,67 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "allocator_utilities_test",
+    srcs = ["allocator_utilities_test.cpp"],
+    deps = [
+        "@boost.array",
+        "@boost.detail",
+    ],
+)
+
+cc_test(
+    name = "binary_search_test",
+    srcs = ["binary_search_test.cpp"],
+    deps = [
+        "@boost.detail",
+    ],
+)
+
+cc_test(
+    name = "blank_test",
+    srcs = ["blank_test.cpp"],
+    deps = [
+        "@boost.detail",
+    ],
+)
+
+cc_test(
+    name = "is_sorted_test",
+    srcs = ["is_sorted_test.cpp"],
+    deps = [
+        "@boost.array",
+        "@boost.detail",
+    ],
+)
+
+cc_test(
+    name = "is_xxx_test",
+    srcs = ["is_xxx_test.cpp"],
+    deps = [
+        "@boost.detail",
+    ],
+)
+
+cc_test(
+    name = "numeric_traits_test",
+    srcs = ["numeric_traits_test.cpp"],
+    deps = [
+        "@boost.detail",
+    ],
+)
+
+cc_test(
+    name = "reference_content_test",
+    srcs = ["reference_content_test.cpp"],
+    deps = [
+        "@boost.detail",
+    ],
+)
+
+# cc_test(
+#     name = "test_utf8_codecvt",
+#     srcs = ["test_utf8_codecvt.cpp"],
+#     deps = [
+#         "@boost.detail",
+#     ],
+# )

--- a/modules/boost.detail/1.83.0.bcr.1/overlay/test/MODULE.bazel
+++ b/modules/boost.detail/1.83.0.bcr.1/overlay/test/MODULE.bazel
@@ -1,0 +1,6 @@
+bazel_dep(name = "boost.array", version = "1.83.0")
+bazel_dep(name = "boost.detail")
+local_path_override(
+    module_name = "boost.detail",
+    path = "..",
+)

--- a/modules/boost.detail/1.83.0.bcr.1/presubmit.yml
+++ b/modules/boost.detail/1.83.0.bcr.1/presubmit.yml
@@ -1,0 +1,42 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - windows
+  bazel: [7.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.detail//:boost.detail'
+bcr_test_module:
+  module_path: test
+  matrix:
+    platform:
+      - debian10
+      - debian11
+      - macos
+      - macos_arm64
+      - ubuntu2004
+      - ubuntu2204
+      - windows
+    bazel: [7.x]
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - '--process_headers_in_dependencies'
+      build_targets:
+        - //...
+      test_targets:
+        - //...

--- a/modules/boost.detail/1.83.0.bcr.1/source.json
+++ b/modules/boost.detail/1.83.0.bcr.1/source.json
@@ -1,0 +1,12 @@
+{
+    "integrity": "sha256-bR2mqmLf56CyWpmlciUYscTTKAq9S05hEloNTWLBuuE=",
+    "strip_prefix": "detail-boost-1.83.0",
+    "url": "https://github.com/boostorg/detail/archive/refs/tags/boost-1.83.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "MODULE.bazel": "sha256-8VPqYuoWCvAamfaW97SQY7egKQQeF/XDlgmZsm8BUM8=",
+        "BUILD.bazel": "sha256-qHIP0R4r8WLrtue4VlIeHM8er5gQJMF5CfutlDCY15I=",
+        "test/MODULE.bazel": "sha256-TVUZuHd0ox1Vn5d3HlrNeSxdFxz9mRlp4F+PLFq5OYE=",
+        "test/BUILD.bazel": "sha256-SFpZRRzwociPZiNFNEn2xX3RiUPdC4YoQwqOolx8mV0="
+    }
+}

--- a/modules/boost.detail/metadata.json
+++ b/modules/boost.detail/metadata.json
@@ -16,7 +16,8 @@
         "github:boostorg/detail"
     ],
     "versions": [
-        "1.83.0"
+        "1.83.0",
+        "1.83.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
- add missing textual hdrs
- need skip url stability check
- boost.serialization needs this header
```
~/workspace/serialization tags/boost-1.77.0* 11s
❯ bazelisk build //... --process_headers_in_dependencies
INFO: Analyzed target //:boost.serialization (0 packages loaded, 0 targets configured).
ERROR: /Users/daisuke/workspace/serialization/BUILD.bazel:5:11: Compiling src/utf8_codecvt_facet.cpp failed: (Exit 1): cc_wrapper.sh failed: error executing CppCompile command (from target //:boost.serialization) external/bazel_tools~cc_configure_extension~local_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object ... (remaining 483 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
src/utf8_codecvt_facet.cpp:19:10: fatal error: 'boost/detail/utf8_codecvt_facet.ipp' file not found
   19 | #include <boost/detail/utf8_codecvt_facet.ipp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
Target //:boost.serialization failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 13.543s, Critical Path: 3.23s
INFO: 62 processes: 9 internal, 53 darwin-sandbox.
ERROR: Build did NOT complete successfully
```