### PR TITLE
pico-sdk, picotool pre-release 2.0.1-develop.bcr.1

### DIFF
--- a/modules/pico-sdk/2.0.1-develop.bcr.1/MODULE.bazel
+++ b/modules/pico-sdk/2.0.1-develop.bcr.1/MODULE.bazel
@@ -1,0 +1,151 @@
+module(
+    name = "pico-sdk",
+    version = "2.0.1-develop.bcr.1",
+)
+
+bazel_dep(name = "platforms", version = "0.0.9")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
+bazel_dep(name = "rules_python", version = "0.22.1")
+bazel_dep(name = "picotool", version = "2.0.0")
+
+# Note: rules_cc is special-cased repository; a dependency on rules_cc in a
+# module will not ensure that the root Bazel module has that same version of
+# rules_cc. For that reason, this primarily acts as a FYI. You'll still need
+# to explicitly list this dependency in your own project's MODULE.bazel file.
+bazel_dep(name = "rules_cc", version = "0.0.9")
+
+# rules_cc v0.0.10 is not yet cut, so manually pull in the desired version.
+# This does not apply to dependent projects, so it needs to be copied to your
+# project's MODULE.bazel too.
+archive_override(
+    module_name = "rules_cc",
+    integrity = "sha256-zdQo/pQWKdIAPKSflBxOSWZNwCbc86T7SechKZo/3Xw=",
+    strip_prefix = "rules_cc-1acf5213b6170f1f0133e273cb85ede0e732048f",
+    urls = "https://github.com/bazelbuild/rules_cc/archive/1acf5213b6170f1f0133e273cb85ede0e732048f.tar.gz",
+)
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "arm_gcc_linux-aarch64",
+    build_file = "//bazel/toolchain:gcc_arm_none_eabi.BUILD",
+    sha256 = "8fd8b4a0a8d44ab2e195ccfbeef42223dfb3ede29d80f14dcf2183c34b8d199a",
+    strip_prefix = "arm-gnu-toolchain-13.2.Rel1-aarch64-arm-none-eabi",
+    url = "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-aarch64-arm-none-eabi.tar.xz",
+)
+
+http_archive(
+    name = "arm_gcc_linux-x86_64",
+    build_file = "//bazel/toolchain:gcc_arm_none_eabi.BUILD",
+    sha256 = "6cd1bbc1d9ae57312bcd169ae283153a9572bd6a8e4eeae2fedfbc33b115fdbb",
+    strip_prefix = "arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi",
+    url = "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz",
+)
+
+http_archive(
+    name = "arm_gcc_win-x86_64",
+    build_file = "//bazel/toolchain:gcc_arm_none_eabi.BUILD",
+    sha256 = "51d933f00578aa28016c5e3c84f94403274ea7915539f8e56c13e2196437d18f",
+    strip_prefix = "arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-arm-none-eabi",
+    url = "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi.zip",
+)
+
+http_archive(
+    name = "arm_gcc_mac-x86_64",
+    build_file = "//bazel/toolchain:gcc_arm_none_eabi.BUILD",
+    sha256 = "075faa4f3e8eb45e59144858202351a28706f54a6ec17eedd88c9fb9412372cc",
+    strip_prefix = "arm-gnu-toolchain-13.2.Rel1-darwin-x86_64-arm-none-eabi",
+    url = "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz",
+)
+
+http_archive(
+    name = "arm_gcc_mac-aarch64",
+    build_file = "//bazel/toolchain:gcc_arm_none_eabi.BUILD",
+    sha256 = "39c44f8af42695b7b871df42e346c09fee670ea8dfc11f17083e296ea2b0d279",
+    strip_prefix = "arm-gnu-toolchain-13.2.Rel1-darwin-arm64-arm-none-eabi",
+    url = "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-arm64-arm-none-eabi.tar.xz",
+)
+
+http_archive(
+    name = "clang_linux-x86_64",
+    build_file = "//bazel/toolchain:clang.BUILD",
+    sha256 = "6c599d1aba568236064c340d7813324849896d5a4e2f3fd8225a8c31bfcbf884",
+    type = "zip",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/linux-amd64/+/git_revision:2b0a708f41dd6291ee744704d43febc975e3d026",
+)
+
+http_archive(
+    name = "clang_win-x86_64",
+    build_file = "//bazel/toolchain:clang.BUILD",
+    sha256 = "f49ba4123ee3958f2b47289d017a5b3f1ca01f82dd7a2168c45412c18101fd13",
+    type = "zip",
+    # Windows doesn't like `:` in the produced filename, so replace it with `%3A`.
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/windows-amd64/+/git_revision:2b0a708f41dd6291ee744704d43febc975e3d026".replace("git_revision:", "git_revision%3A"),
+)
+
+http_archive(
+    name = "clang_mac-x86_64",
+    build_file = "//bazel/toolchain:clang.BUILD",
+    sha256 = "d3516f2eb4c12d17ae77ee84c9226fbea581d4fb806910ceac4717d5adfcf748",
+    type = "zip",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-amd64/+/git_revision:2b0a708f41dd6291ee744704d43febc975e3d026",
+)
+
+http_archive(
+    name = "clang_mac-aarch64",
+    build_file = "//bazel/toolchain:clang.BUILD",
+    sha256 = "68e551f41c7e9473063b09819f6ab8ec6e7e53677f4078189656cb14dc52984b",
+    type = "zip",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-arm64/+/git_revision:2b0a708f41dd6291ee744704d43febc975e3d026",
+)
+
+# TODO: Provide tinyusb as a proper Bazel module.
+http_archive(
+    name = "tinyusb",
+    build_file = "//src/rp2_common/tinyusb:tinyusb.BUILD",
+    sha256 = "d64728aef58b80d5ce3747cad133f520da46e2b7ea3aadfda0e981aba6b658b3",
+    strip_prefix = "tinyusb-4232642899362fa5e9cf0dc59bad6f1f6d32c563",
+    url = "https://github.com/hathach/tinyusb/archive/4232642899362fa5e9cf0dc59bad6f1f6d32c563.tar.gz",
+)
+
+# TODO: Provide btstack as a proper Bazel module.
+http_archive(
+    name = "btstack",
+    build_file = "//src/rp2_common/pico_btstack:btstack.BUILD",
+    sha256 = "64e86d9cf82b346e743fe1d4818b9380712b17abdb3f2c3524e92464b5ef3d19",
+    strip_prefix = "btstack-2b49e57bd1fae85ac32ac1f41cdb7c794de335f6",
+    url = "https://github.com/bluekitchen/btstack/archive/2b49e57bd1fae85ac32ac1f41cdb7c794de335f6.tar.gz",
+)
+
+# TODO: Provide btstack as a proper Bazel module.
+http_archive(
+    name = "cyw43-driver",
+    build_file = "//src/rp2_common/pico_cyw43_driver:cyw43-driver.BUILD",
+    sha256 = "0fcc7707fef95dd562d5572604713266613a27caeeae2f10afeccee9592a53ce",
+    strip_prefix = "cyw43-driver-faf36381bad1f668a30172b6336c9a970966ef4c",
+    url = "https://github.com/georgerobotics/cyw43-driver/archive/faf36381bad1f668a30172b6336c9a970966ef4c.tar.gz",
+)
+
+# TODO: Provide lwip as a proper Bazel module.
+http_archive(
+    name = "lwip",
+    build_file = "//src/rp2_common/pico_lwip:lwip.BUILD",
+    sha256 = "72856d557f72911cf6826ef745c23c54822df83a474557823241164a1d1361aa",
+    strip_prefix = "lwip-0a0452b2c39bdd91e252aef045c115f88f6ca773",
+    url = "https://github.com/lwip-tcpip/lwip/archive/0a0452b2c39bdd91e252aef045c115f88f6ca773.tar.gz",
+)
+
+register_toolchains(
+    "//bazel/toolchain:linux-aarch64-rp2040",
+    "//bazel/toolchain:linux-aarch64-rp2350",
+    "//bazel/toolchain:linux-x86_64-rp2040",
+    "//bazel/toolchain:linux-x86_64-rp2350",
+    "//bazel/toolchain:win-x86_64-rp2040",
+    "//bazel/toolchain:win-x86_64-rp2350",
+    "//bazel/toolchain:mac-x86_64-rp2040",
+    "//bazel/toolchain:mac-x86_64-rp2350",
+    "//bazel/toolchain:mac-aarch64-rp2040",
+    "//bazel/toolchain:mac-aarch64-rp2350",
+    # Require users to opt-in to the Pico SDK's toolchains.
+    dev_dependency = True,
+)

