### PR TITLE
boost.uuid: add missing *.ipp export in hdrs for 1.83.0

### DIFF
--- a/modules/boost.uuid/1.83.0.bcr.1/MODULE.bazel
+++ b/modules/boost.uuid/1.83.0.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "boost.uuid",
+    version = "1.83.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 108300,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/boost.uuid/1.83.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.uuid/1.83.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "boost.uuid",
+    hdrs = glob([
+        "include/**/*.hpp",
+        "include/**/*.ipp",
+        "include/**/*.h",
+    ]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/modules/boost.uuid/1.83.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/boost.uuid/1.83.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/boost.uuid/1.83.0.bcr.1/presubmit.yml
+++ b/modules/boost.uuid/1.83.0.bcr.1/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - windows
+  bazel:
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@boost.uuid//:boost.uuid'

--- a/modules/boost.uuid/1.83.0.bcr.1/source.json
+++ b/modules/boost.uuid/1.83.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/boostorg/uuid/archive/refs/tags/boost-1.83.0.tar.gz",
+    "integrity": "sha256-D9kSkan1QR0Jf4gR5hNz3xPU4b6EWNWLLIas9CYVPBY=",
+    "strip_prefix": "uuid-boost-1.83.0",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-QOWCk45CZMvrkDTYkA1hatLCCprZ6WbZu78GK+YLuRY=",
+        "MODULE.bazel": "sha256-Gv5u8Mtyn1lnrRVKbLbu5GvP5f/nhtg3W7wV+vK0MkA="
+    }
+}

--- a/modules/boost.uuid/metadata.json
+++ b/modules/boost.uuid/metadata.json
@@ -11,7 +11,10 @@
         "github:boostorg/uuid"
     ],
     "versions": [
-        "1.83.0"
+        "1.83.0",
+        "1.83.0.bcr.1"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "1.83.0": "miss *.ipp export in hdrs"
+    }
 }


### PR DESCRIPTION
boost.uuid do not export *.ipp in 1.83.0