### PR TITLE
fix soplex deps; add boost dependency; add cc_binary target

### DIFF
--- a/modules/soplex/7.1.2.bcr.1/MODULE.bazel
+++ b/modules/soplex/7.1.2.bcr.1/MODULE.bazel
@@ -29,3 +29,8 @@ bazel_dep(
     version = "1.3.1.bcr.3",
 )
 
+bazel_dep(
+    name = "zstr",
+    version = "1.0.7",
+)
+

--- a/modules/soplex/7.1.2.bcr.1/MODULE.bazel
+++ b/modules/soplex/7.1.2.bcr.1/MODULE.bazel
@@ -1,0 +1,31 @@
+module(
+    name = "soplex",
+    version = "7.1.2.bcr.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.10",
+)
+
+bazel_dep(
+    name = "fmt",
+    version = "11.1.1",
+)
+
+bazel_dep(
+    name = "boost.multiprecision",
+    version = "1.83.0.bcr.1",
+)
+
+bazel_dep(
+    name = "boost.serialization",
+    version = "1.83.0.bcr.1",
+)
+
+bazel_dep(
+    name = "zlib",
+    version = "1.3.1.bcr.3",
+)
+

--- a/modules/soplex/7.1.2.bcr.1/overlay/BUILD.bazel
+++ b/modules/soplex/7.1.2.bcr.1/overlay/BUILD.bazel
@@ -18,7 +18,7 @@ cc_library(
         "src/soplex/git_hash.cpp",
     ],
     copts = select({
-        "@platforms//os:windows": ["-utf-8"],
+        "@platforms//os:windows": ["/utf-8"],
         "//conditions:default": [],
     }),
     includes = ["src"],
