### PR TITLE
Add rules_perl@0.2.4

### DIFF
--- a/modules/rules_perl/0.2.4/MODULE.bazel
+++ b/modules/rules_perl/0.2.4/MODULE.bazel
@@ -1,0 +1,30 @@
+"""
+Perl rules
+"""
+
+module(
+    name = "rules_perl",
+    version = "0.2.4",
+)
+
+bazel_dep(name = "platforms", version = "0.0.6")
+bazel_dep(name = "bazel_skylib", version = "1.4.2")
+bazel_dep(name = "rules_cc", version = "0.0.8")
+
+repos = use_extension("@rules_perl//perl:extensions.bzl", "perl_repositories")
+use_repo(
+    repos,
+    "perl_darwin_amd64",
+    "perl_darwin_arm64",
+    "perl_linux_amd64",
+    "perl_linux_arm64",
+    "perl_windows_x86_64",
+)
+
+register_toolchains(
+    "@rules_perl//perl:perl_darwin_arm64_toolchain",
+    "@rules_perl//perl:perl_darwin_amd64_toolchain",
+    "@rules_perl//perl:perl_linux_amd64_toolchain",
+    "@rules_perl//perl:perl_linux_arm64_toolchain",
+    "@rules_perl//perl:perl_windows_x86_64_toolchain",
+)

--- a/modules/rules_perl/0.2.4/patches/module_dot_bazel_version.patch
+++ b/modules/rules_perl/0.2.4/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+diff --git MODULE.bazel MODULE.bazel
+index 9b9d232..d45f15c 100644
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -4,7 +4,7 @@ Perl rules
+ 
+ module(
+     name = "rules_perl",
+-    version = "0.1.0",
++    version = "0.2.4",
+ )
+ 
+ bazel_dep(name = "platforms", version = "0.0.6")

--- a/modules/rules_perl/0.2.4/presubmit.yml
+++ b/modules/rules_perl/0.2.4/presubmit.yml
@@ -1,0 +1,24 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+matrix:
+  platform: ["debian11", "macos", "ubuntu2004"]
+  bazel: [6.x, 7.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+    - '@rules_perl//test/...'

--- a/modules/rules_perl/0.2.4/presubmit.yml
+++ b/modules/rules_perl/0.2.4/presubmit.yml
@@ -14,7 +14,7 @@
 
 matrix:
   platform: ["debian11", "macos", "ubuntu2004"]
-  bazel: [6.x, 7.x]
+  bazel: [6.x, 7.x, 8.0.0rc2]
 tasks:
   verify_targets:
     name: Verify build targets

--- a/modules/rules_perl/0.2.4/source.json
+++ b/modules/rules_perl/0.2.4/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-vHVQ84gfYyVaZcbex86Dw14K5I17mqfm6SN7BnM8v/g=",
+    "strip_prefix": "rules_perl-0.2.4",
+    "url": "https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.2.4.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-pNzMxPUBCZaEvGJNW2eZR8X8UoF/pAYzrn/OC7/Fbmg="
+    },
+    "patch_strip": 0
+}

--- a/modules/rules_perl/metadata.json
+++ b/modules/rules_perl/metadata.json
@@ -11,6 +11,7 @@
         }
     ],
     "repository": [
+        "github:bazelbuild/rules_perl",
         "github:bazel-contrib/rules_perl"
     ],
     "versions": [

--- a/modules/rules_perl/metadata.json
+++ b/modules/rules_perl/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/bazelbuild/rules_perl",
+    "homepage": "https://github.com/bazel-contrib/rules_perl",
     "maintainers": [
         {
             "github": "mortenmj",
@@ -11,10 +11,11 @@
         }
     ],
     "repository": [
-        "github:bazelbuild/rules_perl"
+        "github:bazel-contrib/rules_perl"
     ],
     "versions": [
         "0.2.0",
-        "0.2.3.bcr.1"
+        "0.2.3.bcr.1",
+        "0.2.4"
     ]
 }


### PR DESCRIPTION
Add https://github.com/bazel-contrib/rules_perl/releases/tag/0.2.4

Also updates the source url, as rules_perl was moved from bazelbuild to bazel-contrib

Work towards https://github.com/bazelbuild/bazel-central-registry/issues/3056

Vis @skeletonkey

Needs `skip-url-stability-check` label