### PR TITLE
rules_python@0.39.0, rules_python_gazelle_plugin@0.39.0

### DIFF
--- a/modules/rules_python/0.39.0/MODULE.bazel
+++ b/modules/rules_python/0.39.0/MODULE.bazel
@@ -1,0 +1,186 @@
+module(
+    name = "rules_python",
+    version = "0.39.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_features", version = "1.9.1")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_cc", version = "0.0.14")
+bazel_dep(name = "platforms", version = "0.0.4")
+
+# Those are loaded only when using py_proto_library
+bazel_dep(name = "rules_proto", version = "6.0.2")
+bazel_dep(name = "protobuf", version = "29.0-rc2", repo_name = "com_google_protobuf")
+
+internal_deps = use_extension("//python/private:internal_deps.bzl", "internal_deps")
+use_repo(
+    internal_deps,
+    "pypi__build",
+    "pypi__click",
+    "pypi__colorama",
+    "pypi__importlib_metadata",
+    "pypi__installer",
+    "pypi__more_itertools",
+    "pypi__packaging",
+    "pypi__pep517",
+    "pypi__pip",
+    "pypi__pip_tools",
+    "pypi__pyproject_hooks",
+    "pypi__setuptools",
+    "pypi__tomli",
+    "pypi__wheel",
+    "pypi__zipp",
+    "rules_python_internal",
+)
+
+# We need to do another use_extension call to expose the "pythons_hub"
+# repo.
+python = use_extension("//python/extensions:python.bzl", "python")
+
+# The default toolchain to use if nobody configures a toolchain.
+# NOTE: This is not a stable version. It is provided for convenience, but will
+# change frequently to track the most recent Python version.
+# NOTE: The root module can override this.
+python.toolchain(
+    is_default = True,
+    python_version = "3.11",
+)
+use_repo(python, "python_3_11", "python_versions", "pythons_hub")
+
+# This call registers the Python toolchains.
+register_toolchains("@pythons_hub//:all")
+
+#####################
+# Install twine for our own runfiles wheel publishing and allow bzlmod users to use it.
+
+pip = use_extension("//python/private/pypi:pip.bzl", "pip_internal")
+pip.parse(
+    # NOTE @aignas 2024-10-26: We have an integration test that depends on us
+    # being able to build sdists for this hub, so explicitly set this to False.
+    download_only = False,
+    experimental_index_url = "https://pypi.org/simple",
+    hub_name = "rules_python_publish_deps",
+    python_version = "3.11",
+    requirements_by_platform = {
+        "//tools/publish:requirements_darwin.txt": "osx_*",
+        "//tools/publish:requirements_linux.txt": "linux_*",
+        "//tools/publish:requirements_windows.txt": "windows_*",
+    },
+)
+use_repo(pip, "rules_python_publish_deps")
+
+# Not a dev dependency to allow usage of //sphinxdocs code, which refers to stardoc repos.
+bazel_dep(name = "stardoc", version = "0.7.1", repo_name = "io_bazel_stardoc")
+
+# ===== DEV ONLY DEPS AND SETUP BELOW HERE =====
+bazel_dep(name = "rules_bazel_integration_test", version = "0.26.1", dev_dependency = True)
+bazel_dep(name = "rules_testing", version = "0.6.0", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.3.0", dev_dependency = True)
+bazel_dep(name = "rules_multirun", version = "0.9.0", dev_dependency = True)
+bazel_dep(name = "bazel_ci_rules", version = "1.0.0", dev_dependency = True)
+
+# Extra gazelle plugin deps so that WORKSPACE.bzlmod can continue including it for e2e tests.
+# We use `WORKSPACE.bzlmod` because it is impossible to have dev-only local overrides.
+bazel_dep(name = "rules_go", version = "0.41.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_python_gazelle_plugin", version = "0", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.33.0", dev_dependency = True, repo_name = "bazel_gazelle")
+single_version_override(
+    module_name = "gazelle",
+    patch_strip = 1,
+    patches = [
+        # Can be removed once https://github.com/bazel-contrib/bazel-gazelle/issues/1959
+        # is fixed and released.
+        "patches/gazelle_native_sh.patch",
+    ],
+    version = "0.33.0",
+)
+
+internal_dev_deps = use_extension(
+    "//python/private:internal_dev_deps.bzl",
+    "internal_dev_deps",
+    dev_dependency = True,
+)
+use_repo(internal_dev_deps, "buildkite_config", "wheel_for_testing")
+
+# Add gazelle plugin so that we can run the gazelle example as an e2e integration
+# test and include the distribution files.
+local_path_override(
+    module_name = "rules_python_gazelle_plugin",
+    path = "gazelle",
+)
+
+dev_python = use_extension(
+    "//python/extensions:python.bzl",
+    "python",
+    dev_dependency = True,
+)
+dev_python.override(
+    register_all_versions = True,
+)
+
+dev_pip = use_extension(
+    "//python/extensions:pip.bzl",
+    "pip",
+    dev_dependency = True,
+)
+dev_pip.parse(
+    download_only = True,
+    experimental_index_url = "https://pypi.org/simple",
+    hub_name = "dev_pip",
+    python_version = "3.11",
+    requirements_lock = "//docs:requirements.txt",
+)
+dev_pip.parse(
+    download_only = True,
+    experimental_index_url = "https://pypi.org/simple",
+    hub_name = "pypiserver",
+    python_version = "3.11",
+    requirements_lock = "//examples/wheel:requirements_server.txt",
+)
+use_repo(dev_pip, "dev_pip", "pypiserver")
+
+# Bazel integration test setup below
+
+bazel_binaries = use_extension(
+    "@rules_bazel_integration_test//:extensions.bzl",
+    "bazel_binaries",
+    dev_dependency = True,
+)
+
+# Keep in sync with //:version.bzl
+bazel_binaries.local(
+    name = "self",
+    path = "tests/integration/bazel_from_env",
+)
+bazel_binaries.download(version = "6.4.0")
+bazel_binaries.download(version = "7.4.0")
+
+# For now, don't test with rolling, because that's Bazel 9, which is a ways
+# away.
+# bazel_binaries.download(version = "rolling")
+use_repo(
+    bazel_binaries,
+    "bazel_binaries",
+    # These don't appear necessary, but are reported as direct dependencies
+    # that should be use_repo()'d, so we add them as requested
+    "bazel_binaries_bazelisk",
+    "build_bazel_bazel_6_4_0",
+    "build_bazel_bazel_7_4_0",
+    # "build_bazel_bazel_rolling",
+    "build_bazel_bazel_self",
+)
+
+# EXPERIMENTAL: This is experimental and may be removed without notice
+uv = use_extension(
+    "//python/uv:extensions.bzl",
+    "uv",
+    dev_dependency = True,
+)
+uv.toolchain(uv_version = "0.4.25")
+use_repo(uv, "uv_toolchains")
+
+register_toolchains(
+    "@uv_toolchains//:all",
+    dev_dependency = True,
+)

--- a/modules/rules_python/0.39.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_python/0.39.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_python",
+-    version = "0.0.0",
++    version = "0.39.0",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "bazel_features", version = "1.9.1")

--- a/modules/rules_python/0.39.0/presubmit.yml
+++ b/modules/rules_python/0.39.0/presubmit.yml
@@ -16,8 +16,7 @@ bcr_test_module:
   module_path: "examples/bzlmod"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004", "windows"]
-    # last_rc for latest 8.x release
-    bazel: [7.x, last_rc]
+    bazel: [7.x]
   tasks:
     run_tests:
       name: "Run test module"

--- a/modules/rules_python/0.39.0/presubmit.yml
+++ b/modules/rules_python/0.39.0/presubmit.yml
@@ -1,0 +1,32 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bcr_test_module:
+  module_path: "examples/bzlmod"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2004", "windows"]
+    # last_rc for latest 8.x release
+    bazel: [7.x, last_rc]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_flags:
+        - "--keep_going"
+          # Without these cxxopts, BCR's Mac builds fail
+        - '--cxxopt=-std=c++14'
+        - '--host_cxxopt=-std=c++14'
+      test_targets:
+        - "//..."

--- a/modules/rules_python/0.39.0/source.json
+++ b/modules/rules_python/0.39.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-Yt3rt2a01t3xcS91PaxXQL6gcmRvYw65mCyqCa2Kdoc=",
+    "strip_prefix": "rules_python-0.39.0",
+    "url": "https://github.com/bazelbuild/rules_python/releases/download/0.39.0/rules_python-0.39.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-emjReARPusMhC+p8j02uJGBATCdRA98zdd0WOgD/BTg="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_python/metadata.json
+++ b/modules/rules_python/metadata.json
@@ -7,11 +7,6 @@
             "github": "rickeylev"
         },
         {
-            "name": "Thulio Ferraz Assis",
-            "email": "thulio@aspect.dev",
-            "github": "f0rmiga"
-        },
-        {
             "name": "Ignas Anikevicius",
             "email": "bcr-ignas@use.startmail.com",
             "github": "aignas"
@@ -60,7 +55,8 @@
         "0.37.0",
         "0.37.1",
         "0.37.2",
-        "0.38.0"
+        "0.38.0",
+        "0.39.0"
     ],
     "yanked_versions": {
         "0.14.0": "rules_python 0.14.0 is broken due to https://github.com/bazelbuild/bazel-central-registry/issues/287, please upgrade to version >= 0.15.0"

--- a/modules/rules_python_gazelle_plugin/0.39.0/MODULE.bazel
+++ b/modules/rules_python_gazelle_plugin/0.39.0/MODULE.bazel
@@ -1,0 +1,35 @@
+module(
+    name = "rules_python_gazelle_plugin",
+    version = "0.39.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
+bazel_dep(name = "rules_python", version = "0.18.0")
+bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.33.0", repo_name = "bazel_gazelle")
+
+local_path_override(
+    module_name = "rules_python",
+    path = "..",
+)
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bazelbuild_buildtools",
+    "com_github_bmatcuk_doublestar_v4",
+    "com_github_emirpasic_gods",
+    "com_github_ghodss_yaml",
+    "com_github_smacker_go_tree_sitter",
+    "com_github_stretchr_testify",
+    "in_gopkg_yaml_v2",
+    "org_golang_x_sync",
+)
+
+python_stdlib_list = use_extension("//python:extensions.bzl", "python_stdlib_list")
+use_repo(
+    python_stdlib_list,
+    "python_stdlib_list",
+)

--- a/modules/rules_python_gazelle_plugin/0.39.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_python_gazelle_plugin/0.39.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_python_gazelle_plugin",
+-    version = "0.0.0",
++    version = "0.39.0",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.6.1")

--- a/modules/rules_python_gazelle_plugin/0.39.0/presubmit.yml
+++ b/modules/rules_python_gazelle_plugin/0.39.0/presubmit.yml
@@ -16,8 +16,7 @@ bcr_test_module:
   module_path: "../examples/bzlmod_build_file_generation"
   matrix:
     platform: ["debian11", "macos", "ubuntu2004", "windows"]
-    # last_rc for latest 8.x release
-    bazel: [7.x, last_rc]
+    bazel: [7.x]
   tasks:
     run_tests:
       name: "Run test module"

--- a/modules/rules_python_gazelle_plugin/0.39.0/presubmit.yml
+++ b/modules/rules_python_gazelle_plugin/0.39.0/presubmit.yml
@@ -1,0 +1,30 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bcr_test_module:
+  module_path: "../examples/bzlmod_build_file_generation"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2004", "windows"]
+    # last_rc for latest 8.x release
+    bazel: [7.x, last_rc]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."
+        - ":modules_map"
+      test_targets:
+        - "//..."

--- a/modules/rules_python_gazelle_plugin/0.39.0/source.json
+++ b/modules/rules_python_gazelle_plugin/0.39.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-Yt3rt2a01t3xcS91PaxXQL6gcmRvYw65mCyqCa2Kdoc=",
+    "strip_prefix": "rules_python-0.39.0/gazelle",
+    "url": "https://github.com/bazelbuild/rules_python/releases/download/0.39.0/rules_python-0.39.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-lbD9OnqTzJnqdLrADmY/3Ut3YvtIjFxHUWy1b83hDrM="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_python_gazelle_plugin/metadata.json
+++ b/modules/rules_python_gazelle_plugin/metadata.json
@@ -7,9 +7,9 @@
             "github": "rickeylev"
         },
         {
-            "name": "Thulio Ferraz Assis",
-            "email": "thulio@aspect.dev",
-            "github": "f0rmiga"
+            "name": "Ignas Anikevicius",
+            "email": "bcr-ignas@use.startmail.com",
+            "github": "aignas"
         }
     ],
     "repository": [
@@ -38,7 +38,8 @@
         "0.37.0",
         "0.37.1",
         "0.37.2",
-        "0.38.0"
+        "0.38.0",
+        "0.39.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
BCR config for rules_python and rules_python_gazelle_plugin 0.39.0 

This is https://github.com/bazelbuild/bazel-central-registry/pull/3171, but with
presubmit changes to remove Bazel 6 from the test matrix.