### PR TITLE
Use hermetic Python from rules_python for jsonnet

### DIFF
--- a/modules/jsonnet/0.20.0.bcr.1/MODULE.bazel
+++ b/modules/jsonnet/0.20.0.bcr.1/MODULE.bazel
@@ -1,0 +1,20 @@
+module(name = "jsonnet", version = "0.20.0.bcr.1")
+
+bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest")
+bazel_dep(name = "rules_jsonnet", version = "0.6.0", repo_name = "io_bazel_rules_jsonnet")
+bazel_dep(name = "rules_python", version = "1.0.0")
+
+PYTHON_VERSIONS = [
+    "3.10",
+    "3.11",
+    "3.12",
+    "3.13",
+]
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+[
+    python.toolchain(
+        is_default = python_version == PYTHON_VERSIONS[-1],  # Choose last version as default.
+        python_version = python_version,
+    )
+    for python_version in PYTHON_VERSIONS
+]

--- a/modules/jsonnet/0.20.0.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/jsonnet/0.20.0.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,39 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..98229ee
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,20 @@
++module(name = "jsonnet", version = "0.20.0.bcr.1")
++
++bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest")
++bazel_dep(name = "rules_jsonnet", version = "0.6.0", repo_name = "io_bazel_rules_jsonnet")
++bazel_dep(name = "rules_python", version = "1.0.0")
++
++PYTHON_VERSIONS = [
++    "3.10",
++    "3.11",
++    "3.12",
++    "3.13",
++]
++python = use_extension("@rules_python//python/extensions:python.bzl", "python")
++[
++    python.toolchain(
++        is_default = python_version == PYTHON_VERSIONS[-1],  # Choose last version as default.
++        python_version = python_version,
++    )
++    for python_version in PYTHON_VERSIONS
++]
+diff --git a/python/BUILD b/python/BUILD
+index 12936ad..0afe833 100644
+--- a/python/BUILD
++++ b/python/BUILD
+@@ -4,7 +4,7 @@ cc_binary(
+     linkshared = 1,
+     deps = [
+         "//core:libjsonnet",
+-        "@default_python3_headers//:headers",
++        "@rules_python//python/cc:current_py_cc_headers",
+     ],
+ )
+ 

--- a/modules/jsonnet/0.20.0.bcr.1/presubmit.yml
+++ b/modules/jsonnet/0.20.0.bcr.1/presubmit.yml
@@ -1,0 +1,24 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+matrix:
+  platform: ["debian11", "ubuntu2004"]
+  bazel: ["7.x"]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@jsonnet//...'

--- a/modules/jsonnet/0.20.0.bcr.1/source.json
+++ b/modules/jsonnet/0.20.0.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/google/jsonnet/archive/refs/tags/v0.20.0.zip",
+    "integrity": "sha256-Z0/yQbHE2OFbGYwy1d50fUklc/lbS9MesYZNm9m7CYU=",
+    "patches": {
+        "module_dot_bazel.patch": "sha256-mNaqoX5mQP61b0oA7TEsPqcTLLQ4bJKCY9osA1Ueycg="
+    },
+    "strip_prefix": "jsonnet-0.20.0",
+    "patch_strip": 1
+}

--- a/modules/jsonnet/metadata.json
+++ b/modules/jsonnet/metadata.json
@@ -1,16 +1,17 @@
 {
-  "homepage": "https://jsonnet.org",
-  "maintainers": [
-    {
-      "email": "bcr-maintainers@bazel.build",
-      "name": "No Maintainer Specified"
-    }
-  ],
-  "repository": [
-    "github:google/jsonnet"
-  ],
-  "versions": [
-    "0.20.0"
-  ],
-  "yanked_versions": {}
+    "homepage": "https://jsonnet.org",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:google/jsonnet"
+    ],
+    "versions": [
+        "0.20.0",
+        "0.20.0.bcr.1"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
The previous patch used a custom toolchain from [`@bazel_tools`](https://github.com/google/jsonnet/blob/913281d203578bb394995bacc792f2576371e06c/platform_defs/BUILD#L1) which is incompatible with Bazel 8