### PR TITLE
Add generate module diff check

### DIFF
--- a/.github/workflows/dismiss_approvals.yml
+++ b/.github/workflows/dismiss_approvals.yml
@@ -15,7 +15,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@2997e589af56c74eeccaf79640f20a6b40e1b0b6 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@abb92bbd05306ecf90ac61baeaa534823d5f122a # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/generate_module_diff.yml
+++ b/.github/workflows/generate_module_diff.yml
@@ -1,0 +1,27 @@
+name: Generate module diff
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'modules/**'
+
+jobs:
+  generate_module_diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+
+      - name: Check out PR code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Generate module diff ( ⭐ 🔍 Expand here to see the diff ⭐)
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@abb92bbd05306ecf90ac61baeaa534823d5f122a
+        with:
+          action-type: diff_module

--- a/.github/workflows/notify_maintainers.yml
+++ b/.github/workflows/notify_maintainers.yml
@@ -16,7 +16,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@2997e589af56c74eeccaf79640f20a6b40e1b0b6 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@abb92bbd05306ecf90ac61baeaa534823d5f122a # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/review_prs.yml
+++ b/.github/workflows/review_prs.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Run BCR PR Reviewer
         if: github.repository_owner == 'bazelbuild'
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@2997e589af56c74eeccaf79640f20a6b40e1b0b6 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@abb92bbd05306ecf90ac61baeaa534823d5f122a # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/skip_check.yml
+++ b/.github/workflows/skip_check.yml
@@ -18,7 +18,7 @@ jobs:
           egress-policy: audit
 
       - name: Run bot
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@854de5d7871f734a858bf1efa4454e8260e620a0 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@abb92bbd05306ecf90ac61baeaa534823d5f122a # master
         with:
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}
           action-type: skip_check


### PR DESCRIPTION
This action will diff new module versions in a BCR PR against its previous version. Making it much easier to review changes between module versions.

Test run: https://github.com/meteorcloudy/bazel-central-registry/actions/runs/12805364325/job/35765475520