### PR TITLE
Create protobuf 29.0-rc2.bcr.1

### DIFF
--- a/modules/protobuf/29.0-rc2.bcr.1/MODULE.bazel
+++ b/modules/protobuf/29.0-rc2.bcr.1/MODULE.bazel
@@ -1,0 +1,181 @@
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/protocolbuffers/protobuf/issues/14313
+
+module(
+    name = "protobuf",
+    version = "29.0-rc2.bcr.1",  # Automatically updated on release
+    compatibility_level = 1,
+    repo_name = "com_google_protobuf",
+)
+
+# LOWER BOUND dependency versions.
+# Bzlmod follows MVS:
+# https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
+# Thus the highest version in their module graph is resolved.
+bazel_dep(
+    name = "abseil-cpp",
+    version = "20230802.0.bcr.1",
+    repo_name = "com_google_absl",
+)
+
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.7.0",
+)
+
+bazel_dep(
+    name = "jsoncpp",
+    version = "1.9.5",
+)
+
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.13",
+)
+
+bazel_dep(
+    name = "rules_fuzzing",
+    version = "0.5.2",
+)
+
+bazel_dep(
+    name = "rules_java",
+    version = "7.12.2",
+)
+
+bazel_dep(
+    name = "rules_jvm_external",
+    version = "6.3",
+)
+
+bazel_dep(
+    name = "rules_kotlin",
+    version = "1.9.6",
+)
+
+bazel_dep(
+    name = "rules_license",
+    version = "1.0.0",
+)
+
+bazel_dep(
+    name = "rules_pkg",
+    version = "1.0.1",
+)
+
+bazel_dep(
+    name = "rules_python",
+    version = "0.28.0",
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.8",
+)
+
+bazel_dep(
+    name = "zlib",
+    version = "1.3.1",
+)
+
+bazel_dep(
+    name = "bazel_features",
+    version = "1.17.0",
+    repo_name = "proto_bazel_features",
+)
+
+bazel_dep(
+    name = "rules_shell",
+    version = "0.2.0"
+)
+
+# Proto toolchains
+register_toolchains("//bazel/private/toolchains:all")
+
+SUPPORTED_PYTHON_VERSIONS = [
+    "3.8",
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+]
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+
+[
+    python.toolchain(
+        is_default = python_version == SUPPORTED_PYTHON_VERSIONS[-1],
+        python_version = python_version,
+    )
+    for python_version in SUPPORTED_PYTHON_VERSIONS
+]
+
+use_repo(
+    python,
+    system_python = "python_{}".format(SUPPORTED_PYTHON_VERSIONS[-1].replace(".", "_")),
+)
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
+[
+    pip.parse(
+        hub_name = "pip_deps",
+        python_version = python_version,
+        requirements_lock = "//python:requirements.txt",
+    )
+    for python_version in SUPPORTED_PYTHON_VERSIONS
+]
+
+use_repo(pip, "pip_deps")
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+
+maven.install(
+    artifacts = [
+        "com.google.caliper:caliper:1.0-beta-3",
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.code.gson:gson:2.8.9",
+        "com.google.errorprone:error_prone_annotations:2.5.1",
+        "com.google.j2objc:j2objc-annotations:2.8",
+        "com.google.guava:guava:32.0.1-jre",
+        "com.google.guava:guava-testlib:32.0.1-jre",
+        "com.google.truth:truth:1.1.2",
+        "junit:junit:4.13.2",
+        "org.mockito:mockito-core:4.3.1",
+        "biz.aQute.bnd:biz.aQute.bndlib:6.4.0",
+        "info.picocli:picocli:4.6.3",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://repo.maven.apache.org/maven2",
+    ],
+)
+
+use_repo(maven, "maven")
+
+# Development dependencies
+bazel_dep(
+    name = "googletest",
+    version = "1.14.0",
+    dev_dependency = True,
+    repo_name = "com_google_googletest",
+)
+
+bazel_dep(
+    name = "rules_buf",
+    version = "0.3.0",
+    dev_dependency = True,
+)
+
+bazel_dep(
+    name = "rules_testing",
+    version = "0.6.0",
+    dev_dependency = True,
+)
+
+# rules_proto are needed for @com_google_protobuf_v25.0 used in //compatibility/... tests
+bazel_dep(
+    name = "rules_proto",
+    version = "4.0.0",
+    dev_dependency = True,
+)