--- a/modules/pico-sdk/2.0.1-develop.bcr.1/patches/0001-Patch-version-string.patch
+++ b/modules/pico-sdk/2.0.1-develop.bcr.1/patches/0001-Patch-version-string.patch
@@ -1,0 +1,12 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index d5f615aa..36ad4e26 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "pico-sdk",
+-    version = "2.0.1-develop",
++    version = "2.0.1-develop.bcr.1",
+ )
+ 
+ bazel_dep(name = "platforms", version = "0.0.9")

--- a/modules/pico-sdk/2.0.1-develop.bcr.1/presubmit.yml
+++ b/modules/pico-sdk/2.0.1-develop.bcr.1/presubmit.yml
@@ -1,0 +1,12 @@
+
+matrix:
+  platform: ["debian10", "ubuntu2004", "macos", "macos_arm64", "windows"]
+tasks:
+  verify_device_build:
+    name: "Build test"
+    platform: ${{ platform }}
+    bazel: "7.x"
+    build_flags:
+      - "--platforms=@pico-sdk//bazel/platform:rp2040"
+    build_targets:
+      - "//..."

--- a/modules/pico-sdk/2.0.1-develop.bcr.1/source.json
+++ b/modules/pico-sdk/2.0.1-develop.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "type": "git_repository",
+    "remote": "https://github.com/raspberrypi/pico-sdk.git",
+    "commit": "37085889b0a1d99d50cf06f77ae08e2541c4c0f7",
+    "patch_strip": 1,
+    "patches": {
+        "0001-Patch-version-string.patch": "sha256-idZuC9uN6/3dVO92Ki50zghNO/K+7F1PZCO6Bxy0dgo="
+    }
+}

