### PR TITLE
bcr_validation: check if a commit/reference in the github url is from the original repo

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -51,6 +51,7 @@ py_binary(
     deps = [
         ":registry",
         ":verify_stable_archives",
+        requirement("requests"),
     ],
 )
 

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -132,7 +132,7 @@ def extract_commit(repo_path, path):
     Returns:
         The commit ID if found, otherwise None.
     """
-    pattern = rf'/{re.escape(repo_path)}/archive/([a-f0-9]+)\.(zip|tar\.gz)'
+    pattern = rf"/{re.escape(repo_path)}/archive/([a-f0-9]+)\.(zip|tar\.gz)"
     match = re.search(pattern, path)
     if match:
         return match.group(1)

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -181,7 +181,7 @@ def check_github_url(repo_path, source_url):
         return False
 
     # Allow paths under /<repo_path>/releases/download
-    if normalized_path.startswith(f"/{repo_path}/releases/download"):
+    if normalized_path.startswith(f"/{repo_path}/releases/download/"):
         return True
 
     # Otherwise, the source archive must match /<repo_path>/archive/<reference>.<extension>

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -121,47 +121,47 @@ def fix_line_endings(lines):
     return [line.rstrip() + "\n" for line in lines]
 
 
-def extract_commit(repo_path, path):
+def extract_reference(repo_path, path):
     """
-    Extracts the commit ID from a path matching the pattern /<repo_path>/archive/<commit>.zip or /<repo_path>/archive/<commit>.tar.gz
+    Extracts the reference from a path matching the pattern /<repo_path>/archive/<ref>.zip or /<repo_path>/archive/<ref>.tar.gz
 
     Args:
         repo_path: The repository path.
-        path: The path to extract the commit ID from.
+        path: The path to extract the reference from.
 
     Returns:
-        The commit ID if found, otherwise None.
+        The reference if found, otherwise None.
     """
-    pattern = rf"/{re.escape(repo_path)}/archive/([a-f0-9]+)\.(zip|tar\.gz)"
+    pattern = rf"^/{re.escape(repo_path)}/archive/(.+)\.(zip|tar\.gz)$"
     match = re.search(pattern, path)
     if match:
         return match.group(1)
     return None
 
 
-def is_commit_in_original_repo(repo_path, commit) -> bool:
+def is_ref_in_original_repo(repo_path, reference) -> bool:
     """
-    Checks if the given commit SHA is truly part of the original GitHub repository's history.
+    Checks if the given reference is truly part of the original GitHub repository's history.
 
-    Uses the unofficial '/latest-commit/<SHA>' endpoint, which returns JSON containing "isSpoofed".
+    Uses the unofficial '/latest-commit/<REF>' endpoint, which returns JSON containing "isSpoofed".
 
     Args:
         repo_path: The repository path.
-        commit: The full commit hash to check
+        reference: The reference to check
 
     Returns:
-        True if the commit is found AND not spoofed; False otherwise
+        True if the reference is found AND not spoofed; False otherwise
     """
-    url = f"https://github.com/{repo_path}/latest-commit/{commit}"
+    url = f"https://github.com/{repo_path}/latest-commit/{reference}"
     headers = {"Accept": "application/json"}
 
     try:
         response = requests.get(url, headers=headers)
     except requests.RequestException:
-        raise BcrValidationException(f"Failed to check if commit is from the original repository via {url}")
+        raise BcrValidationException(f"Failed to check if reference is from the original repository via {url}")
 
     if not response.status_code == 200:
-        # Commit doesn't exist at all
+        # reference doesn't exist at all
         return False
 
     data = response.json()
@@ -169,6 +169,25 @@ def is_commit_in_original_repo(repo_path, commit) -> bool:
         raise BcrValidationException(f"Missing 'isSpoofed' attribute in response from {url}: {data}")
 
     return not data.get("isSpoofed")
+
+
+def check_github_url(repo_path, source_url):
+    parts = urlparse(source_url)
+    # Avoid potential path manipulations with "../"
+    normalized_path = os.path.abspath(parts.path)
+
+    # If the URL doesn't starts with https://github.com/<repo_path>, return False
+    if parts.scheme != "https" or parts.netloc != "github.com" or not normalized_path.startswith(f"/{repo_path}/"):
+        return False
+
+    # Allow paths under /<repo_path>/releases/download
+    if normalized_path.startswith(f"/{repo_path}/releases/download"):
+        return True
+
+    # Otherwise, the source archive must match /<repo_path>/archive/<reference>.<extension>
+    # And we check if the reference does come from the original repository.
+    reference = extract_reference(repo_path, normalized_path)
+    return reference and is_ref_in_original_repo(repo_path, reference)
 
 
 class BcrValidationException(Exception):
@@ -225,15 +244,7 @@ class BcrValidator:
                 break
             repo_type, repo_path = source_repository.split(":")
             if repo_type == "github":
-                parts = urlparse(source_url)
-                commit = extract_commit(repo_path, parts.path)
-                matched = (
-                    parts.scheme == "https"
-                    and parts.netloc == "github.com"
-                    and os.path.abspath(parts.path).startswith(f"/{repo_path}/")
-                    # If the URL is a source archive at a commit, then check the commit is from the original repo.
-                    and (not commit or is_commit_in_original_repo(repo_path, commit))
-                )
+                matched = check_github_url(repo_path, source_url)
             elif repo_type == "https":
                 repo = urlparse(source_repository)
                 parts = urlparse(source_url)
@@ -245,7 +256,10 @@ class BcrValidator:
         if not matched:
             self.report(
                 BcrValidationResult.FAILED,
-                f"The source URL of {module_name}@{version} ({source_url}) doesn't match any of the module's source repositories {source_repositories}.",
+                f"The source URL of {module_name}@{version} ({source_url}) doesn't match any of the module's source repositories {source_repositories}.\n"
+                + "If it's a GitHub URL, only the following forms are allowed:\n"
+                + "  1) https://github.com/<OWNER>/<REPO>/releases/download/... (Recommended)\n"
+                + "  2) https://github.com/<OWNER>/<REPO>/archive/<REF>.(tar.gz|zip) where REF must come from the original repository",
             )
         else:
             self.report(BcrValidationResult.GOOD, "The source URL matches one of the source repositories.")


### PR DESCRIPTION
A source archive URL in the form of `https//github.com/OWNER/REPO/archive/<commit>.zip` isn't guaranteed to point source code from the original repository because `<commit>` can be a fork and GitHub will happily generate the source archive under this URL. An attacker can use such an URL to confuse BCR maintainer that the URL is from the source repo.

This PR adds a check to make sure the commit is actually coming from the original repository via a GitHub API (unofficial).