--- a/modules/protobuf/29.0-rc2.bcr.1/patches/java_library_load.patch
+++ b/modules/protobuf/29.0-rc2.bcr.1/patches/java_library_load.patch
@@ -1,0 +1,15 @@
+diff --git a/java/core/BUILD.bazel b/java/core/BUILD.bazel
+index 423f0bbb8..63b5f4af5 100644
+--- a/java/core/BUILD.bazel
++++ b/java/core/BUILD.bazel
+@@ -1,4 +1,5 @@
+ load("@bazel_skylib//rules:build_test.bzl", "build_test")
++load("@rules_java//java:java_library.bzl", "java_library")
+ load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
+ load("//:protobuf.bzl", "internal_gen_well_known_protos_java")
+ load("//:protobuf_version.bzl", "PROTOBUF_JAVA_VERSION")
+@@ -705,3 +706,4 @@ pkg_files(
+     strip_prefix = strip_prefix.from_root(""),
+     visibility = ["//java:__pkg__"],
+ )
++

--- a/modules/protobuf/29.0-rc2.bcr.1/patches/java_library_load.patch
+++ b/modules/protobuf/29.0-rc2.bcr.1/patches/java_library_load.patch
@@ -1,3 +1,16 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 5dbba8864..9798f568a 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -3,7 +3,7 @@
+ 
+ module(
+     name = "protobuf",
+-    version = "29.0-rc2",  # Automatically updated on release
++    version = "29.0-rc2.bcr.1",  # Automatically updated on release
+     compatibility_level = 1,
+     repo_name = "com_google_protobuf",
+ )
 diff --git a/java/core/BUILD.bazel b/java/core/BUILD.bazel
 index 423f0bbb8..63b5f4af5 100644
 --- a/java/core/BUILD.bazel

--- a/modules/protobuf/29.0-rc2.bcr.1/presubmit.yml
+++ b/modules/protobuf/29.0-rc2.bcr.1/presubmit.yml
@@ -1,0 +1,36 @@
+matrix:
+  platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  bazel: [7.x]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--host_cxxopt=-std=c++14'
+    - '--cxxopt=-std=c++14'
+    build_targets:
+    - '@protobuf//:protobuf'
+    - '@protobuf//:protobuf_lite'
+    - '@protobuf//:protobuf_python'
+    - '@protobuf//:protobuf_java'
+    - '@protobuf//:protoc'
+    - '@protobuf//:test_messages_proto2_cc_proto'
+    - '@protobuf//:test_messages_proto3_cc_proto'
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+      - '--host_cxxopt=-std=c++14'
+      - '--cxxopt=-std=c++14'
+      build_targets:
+      - "//..."

--- a/modules/protobuf/29.0-rc2.bcr.1/source.json
+++ b/modules/protobuf/29.0-rc2.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-IwgtyhynOh6cbL5ACXtB6B9x87TWIB42wTSswwobNmA=",
+    "strip_prefix": "protobuf-29.0-rc2",
+    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v29.0-rc2/protobuf-29.0-rc2.zip"
+    "patches": {
+        "java_library_load.patch": "sha256-dSfMN4YB4a1pvEPLce+/A6dNd+g152RZByzGWaZr+/I="
+    },
+    "patch_strip": 1
+}

--- a/modules/protobuf/29.0-rc2.bcr.1/source.json
+++ b/modules/protobuf/29.0-rc2.bcr.1/source.json
@@ -3,7 +3,7 @@
     "strip_prefix": "protobuf-29.0-rc2",
     "url": "https://github.com/protocolbuffers/protobuf/releases/download/v29.0-rc2/protobuf-29.0-rc2.zip",
     "patches": {
-        "java_library_load.patch": "sha256-dSfMN4YB4a1pvEPLce+/A6dNd+g152RZByzGWaZr+/I="
+        "java_library_load.patch": "sha256-RqbB1Mho88jPxrCdps3bNt/7BWKusNDJOm+14xUcFrI="
     },
     "patch_strip": 1
 }

--- a/modules/protobuf/29.0-rc2.bcr.1/source.json
+++ b/modules/protobuf/29.0-rc2.bcr.1/source.json
@@ -1,7 +1,7 @@
 {
     "integrity": "sha256-IwgtyhynOh6cbL5ACXtB6B9x87TWIB42wTSswwobNmA=",
     "strip_prefix": "protobuf-29.0-rc2",
-    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v29.0-rc2/protobuf-29.0-rc2.zip"
+    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v29.0-rc2/protobuf-29.0-rc2.zip",
     "patches": {
         "java_library_load.patch": "sha256-dSfMN4YB4a1pvEPLce+/A6dNd+g152RZByzGWaZr+/I="
     },

--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -123,7 +123,8 @@
         "28.2",
         "28.3",
         "29.0-rc1",
-        "29.0-rc2"
+        "29.0-rc2",
+        "29.0-rc2.bcr.1"
     ],
     "yanked_versions": {
         "3.19.0": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)",


### PR DESCRIPTION
Just adds a missing java_library load statement. This unblocks rule repositories supporting Bazel 8 who depend on protobuf.