### PR TITLE
openssh: fix include of crypt.h in libssh

### DIFF
--- a/modules/libxcrypt/4.4.36/overlay/BUILD.bazel
+++ b/modules/libxcrypt/4.4.36/overlay/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 expand_template(
     name = "header",
@@ -48,5 +49,13 @@ genrule(
 alias(
     name = "libxcrypt",
     actual = "//lib",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "crypt_interface",
+    hdrs = [":crypt.h"],
+    includes = ["."],
+    local_defines = ["HAVE_CONFIG_H"],
     visibility = ["//visibility:public"],
 )

--- a/modules/libxcrypt/4.4.36/source.json
+++ b/modules/libxcrypt/4.4.36/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-5eH0yu4KAd4q7ibjE4gH1tPKK45nKHlm0f79ZeH9iUM=",
     "strip_prefix": "libxcrypt-4.4.36",
     "overlay": {
-        "BUILD.bazel": "sha256-IXtwkDbAL4vAqF3I46VlzXFVL6o0UTA0KOZvSWxgn3I=",
+        "BUILD.bazel": "sha256-HfEh363te4GctQ7mnanYgFib6wzsUisc+QQNPmvX01I=",
         "config/amd64-linux.h": "sha256-hJYeQbUnimANY8ZwUzSnuq0gm4Jf5ds7Ba+DpeFOxL8=",
         "config/arm64-linux.h": "sha256-hJYeQbUnimANY8ZwUzSnuq0gm4Jf5ds7Ba+DpeFOxL8=",
         "config/BUILD.bazel": "sha256-43dsykMdU03ffihnxaQOZqgLAEHZc7VOFw6/u0bJrng=",

--- a/modules/openssh/9.9p1/overlay/BUILD.bazel
+++ b/modules/openssh/9.9p1/overlay/BUILD.bazel
@@ -318,6 +318,7 @@ cc_library(
     textual_hdrs = ["umac.c"],
     deps = [
         "@boringssl//:crypto",
+        "@libxcrypt//:crypt_interface",
         "@zlib",
     ],
 )

--- a/modules/openssh/9.9p1/source.json
+++ b/modules/openssh/9.9p1/source.json
@@ -7,7 +7,7 @@
     },
     "patch_strip": 1,
     "overlay": {
-        "BUILD.bazel": "sha256-i7s2gvhplko+6PplHgKInQXQyyDVq5R/pn209gdevrg=",
+        "BUILD.bazel": "sha256-BRE0UFsaF0MNJY8tMY1YrWpcu6z6b683B3tvfNTjekA=",
         "config/amd64-linux.h": "sha256-Qn/DKF97jQeZW4q1hUd0sYQn3DqyPafgOtB1kUJr3eI=",
         "config/arm64-linux.h": "sha256-Qn/DKF97jQeZW4q1hUd0sYQn3DqyPafgOtB1kUJr3eI=",
         "config/BUILD.bazel": "sha256-RgmVM13cTg/VECz6esb6oXPjW76L9s2ySQuRNM4GoRQ=",


### PR DESCRIPTION
Fixes the following issue when building `@openssh//:ssh`:

```
$ bazel build @openssh//:ssh
INFO: Invocation ID: fa33e329-b8ee-4aa7-96ce-c01cb8d08946
INFO: Analyzed target @@openssh~//:ssh (249 packages loaded, 7004 targets configured).
ERROR: /home/malte/.cache/bazel/_bazel_malte/211e25d6bb03968e22a3b023ac8798ca/external/openssh~/BUILD.bazel:12:11: Compiling openbsd-compat/xcrypt.c failed: (Exit 1): gcc failed: error executing CppCompile command (from target @@openssh~//:openssh-portable) external/gcc~/usr/bin/gcc @bazel-out/k8-fastbuild/bin/external/openssh~/_objs/openssh-portable/xcrypt.pic.o.params
Action details (uncached result): REDACTED
external/openssh~/openbsd-compat/xcrypt.c:33:12: fatal error: crypt.h: No such file or directory
   33 | #  include <crypt.h>
      |            ^~~~~~~~~
compilation terminated.
Target @@openssh~//:ssh failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 3.723s, Critical Path: 1.41s
INFO: 23 processes: 20 remote cache hit, 3 internal.
ERROR: Build did NOT complete successfully
```

We are not sure if it is okay to fix an existing version in this way.
If not, we are happy to instead add new versions of `libxcrypt` and `openssh` with a `.bcr.1` suffix.