--- a/modules/pico-sdk/metadata.json
+++ b/modules/pico-sdk/metadata.json
@@ -23,7 +23,8 @@
     ],
     "versions": [
         "1.6.0-rc1",
-        "2.0.0"
+        "2.0.0",
+        "2.0.1-develop.bcr.1"
     ],
     "yanked_versions": {}
 }

--- a/modules/picotool/2.0.1-develop.bcr.1/MODULE.bazel
+++ b/modules/picotool/2.0.1-develop.bcr.1/MODULE.bazel
@@ -1,0 +1,26 @@
+module(
+    name = "picotool",
+    version = "2.0.1-develop.bcr.1",
+)
+
+bazel_dep(name = "rules_libusb", version = "0.1.0-rc1")
+bazel_dep(name = "pico-sdk", version = "2.0.1-develop.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
+bazel_dep(name = "rules_python", version = "0.22.1")
+bazel_dep(name = "platforms", version = "0.0.9")
+
+libusb = use_extension("@rules_libusb//:extensions.bzl", "libusb")
+libusb.source_release(min_version = "1.0.22")
+use_repo(libusb, "libusb")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# TODO: Upstream a bazel build
+http_archive(
+    name = "mbedtls",
+    build_file = "//bazel:mbedtls.BUILD",
+    sha256 = "241c68402cef653e586be3ce28d57da24598eb0df13fcdea9d99bfce58717132",
+    strip_prefix = "mbedtls-2.28.8",
+    url = "https://github.com/Mbed-TLS/mbedtls/releases/download/v2.28.8/mbedtls-2.28.8.tar.bz2",
+)

--- a/modules/picotool/2.0.1-develop.bcr.1/patches/0001-Patch-version-string.patch
+++ b/modules/picotool/2.0.1-develop.bcr.1/patches/0001-Patch-version-string.patch
@@ -1,0 +1,12 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 2c22158..6bcd167 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "picotool",
+-    version = "2.0.0",
++    version = "2.0.1-develop.bcr.1",
+ )
+ 
+ bazel_dep(name = "rules_libusb", version = "0.1.0-rc1")

--- a/modules/picotool/2.0.1-develop.bcr.1/patches/0002-Patch-required-pico-sdk-version.patch
+++ b/modules/picotool/2.0.1-develop.bcr.1/patches/0002-Patch-required-pico-sdk-version.patch
@@ -1,0 +1,13 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 6bcd167..b6bb738 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -4,7 +4,7 @@ module(
+ )
+ 
+ bazel_dep(name = "rules_libusb", version = "0.1.0-rc1")
+-bazel_dep(name = "pico-sdk", version = "2.0.0")
++bazel_dep(name = "pico-sdk", version = "2.0.1-develop.bcr.1")
+ bazel_dep(name = "rules_cc", version = "0.0.9")
+ bazel_dep(name = "bazel_skylib", version = "1.6.1")
+ bazel_dep(name = "rules_python", version = "0.22.1")

--- a/modules/picotool/2.0.1-develop.bcr.1/presubmit.yml
+++ b/modules/picotool/2.0.1-develop.bcr.1/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform:
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@picotool'

--- a/modules/picotool/2.0.1-develop.bcr.1/source.json
+++ b/modules/picotool/2.0.1-develop.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "type": "git_repository",
+    "remote": "https://github.com/raspberrypi/picotool.git",
+    "commit": "c2fca5a6a7cee3591f739e9cc81f021e04350753",
+    "patch_strip": 1,
+    "patches": {
+        "0001-Patch-version-string.patch": "sha256-LPo3YiKB7/bG2kCxDjRObTSh/IZrDtxbQcmSIwEzb+o=",
+        "0002-Patch-required-pico-sdk-version.patch": "sha256-3yNjKv88IR0B5OzAb8DmGzr14QFfQJNihFXDxhTtOlQ="
+    }
+}

--- a/modules/picotool/metadata.json
+++ b/modules/picotool/metadata.json
@@ -17,7 +17,8 @@
     ],
     "versions": [
         "1.1.3-rc1",
-        "2.0.0"
+        "2.0.0",
+        "2.0.1-develop.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds an intermediate release of Picotool and Pico SDK. This is not an official release, but instead a pre-release to give users access to recent fixes on a rolling basis.