### PR TITLE
Fix rules_helm dependencies

### DIFF
--- a/modules/rules_helm/0.6.0.bcr.1/MODULE.bazel
+++ b/modules/rules_helm/0.6.0.bcr.1/MODULE.bazel
@@ -1,0 +1,47 @@
+"""abrisco/rules_helm"""
+
+module(
+    name = "rules_helm",
+    version = "0.6.0.bcr.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_go", version = "0.45.1", repo_name = "io_bazel_rules_go")
+
+# This is unfortunately required by `rules_oci`.
+# https://github.com/bazel-contrib/rules_oci/issues/575
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.2", dev_dependency = True)
+bazel_dep(name = "rules_oci", version = "2.0.0")
+bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.18.10")
+
+helm = use_extension("@rules_helm//helm:extensions.bzl", "helm")
+helm.options()
+use_repo(
+    helm,
+    "helm",
+    "helm_darwin_amd64_toolchain",
+    "helm_darwin_arm64_toolchain",
+    "helm_linux_amd64_toolchain",
+    "helm_linux_arm64_toolchain",
+    "helm_windows_amd64_toolchain",
+)
+use_repo(helm, "go_yaml_yaml")
+use_repo(
+    helm,
+    "helm_test_deps__with_chart_deps_postgresql",
+    "helm_test_deps__with_chart_deps_redis",
+    "rules_helm_test_container_base",
+)
+
+register_toolchains(
+    "@helm_darwin_amd64_toolchain//:toolchain",
+    "@helm_darwin_arm64_toolchain//:toolchain",
+    "@helm_linux_amd64_toolchain//:toolchain",
+    "@helm_linux_arm64_toolchain//:toolchain",
+    "@helm_windows_amd64_toolchain//:toolchain",
+)

--- a/modules/rules_helm/0.6.0.bcr.1/patches/deps-rules-oci.patch
+++ b/modules/rules_helm/0.6.0.bcr.1/patches/deps-rules-oci.patch
@@ -1,0 +1,22 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index ff711b1..7c17693 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -2,7 +2,7 @@
+ 
+ module(
+     name = "rules_helm",
+-    version = "0.6.0",
++    version = "0.6.0.bcr.1",
+     compatibility_level = 1,
+ )
+ 
+@@ -13,7 +13,7 @@ bazel_dep(name = "rules_go", version = "0.45.1", repo_name = "io_bazel_rules_go"
+ # This is unfortunately required by `rules_oci`.
+ # https://github.com/bazel-contrib/rules_oci/issues/575
+ bazel_dep(name = "aspect_bazel_lib", version = "2.7.2", dev_dependency = True)
+-bazel_dep(name = "rules_oci", version = "2.0.0", dev_dependency = True)
++bazel_dep(name = "rules_oci", version = "2.0.0")
+ bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
+ 
+ go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")

--- a/modules/rules_helm/0.6.0.bcr.1/patches/version.patch
+++ b/modules/rules_helm/0.6.0.bcr.1/patches/version.patch
@@ -1,0 +1,9 @@
+diff --git a/version.bzl b/version.bzl
+index 4f16634..8968974 100644
+--- a/version.bzl
++++ b/version.bzl
+@@ -1,3 +1,3 @@
+ """ Version info for the `rules_helm` repository """
+ 
+-VERSION = "0.6.0"
++VERSION = "0.6.0.bcr.1"

--- a/modules/rules_helm/0.6.0.bcr.1/presubmit.yml
+++ b/modules/rules_helm/0.6.0.bcr.1/presubmit.yml
@@ -1,0 +1,21 @@
+---
+bcr_test_module:
+  # TODO(abrisco/rules_helm#38): Have this run in a regression test
+  # directory which is consuming rules_helm and not just testing
+  # within the same repository.
+  module_path: "."
+  matrix:
+    platform: ["macos", "ubuntu2004", "windows"]
+    bazel: ["6.x", "7.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--config=strict"
+      test_targets:
+        - "--"
+        - "//..."
+        # Docs test renders differently in bcr CI, don't test this.
+        - "-//docs:docs_diff_test"

--- a/modules/rules_helm/0.6.0.bcr.1/source.json
+++ b/modules/rules_helm/0.6.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-easVF1EdnzWNj0sqE7TgqwCfvq3BEfA/poKPAfLA4Kw=",
+    "strip_prefix": "",
+    "url": "https://github.com/abrisco/rules_helm/releases/download/0.6.0/rules_helm-v0.6.0.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "deps-rules-oci.patch": "sha256-xm23d3WfUPhxIHRfBMluVoL8AP60v+hD8LSqm7fPAqg=",
+        "version.patch": "sha256-Qk57XPMPiu9BCedVNTDGAvrNxaryXKD8H+MdeFwFhfI="
+    }
+}

--- a/modules/rules_helm/metadata.json
+++ b/modules/rules_helm/metadata.json
@@ -2,9 +2,9 @@
     "homepage": "https://github.com/abrisco/rules_helm",
     "maintainers": [
         {
-            "name": "Andre Brisco",
             "email": "91817010+abrisco@users.noreply.github.com",
-            "github": "abrisco"
+            "github": "abrisco",
+            "name": "Andre Brisco"
         }
     ],
     "repository": [
@@ -20,6 +20,7 @@
         "0.5.0",
         "0.5.1",
         "0.6.0",
+        "0.6.0.bcr.1",
         "0.7.0",
         "0.8.0",
         "0.9.1",


### PR DESCRIPTION
rules_oci is loaded by a non dev_dependencies module extension and therefore musn't be a dev_dependency itself.

Proposed an upstream fix for future versions in https://github.com/abrisco/rules_helm/pull/107.