### PR TITLE
Allow users to skip the URL stability check themselves

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -1,0 +1,23 @@
+name: comment_bot
+on:
+  issue_comment:
+    types: [created, edited]
+permissions:
+  contents: read
+
+jobs:
+  comment_bot:
+    if: startsWith(github.event.comment.body, '@bazel-io ')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: Run bot
+        uses: bazelbuild/continuous-integration/actions/release-helper@728620684433bc54e4bb77613fa79977ba8da106 # master
+        with:
+          token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/skip_check.yml
+++ b/.github/workflows/skip_check.yml
@@ -1,4 +1,4 @@
-name: comment_bot
+name: skip_check
 on:
   issue_comment:
     types: [created, edited]
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   comment_bot:
-    if: startsWith(github.event.comment.body, '@bazel-io ')
+    if: startsWith(github.event.comment.body, '@bazel-io skip_check ')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -18,6 +18,7 @@ jobs:
           egress-policy: audit
 
       - name: Run bot
-        uses: bazelbuild/continuous-integration/actions/release-helper@728620684433bc54e4bb77613fa79977ba8da106 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@854de5d7871f734a858bf1efa4454e8260e620a0 # master
         with:
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}
+          action_type: skip_check

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -184,7 +184,7 @@ class BcrValidator:
                 + "to ensure the archive checksum stability.\n"
                 + "See https://blog.bazel.build/2023/02/15/github-archive-checksum.html for more context.\n"
                 + "If no release archives are available, please add a comment to your BCR PR with the text\n"
-                + "    @bazel-io unstable_ack\n"
+                + "    @bazel-io skip_check unstable_url\n"
                 + "and this check will be skipped.",
             )
         else:

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -179,10 +179,13 @@ class BcrValidator:
             self.report(
                 BcrValidationResult.FAILED,
                 f"{module_name}@{version} is using an unstable source url: `{source_url}`.\n"
-                + "You should use a release archive URL in the format of "
+                + "If at all possible, you should use a release archive URL in the format of "
                 + "`https://github.com/<ORGANIZATION>/<REPO>/releases/download/<version>/<name>.tar.gz` "
                 + "to ensure the archive checksum stability.\n"
-                + "See https://blog.bazel.build/2023/02/15/github-archive-checksum.html for more context.",
+                + "See https://blog.bazel.build/2023/02/15/github-archive-checksum.html for more context.\n"
+                + "If no release archives are available, please add a comment to your BCR PR with the text\n"
+                + "    @bazel-io unstable_ack\n"
+                + "and this check will be skipped.",
             )
         else:
             self.report(BcrValidationResult.GOOD, "The source URL doesn't look unstable.")


### PR DESCRIPTION
by adding a comment saying `@bazel-io skip_check unstable_url`.