### PR TITLE
feat: Vulkan-Headers 1.1.130-beta1 (it is headers-only library)

### DIFF
--- a/modules/vulkan_headers/1.1.130-beta1/MODULE.bazel
+++ b/modules/vulkan_headers/1.1.130-beta1/MODULE.bazel
@@ -1,0 +1,10 @@
+"""VulkanSceneGraph"""
+
+module(
+    name = "vulkan_headers",
+    version = "1.1.130-beta1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.13")

--- a/modules/vulkan_headers/1.1.130-beta1/overlay/BUILD.bazel
+++ b/modules/vulkan_headers/1.1.130-beta1/overlay/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Vulkan-Headers library
+cc_library(
+    name = "vulkan_headers",
+    hdrs = glob([
+        "include/vulkan/**",
+    ]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)
+
+# Vulkan-Registry library
+cc_library(
+    name = "vulkan_registry",
+    data = glob([
+        "registry/**",
+    ]),
+    includes = ["registry"],
+    visibility = ["//visibility:public"],
+)

--- a/modules/vulkan_headers/1.1.130-beta1/overlay/MODULE.bazel
+++ b/modules/vulkan_headers/1.1.130-beta1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/vulkan_headers/1.1.130-beta1/presubmit.yml
+++ b/modules/vulkan_headers/1.1.130-beta1/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel:
+    - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@vulkan_headers//:vulkan_headers"
+      - "@vulkan_headers//:vulkan_registry"

--- a/modules/vulkan_headers/1.1.130-beta1/source.json
+++ b/modules/vulkan_headers/1.1.130-beta1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.1.130.tar.gz",
+    "integrity": "sha256-gwDo3csksCDyEQey8knBQj2IYYe26QnBH0/eY8rNjaQ=",
+    "strip_prefix": "Vulkan-Headers-1.1.130",
+    "overlay": {
+        "BUILD.bazel": "sha256-/r5Sp/LQZ3sil71eGVSa2LH50DCeUwv9vfgwyidVTgk=",
+        "MODULE.bazel": "sha256-fjwhLrNSxHLJdxAGoXgMwM+uHtku0vi7xE1AhzENZdw="
+    },
+    "patch_strip": 0
+}

--- a/modules/vulkan_headers/metadata.json
+++ b/modules/vulkan_headers/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/KhronosGroup/Vulkan-Headers",
+    "maintainers": [
+        {
+            "email": "artemis.korolevski@gmail.com",
+            "github": "artem-korolev",
+            "name": "Artem Korolev"
+        }
+    ],
+    "repository": [
+        "github:KhronosGroup/Vulkan-Headers"
+    ],
+    "versions": [
+        "1.1.130-beta1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Dear BCR team. My second pull request :)
Give ma a tip please. This is headers-only library and it is potentially platform-agnostic. Does not require build at all (only bundling and configuring includes).
Currently I specified in matrix.platforms huge list. As I understand this is needed to just check it on every possible platform. But what is best practice for such libraries? Maybe it is just too much to specify so many platforms and enough to have only one?