### PR TITLE
add rules_docker_compose_test 1.1.0 to bazel-central-registry

### DIFF
--- a/modules/rules_docker_compose_test/1.1.0/MODULE.bazel
+++ b/modules/rules_docker_compose_test/1.1.0/MODULE.bazel
@@ -1,0 +1,27 @@
+# Copyright (c) 2025, Salesforce, Inc.
+# SPDX-License-Identifier: Apache-2
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "rules_docker_compose_test",
+    version = "1.1.0",
+)
+
+bazel_dep(name = "rules_pkg", version = "0.10.1")
+bazel_dep(name = "rules_oci", version = "2.2.0")
+bazel_dep(name = "rules_go", version = "0.50.1")
+
+repo_absolute_path = use_repo_rule("//:setup.bzl", "repo_absolute_path")
+
+repo_absolute_path(name = "repo_absolute_path")

--- a/modules/rules_docker_compose_test/1.1.0/presubmit.yml
+++ b/modules/rules_docker_compose_test/1.1.0/presubmit.yml
@@ -1,0 +1,16 @@
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    bazel: ["7.x", "8.x"]
+    platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+  tasks:
+    test:
+      name: "Run test module"
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_docker_compose_test/1.1.0/presubmit.yml
+++ b/modules/rules_docker_compose_test/1.1.0/presubmit.yml
@@ -8,9 +8,17 @@ bcr_test_module:
     - macos
     - macos_arm64
   tasks:
-    test:
+    test_linux:
       name: "Run test module"
       bazel: ${{ bazel }}
       platform: ${{ platform }}
       test_targets:
         - "//..."
+        # This test requires ability to write to the filesystem, not possible from BCR CI
+        - "-//pre-compose-up-script-test:pre-compose-up-script-test"
+    test_macos:
+      name: "Run test module"
+      bazel: ${{ bazel }}
+      platform: macos
+      # These tests requires a docker daemon, not available on BCR CI (macos)
+      test_targets: []

--- a/modules/rules_docker_compose_test/1.1.0/presubmit.yml
+++ b/modules/rules_docker_compose_test/1.1.0/presubmit.yml
@@ -5,8 +5,9 @@ bcr_test_module:
     platform:
     - debian10
     - ubuntu2004
-    - macos
-    - macos_arm64
+    # These tests requires a docker daemon, not available on BCR CI (macos)
+    # - macos
+    # - macos_arm64
   tasks:
     test_linux:
       name: "Run test module"
@@ -16,9 +17,3 @@ bcr_test_module:
         - "//..."
         # This test requires ability to write to the filesystem, not possible from BCR CI
         - "-//pre-compose-up-script-test:pre-compose-up-script-test"
-    test_macos:
-      name: "Run test module"
-      bazel: ${{ bazel }}
-      platform: macos
-      # These tests requires a docker daemon, not available on BCR CI (macos)
-      test_targets: []

--- a/modules/rules_docker_compose_test/1.1.0/source.json
+++ b/modules/rules_docker_compose_test/1.1.0/source.json
@@ -1,4 +1,4 @@
 {
     "url": "https://github.com/salesforce/rules_docker_compose_test/releases/download/v1.1.0/rules_docker_compose_test-v1.1.0.tar.gz",
-    "integrity": "sha256-VgEy1Y5cUw8eAneC4l3d2y8pP8Y1AyAY6Lz2NEFj0Qs="
+    "integrity": "sha256-B+oM+4ny7fL3rHtox21EYH6upQjOgDGc0YOIE++EVcw="
 }

--- a/modules/rules_docker_compose_test/1.1.0/source.json
+++ b/modules/rules_docker_compose_test/1.1.0/source.json
@@ -1,0 +1,4 @@
+{
+    "url": "https://github.com/salesforce/rules_docker_compose_test/releases/download/v1.1.0/rules_docker_compose_test-v1.1.0.tar.gz",
+    "integrity": "sha256-VgEy1Y5cUw8eAneC4l3d2y8pP8Y1AyAY6Lz2NEFj0Qs="
+}

--- a/modules/rules_docker_compose_test/metadata.json
+++ b/modules/rules_docker_compose_test/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/salesforce/rules_docker_compose_test",
+    "maintainers": [
+        {
+            "email": "krisfoster@live.ie",
+            "github": "kriscfoster",
+            "name": "Kris Foster"
+        }
+    ],
+    "repository": [
+        "github:salesforce/rules_docker_compose_test"
+    ],
+    "versions": [
+        "1.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adding https://github.com/salesforce/rules_docker_compose_test.