### PR TITLE
Add default visibility public for universal_robots_client_library.

### DIFF
--- a/modules/universal-robots-client-library/1.4.0.bcr.1/MODULE.bazel
+++ b/modules/universal-robots-client-library/1.4.0.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "universal-robots-client-library",
+    version = "1.4.0.bcr.1",
+    compatibility_level = 1,
+)
+
+# Most recent version from https://registry.bazel.build/modules/googletest
+bazel_dep(name = "googletest", version = "1.15.2")
+bazel_dep(name = "rules_license", version = "0.0.8")

--- a/modules/universal-robots-client-library/1.4.0.bcr.1/patches/add_build_file.patch
+++ b/modules/universal-robots-client-library/1.4.0.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,407 @@
+diff --git a/BUILD b/1.4.0/BUILD
+new file mode 100644
+index 00000000..8a192238
+--- /dev/null
++++ b/BUILD
+@@ -0,0 +1,401 @@
++load("@rules_license//rules:license.bzl", "license")
++
++package(
++    default_applicable_licenses = [":license", ":license_bsd", ":license_zlib"],
++    default_visibility = ["//visibility:public"],
++)
++
++exports_files([
++    "LICENSE_apache_2_0",
++    "include/ur_client_library/queue/LICENSE.md",
++    "include/ur_client_library/queue/atomicops.h",
++])
++
++license(
++    name = "license",
++    package_name = "universal-robots-client-library",
++    license_kinds = [
++        "@rules_license//licenses/spdx:Apache-2.0",
++    ],
++    license_text = "LICENSE_apache_2_0",
++)
++
++license(
++    name = "license_bsd",
++    package_name = "universal-robots-client-library",
++    license_kinds = [
++        "@rules_license//licenses/spdx:BSD-2-Clause",
++    ],
++    license_text = "include/ur_client_library/queue/LICENSE.md",
++)
++
++license(
++    name = "license_zlib",
++    package_name = "universal-robots-client-library",
++    license_kinds = [
++        "@rules_license//licenses/spdx:Zlib",
++    ],
++    license_text = "include/ur_client_library/queue/atomicops.h",
++)
++
++filegroup(
++    name = "rtde_files",
++    srcs = [
++        "examples/resources/rtde_input_recipe.txt",
++        "examples/resources/rtde_output_recipe.txt",
++        "resources/external_control.urscript",
++    ],
++)
++
++DEFAULT_OPTIONS = ["-fexceptions"]
++
++PEDANTIC_OPTIONS = [
++    "-fexceptions",
++    "-Wall",
++    "-pedantic",
++]
++
++cc_library(
++    name = "ur_client_library",
++    srcs = glob(
++        [
++            "src/**/*.cpp",
++        ],
++    ),
++    hdrs = glob(
++        [
++            "include/**/*.h",
++        ],
++        exclude = [],
++    ),
++    copts = PEDANTIC_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    includes = ["include"],
++)
++
++cc_binary(
++    name = "full_driver",
++    srcs = [
++        "examples/full_driver.cpp",
++    ],
++    copts = PEDANTIC_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++    ],
++)
++
++cc_binary(
++    name = "primary_pipeline",
++    srcs = [
++        "examples/primary_pipeline.cpp",
++    ],
++    copts = PEDANTIC_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++    ],
++)
++
++cc_binary(
++    name = "primary_pipeline_calibration",
++    srcs = [
++        "examples/primary_pipeline_calibration.cpp",
++    ],
++    copts = PEDANTIC_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++    ],
++)
++
++cc_binary(
++    name = "rtde_client",
++    srcs = [
++        "examples/rtde_client.cpp",
++    ],
++    copts = PEDANTIC_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++    ],
++)
++
++cc_binary(
++    name = "dashboard_example",
++    srcs = [
++        "examples/dashboard_example.cpp",
++    ],
++    copts = PEDANTIC_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++    ],
++)
++
++cc_test(
++    name = "test_bin_parser",
++    srcs = ["tests/test_bin_parser.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_package_serializer",
++    srcs = ["tests/test_package_serializer.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_primary_parser",
++    srcs = ["tests/test_primary_parser.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_rtde_control_package_pause",
++    srcs = ["tests/test_rtde_control_package_pause.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_rtde_control_package_setup_inputs",
++    srcs = ["tests/test_rtde_control_package_setup_inputs.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_rtde_control_package_setup_outputs",
++    srcs = ["tests/test_rtde_control_package_setup_outputs.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_rtde_control_package_start",
++    srcs = ["tests/test_rtde_control_package_start.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_rtde_data_package",
++    srcs = ["tests/test_rtde_data_package.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_rtde_get_urcontrol_version",
++    srcs = ["tests/test_rtde_get_urcontrol_version.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_rtde_parser",
++    srcs = ["tests/test_rtde_parser.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_rtde_request_protocol_version",
++    srcs = ["tests/test_rtde_request_protocol_version.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    tags = [
++        "requires-net:ipv4",
++        "requires-net:loopback",
++    ],
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_rtde_writer",
++    srcs = ["tests/test_rtde_writer.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    tags = [
++        "notsan",
++        "requires-net:ipv4",
++        "requires-net:loopback",
++    ],
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_script_sender",
++    srcs = ["tests/test_script_sender.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    tags = [
++        "requires-net:ipv4",
++        "requires-net:loopback",
++    ],
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_stream",
++    srcs = ["tests/test_stream.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    tags = [
++        "notsan",
++        "requires-net:ipv4",
++        "requires-net:loopback",
++    ],
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_tcp_server",
++    srcs = ["tests/test_tcp_server.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    tags = [
++        "notsan",
++        "requires-net:ipv4",
++        "requires-net:loopback",
++    ],
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_tcp_socket",
++    srcs = ["tests/test_tcp_socket.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    tags = [
++        "notsan",
++        "requires-net:ipv4",
++        "requires-net:loopback",
++    ],
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_trajectory_point_interface",
++    srcs = ["tests/test_trajectory_point_interface.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    tags = [
++        "notsan",
++        "requires-net:ipv4",
++        "requires-net:loopback",
++    ],
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)
++
++cc_test(
++    name = "test_version_information",
++    srcs = ["tests/test_version_information.cpp"],
++    copts =
++        DEFAULT_OPTIONS,
++    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
++    deps = [
++        ":ur_client_library",
++        "@googletest//:gtest",
++        "@googletest//:gtest_main",
++    ],
++)

--- a/modules/universal-robots-client-library/1.4.0.bcr.1/patches/add_module_file.patch
+++ b/modules/universal-robots-client-library/1.4.0.bcr.1/patches/add_module_file.patch
@@ -1,0 +1,15 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 00000000..32fbd345
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -0,0 +1,9 @@
++module(
++    name = "universal-robots-client-library",
++    version = "1.4.0.bcr.1",
++    compatibility_level = 1,
++)
++
++# Most recent version from https://registry.bazel.build/modules/googletest
++bazel_dep(name = "googletest", version = "1.15.2")
++bazel_dep(name = "rules_license", version = "0.0.8")

--- a/modules/universal-robots-client-library/1.4.0.bcr.1/presubmit.yml
+++ b/modules/universal-robots-client-library/1.4.0.bcr.1/presubmit.yml
@@ -1,0 +1,27 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  bazel:
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    - "--copt=-pthread"
+    - "--linkopt=-pthread"
+    test_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    - "--copt=-pthread"
+    - "--linkopt=-pthread"
+    build_targets:
+    - '@universal-robots-client-library//:*'
+    test_targets:
+    - '@universal-robots-client-library//:test_bin_parser'
+    - '@universal-robots-client-library//:test_primary_parser'

--- a/modules/universal-robots-client-library/1.4.0.bcr.1/source.json
+++ b/modules/universal-robots-client-library/1.4.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/UniversalRobots/Universal_Robots_Client_Library/archive/refs/tags/1.4.0.tar.gz",
+    "integrity": "sha256-MwDLEXMBpidJEpsO47k/wzaHGFxOs5n0g/To3o1PnNs=",
+    "strip_prefix": "Universal_Robots_Client_Library-1.4.0",
+    "patch_strip": 1,
+    "patches": {
+        "add_build_file.patch": "sha256-fCil/zaqY/C8+NIER4Ch8Igk+puyZN/Z6R+6I9d8DRU=",
+        "add_module_file.patch": "sha256-mXTRx3uqHT+jeT+Pg/FeL833OjzkIo+zEQHbScVc4GI="
+    }
+}

--- a/modules/universal-robots-client-library/metadata.json
+++ b/modules/universal-robots-client-library/metadata.json
@@ -11,7 +11,8 @@
         "github:UniversalRobots/Universal_Robots_Client_Library"
     ],
     "versions": [
-        "1.4.0"
+        "1.4.0",
+        "1.4.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
I forgot the visibility spec in https://github.com/bazelbuild/bazel-central-registry/pull/3229.

@bazel-io skip_check unstable_url upstream doesn't publish stable release.