### PR TITLE
Add websocket with configurable boost

### DIFF
--- a/modules/websocketpp/0.8.2.bcr.2/MODULE.bazel
+++ b/modules/websocketpp/0.8.2.bcr.2/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "websocketpp",
+    version = "0.8.2.bcr.2",
+    compatibility_level = 1,
+)
+bazel_dep(name = "asio", version = "1.28.2")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "boost.asio", version = "1.83.0")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "zlib", version = "1.3")

--- a/modules/websocketpp/0.8.2.bcr.2/overlay/BUILD.bazel
+++ b/modules/websocketpp/0.8.2.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+bool_flag(
+    name = "use_boost",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "use_boost_setting",
+    flag_values = {":use_boost": "True"},
+)
+
+cc_library(
+    name = "websocketpp",
+    hdrs = glob(["websocketpp/**/*.hpp"]),
+    defines = [
+        "_WEBSOCKETPP_CPP11_STL_",
+    ] + select({
+        ":use_boost_setting": [""],
+        "//conditions:default": ["ASIO_STANDALONE"],
+    }),
+    includes = ["."],
+    linkopts = select({
+        "@platforms//os:osx": [
+            "-lpthread",
+        ],
+        "//conditions:default": [
+            "-lpthread",
+            "-lrt",
+        ],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@zlib",
+    ] + select({
+        ":use_boost_setting": ["@boost.asio"],
+        "//conditions:default": ["@asio"],
+    }),
+)

--- a/modules/websocketpp/0.8.2.bcr.2/overlay/BUILD.bazel
+++ b/modules/websocketpp/0.8.2.bcr.2/overlay/BUILD.bazel
@@ -14,11 +14,12 @@ config_setting(
 cc_library(
     name = "websocketpp",
     hdrs = glob(["websocketpp/**/*.hpp"]),
-    defines = [
-        "_WEBSOCKETPP_CPP11_STL_",
-    ] + select({
-        ":use_boost_setting": [""],
-        "//conditions:default": ["ASIO_STANDALONE"],
+    defines = select({
+        ":use_boost_setting": ["_WEBSOCKETPP_CPP11_STL_"],
+        "//conditions:default": [
+            "_WEBSOCKETPP_CPP11_STL_",
+            "ASIO_STANDALONE",
+        ],
     }),
     includes = ["."],
     linkopts = select({

--- a/modules/websocketpp/0.8.2.bcr.2/overlay/MODULE.bazel
+++ b/modules/websocketpp/0.8.2.bcr.2/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/websocketpp/0.8.2.bcr.2/presubmit.yml
+++ b/modules/websocketpp/0.8.2.bcr.2/presubmit.yml
@@ -1,0 +1,22 @@
+matrix:
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+  bazel: [6.x, 7.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@websocketpp"
+  verify_targets_boost:
+    name: Verify build targets using boost asio
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@websocketpp"
+    build_flags:
+    - '--@websocketpp//:use_boost=true'

--- a/modules/websocketpp/0.8.2.bcr.2/presubmit.yml
+++ b/modules/websocketpp/0.8.2.bcr.2/presubmit.yml
@@ -4,7 +4,8 @@ matrix:
     - ubuntu2004
     - macos
     - macos_arm64
-  bazel: [6.x, 7.x]
+  bazel:
+    - 7.x
 tasks:
   verify_targets:
     name: Verify build targets

--- a/modules/websocketpp/0.8.2.bcr.2/source.json
+++ b/modules/websocketpp/0.8.2.bcr.2/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "websocketpp-0.8.2",
     "overlay": {
         "MODULE.bazel": "sha256-MmqOQI1EtRqoMO42ogfsACw86/eLQ7dq6TInLEp0sgk=",
-        "BUILD.bazel": "sha256-kDEixPl4czII7xs1NDtac0wlRZmnwkyUECjp9gSb3oQ="
+        "BUILD.bazel": "sha256-Awc0CFGb0fJhuWFn/zl7DUM/95rnuXc+k8YN7D5QQWE="
     },
     "patch_strip": 0
 }

--- a/modules/websocketpp/0.8.2.bcr.2/source.json
+++ b/modules/websocketpp/0.8.2.bcr.2/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/zaphoyd/websocketpp/archive/refs/tags/0.8.2.tar.gz",
+    "integrity": "sha256-bOiJ2F7Nwtj6B0CNZ4fnNSUQdQ2qZrWtRKrLR76nZ1U=",
+    "strip_prefix": "websocketpp-0.8.2",
+    "overlay": {
+        "MODULE.bazel": "sha256-MmqOQI1EtRqoMO42ogfsACw86/eLQ7dq6TInLEp0sgk=",
+        "BUILD.bazel": "sha256-k/+nBgpRUrL5riMuzhcAQXpYgjcn1umtj8lOWBLqU64="
+    },
+    "patch_strip": 0
+}

--- a/modules/websocketpp/0.8.2.bcr.2/source.json
+++ b/modules/websocketpp/0.8.2.bcr.2/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "websocketpp-0.8.2",
     "overlay": {
         "MODULE.bazel": "sha256-MmqOQI1EtRqoMO42ogfsACw86/eLQ7dq6TInLEp0sgk=",
-        "BUILD.bazel": "sha256-k/+nBgpRUrL5riMuzhcAQXpYgjcn1umtj8lOWBLqU64="
+        "BUILD.bazel": "sha256-kDEixPl4czII7xs1NDtac0wlRZmnwkyUECjp9gSb3oQ="
     },
     "patch_strip": 0
 }

--- a/modules/websocketpp/metadata.json
+++ b/modules/websocketpp/metadata.json
@@ -11,7 +11,8 @@
   ],
   "versions": [
     "0.8.2",
-    "0.8.2.bcr.1"
+    "0.8.2.bcr.1",
+    "0.8.2.bcr.2"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
Closes #3045

---

Please note that with `boost.asio`, only Bazel 7.x is supported. With Bazel 6, I ran into [this error](https://buildkite.com/bazel/bcr-presubmit/builds/8436#0192dd4c-016a-4d23-8724-30cdc578f223): `Error computing the main repository mapping: in module dependency chain <root> -> websocketpp@0.8.2.bcr.2 -> boost.asio@1.83.0 -> boringssl@0.20240913.0 -> googletest@1.15.2: error executing MODULE.bazel file for googletest@1.15.2`. [The googletest version](https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/googletest/1.15.2/presubmit.yml) only supports Bazel 7.x in CI, so I do the same.