### PR TITLE
rules_android 0.6.0-alpha1.bcr.1

### DIFF
--- a/modules/rules_android/0.6.0-alpha1.bcr.1/MODULE.bazel
+++ b/modules/rules_android/0.6.0-alpha1.bcr.1/MODULE.bazel
@@ -1,0 +1,176 @@
+module(
+    name = "rules_android",
+    version = "0.6.0-alpha1.bcr.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.5")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_java", version = "8.5.1")
+bazel_dep(name = "rules_shell", version = "0.1.2")
+
+bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True)
+
+rules_java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
+use_repo(rules_java_toolchains, "remote_java_tools")
+
+bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_jvm_external", version = "6.6")
+bazel_dep(name = "bazel_skylib", version = "1.0.3")
+bazel_dep(name = "rules_robolectric", version = "4.14.1", repo_name = "robolectric")
+
+# To include PR #123
+git_override(
+    module_name = "rules_robolectric",
+    commit = "f38b7365361f382ecdad255af69b37413dd48ead",
+    remote = "https://github.com/robolectric/robolectric-bazel",
+)
+
+register_toolchains("//toolchains/android:all")
+
+register_toolchains("//toolchains/android_sdk:all")
+
+# go-related dependency setup
+bazel_dep(name = "rules_go", version = "0.51.0-rc2", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.40.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "abseil-py", version = "2.1.0", repo_name = "py_absl")
+bazel_dep(name = "bazel_worker_api", version = "0.0.4")
+bazel_dep(name = "bazel_worker_java", version = "0.0.4")
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.22.4")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_golang_glog",
+    "com_github_google_go_cmp",
+    "org_bitbucket_creachadair_stringset",
+    "org_golang_google_protobuf",
+    "org_golang_x_sync",
+)
+
+# python-related dependency setup
+bazel_dep(name = "rules_python", version = "0.37.1", repo_name = "rules_python")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    is_default = True,
+    python_version = "3.11",
+)
+
+# proto-related dependency setup
+bazel_dep(name = "rules_proto", version = "6.0.2", repo_name = "rules_proto")
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.install(
+    name = "rules_android_maven",
+    aar_import_bzl_label = "@rules_android//rules:rules.bzl",
+    artifacts = [
+        "androidx.privacysandbox.tools:tools:1.0.0-alpha06",
+        "androidx.privacysandbox.tools:tools-apigenerator:1.0.0-alpha06",
+        "androidx.privacysandbox.tools:tools-apipackager:1.0.0-alpha06",
+        "androidx.test:core:1.6.0-alpha01",
+        "androidx.test.ext:junit:1.2.0-alpha01",
+        "com.android.tools.apkdeployer:apkdeployer:8.8.0-alpha05",
+        "org.gradle:gradle-core:4.2.1",
+        "com.android.tools.build:bundletool:1.15.5",
+        "com.android.tools:desugar_jdk_libs_minimal:2.0.4",
+        "com.android.tools:desugar_jdk_libs_configuration_minimal:2.0.4",
+        "com.android.tools:desugar_jdk_libs_nio:2.0.4",
+        "com.android.tools:desugar_jdk_libs_configuration_nio:2.0.4",
+        "com.android.tools.build:gradle:8.7.0",
+        "com.android.tools:r8:8.5.35",
+        "org.bouncycastle:bcprov-jdk18on:1.77",
+        "org.hamcrest:hamcrest-core:2.2",
+        "org.robolectric:robolectric:4.14.1",
+        "com.google.flogger:flogger:0.8",
+        "com.google.guava:guava:32.1.2-jre",
+        "com.google.truth:truth:1.1.5",
+        "info.picocli:picocli:4.7.4",
+        "jakarta.inject:jakarta.inject-api:2.0.1",
+        "junit:junit:4.13.2",
+        "com.beust:jcommander:1.82",
+        "com.google.protobuf:protobuf-java:4.29.0",
+        "com.google.protobuf:protobuf-java-util:4.29.0",
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "androidx.databinding:databinding-compiler:8.7.0",
+        "org.ow2.asm:asm:9.6",
+        "org.ow2.asm:asm-commons:9.6",
+        "org.ow2.asm:asm-tree:9.6",
+        "org.ow2.asm:asm-util:9.6",
+        "com.android.tools.layoutlib:layoutlib-api:30.1.3",
+        "com.android:zipflinger:8.7.0",
+        "com.android.tools.build:manifest-merger:30.1.3",
+        "com.android:signflinger:8.7.0",
+        "com.android.tools.build:aapt2-proto:8.6.1-11315950",
+        "com.android.tools.analytics-library:protos:30.1.3",
+        "com.android.tools.analytics-library:shared:30.1.3",
+        "com.android.tools.analytics-library:tracker:30.1.3",
+        "com.android.tools:annotations:30.1.3",
+        "com.android.tools.build:apksig:8.7.0",
+        "com.android.tools.build:apkzlib:8.7.0",
+        "com.android.tools.build:builder:8.7.0",
+        "com.android.tools.build:builder-model:8.7.0",
+        "com.google.auto.value:auto-value:1.11.0",
+        "com.google.auto.value:auto-value-annotations:1.11.0",
+        "com.google.auto:auto-common:1.2.2",
+        "com.google.auto.service:auto-service:1.1.1",
+        "com.google.auto.service:auto-service-annotations:1.1.1",
+        "com.google.errorprone:error_prone_annotations:2.33.0",
+        "com.google.errorprone:error_prone_type_annotations:2.33.0",
+        "com.google.errorprone:error_prone_check_api:2.33.0",
+        "com.google.errorprone:error_prone_core:2.33.0",
+    ],
+    repositories = [
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+        "https://repo.gradle.org/gradle/libs-releases",
+    ],
+    # To generate, run:
+    # REPIN=1 bazelisk run --enable_bzlmod @rules_android_maven//:pin
+    # lock_file = "//:rules_android_maven_install.json",
+    use_starlark_android_rules = True,
+)
+use_repo(
+    maven,
+    "rules_android_maven",
+)
+
+remote_android_extensions = use_extension("//bzlmod_extensions:android_extensions.bzl", "remote_android_tools_extensions")
+use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
+
+# integration test setup
+bazel_dep(
+    name = "rules_cc",
+    version = "0.0.16",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "rules_bazel_integration_test",
+    version = "0.27.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "cgrindel_bazel_starlib",
+    version = "0.17.0",
+    dev_dependency = True,
+)
+
+bazel_binaries = use_extension(
+    "@rules_bazel_integration_test//:extensions.bzl",
+    "bazel_binaries",
+    dev_dependency = True,
+)
+bazel_binaries.download(version = "last_green")
+use_repo(bazel_binaries, "bazel_binaries")
+
+# extension for apksignerextensions
+apksig_extension = use_extension("//bzlmod_extensions:apksig.bzl", "apksig_extension")
+use_repo(apksig_extension, "apksig")
+
+android_sdk_repository_extension = use_extension("//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension")
+use_repo(android_sdk_repository_extension, "androidsdk")
+
+register_toolchains("@androidsdk//:sdk-toolchain", "@androidsdk//:all")

