### PR TITLE
Unyank `rules_cc@0.1.0`

### DIFF
--- a/modules/rules_cc/metadata.json
+++ b/modules/rules_cc/metadata.json
@@ -27,6 +27,5 @@
     ],
     "yanked_versions": {
         "0.0.14": "rules_cc 0.0.14 is yanked due to incompatible change (prematurely removing cc_proto_library from defs.bzl), please upgrade to 0.0.15", 
-        "0.1.0": "rules_cc 0.1.0 is yanked due to incompatible change (prematurely removing cc_proto_library from defs.bzl), please downgrade to 0.0.15" 
     }
 }

--- a/modules/rules_cc/metadata.json
+++ b/modules/rules_cc/metadata.json
@@ -26,6 +26,6 @@
         "0.1.0"
     ],
     "yanked_versions": {
-        "0.0.14": "rules_cc 0.0.14 is yanked due to incompatible change (prematurely removing cc_proto_library from defs.bzl), please upgrade to 0.0.15", 
+        "0.0.14": "rules_cc 0.0.14 is yanked due to incompatible change (prematurely removing cc_proto_library from defs.bzl), please upgrade to 0.0.15"
     }
 }


### PR DESCRIPTION
Yanking a module version with no higher version available is highly disruptive as users can't rely on `bazel_dep` to fix the breakage, but have to resort to `single_version_override`.

Related to #3596