### PR TITLE
[rules_pkl] Add Kushal and Romain as maintainers

### DIFF
--- a/modules/rules_pkl/metadata.json
+++ b/modules/rules_pkl/metadata.json
@@ -11,6 +11,16 @@
         "name": "Philip K.F. Hölzenspies"
       },
       {
+        "email": "romainchossart@gmail.com",
+        "github": "sitaktif",
+        "name": "Romain Chossart"
+      },
+      {
+        "email": "",
+        "github": "KushalP",
+        "name": "Kushal Pisavadia"
+      },
+      {
         "email": "simon.m.stewart@gmail.com",
         "github": "shs96c",
         "name": "Simon Mavi Stewart"


### PR DESCRIPTION
Leaving Phil as the first maintainer, and then ordering the remaining names by their surnames.