### PR TITLE
Set maintainers for sqlite3

### DIFF
--- a/modules/sqlite3/metadata.json
+++ b/modules/sqlite3/metadata.json
@@ -2,8 +2,9 @@
     "homepage": "https://sqlite.org/",
     "maintainers": [
         {
-            "email": "bcr-maintainers@bazel.build",
-            "name": "No Maintainer Specified"
+            "email": "john@john-millikin.com",
+            "github": "jmillikin",
+            "name": "John Millikin"
         }
     ],
     "versions": [


### PR DESCRIPTION
I originally added this module in https://github.com/bazelbuild/bazel-central-registry/pull/641, so I figure I might as well set myself as the maintainer now that it's used enough to require some level of ownership.

Note: diff appears to be due to CRLF line endings accidentally introduced in <https://github.com/bazelbuild/bazel-central-registry/pull/2132>.