### PR TITLE
Resolve source_root when checking overlay file path

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -286,11 +286,11 @@ class BcrValidator:
                 overlay_src = overlay_dir / overlay_file
                 overlay_dst = source_root / overlay_file
                 try:
-                    overlay_dst.resolve().relative_to(source_root)
-                except ValueError:
+                    overlay_dst.resolve().relative_to(source_root.resolve())
+                except ValueError as e:
                     self.report(
                         BcrValidationResult.FAILED,
-                        f"The overlay file path `{overlay_file}` must point inside the source archive.",
+                        f"The overlay file path `{overlay_file}` must point inside the source archive.\n {e}",
                     )
                     continue
                 try:


### PR DESCRIPTION
On mac, it's possible that:
```
$ ll /var
lrwxr-xr-x@ 1 root  wheel  11 Oct 15 13:22 /var@ -> private/var
```

If we only resolve overlay_dst but not source_root, it'll fail the check