### PR TITLE
Add opencensus-cpp

### DIFF
--- a/modules/opencensus-cpp/0.0.0-20230502-50eb5de/MODULE.bazel
+++ b/modules/opencensus-cpp/0.0.0-20230502-50eb5de/MODULE.bazel
@@ -1,0 +1,26 @@
+module(
+    name = "opencensus-cpp",
+    version = "0.0.0-20230502-50eb5de",
+    repo_name = "io_opencensus_cpp",
+)
+
+bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "boringssl", version = "0.20240913.0") # Bump transitive dependency for copmatibility with newer compilers
+bazel_dep(name = "civetweb", version = "1.16", dev_dependency = True)
+bazel_dep(name = "curl", version = "8.7.1", repo_name = "com_github_curl")
+bazel_dep(name = "google_benchmark", version = "1.8.4", repo_name = "com_github_google_benchmark")
+bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", repo_name = "com_google_googleapis")
+bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
+bazel_dep(name = "grpc", version = "1.66.0.bcr.3", repo_name = "com_github_grpc_grpc")
+bazel_dep(name = "opencensus-proto", version = "0.4.1", repo_name = "opencensus_proto")
+bazel_dep(name = "prometheus-cpp", version = "1.3.0", repo_name = "com_github_jupp0r_prometheus_cpp")
+bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
+bazel_dep(name = "rapidjson", version = "1.1.0.bcr.20241007", repo_name = "com_github_tencent_rapidjson")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
+
+switched_rules = use_extension("@com_google_googleapis//:extensions.bzl", "switched_rules")
+switched_rules.use_languages(
+    cc = True,
+    grpc = True,
+)

--- a/modules/opencensus-cpp/0.0.0-20230502-50eb5de/patches/module_dot_bazel.patch
+++ b/modules/opencensus-cpp/0.0.0-20230502-50eb5de/patches/module_dot_bazel.patch
@@ -1,0 +1,32 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..839aaef
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,26 @@
++module(
++    name = "opencensus-cpp",
++    version = "0.0.0-20230502-50eb5de",
++    repo_name = "io_opencensus_cpp",
++)
++
++bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
++bazel_dep(name = "bazel_skylib", version = "1.7.1")
++bazel_dep(name = "boringssl", version = "0.20240913.0") # Bump transitive dependency for copmatibility with newer compilers
++bazel_dep(name = "civetweb", version = "1.16", dev_dependency = True)
++bazel_dep(name = "curl", version = "8.7.1", repo_name = "com_github_curl")
++bazel_dep(name = "google_benchmark", version = "1.8.4", repo_name = "com_github_google_benchmark")
++bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", repo_name = "com_google_googleapis")
++bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
++bazel_dep(name = "grpc", version = "1.66.0.bcr.3", repo_name = "com_github_grpc_grpc")
++bazel_dep(name = "opencensus-proto", version = "0.4.1", repo_name = "opencensus_proto")
++bazel_dep(name = "prometheus-cpp", version = "1.3.0", repo_name = "com_github_jupp0r_prometheus_cpp")
++bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
++bazel_dep(name = "rapidjson", version = "1.1.0.bcr.20241007", repo_name = "com_github_tencent_rapidjson")
++bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
++
++switched_rules = use_extension("@com_google_googleapis//:extensions.bzl", "switched_rules")
++switched_rules.use_languages(
++    cc = True,
++    grpc = True,
++)

--- a/modules/opencensus-cpp/0.0.0-20230502-50eb5de/presubmit.yml
+++ b/modules/opencensus-cpp/0.0.0-20230502-50eb5de/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+  - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@opencensus-cpp//opencensus/...'
+    - '-@opencensus-cpp//opencensus/exporters/...'

--- a/modules/opencensus-cpp/0.0.0-20230502-50eb5de/source.json
+++ b/modules/opencensus-cpp/0.0.0-20230502-50eb5de/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/census-instrumentation/opencensus-cpp/archive/50eb5de762e5f87e206c011a4f930adb1a1775b1.tar.gz",
+    "integrity": "sha256-44V+EmfLYymnsjIJzoohCLjyZOSt8zZ3YyP7Fj+iP5o=",
+    "strip_prefix": "opencensus-cpp-50eb5de762e5f87e206c011a4f930adb1a1775b1",
+    "patches": {
+        "module_dot_bazel.patch": "sha256-ug60b3gk0eF5aDTi+UkGkRA/iZuKTVc3+veOtaT5GB4="
+    },
+    "patch_strip": 1
+}

--- a/modules/opencensus-cpp/metadata.json
+++ b/modules/opencensus-cpp/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/census-instrumentation/opencensus-cpp",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:census-instrumentation/opencensus-cpp"
+    ],
+    "versions": [
+        "0.0.0-20230502-50eb5de"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Even though this repository is already archived, there are still many consumers which fall back to module extensions. Uploading this to allow at least using a module dependency until consumers are migrated.

Using the latest commit as it contains several unreleased fixes (for example adding compatibility for newer abseil-cpp versions).