### PR TITLE
Fix symlink issue with boost.asio

### DIFF
--- a/modules/boost.asio/1.83.0.bcr.3/MODULE.bazel
+++ b/modules/boost.asio/1.83.0.bcr.3/MODULE.bazel
@@ -1,0 +1,29 @@
+module(
+    name = "boost.asio",
+    version = "1.83.0.bcr.3",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 108300,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "boringssl", version = "0.20240913.0")
+bazel_dep(name = "boost.align", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.array", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.assert", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.bind", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.chrono", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.config", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.context", version = "1.83.0.bcr.2")
+bazel_dep(name = "boost.core", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.coroutine", version = "1.83.0.bcr.2")
+bazel_dep(name = "boost.date_time", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.exception", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.function", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.regex", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.smart_ptr", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.system", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.throw_exception", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.type_traits", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.utility", version = "1.83.0.bcr.1")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.13")

--- a/modules/boost.asio/1.83.0.bcr.3/overlay/BUILD.bazel
+++ b/modules/boost.asio/1.83.0.bcr.3/overlay/BUILD.bazel
@@ -1,0 +1,1 @@
+../../1.83.0.bcr.1/overlay/BUILD.bazel

--- a/modules/boost.asio/1.83.0.bcr.3/overlay/MODULE.bazel
+++ b/modules/boost.asio/1.83.0.bcr.3/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/boost.asio/1.83.0.bcr.3/overlay/test/BUILD.bazel
+++ b/modules/boost.asio/1.83.0.bcr.3/overlay/test/BUILD.bazel
@@ -1,0 +1,1 @@
+../../../1.83.0.bcr.1/overlay/test/BUILD.bazel

--- a/modules/boost.asio/1.83.0.bcr.3/overlay/test/MODULE.bazel
+++ b/modules/boost.asio/1.83.0.bcr.3/overlay/test/MODULE.bazel
@@ -1,0 +1,1 @@
+../../../1.83.0.bcr.1/overlay/test/MODULE.bazel

--- a/modules/boost.asio/1.83.0.bcr.3/overlay/test/archetypes/BUILD.bazel
+++ b/modules/boost.asio/1.83.0.bcr.3/overlay/test/archetypes/BUILD.bazel
@@ -1,0 +1,1 @@
+../../../../1.83.0.bcr.1/overlay/test/archetypes/BUILD.bazel

--- a/modules/boost.asio/1.83.0.bcr.3/presubmit.yml
+++ b/modules/boost.asio/1.83.0.bcr.3/presubmit.yml
@@ -1,0 +1,52 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2004_arm64
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.asio//:boost.asio'
+bcr_test_module:
+  module_path: test
+  matrix:
+    platform:
+      - debian10
+      - debian11
+      - macos
+      - macos_arm64
+      - ubuntu2004
+      - ubuntu2004_arm64
+      - ubuntu2204
+      - ubuntu2404
+      - windows
+    bazel:
+      - 7.x
+      - 8.x
+      - rolling
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - '--process_headers_in_dependencies'
+      build_targets:
+        - //...
+      test_targets:
+        - //...

--- a/modules/boost.asio/1.83.0.bcr.3/source.json
+++ b/modules/boost.asio/1.83.0.bcr.3/source.json
@@ -1,0 +1,12 @@
+{
+    "integrity": "sha256-/mOmHwuTI67iCQpPW6yY7g+0X9L/4xYQXCbfVNAbtj8=",
+    "strip_prefix": "asio-boost-1.83.0",
+    "url": "https://github.com/boostorg/asio/archive/refs/tags/boost-1.83.0.tar.gz",
+    "overlay": {
+        "BUILD.bazel": "sha256-7dsPuPevCutp/EdPRxhW0dlbB1wNJFseGx4b35TS2WA=",
+        "MODULE.bazel": "sha256-9rLz66TJ71j3KjT+UJ+svtfQQ0vNZ5e9uObjfB6xmVA=",
+        "test/BUILD.bazel": "sha256-8fcIeYXVWHay4eYnKwdrvdtlPAEtVEqqBlUKdwZcCDY=",
+        "test/MODULE.bazel": "sha256-ZfKUEr6nY1wNwo+vePuodiCVMd3lD5DpnvfAGdDopjE=",
+        "test/archetypes/BUILD.bazel": "sha256-d5MKVHwxKqaRPwR2x7feBKD6ovoOFZW9jzJSKwIRgdg="
+    }
+}

--- a/modules/boost.asio/metadata.json
+++ b/modules/boost.asio/metadata.json
@@ -18,7 +18,9 @@
     "versions": [
         "1.83.0",
         "1.83.0.bcr.1",
-        "1.83.0.bcr.2"
+        "1.83.0.bcr.3"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "1.83.0.bcr.2": "boost.asio 1.83.0.bcr.2 is yanked due to test dir symlink being broken on aarch64"
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel-central-registry/issues/3631

It seems there is a problem with symlinking a directory in the BCR. The fix in this case is to create all the sub-directories, and symlink each individual file to the file in the previous version.

It could be worth adding a presubmit check for symlinks to directories, to ensure this doesn't happen again in the future.

I would also recommend adding ubuntu2004_arm64 to the presubmit platforms wherever possible, for all packages.