### PR TITLE
nanobind@2.1.0

### DIFF
--- a/modules/nanobind/2.1.0/MODULE.bazel
+++ b/modules/nanobind/2.1.0/MODULE.bazel
@@ -1,0 +1,15 @@
+module(
+    name = "nanobind",
+    version = "2.1.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_python", version = "0.36.0")
+bazel_dep(name = "robin-map", version = "1.3.0")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.8")
+use_repo(python, "python_3_8")
+
+# No need to register the toolchain for Python, we just want the headers.

--- a/modules/nanobind/2.1.0/patches/add_build_file.patch
+++ b/modules/nanobind/2.1.0/patches/add_build_file.patch
@@ -1,0 +1,68 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,65 @@
++config_setting(
++    name = "macos",
++    constraint_values = ["@platforms//os:macos"],
++    visibility = ["//visibility:public"],
++)
++
++config_setting(
++    name = "msvc_compiler",
++    flag_values = {"@bazel_tools//tools/cpp:compiler": "msvc-cl"},
++)
++
++cc_library(
++    name = "nanobind",
++    srcs = [
++        "include/nanobind/stl/detail/nb_dict.h",
++        "include/nanobind/stl/detail/nb_list.h",
++        "include/nanobind/stl/detail/traits.h",
++        "src/buffer.h",
++        "src/common.cpp",
++        "src/error.cpp",
++        "src/hash.h",
++        "src/implicit.cpp",
++        "src/nb_enum.cpp",
++        "src/nb_func.cpp",
++        "src/nb_internals.cpp",
++        "src/nb_internals.h",
++        "src/nb_ndarray.cpp",
++        "src/nb_static_property.cpp",
++        "src/nb_type.cpp",
++        "src/trampoline.cpp",
++    ],
++    hdrs = glob(
++        include = [
++            "include/nanobind/*.h",
++            "include/nanobind/eigen/*.h",
++            "include/nanobind/stl/*.h",
++            "include/nanobind/stl/detail/*.h",
++        ],
++        allow_empty = False,
++    ),
++    copts = select({
++        ":msvc_compiler": ["/std:c++17"],
++        "//conditions:default": [
++            "--std=c++17",
++            "-fexceptions",
++            "-Os",  # size optimization
++            "-flto",  # enable LTO
++        ],
++    }),
++    includes = ["include"],
++    linkopts = select({
++        ":macos": [
++            "-undefined dynamic_lookup",
++            "-Wl,-no_fixup_chains",
++            "-Wl,-dead_strip",
++        ],
++        "//conditions:default": [],
++    }),
++    strip_include_prefix = "include",
++    visibility = ["//visibility:public"],
++    deps = [
++        "@python_3_8//:python_headers",
++        "@robin-map//:robin-map",
++    ],
++)

--- a/modules/nanobind/2.1.0/patches/module_dot_bazel.patch
+++ b/modules/nanobind/2.1.0/patches/module_dot_bazel.patch
@@ -1,0 +1,18 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,15 @@
++module(
++    name = "nanobind",
++    version = "2.1.0",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "platforms", version = "0.0.10")
++bazel_dep(name = "rules_python", version = "0.36.0")
++bazel_dep(name = "robin-map", version = "1.3.0")
++
++python = use_extension("@rules_python//python/extensions:python.bzl", "python")
++python.toolchain(python_version = "3.8")
++use_repo(python, "python_3_8")
++
++# No need to register the toolchain for Python, we just want the headers.

--- a/modules/nanobind/2.1.0/presubmit.yml
+++ b/modules/nanobind/2.1.0/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--process_headers_in_dependencies'
+    build_targets:
+    - '@nanobind//:nanobind'

--- a/modules/nanobind/2.1.0/source.json
+++ b/modules/nanobind/2.1.0/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-w3xTxgraX+HJVuJL1Lg69mmiMJv5Ur0lHzan0vo7rPA=",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-Tdq1UABJvqzdiuVljZNF6BNmQuNd83jGqVFnTSS7094=",
+        "module_dot_bazel.patch": "sha256-eisuHLciYsvSjWNRr4TWCWAojyz2o1JpzJfN1L4R+r4="
+    },
+    "strip_prefix": "nanobind-2.1.0",
+    "url": "https://github.com/wjakob/nanobind/archive/refs/tags/v2.1.0.tar.gz"
+}

--- a/modules/nanobind/metadata.json
+++ b/modules/nanobind/metadata.json
@@ -1,16 +1,18 @@
 {
-  "homepage": "https://github.com/wjakob/nanobind",
-  "maintainers": [
-    {
-      "email": "bcr-maintainers@bazel.build",
-      "name": "No Maintainer Specified"
-    }
-  ],
-  "repository": [
-    "github:wjakob/nanobind"
-  ],
-  "versions": [
-    "1.2.0"
-  ],
-  "yanked_versions": {}
+    "homepage": "https://github.com/wjakob/nanobind",
+    "maintainers": [
+        {
+            "email": "nikolaus.wittenstein@gmail.com",
+            "github": "adzenith",
+            "name": "Nikolaus Wittenstein"
+        }
+    ],
+    "repository": [
+        "github:wjakob/nanobind"
+    ],
+    "versions": [
+        "1.2.0",
+        "2.1.0"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
This builds on top of #2847 and adds nanobind@2.1.0.
It has the same issues as that PR as far as lacking a stable URL (nanobind only has tags, and no releases) and including changes to the presubmit config. Let me know if any changes are needed here.

Thanks!