### PR TITLE
Revert "Validate `MODULE.bazel` version equals module directory version (#3059)"

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -28,7 +28,6 @@ Validations performed are:
 """
 
 import argparse
-import ast
 import json
 import subprocess
 from pathlib import Path
@@ -337,17 +336,6 @@ class BcrValidator:
                 self.add_module_dot_bazel_patch(diff, module_name, version)
         else:
             self.report(BcrValidationResult.GOOD, "Checked in MODULE.bazel matches the sources.")
-
-        tree = ast.parse("".join(bcr_module_dot_bazel_content), filename=source_root)
-        for node in tree.body:
-            if isinstance(node, ast.Expr):
-                if isinstance(node.value, ast.Call) and node.value.func.id == "module":
-                    keywords = {k.arg: k.value.value for k in node.value.keywords if isinstance(k.value, ast.Constant)}
-                    if keywords.get("version", version) != version:
-                        self.report(
-                            BcrValidationResult.FAILED,
-                            "Checked in MODULE.bazel version does not match the version of the module directory added.",
-                        )
 
         shutil.rmtree(tmp_dir)
 


### PR DESCRIPTION


This reverts commit f42a93df1e23c161f3ef16b2799072d92c4f3548.

Address https://github.com/bazelbuild/bazel-central-registry/pull/3065#issuecomment-2447757056