### PR TITLE
Updated rules_req_compile repository location

### DIFF
--- a/modules/rules_req_compile/1.0.0rc29/source.json
+++ b/modules/rules_req_compile/1.0.0rc29/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-fBIS45z4WqiciHx766tvGy664CSkLKLj1wfgBGzWWmA=",
     "strip_prefix": "",
-    "url": "https://github.com/sputt/req-compile/releases/download/1.0.0rc29/rules_req_compile-1.0.0rc29.tar.gz"
+    "url": "https://github.com/periareon/req-compile/releases/download/1.0.0rc29/rules_req_compile-1.0.0rc29.tar.gz"
 }

--- a/modules/rules_req_compile/metadata.json
+++ b/modules/rules_req_compile/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/sputt/req-compile",
+    "homepage": "https://github.com/periareon/req-compile",
     "maintainers": [
         {
             "name": "Spencer Putt",
@@ -13,7 +13,7 @@
         }
     ],
     "repository": [
-        "github:sputt/req-compile"
+        "github:periareon/req-compile"
     ],
     "versions": [
         "1.0.0rc29"


### PR DESCRIPTION
Addresses the `rules_req_compile` issue on https://github.com/bazelbuild/bazel-central-registry/issues/3260