### PR TITLE
Publish `@engflowapis` `2025.01.17-16.55.05` (+ language bindings)

### DIFF
--- a/modules/engflowapis-go/2025.01.17-16.55.05/MODULE.bazel
+++ b/modules/engflowapis-go/2025.01.17-16.55.05/MODULE.bazel
@@ -1,0 +1,43 @@
+module(
+    name = "engflowapis-go",
+    version = "2025.01.17-16.55.05",  # Automatically updated by release pipeline.
+)
+
+bazel_dep(
+    name = "engflowapis",
+    version = "2025.01.17-16.55.05",  # Automatically updated by release pipeline.
+)
+bazel_dep(
+    name = "rules_go",
+    version = "0.50.1",
+    repo_name = "io_bazel_rules_go",
+)
+bazel_dep(
+    name = "gazelle",
+    version = "0.31.0",
+)
+bazel_dep(
+    name = "googleapis",
+    version = "0.0.0-20240819-fe8ba054a",
+)
+
+switched_rules = use_extension("@googleapis//:extensions.bzl", "switched_rules")
+switched_rules.use_languages(
+    go = True,
+)
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.module(
+    path = "google.golang.org/protobuf",
+    sum = "h1:yBPeRvTftaleIgM3PZ/WBIZ7XM/eEYAaEyCwvyjq/gk=",
+    version = "v1.36.1",
+)
+use_repo(
+    go_deps,
+    "org_golang_google_protobuf",
+)
+
+local_path_override(
+    module_name = "engflowapis",
+    path = "..",
+)

--- a/modules/engflowapis-go/2025.01.17-16.55.05/presubmit.yml
+++ b/modules/engflowapis-go/2025.01.17-16.55.05/presubmit.yml
@@ -13,5 +13,4 @@ tasks:
     name: Verify build targets
     platform: ${{ platform }}
     bazel: ${{ bazel }}
-    build_targets:
-    - '@engflowapis-go//...'
+    build_targets: []

--- a/modules/engflowapis-go/2025.01.17-16.55.05/presubmit.yml
+++ b/modules/engflowapis-go/2025.01.17-16.55.05/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@engflowapis-go//...'

--- a/modules/engflowapis-go/2025.01.17-16.55.05/source.json
+++ b/modules/engflowapis-go/2025.01.17-16.55.05/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/EngFlow/engflowapis/releases/download/2025.01.17-16.55.05/engflowapis-2025.01.17-16.55.05.tar.gz",
+    "integrity": "sha256-3fj9Xp/BRSDWGCMZ3OxqgijlEMN/5GFaU8h/3LcCqZ0=",
+    "strip_prefix": "go"
+}

--- a/modules/engflowapis-go/metadata.json
+++ b/modules/engflowapis-go/metadata.json
@@ -12,6 +12,11 @@
             "name": "Antonio Di Stefano"
         },
         {
+            "email": "jay@engflow.com",
+            "github": "jayconrod",
+            "name": "Jay Conrod"
+        },
+        {
             "email": "yannic@engflow.com",
             "github": "Yannic",
             "name": "Yannic Bonenberger"
@@ -21,7 +26,6 @@
         "github:EngFlow/engflowapis"
     ],
     "versions": [
-        "2025.01.17-13.50.20",
         "2025.01.17-16.55.05"
     ],
     "yanked_versions": {}

--- a/modules/engflowapis-java/2025.01.17-16.55.05/MODULE.bazel
+++ b/modules/engflowapis-java/2025.01.17-16.55.05/MODULE.bazel
@@ -1,0 +1,27 @@
+module(
+    name = "engflowapis-java",
+    version = "2025.01.17-16.55.05",  # Automatically updated by release pipeline.
+)
+
+bazel_dep(
+    name = "engflowapis",
+    version = "2025.01.17-16.55.05",  # Automatically updated by release pipeline.
+)
+bazel_dep(
+    name = "grpc-java",
+    version = "1.67.1",
+)
+bazel_dep(
+    name = "protobuf",
+    version = "28.2",
+    repo_name = "com_google_protobuf",
+)
+bazel_dep(
+    name = "rules_java",
+    version = "8.7.0",
+)
+
+local_path_override(
+    module_name = "engflowapis",
+    path = "..",
+)

--- a/modules/engflowapis-java/2025.01.17-16.55.05/presubmit.yml
+++ b/modules/engflowapis-java/2025.01.17-16.55.05/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@engflowapis-java//...'

--- a/modules/engflowapis-java/2025.01.17-16.55.05/source.json
+++ b/modules/engflowapis-java/2025.01.17-16.55.05/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/EngFlow/engflowapis/releases/download/2025.01.17-16.55.05/engflowapis-2025.01.17-16.55.05.tar.gz",
+    "integrity": "sha256-3fj9Xp/BRSDWGCMZ3OxqgijlEMN/5GFaU8h/3LcCqZ0=",
+    "strip_prefix": "java"
+}

--- a/modules/engflowapis/2025.01.17-16.55.05/MODULE.bazel
+++ b/modules/engflowapis/2025.01.17-16.55.05/MODULE.bazel
@@ -1,0 +1,19 @@
+module(
+    name = "engflowapis",
+    version = "2025.01.17-16.55.05",  # Automatically updated by release pipeline.
+)
+
+bazel_dep(
+    name = "rules_proto",
+    version = "6.0.2",
+)
+bazel_dep(
+    name = "protobuf",
+    version = "28.2",
+    repo_name = "com_google_protobuf",
+)
+bazel_dep(
+    name = "googleapis",
+    version = "0.0.0-20240819-fe8ba054a",
+    repo_name = "com_google_googleapis",
+)

--- a/modules/engflowapis/2025.01.17-16.55.05/presubmit.yml
+++ b/modules/engflowapis/2025.01.17-16.55.05/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@engflowapis//...'

--- a/modules/engflowapis/2025.01.17-16.55.05/source.json
+++ b/modules/engflowapis/2025.01.17-16.55.05/source.json
@@ -1,0 +1,4 @@
+{
+    "url": "https://github.com/EngFlow/engflowapis/releases/download/2025.01.17-16.55.05/engflowapis-2025.01.17-16.55.05.tar.gz",
+    "integrity": "sha256-3fj9Xp/BRSDWGCMZ3OxqgijlEMN/5GFaU8h/3LcCqZ0="
+}

--- a/modules/engflowapis/metadata.json
+++ b/modules/engflowapis/metadata.json
@@ -2,6 +2,11 @@
     "homepage": "https://github.com/EngFlow/engflowapis",
     "maintainers": [
         {
+            "email": "andres@engflow.com",
+            "github": "anfelbar",
+            "name": "Andrés Felipe Barco Santa"
+        },
+        {
             "email": "antonio@engflow.com",
             "github": "TheGrizzlyDev",
             "name": "Antonio Di Stefano"
@@ -24,7 +29,8 @@
         "2024.12.05-12.44.49",
         "2024.12.06-06.17.32",
         "2025.01.15-16.16.07",
-        "2025.01.17-13.50.20"
+        "2025.01.17-13.50.20",
+        "2025.01.17-16.55.05"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This change updates `@engflowapis` and `@engflowapis-java` and adds `@engflowapis-go`.

Also, updates maintainers.