@@ -34,6 +34,10 @@ cc_library(
 cc_binary(
     name = "soplex_interactive",
     srcs = ["src/soplexmain.cpp"],
+    copts = select({
+        "@platforms//os:windows": ["/utf-8"],
+        "//conditions:default": [],
+    }),
     deps = [
         ":soplex",
         "@boost.multiprecision",

--- a/modules/soplex/7.1.2.bcr.1/overlay/BUILD.bazel
+++ b/modules/soplex/7.1.2.bcr.1/overlay/BUILD.bazel
@@ -1,8 +1,8 @@
 # Description:
-# Soplex is a LP solver, a common tool in Operations Research.git
+# Soplex is a LP solver, a common tool in Operations Research.
 
 cc_library(
-    name = "libsoplex",
+    name = "soplex",
     srcs = glob(
         ["src/soplex/*.cpp"],
         exclude = ["src/git_hash.cpp"],
@@ -20,12 +20,8 @@ cc_library(
     copts = select({
         "@platforms//os:windows": ["-utf-8"],
         "//conditions:default": [],
-    }) + [
-        "-Isrc/soplex/external",
-    ],
-    includes = [
-        "src",
-    ],
+    }),
+    includes = ["src"],
     visibility = ["//visibility:public"],
     deps = [
         "@boost.multiprecision",
@@ -36,10 +32,10 @@ cc_library(
 )
 
 cc_binary(
-    name = "soplex",
+    name = "soplex_interactive",
     srcs = ["src/soplexmain.cpp"],
     deps = [
-        ":libsoplex",
+        ":soplex",
         "@boost.multiprecision",
         "@zlib",
     ],

--- a/modules/soplex/7.1.2.bcr.1/overlay/BUILD.bazel
+++ b/modules/soplex/7.1.2.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,53 @@
+# Description:
+# Soplex is a LP solver, a common tool in Operations Research.git
+
+cc_library(
+    name = "zstr",
+    hdrs = glob(["src/soplex/external/zstr/*.hpp"]),
+    includes = ["src/soplex/external"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "libsoplex",
+    srcs = glob(
+        ["src/soplex/*.cpp"],
+        exclude = ["src/git_hash.cpp"],
+    ),
+    hdrs = glob(
+        [
+            "src/soplex/*.h",
+            "src/soplex/*.hpp",
+        ],
+    ) + [
+        "src/soplex.h",
+        "src/soplex.hpp",
+        "src/soplex/git_hash.cpp",
+    ],
+    copts = select({
+        "@platforms//os:windows": ["-utf-8"],
+        "//conditions:default": [],
+    }) + [
+        "-Isrc/soplex/external",
+    ],
+    includes = [
+        "src",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":zstr",
+        "@boost.multiprecision",
+        "@boost.serialization",
+        "@fmt",
+    ],
+)
+
+cc_binary(
+    name = "soplex",
+    srcs = ["src/soplexmain.cpp"],
+    deps = [
+        ":libsoplex",
+        "@boost.multiprecision",
+        "@zlib",
+    ],
+)

--- a/modules/soplex/7.1.2.bcr.1/overlay/BUILD.bazel
+++ b/modules/soplex/7.1.2.bcr.1/overlay/BUILD.bazel
@@ -2,13 +2,6 @@
 # Soplex is a LP solver, a common tool in Operations Research.git
 
 cc_library(
-    name = "zstr",
-    hdrs = glob(["src/soplex/external/zstr/*.hpp"]),
-    includes = ["src/soplex/external"],
-    visibility = ["//visibility:public"],
-)
-
-cc_library(
     name = "libsoplex",
     srcs = glob(
         ["src/soplex/*.cpp"],
@@ -35,10 +28,10 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":zstr",
         "@boost.multiprecision",
         "@boost.serialization",
         "@fmt",
+        "@zstr",
     ],
 )
 

--- a/modules/soplex/7.1.2.bcr.1/overlay/MODULE.bazel
+++ b/modules/soplex/7.1.2.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/soplex/7.1.2.bcr.1/patches/add_config_dot_h.patch
+++ b/modules/soplex/7.1.2.bcr.1/patches/add_config_dot_h.patch
@@ -1,0 +1,24 @@
+diff --git a/src/soplex/config.h b/src/soplex/config.h
+new file mode 100644
+index 00000000..e465106c
+--- /dev/null
++++ b/src/soplex/config.h
+@@ -0,0 +1,18 @@
++#ifndef __SPXCONFIG_H__
++#define __SPXCONFIG_H__
++
++#define CMAKE_BUILD_TYPE "Release"
++
++#define SOPLEX_VERSION_MAJOR 7
++#define SOPLEX_VERSION_MINOR 1
++#define SOPLEX_VERSION_PATCH 2
++#define SOPLEX_VERSION_SUB 0
++#define SOPLEX_WITH_BOOST
++#define SOPLEX_WITH_CPPMPF
++/* #undef SOPLEX_WITH_FLOAT128 */
++/* #undef SOPLEX_WITH_GMP */
++/* #undef SOPLEX_WITH_MPFR */
++/* #undef SOPLEX_WITH_PAPILO */
++#define SOPLEX_WITH_ZLIB
++
++#endif

--- a/modules/soplex/7.1.2.bcr.1/patches/add_git_hash_dot_cpp.patch
+++ b/modules/soplex/7.1.2.bcr.1/patches/add_git_hash_dot_cpp.patch
@@ -1,0 +1,7 @@
+diff --git a/src/soplex/git_hash.cpp b/src/soplex/git_hash.cpp
+new file mode 100644
+index 00000000..bc2d689d
+--- /dev/null
++++ b/src/soplex/git_hash.cpp
+@@ -0,0 +1 @@
++#define SPX_GITHASH "NoGitInfo"

--- a/modules/soplex/7.1.2.bcr.1/patches/add_git_hash_dot_cpp.patch
+++ b/modules/soplex/7.1.2.bcr.1/patches/add_git_hash_dot_cpp.patch
@@ -4,4 +4,4 @@ index 00000000..bc2d689d
 --- /dev/null
 +++ b/src/soplex/git_hash.cpp
 @@ -0,0 +1 @@
-+#define SPX_GITHASH "NoGitInfo"
++#define SPX_GITHASH "b040369c"

--- a/modules/soplex/7.1.2.bcr.1/patches/fmt_dot_hpp.patch
+++ b/modules/soplex/7.1.2.bcr.1/patches/fmt_dot_hpp.patch
@@ -1,0 +1,15 @@
+diff --git a/src/soplex/fmt.hpp b/src/soplex/fmt.hpp
+index 934cb085..c3a31bb8 100644
+--- a/src/soplex/fmt.hpp
++++ b/src/soplex/fmt.hpp
+@@ -49,8 +49,8 @@
+ 
+ /* to provide backwards compatibility use fmt of PaPILO <= 2.3 due to breaking changes in fmt 7 */
+ #if !defined(SOPLEX_WITH_PAPILO) || PAPILO_VERSION_MAJOR > 2 || (PAPILO_VERSION_MAJOR == 2 && PAPILO_VERSION_MINOR > 3)
+-#include "soplex/external/fmt/format.h"
+-#include "soplex/external/fmt/ostream.h"
++#include "fmt/format.h"
++#include "fmt/ostream.h"
+ #else
+ #include "papilo/external/fmt/format.h"
+ #include "papilo/external/fmt/ostream.h"

--- a/modules/soplex/7.1.2.bcr.1/patches/spxfileio_dot_h.patch
+++ b/modules/soplex/7.1.2.bcr.1/patches/spxfileio_dot_h.patch
@@ -1,0 +1,13 @@
+diff --git a/src/soplex/spxfileio.h b/src/soplex/spxfileio.h
+index 035b30e0..4bff223c 100644
+--- a/src/soplex/spxfileio.h
++++ b/src/soplex/spxfileio.h
+@@ -41,7 +41,7 @@
+  *-----------------------------------------------------------------------------
+  */
+ #ifdef SOPLEX_WITH_ZLIB
+-#include "soplex/external/zstr/zstr.hpp"
++#include "zstr.hpp"
+ #endif // WITH_GSZSTREAM
+ 
+ namespace soplex

--- a/modules/soplex/7.1.2.bcr.1/presubmit.yml
+++ b/modules/soplex/7.1.2.bcr.1/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@soplex//...'

--- a/modules/soplex/7.1.2.bcr.1/source.json
+++ b/modules/soplex/7.1.2.bcr.1/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "soplex-release-712",
     "patches": {
         "add_config_dot_h.patch": "sha256-b7x5Pyms8oDiaXQc1u7BLgo33kbDyAXJPsf0XGVfv6s=",
-        "add_git_hash_dot_cpp.patch": "sha256-QVgHvann6fzS5c58GflysP/vryBJT1C8wADUZ44dTWo=",
+        "add_git_hash_dot_cpp.patch": "sha256-dr5ytJPP3IfeKS/F5fnGp37XRvb3HyADwp4TIx7aiXE=",
         "fmt_dot_hpp.patch": "sha256-l3uQmHQOXJhsyGfBArkMIUI0n3t1BsvGD2r3d0CtVrc="
     },
     "patch_strip": 1,

--- a/modules/soplex/7.1.2.bcr.1/source.json
+++ b/modules/soplex/7.1.2.bcr.1/source.json
@@ -10,7 +10,7 @@
     },
     "patch_strip": 1,
     "overlay": {
-        "BUILD.bazel": "sha256-0PyNd35GEc05BSknQjzs8frwGBufXi1cpmzvmfEc5Xg=",
+        "BUILD.bazel": "sha256-xFOmYj3tIpHXZOeEhuPEMYrKo8AEOZvgv0lYcKchBY0=",
         "MODULE.bazel": "sha256-JSEr3bYeVvq0K35PrwOYgKqGixoRZiH7pZQetttBs5M="
     }
 }

--- a/modules/soplex/7.1.2.bcr.1/source.json
+++ b/modules/soplex/7.1.2.bcr.1/source.json
@@ -5,11 +5,12 @@
     "patches": {
         "add_config_dot_h.patch": "sha256-b7x5Pyms8oDiaXQc1u7BLgo33kbDyAXJPsf0XGVfv6s=",
         "add_git_hash_dot_cpp.patch": "sha256-dr5ytJPP3IfeKS/F5fnGp37XRvb3HyADwp4TIx7aiXE=",
-        "fmt_dot_hpp.patch": "sha256-l3uQmHQOXJhsyGfBArkMIUI0n3t1BsvGD2r3d0CtVrc="
+        "fmt_dot_hpp.patch": "sha256-l3uQmHQOXJhsyGfBArkMIUI0n3t1BsvGD2r3d0CtVrc=",
+        "spxfileio_dot_h.patch": "sha256-g3qdN7pcA2Ef64Kx3vb2xjyNJrKRjLIPJCI6dLkj/N8="
     },
     "patch_strip": 1,
     "overlay": {
-        "BUILD.bazel": "sha256-u8+431jtHNbHXszeueXdBV6aR6Mu8EBf+tBw8D00Res=",
-        "MODULE.bazel": "sha256-ohssuS7/XCoDoU/kSSQZ81hiKq1xkvtknPaydLfrquM="
+        "BUILD.bazel": "sha256-iChG1nWE8G5adFDB20qXvfVyODJvq4S2fC/fhcZCmto=",
+        "MODULE.bazel": "sha256-JSEr3bYeVvq0K35PrwOYgKqGixoRZiH7pZQetttBs5M="
     }
 }

--- a/modules/soplex/7.1.2.bcr.1/source.json
+++ b/modules/soplex/7.1.2.bcr.1/source.json
@@ -1,0 +1,15 @@
+{
+    "url": "https://github.com/scipopt/soplex/archive/refs/tags/release-712.tar.gz",
+    "integrity": "sha256-oafX9+MNHbZVSLMvddby7ZvQvyifY560SB09FBxnozI=",
+    "strip_prefix": "soplex-release-712",
+    "patches": {
+        "add_config_dot_h.patch": "sha256-b7x5Pyms8oDiaXQc1u7BLgo33kbDyAXJPsf0XGVfv6s=",
+        "add_git_hash_dot_cpp.patch": "sha256-QVgHvann6fzS5c58GflysP/vryBJT1C8wADUZ44dTWo=",
+        "fmt_dot_hpp.patch": "sha256-l3uQmHQOXJhsyGfBArkMIUI0n3t1BsvGD2r3d0CtVrc="
+    },
+    "patch_strip": 1,
+    "overlay": {
+        "BUILD.bazel": "sha256-u8+431jtHNbHXszeueXdBV6aR6Mu8EBf+tBw8D00Res=",
+        "MODULE.bazel": "sha256-ohssuS7/XCoDoU/kSSQZ81hiKq1xkvtknPaydLfrquM="
+    }
+}

--- a/modules/soplex/7.1.2.bcr.1/source.json
+++ b/modules/soplex/7.1.2.bcr.1/source.json
@@ -10,7 +10,7 @@
     },
     "patch_strip": 1,
     "overlay": {
-        "BUILD.bazel": "sha256-iChG1nWE8G5adFDB20qXvfVyODJvq4S2fC/fhcZCmto=",
+        "BUILD.bazel": "sha256-0PyNd35GEc05BSknQjzs8frwGBufXi1cpmzvmfEc5Xg=",
         "MODULE.bazel": "sha256-JSEr3bYeVvq0K35PrwOYgKqGixoRZiH7pZQetttBs5M="
     }
 }

--- a/modules/soplex/metadata.json
+++ b/modules/soplex/metadata.json
@@ -2,8 +2,8 @@
     "homepage": "https://github.com/scipopt/soplex",
     "maintainers": [
         {
-            "email": "bcr-maintainers@bazel.build",
-            "name": "No Maintainer Specified"
+            "email": "lperron@google.com",
+            "name": "Laurent Perron"
         }
     ],
     "repository": [

--- a/modules/soplex/metadata.json
+++ b/modules/soplex/metadata.json
@@ -10,7 +10,8 @@
         "github:scipopt/soplex"
     ],
     "versions": [
-        "7.1.2"
+        "7.1.2",
+        "7.1.2.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Fix soplex:
  - move zstr as a deps as it leaks on the client build file otherwise (not an issue as it is a header only library)
  - add missing multiprecision option
  - add cc_binary rule to build the soplex binary (and verify the compilation went well)