### PR TITLE
Improve module_analyzer

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -105,15 +105,15 @@ This script calculates the importance of each module in the BCR based on their P
 The graph is constructed based on dependencies of the latest version of each module.
 
 ```
-usage: module_analyzer.py [-h] [--registry REGISTRY] [--top_n TOP_N] [--include-dev-deps] [--name-only]
+usage: module_analyzer.py [-h] [--registry REGISTRY] [--top_n TOP_N] [--exclude-dev-deps] [--name-only]
 
 Select module versions matching given patterns.
 
-optional arguments:
+options:
   -h, --help           show this help message and exit
   --registry REGISTRY  Specify the root path of the registry (default: the current working directory or the workspace root if running with Bazel).
   --top_n TOP_N        Specify the top N important modules to print out (default: 50).
-  --include-dev-deps   Include dev dependencies when constructing the dependency graph (default: False).
+  --exclude-dev-deps   Exclude dev dependencies when constructing the dependency graph (default: False).
   --name-only          Only print the module names without the scores (default: False).
 ```
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -105,7 +105,7 @@ This script calculates the importance of each module in the BCR based on their P
 The graph is constructed based on dependencies of the latest version of each module.
 
 ```
-usage: module_analyzer.py [-h] [--registry REGISTRY] [--top_n TOP_N]
+usage: module_analyzer.py [-h] [--registry REGISTRY] [--top_n TOP_N] [--include-dev-deps] [--name-only]
 
 Select module versions matching given patterns.
 
@@ -113,6 +113,8 @@ optional arguments:
   -h, --help           show this help message and exit
   --registry REGISTRY  Specify the root path of the registry (default: the current working directory or the workspace root if running with Bazel).
   --top_n TOP_N        Specify the top N important modules to print out (default: 50).
+  --include-dev-deps   Include dev dependencies when constructing the dependency graph (default: False).
+  --name-only          Only print the module names without the scores (default: False).
 ```
 
 You can also run with Bazel, for example:

--- a/tools/README.md
+++ b/tools/README.md
@@ -109,7 +109,7 @@ usage: module_analyzer.py [-h] [--registry REGISTRY] [--top_n TOP_N] [--exclude-
 
 Select module versions matching given patterns.
 
-options:
+optional arguments:
   -h, --help           show this help message and exit
   --registry REGISTRY  Specify the root path of the registry (default: the current working directory or the workspace root if running with Bazel).
   --top_n TOP_N        Specify the top N important modules to print out (default: 50).

--- a/tools/module_analyzer.py
+++ b/tools/module_analyzer.py
@@ -35,7 +35,7 @@ def get_buildozer_path():
     return "buildozer"
 
 
-def get_direct_dependencies(module_name, version, registry_dir, buildozer, include_dev_deps):
+def get_direct_dependencies(module_name, version, registry_dir, buildozer, exclude_dev_deps):
     deps = (
         subprocess.check_output(
             [buildozer, "print name", f"//modules/{module_name}/{version}/MODULE.bazel:%bazel_dep"],
@@ -45,7 +45,7 @@ def get_direct_dependencies(module_name, version, registry_dir, buildozer, inclu
         .split()
     )
 
-    if include_dev_deps:
+    if not exclude_dev_deps:
         return deps
 
     dev_deps_stat = (
@@ -81,9 +81,9 @@ def main():
         help="Specify the top N important modules to print out (default: 50).",
     )
     parser.add_argument(
-        "--include-dev-deps",
+        "--exclude-dev-deps",
         action="store_true",
-        help="Include dev dependencies when constructing the dependency graph (default: False).",
+        help="Exclude dev dependencies when constructing the dependency graph (default: False).",
     )
     parser.add_argument(
         "--name-only",
@@ -104,7 +104,7 @@ def main():
     G = nx.DiGraph()
     for module in modules:
         module_name, version = module.split("@")
-        for dep in get_direct_dependencies(module_name, version, args.registry, buildozer, args.include_dev_deps):
+        for dep in get_direct_dependencies(module_name, version, args.registry, buildozer, args.exclude_dev_deps):
             # It is possible for a MODULE.bazel to contain a bazel_dep with an override that is not in the registry
             if not registry.contains(dep):
                 continue


### PR DESCRIPTION
- Fixed a bug that `direct_deps` wasn't actually returned.
- Added `--exclude-dev-deps` to support calculating without dev dependencies
- Added `--name-only` flag to only print out module names without scores.
- Filtered out potential modules parsed that actually don't exist in BCR. (bazel_dep with override)