### PR TITLE
Add repository fields to all metadata.json files

### DIFF
--- a/modules/bazel_env.bzl/metadata.json
+++ b/modules/bazel_env.bzl/metadata.json
@@ -7,6 +7,9 @@
             "name": "Fabian Meumertzheim"
         }
     ],
+    "repository": [
+        "github:buildbuddy-io/bazel_env.bzl"
+    ],
     "versions": [
         "0.1.0",
         "0.1.1",

--- a/modules/bzip2/metadata.json
+++ b/modules/bzip2/metadata.json
@@ -6,6 +6,9 @@
       "name": "No Maintainer Specified"
     }
   ],
+  "repository": [
+    "git://sourceware.org/git/bzip2.git"
+  ],
   "versions": [
     "1.0.8",
     "1.0.8.bcr.1"

--- a/modules/darts-clone/metadata.json
+++ b/modules/darts-clone/metadata.json
@@ -6,6 +6,9 @@
             "name": "No Maintainer Specified"
         }
     ],
+    "repository": [
+        "github:s-yata/darts-clone"
+    ],
     "versions": [
         "0.32"
     ],

--- a/modules/nasm/metadata.json
+++ b/modules/nasm/metadata.json
@@ -1,11 +1,14 @@
 {
-    "homepage": "http://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.bz2",
+    "homepage": "http://www.nasm.us/",
     "maintainers": [
         {
             "email": "julian.amann@tum.de",
             "github": "Vertexwahn",
             "name": "Julian Amann"
         }
+    ],
+    "repository": [
+        "github:netwide-assembler/nasm"
     ],
     "versions": [
         "2.14.02"

--- a/modules/rules_cc/metadata.json
+++ b/modules/rules_cc/metadata.json
@@ -7,6 +7,9 @@
             "name": "Ivo Ristovski List"
         }
     ],
+    "repository": [
+        "github:bazelbuild/rules_cc"
+    ],
     "versions": [
         "0.0.1",
         "0.0.2",

--- a/modules/rules_jni/metadata.json
+++ b/modules/rules_jni/metadata.json
@@ -7,6 +7,9 @@
             "name": "Fabian Meumertzheim"
         }
     ],
+    "repository": [
+        "github:fmeum/rules_jni"
+    ],
     "versions": [
         "0.3.1",
         "0.4.0",

--- a/modules/rules_libusb/metadata.json
+++ b/modules/rules_libusb/metadata.json
@@ -18,6 +18,9 @@
             "name": "The Pigweed Team"
         }
     ],
+    "repository": [
+        "https://pigweed.googlesource.com/pigweed/rules_libusb"
+    ],
     "versions": [
         "0.1.0-rc1"
     ],

--- a/modules/rules_sh/metadata.json
+++ b/modules/rules_sh/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/tweag/rules_sh#readme",
+    "homepage": "https://github.com/tweag/rules_sh",
     "maintainers": [
         {
             "email": "claudio.bley@tweag.io",
@@ -11,6 +11,9 @@
             "github": "aherrmann",
             "name": "Andreas Herrmann"
         }
+    ],
+    "repository": [
+        "github:tweag/rules_sh"
     ],
     "versions": [
         "0.2.0",

--- a/modules/sqlite3/metadata.json
+++ b/modules/sqlite3/metadata.json
@@ -7,6 +7,9 @@
             "name": "John Millikin"
         }
     ],
+    "repository": [
+        "github:sqlite/sqlite"
+    ],
     "versions": [
         "3.42.0",
         "3.42.0.bcr.1",

--- a/modules/toolchains_musl/metadata.json
+++ b/modules/toolchains_musl/metadata.json
@@ -12,6 +12,9 @@
             "name": "Fabian Meumertzheim"
         }
     ],
+    "repository": [
+        "github:bazel-contrib/musl-toolchain"
+    ],
     "versions": [
         "0.1.14",
         "0.1.15",


### PR DESCRIPTION
There were ten `metadata.json` files that had no repository set:
```
$ rg homepage -tjson | wc -l
504
$ rg repository -tjson | wc -l
494
```

This PR sets all the missing repositories.