### PR TITLE
robin-map@1.3.0

### DIFF
--- a/modules/robin-map/1.3.0/MODULE.bazel
+++ b/modules/robin-map/1.3.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "robin-map",
+    version = "1.3.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/robin-map/1.3.0/patches/add_build_file.patch
+++ b/modules/robin-map/1.3.0/patches/add_build_file.patch
@@ -1,0 +1,9 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,6 @@
++cc_library(
++    name = "robin-map",
++    hdrs = glob(["include/tsl/*.h"]),
++    strip_include_prefix = "include/",
++    visibility = ["//visibility:public"],
++)

--- a/modules/robin-map/1.3.0/patches/module_dot_bazel.patch
+++ b/modules/robin-map/1.3.0/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "robin-map",
++    version = "1.3.0",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/robin-map/1.3.0/presubmit.yml
+++ b/modules/robin-map/1.3.0/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--process_headers_in_dependencies'
+    build_targets:
+    - '@robin-map//:robin-map'

--- a/modules/robin-map/1.3.0/source.json
+++ b/modules/robin-map/1.3.0/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-qEJK07Cv/UxX7Sbw89iilgTw4fLvIIn0l/YUsclMcjY=",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-cqUpStaGktaU2ZQgWoO588fyyWq58to8Xrs6IpqskAw=",
+        "module_dot_bazel.patch": "sha256-NNr/rpqBn/Ux+9wBCsitKBgZE/XgL1oRHv5MVAm4Ktc="
+    },
+    "strip_prefix": "robin-map-1.3.0",
+    "url": "https://github.com/Tessil/robin-map/archive/refs/tags/v1.3.0.tar.gz"
+}

--- a/modules/robin-map/metadata.json
+++ b/modules/robin-map/metadata.json
@@ -1,16 +1,17 @@
 {
-  "homepage": "https://github.com/Tessil/robin-map",
-  "maintainers": [
-    {
-      "email": "bcr-maintainers@bazel.build",
-      "name": "No Maintainer Specified"
-    }
-  ],
-  "repository": [
-    "github:Tessil/robin-map"
-  ],
-  "versions": [
-    "1.2.1"
-  ],
-  "yanked_versions": {}
+    "homepage": "https://github.com/Tessil/robin-map",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:Tessil/robin-map"
+    ],
+    "versions": [
+        "1.2.1",
+        "1.3.0"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Add the newest version of robin-map, which is required by nanobind@2.

This validation fails:
```
BcrValidationResult.FAILED: robin-map@1.3.0 is using an unstable source url: `https://github.com/Tessil/robin-map/archive/refs/tags/v1.3.0.tar.gz`.
You should use a release archive URL in the format of `https://github.com/<ORGANIZATION>/<REPO>/releases/download/<version>/<name>.tar.gz` to ensure the archive checksum stability.
See https://blog.bazel.build/2023/02/15/github-archive-checksum.html for more context.
```
I'm using the same URL format as the existing version, and robin-map doesn't seem to publish the sort of archive expected here. Compare e.g. the [rules_helm release assets](https://github.com/abrisco/rules_helm/releases/tag/0.4.0), which include a tarball artifact, to the [robin-map release assets](https://github.com/Tessil/robin-map/releases/tag/v1.3.0), which don't. Let me know if there's a better approach here.

There's also this validation warning:
```
BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW: The presubmit.yml file of robin-map@1.3.0 doesn't match its previous version robin-map@1.2.1, the following presubmit.yml file change should be reviewed by a BCR maintainer.
    --- modules/robin-map/1.2.1/presubmit.yml
    +++ modules/robin-map/1.3.0/presubmit.yml
    @@ -1,13 +1,17 @@
     matrix:
       platform:
    -  - centos7
       - debian10
       - ubuntu2004
       - macos
    +  - macos_arm64
       - windows
    +  bazel:
    +  - 7.x
    +  - 6.x
     tasks:
       verify_targets:
         name: Verify build targets
         platform: ${{ platform }}
    +    bazel: ${{ bazel }}
         build_targets:
         - '@robin-map//:robin-map'
```
I just used the default output from the `add_module` tool. Let me know if I should instead use the settings from the previous version.

Thanks!