### PR TITLE
Add module_selector.py

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -100,3 +100,13 @@ py_test(
         "registry",
     ],
 )
+
+py_test(
+    name = "module_selector_test",
+    srcs = [
+        "module_selector_test.py",
+    ],
+    deps = [
+        "module_selector",
+    ],
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -77,6 +77,14 @@ py_binary(
     ],
 )
 
+py_binary(
+    name = "module_selector",
+    srcs = ["module_selector.py"],
+    deps = [
+        ":registry",
+    ],
+)
+
 sh_test(
     name = "update_integrity_test",
     srcs = ["update_integrity_test.sh"],

--- a/tools/README.md
+++ b/tools/README.md
@@ -67,3 +67,23 @@ options:
 
 Example usage: change into your project directory and run `<path to BCR repo>/tools/migrate_to_bzlmod.py --target //foo:bar`
 ```
+
+## module_selector.py
+
+This script provides a way to select specific versions of Bazel modules from the Bazel Central Registry (BCR). It supports wildcard patterns for flexible module and version matching, as well as the option to randomly sample a percentage of the matching modules.
+
+```
+usage: module_selector.py [-h] [--registry REGISTRY] --select SELECT [--random-percentage PERCENTAGE]
+
+Select module versions matching given patterns.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --registry REGISTRY   Specify the root path of the registry (default: the current working directory).
+  --select SELECT       Specify module selection patterns in the format <module_pattern>@<version_pattern>. The <module_pattern> can include wildcards (*) to match multiple modules. The
+                        <version_pattern> can be: - A specific version (e.g., "1.2.3") - "latest" to select the latest version - A comparison operator followed by a version (e.g.,
+                        ">=1.0.0", "<2.0.0") You can provide multiple --select options to combine patterns. Examples: --select "zlib@latest" --select "protobuf@>=27" --select
+                        "rules_*@<1.5.0" --select "*@latest"
+  --random-percentage PERCENTAGE
+                        Percentage of modules to randomly select from the modules matching any of the patterns. Must be an integer between 1 and 100.
+```

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -347,18 +347,16 @@ class BcrValidator:
                     "Missing bazel version for task '%s' in the presubmit.yml file." % task_name,
                 )
 
-    def validate_presubmit_yml(self, module_name, version, skip_bazel_version_check):
+    def validate_presubmit_yml(self, module_name, version):
         presubmit_yml = self.registry.get_presubmit_yml_path(module_name, version)
         presubmit = yaml.safe_load(open(presubmit_yml, "r"))
         report_num_old = len(self.validation_results)
         tasks = presubmit.get("tasks", {})
-        if not skip_bazel_version_check:
-          self.check_if_bazel_version_is_set(tasks)
+        self.check_if_bazel_version_is_set(tasks)
         test_module_tasks = {}
         if "bcr_test_module" in presubmit:
             test_module_tasks = presubmit["bcr_test_module"].get("tasks", {})
-            if not skip_bazel_version_check:
-              self.check_if_bazel_version_is_set(test_module_tasks)
+            self.check_if_bazel_version_is_set(test_module_tasks)
         if not tasks and not test_module_tasks:
             self.report(BcrValidationResult.FAILED, "At least one task should be specified in the presubmit.yml file.")
         report_num_new = len(self.validation_results)
@@ -392,8 +390,7 @@ class BcrValidator:
         self.verify_source_archive_url_integrity(module_name, version)
         if "presubmit_yml" not in skipped_validations:
             self.verify_presubmit_yml_change(module_name, version)
-        skip_bazel_version_check = "bazel_version" in skipped_validations
-        self.validate_presubmit_yml(module_name, version, skip_bazel_version_check)
+        self.validate_presubmit_yml(module_name, version)
         self.verify_module_dot_bazel(module_name, version)
 
     def validate_all_metadata(self):
@@ -477,7 +474,7 @@ def main(argv=None):
         action="append",
         help='Bypass the given step for validating modules. Supported values are: "url_stability", '
         + 'to bypass the URL stability check; "presubmit_yml", to bypass the presubmit.yml check; '
-        + '"source_repo", to bypass the source repo verification; "bazel_version", to bypass bazel version check for task config.'
+        + '"source_repo", to bypass the source repo verification; '
         + "This flag can be repeated to skip multiple validations.",
     )
 

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -347,16 +347,18 @@ class BcrValidator:
                     "Missing bazel version for task '%s' in the presubmit.yml file." % task_name,
                 )
 
-    def validate_presubmit_yml(self, module_name, version):
+    def validate_presubmit_yml(self, module_name, version, skip_bazel_version_check):
         presubmit_yml = self.registry.get_presubmit_yml_path(module_name, version)
         presubmit = yaml.safe_load(open(presubmit_yml, "r"))
         report_num_old = len(self.validation_results)
         tasks = presubmit.get("tasks", {})
-        self.check_if_bazel_version_is_set(tasks)
+        if not skip_bazel_version_check:
+          self.check_if_bazel_version_is_set(tasks)
         test_module_tasks = {}
         if "bcr_test_module" in presubmit:
             test_module_tasks = presubmit["bcr_test_module"].get("tasks", {})
-            self.check_if_bazel_version_is_set(test_module_tasks)
+            if not skip_bazel_version_check:
+              self.check_if_bazel_version_is_set(test_module_tasks)
         if not tasks and not test_module_tasks:
             self.report(BcrValidationResult.FAILED, "At least one task should be specified in the presubmit.yml file.")
         report_num_new = len(self.validation_results)
@@ -390,7 +392,8 @@ class BcrValidator:
         self.verify_source_archive_url_integrity(module_name, version)
         if "presubmit_yml" not in skipped_validations:
             self.verify_presubmit_yml_change(module_name, version)
-        self.validate_presubmit_yml(module_name, version)
+        skip_bazel_version_check = "bazel_version" in skipped_validations
+        self.validate_presubmit_yml(module_name, version, skip_bazel_version_check)
         self.verify_module_dot_bazel(module_name, version)
 
     def validate_all_metadata(self):
@@ -474,7 +477,7 @@ def main(argv=None):
         action="append",
         help='Bypass the given step for validating modules. Supported values are: "url_stability", '
         + 'to bypass the URL stability check; "presubmit_yml", to bypass the presubmit.yml check; '
-        + '"source_repo", to bypass the source repo verification; '
+        + '"source_repo", to bypass the source repo verification; "bazel_version", to bypass bazel version check for task config.'
         + "This flag can be repeated to skip multiple validations.",
     )
 

--- a/tools/module_selector.py
+++ b/tools/module_selector.py
@@ -20,6 +20,7 @@ import re
 import random
 
 from registry import RegistryClient
+from registry import Version
 
 def select_modules(registry, selections, random_percentage=None):
     """
@@ -52,10 +53,15 @@ def select_modules(registry, selections, random_percentage=None):
             if version == 'latest':
                 latest_version = module_versions[-1]
                 selected_modules.append(f"{module}@{latest_version}")
+            elif version.startswith('>='):
+                selected_modules.extend([f"{module}@{v}" for v in module_versions if Version(v) >= Version(version[2:])])
+            elif version.startswith('<='):
+                selected_modules.extend([f"{module}@{v}" for v in module_versions if Version(v) <= Version(version[2:])])
+            elif version.startswith('>'):
+                selected_modules.extend([f"{module}@{v}" for v in module_versions if Version(v) > Version(version[1:])])
+            elif version.startswith('<'):
+                selected_modules.extend([f"{module}@{v}" for v in module_versions if Version(v) < Version(version[1:])])
             else:
-                if len(matching_modules) > 2:
-                    # Pattern like rules_*@1.2 should not be allowed.
-                    raise ValueError(f"Cannot specify a specific version for multiple matching modules: {module_pattern}")
                 if version in module_versions:
                     selected_modules.append(f"{module}@{version}")
                 else:

--- a/tools/module_selector.py
+++ b/tools/module_selector.py
@@ -26,9 +26,6 @@ def select_modules(registry, selections, random_percentage=None):
     """
     Select module versions matching the given patterns and optionally apply a random sample percentage.
     """
-    if not selections:
-        return []
-
     selected_modules = []
 
     for selection in selections:

--- a/tools/module_selector.py
+++ b/tools/module_selector.py
@@ -87,7 +87,24 @@ def select_modules(registry, selections, random_percentage=None):
 def main():
     parser = argparse.ArgumentParser(description='Select module versions matching given patterns.')
     parser.add_argument("--registry", type=str, default=".", help="Specify the root path of the registry (default: the current working directory).")
-    parser.add_argument('--select', action="append", required=True, help='Module selection patterns, supporting wildcards.')
+    parser.add_argument(
+        '--select',
+        action="append",
+        required=True,
+        help=(
+            'Specify module selection patterns in the format <module_pattern>@<version_pattern>. '
+            'The <module_pattern> can include wildcards (*) to match multiple modules. '
+            'The <version_pattern> can be:\n'
+            '  - A specific version (e.g., "1.2.3")\n'
+            '  - "latest" to select the latest version\n'
+            '  - A comparison operator followed by a version (e.g., ">=1.0.0", "<2.0.0")\n'
+            'You can provide multiple --select options to combine patterns. Examples:\n'
+            '  --select "zlib@latest"\n'
+            '  --select "protobuf@>=27"\n'
+            '  --select "rules_*@<1.5.0"\n'
+            '  --select "*@latest"'
+        )
+    )
     parser.add_argument('--random-percentage', type=int, metavar='PERCENTAGE',
                         help='Percentage of modules to randomly select from the modules matching any of the patterns. Must be an integer between 1 and 100.')
 

--- a/tools/module_selector.py
+++ b/tools/module_selector.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+#
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tool script for select module versions from BCR"""
+
+import argparse
+import re
+import random
+
+from registry import RegistryClient
+
+def select_modules(registry, selections, random_percentage=None):
+    """
+    Select module versions matching the given patterns and optionally apply a random sample percentage.
+    """
+    if not selections:
+        return []
+
+    selected_modules = []
+
+    for selection in selections:
+        if '@' not in selection:
+            raise ValueError(f"Invalid selection pattern (missing '@'): {selection}")
+
+        module_pattern, version = selection.split('@', 1)
+
+        if not module_pattern or not version:
+            raise ValueError(f"Invalid selection pattern: {selection}")
+
+        regex_pattern = '^' + module_pattern.replace('.', '\\.').replace('*', '.*') + '$'
+        module_regex = re.compile(regex_pattern)
+
+        matching_modules = [
+            module for module in registry.get_all_modules()
+            if module_regex.match(module)
+        ]
+
+        for module in matching_modules:
+            module_versions = [m[1] for m in registry.get_module_versions(module)] # This should be sorted already
+            if version == 'latest':
+                latest_version = module_versions[-1]
+                selected_modules.append(f"{module}@{latest_version}")
+            else:
+                if len(matching_modules) > 2:
+                    # Pattern like rules_*@1.2 should not be allowed.
+                    raise ValueError(f"Cannot specify a specific version for multiple matching modules: {module_pattern}")
+                if version in module_versions:
+                    selected_modules.append(f"{module}@{version}")
+                else:
+                    raise ValueError(f"Version {version} of module {module} not found.")
+
+    if random_percentage is not None:
+        try:
+            percentage = int(random_percentage)
+            if not (0 < percentage <= 100):
+                raise ValueError
+        except ValueError:
+            raise ValueError("Random percentage must be an integer between 1 and 100.")
+
+        total_modules = len(selected_modules)
+        num_to_select = max(1, (percentage * total_modules) // 100)
+        selected_modules = random.sample(selected_modules, num_to_select)
+
+    if not selected_modules:
+        raise ValueError("No matching modules found.")
+
+    return selected_modules
+
+def main():
+    parser = argparse.ArgumentParser(description='Select module versions matching given patterns.')
+    parser.add_argument("--registry", type=str, default=".", help="Specify the root path of the registry (default: the current working directory).")
+    parser.add_argument('--select', action="append", required=True, help='Module selection patterns, supporting wildcards.')
+    parser.add_argument('--random-percentage', type=int, metavar='PERCENTAGE',
+                        help='Percentage of modules to randomly select from the modules matching any of the patterns. Must be an integer between 1 and 100.')
+
+    args = parser.parse_args()
+
+    registry = RegistryClient(args.registry)
+    module_selections = args.select
+    random_percentage = args.random_percentage
+
+    selected_module_versions = select_modules(registry, module_selections, random_percentage)
+    for module_version in selected_module_versions:
+        print(module_version)
+
+if __name__ == "__main__":
+    main()

--- a/tools/module_selector.py
+++ b/tools/module_selector.py
@@ -76,7 +76,7 @@ def select_modules(registry, selections, random_percentage=None):
     if not selected_modules:
         raise ValueError("No matching modules found.")
 
-    return selected_modules
+    return sorted(set(selected_modules))
 
 def main():
     parser = argparse.ArgumentParser(description='Select module versions matching given patterns.')

--- a/tools/module_selector_test.py
+++ b/tools/module_selector_test.py
@@ -1,0 +1,91 @@
+import unittest
+
+from unittest.mock import MagicMock
+from registry import RegistryClient
+from module_selector import select_modules
+
+class TestSelectModules(unittest.TestCase):
+    def setUp(self):
+        # Create a mock registry client
+        self.registry = RegistryClient("/fake")
+        self.registry.get_all_modules = MagicMock(return_value=[
+            'foo_module', 'bar_module', 'baz_module', 'qux_module'
+        ])
+        self.registry.get_module_versions = MagicMock(side_effect=self.mock_get_module_versions)
+
+    def mock_get_module_versions(self, module_name):
+        versions = {
+            'foo_module': [('foo_module', '1.0.0'), ('foo_module', '1.1.0'), ('foo_module', '1.2.0')],
+            'bar_module': [('bar_module', '2.0.0'), ('bar_module', '2.1.0')],
+            'baz_module': [('baz_module', '0.9.0'), ('baz_module', '1.0.0')],
+            'qux_module': [('qux_module', '3.0.0')],
+        }
+        return versions.get(module_name, [])
+
+    def test_select_specific_version(self):
+        selections = ['foo_module@1.1.0']
+        result = select_modules(self.registry, selections)
+        expected = ['foo_module@1.1.0']
+        self.assertEqual(result, expected)
+
+    def test_select_latest_version(self):
+        selections = ['foo_module@latest']
+        result = select_modules(self.registry, selections)
+        expected = ['foo_module@1.2.0']
+        self.assertEqual(result, expected)
+
+    def test_select_version_greater_than(self):
+        selections = ['foo_module@>1.0.0']
+        result = select_modules(self.registry, selections)
+        expected = ['foo_module@1.1.0', 'foo_module@1.2.0']
+        self.assertEqual(result, expected)
+
+    def test_select_version_less_than_or_equal(self):
+        selections = ['bar_module@<=2.0.0']
+        result = select_modules(self.registry, selections)
+        expected = ['bar_module@2.0.0']
+        self.assertEqual(result, expected)
+
+    def test_select_with_wildcard(self):
+        selections = ['ba*_module@latest']
+        result = select_modules(self.registry, selections)
+        expected = ['bar_module@2.1.0', 'baz_module@1.0.0']
+        self.assertEqual(sorted(result), sorted(expected))
+
+    def test_select_random_percentage(self):
+        selections = ['foo_module@>0']
+        result = select_modules(self.registry, selections, random_percentage=50)
+        possible_versions = ['foo_module@1.0.0', 'foo_module@1.1.0', 'foo_module@1.2.0']
+        # Ensure that the result is a subset of possible_versions
+        self.assertTrue(set(result).issubset(set(possible_versions)))
+        # Check that the number of selected modules is correct
+        expected_count = max(1, (50 * len(possible_versions)) // 100)
+        self.assertEqual(len(result), expected_count)
+
+    def test_invalid_selection_pattern_missing_at(self):
+        selections = ['foo_module']
+        with self.assertRaises(ValueError):
+            select_modules(self.registry, selections)
+
+    def test_invalid_selection_pattern_empty_module(self):
+        selections = ['@1.0.0']
+        with self.assertRaises(ValueError):
+            select_modules(self.registry, selections)
+
+    def test_invalid_version_not_found(self):
+        selections = ['foo_module@9.9.9']
+        with self.assertRaises(ValueError):
+            select_modules(self.registry, selections)
+
+    def test_no_matching_modules(self):
+        selections = ['nonexistent_module@latest']
+        with self.assertRaises(ValueError):
+            select_modules(self.registry, selections)
+
+    def test_empty_selections(self):
+        selections = []
+        with self.assertRaises(ValueError):
+            select_modules(self.registry, selections)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This script provides a way to select specific versions of Bazel modules from the Bazel Central Registry (BCR). It supports wildcard patterns for flexible module and version matching, as well as the option to randomly sample a percentage of the matching modules.

```
usage: module_selector.py [-h] [--registry REGISTRY] --select SELECT [--random-percentage PERCENTAGE]
Select module versions matching given patterns.
optional arguments:
  -h, --help            show this help message and exit
  --registry REGISTRY   Specify the root path of the registry (default: the current working directory).
  --select SELECT       Specify module selection patterns in the format <module_pattern>@<version_pattern>. The <module_pattern> can include wildcards (*) to match multiple modules. The
                        <version_pattern> can be: - A specific version (e.g., "1.2.3") - "latest" to select the latest version - A comparison operator followed by a version (e.g.,
                        ">=1.0.0", "<2.0.0") You can provide multiple --select options to combine patterns. Examples: --select "zlib@latest" --select "protobuf@>=27" --select
                        "rules_*@<1.5.0" --select "*@latest"
  --random-percentage PERCENTAGE
                        Percentage of modules to randomly select from the modules matching any of the patterns. Must be an integer between 1 and 100.
```

This script will later be used on Bazel CI to select which modules to test against specific Bazel versions to detect incompatibility.