--- a/modules/rules_android/0.6.0-alpha1.bcr.1/patches/bcr.patch
+++ b/modules/rules_android/0.6.0-alpha1.bcr.1/patches/bcr.patch
@@ -1,0 +1,38 @@
+diff --git a/.bcr/presubmit.yml b/.bcr/presubmit.yml
+index c004650..fd2cf91 100644
+--- a/.bcr/presubmit.yml
++++ b/.bcr/presubmit.yml
+@@ -2,7 +2,7 @@ bcr_test_module:
+   module_path: examples/basicapp
+   matrix:
+     platform: ["ubuntu2004", "macos", "windows"]
+-    bazel: ["7.2.1", "7.4.0", "8.x", "rolling"]
++    bazel: ["7.4.1", "8.0.0", "rolling"]
+   tasks:
+     run_test_module:
+       name: "Verify build targets with bzlmod"
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 43208ba..6ce3046 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "rules_android",
+-    version = "0.6.0",
++    version = "0.6.0-alpha1.bcr.1",
+     compatibility_level = 1,
+ )
+ 
+diff --git a/examples/basicapp/MODULE.bazel b/examples/basicapp/MODULE.bazel
+index 9ae567b..d3fd39c 100644
+--- a/examples/basicapp/MODULE.bazel
++++ b/examples/basicapp/MODULE.bazel
+@@ -7,7 +7,7 @@ bazel_dep(name = "bazel_skylib", version = "1.3.0")
+ 
+ bazel_dep(
+     name = "rules_android",
+-    version = "0.6.0",
++    version = "0.6.0-alpha1.bcr.1",
+ )
+ 
+ local_path_override(

--- a/modules/rules_android/0.6.0-alpha1.bcr.1/presubmit.yml
+++ b/modules/rules_android/0.6.0-alpha1.bcr.1/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: examples/basicapp
+  matrix:
+    platform: ["ubuntu2004", "macos", "windows"]
+    bazel: ["7.4.1", "8.0.0", "rolling"]
+  tasks:
+    run_test_module:
+      name: "Verify build targets with bzlmod"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//java/com/basicapp:basic_app"

--- a/modules/rules_android/0.6.0-alpha1.bcr.1/source.json
+++ b/modules/rules_android/0.6.0-alpha1.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-/j2MSVWFe0QBnYPQWgsVwqAzCmoKq5kFdbs5fpVw/xs=",
+    "strip_prefix": "rules_android-0.6.0-alpha1",
+    "url": "https://github.com/bazelbuild/rules_android/releases/download/v0.6.0-alpha1/rules_android-v0.6.0-alpha1.tar.gz",
+    "patches": {
+        "bcr.patch": "sha256-Ctxcs5SGkcUVOSmiNwjnaq8E3yLaIqyM9GZBKaiP214="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_android/metadata.json
+++ b/modules/rules_android/metadata.json
@@ -19,9 +19,10 @@
     "0.1.1",
     "0.5.0.bcr.1",
     "0.5.1",
-    "0.6.0-alpha1"
+    "0.6.0-alpha1.bcr.1"
   ],
   "yanked_versions": {
-    "0.5.0": "Bug in compatibility_level made v0.5.0 incompatible with rules_jvm_external."
+    "0.5.0": "Bug in compatibility_level made v0.5.0 incompatible with rules_jvm_external.",
+    "0.6.0-alpha1": "Patch of a file with no newline before EOF not compatible with bzlmod."
   }
 }


### PR DESCRIPTION
Fixes the issue with 0.6.0-alpha1, where the lack of a newline at the end of README.md caused bzlmod repo patching to fail.

See https://github.com/bazelbuild/bazel/issues/17376