### PR TITLE
Update protobuf-matchers to v0.1.0 to fix missing includes.

### DIFF
--- a/modules/protobuf-matchers/0.1.0/MODULE.bazel
+++ b/modules/protobuf-matchers/0.1.0/MODULE.bazel
@@ -1,0 +1,20 @@
+#
+# Copyright 2020 Igor Nazarenko
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module(name = "protobuf-matchers", version = "0.1.0")
+bazel_dep(name = "protobuf", version = "27.3", repo_name = "com_google_protobuf")
+bazel_dep(name = "googletest", version = "1.14.0", repo_name = "com_google_googletest")
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/protobuf-matchers/0.1.0/presubmit.yml
+++ b/modules/protobuf-matchers/0.1.0/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@protobuf-matchers//...'

--- a/modules/protobuf-matchers/0.1.0/source.json
+++ b/modules/protobuf-matchers/0.1.0/source.json
@@ -1,0 +1,4 @@
+{
+    "url": "https://github.com/inazarenko/protobuf-matchers/releases/download/v0.1.0/protobuf-matchers-v0.1.0.tar.gz",
+    "integrity": "sha256-YpMZ6Ia9OgVS0h6QXNKsqkFzfNKF+c1Y4tiZK4PiNOE="
+}

--- a/modules/protobuf-matchers/metadata.json
+++ b/modules/protobuf-matchers/metadata.json
@@ -11,7 +11,8 @@
         "github:inazarenko/protobuf-matchers"
     ],
     "versions": [
-        "0.0.0-20240603-9f688b0"
+        "0.0.0-20240603-9f688b0",
+        "0.1.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
No changes to functionality. Fixes a few missing includes. 