### PR TITLE
fix(tools/bcr_validation): parse `MODULE.bazel` AST correctly

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -340,14 +340,18 @@ class BcrValidator:
 
         tree = ast.parse("".join(bcr_module_dot_bazel_content), filename=source_root)
         for node in tree.body:
-            if isinstance(node, ast.Expr):
-                if isinstance(node.value, ast.Call) and node.value.func.id == "module":
-                    keywords = {k.arg: k.value.value for k in node.value.keywords if isinstance(k.value, ast.Constant)}
-                    if keywords.get("version", version) != version:
-                        self.report(
-                            BcrValidationResult.FAILED,
-                            "Checked in MODULE.bazel version does not match the version of the module directory added.",
-                        )
+            if (
+                isinstance(node, ast.Expr)
+                and isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Name)
+                and node.value.func.id == "module"
+            ):
+                keywords = {k.arg: k.value.value for k in node.value.keywords if isinstance(k.value, ast.Constant)}
+                if keywords.get("version", version) != version:
+                    self.report(
+                        BcrValidationResult.FAILED,
+                        "Checked in MODULE.bazel version does not match the version of the module directory added.",
+                    )
 
         shutil.rmtree(tmp_dir)
 


### PR DESCRIPTION
Fixes up a bug in #3059.