### PR TITLE
rules_openscad: Add version 0.2

### DIFF
--- a/modules/rules_openscad/0.2/MODULE.bazel
+++ b/modules/rules_openscad/0.2/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "rules_openscad",
+    version = "0.2",
+    compatibility_level = 0,
+)

--- a/modules/rules_openscad/0.2/patches/module_dot_bazel.patch
+++ b/modules/rules_openscad/0.2/patches/module_dot_bazel.patch
@@ -1,0 +1,33 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -3,30 +3,3 @@
+     version = "0.2",
+     compatibility_level = 0,
+ )
+-
+-# Here are the files being defined for each OS
+-http_appimage = use_repo_rule("//:http_appimage.bzl", "http_appimage")
+-http_appimage(
+-    name = "openscad_linux_x86_64",
+-    url = "https://files.openscad.org/snapshots/OpenSCAD-2024.09.20.ai20452-x86_64.AppImage",
+-    sha256 = "eb5bfcc0a19df3016e3e00f3e135695020371c24f2a8629bf1e096009bef8a47",
+-)
+-http_appimage(
+-    name = "openscad_linux_aarch64",
+-    url = "https://files.openscad.org/snapshots/OpenSCAD-2023.09.11.ai-aarch64.AppImage",
+-    sha256 = "84d7bb1c71e14b4e248a84fbe0a4b02f58bcbf5326f0ee81c8a4de3653a3b568",
+-)
+-# This is the code that will be required once we support MacOS and Windows
+-# http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+-# http_file(
+-#     name = "openscad_windows_",
+-#     executable = True,
+-#     url = "https://files.openscad.org/snapshots/OpenSCAD-2024.09.20-x86-64.zip",
+-#     sha256 = "6ae4f92fc3fb4bf38efe1a7029f03f018707b376f954d886a635dc41bb6b0ccd",
+-# )
+-# http_file(
+-#     name = "openscad_darwin",
+-#     executable = True,
+-#     url = "https://files.openscad.org/snapshots/OpenSCAD-2024.09.20.dmg",
+-#     sha256 = "8ca81fe343d359b52b058d3c8cff2ac0673f508691a3270c64d8c22ef4beb3f0",
+-# )

--- a/modules/rules_openscad/0.2/presubmit.yml
+++ b/modules/rules_openscad/0.2/presubmit.yml
@@ -2,10 +2,9 @@ matrix:
   platform:
   - debian10
   - ubuntu2004
-  # Thus far only Linux is supported
-  # - macos
-  # - macos_arm64
-  # - windows
+  - macos
+  - macos_arm64
+  - windows
   bazel:
   - 7.x
   - 6.x
@@ -23,29 +22,30 @@ bcr_test_module:
     platform:
     - debian10
     - ubuntu2004
-    # Thus far only Linux is supported
-    # - macos
-    # - macos_arm64
-    # - windows
+    - macos
+    - macos_arm64
+    - windows
     bazel:
     - 7.x
-    - 6.x
+    # Disable bazel 6 support for now, as the library doesn't support it. This is a target for v0.2
+    # - 6.x
   tasks:
     run_test_module:
       name: Run test module
       platform: ${{ platform }}
       bazel: ${{ bazel }}
       build_targets:
+      # Only build libraries, as we cannot run openscad in test platforms. Also, don't run any test targets
       - //:cylinder_section
-      - //:cylinder_section_obj
-      - //:cylinder_section_test
+      # - //:cylinder_section_obj
+      # - //:cylinder_section_test
       - //:hardware
-      - //:hardware_obj
-      - //:hardware_test
+      # - //:hardware_obj
+      # - //:hardware_test
       - //:hollow_cylinder
-      - //:hollow_cylinder_obj
-      - //:hollow_cylinder_test
-      test_targets:
-      - //:cylinder_section_test
-      - //:hardware_test
-      - //:hollow_cylinder_test
+      # - //:hollow_cylinder_obj
+      # - //:hollow_cylinder_test
+      # test_targets:
+      # - //:cylinder_section_test
+      # - //:hardware_test
+      # - //:hollow_cylinder_test

--- a/modules/rules_openscad/0.2/source.json
+++ b/modules/rules_openscad/0.2/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/roleroz/rules_openscad/releases/download/v0.2/rules_openscad-0.2.zip",
+    "integrity": "sha256-BZMBvNgPgeV4fCjUJ0h2oZtWPH9D1dDLhFmo8cPLbVg=",
+    "strip_prefix": "rules_openscad-0.2",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-EFSmuA2cgKMMqYCTtyDjUNi9i98FKCZsG7qgYSPHAZY="
+    }
+}

--- a/modules/rules_openscad/metadata.json
+++ b/modules/rules_openscad/metadata.json
@@ -11,7 +11,8 @@
         "github:roleroz/rules_openscad"
     ],
     "versions": [
-        "0.1"
+        "0.1",
+        "0.2"
     ],
     "yanked_versions": {}
 }

--- a/rules_openscad.20240928-002431.json
+++ b/rules_openscad.20240928-002431.json
@@ -1,0 +1,17 @@
+{
+    "build_file": null,
+    "build_targets": [],
+    "compatibility_level": "0",
+    "deps": [],
+    "module_dot_bazel": null,
+    "name": "rules_openscad",
+    "patch_strip": 0,
+    "patches": [],
+    "presubmit_yml": "/home/joso/git/bazel-central-registry/modules/rules_openscad/0.1/presubmit.yml",
+    "strip_prefix": "rules_openscad-0.2",
+    "test_module_build_targets": [],
+    "test_module_path": null,
+    "test_module_test_targets": [],
+    "url": "https://github.com/roleroz/rules_openscad/releases/download/v0.2/rules_openscad-0.2.zip",
+    "version": "0.2"
+}


### PR DESCRIPTION
- Support Bazel 6 through WORKSPACE files
- Fetch OpenSCAD binary directly from repository
  - OpenSCAD doesn't need to be installed on the host machine to be used
  - Rules download always the same version of OpenSCAD, which makes the builds hermetic
- Add testing script that verifies that the code works with multiple bazel versions (all versions installed in the testing machine)
- Increase debugability of the tests by actually saving the result files (sorry about that in v0.1 ;) )