### PR TITLE
bzip2: use mirror archive

### DIFF
--- a/modules/bzip2/1.0.8.bcr.2/MODULE.bazel
+++ b/modules/bzip2/1.0.8.bcr.2/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "bzip2",
+    version = "1.0.8.bcr.2",
+    compatibility_level = 1,
+)

--- a/modules/bzip2/1.0.8.bcr.2/patches/add_build_file.patch
+++ b/modules/bzip2/1.0.8.bcr.2/patches/add_build_file.patch
@@ -1,0 +1,37 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,34 @@
++cc_binary(
++    name = "bzip2",
++    srcs = ["bzip2.c"],
++    defines = [
++        "_FILE_OFFSET_BITS=64",
++    ],
++    deps = [
++        ":bz2",
++    ],
++    visibility = ["//visibility:public"],
++)
++
++cc_library(
++    name = "bz2",
++    srcs = [
++        "blocksort.c",
++        "bzlib.c",
++        "bzlib_private.h",
++        "compress.c",
++        "crctable.c",
++        "decompress.c",
++        "huffman.c",
++        "randtable.c",
++    ],
++    hdrs = [
++        "bzlib.h",
++    ],
++    defines = [
++        "_FILE_OFFSET_BITS=64",
++    ],
++    includes = ["."],
++    strip_include_prefix = "",
++    visibility = ["//visibility:public"],
++)

--- a/modules/bzip2/1.0.8.bcr.2/patches/module_dot_bazel.patch
+++ b/modules/bzip2/1.0.8.bcr.2/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "bzip2",
++    version = "1.0.8.bcr.2",
++    compatibility_level = 1,
++)

--- a/modules/bzip2/1.0.8.bcr.2/presubmit.yml
+++ b/modules/bzip2/1.0.8.bcr.2/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+  - centos7
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+  bazel: [6.x, 7.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@bzip2//:bzip2'
+    - '@bzip2//:bz2'

--- a/modules/bzip2/1.0.8.bcr.2/source.json
+++ b/modules/bzip2/1.0.8.bcr.2/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-q1oDF27hBtPw+pDjgdpHjdrkBZGBU8yiSOaCzQxKImk=",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-QPcAoslzyuAkL4VQgb18uhZaUu8A30/LUrD8wHaKZHY=",
+        "module_dot_bazel.patch": "sha256-gwdtLOrUzwyRC3tAJJNPeB5pjz8uHlAsGXZjL/kCZOc="
+    },
+    "strip_prefix": "bzip2-1.0.8",
+    "url": "https://mirror.bazel.build/sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
+}

--- a/modules/bzip2/metadata.json
+++ b/modules/bzip2/metadata.json
@@ -8,7 +8,8 @@
   ],
   "versions": [
     "1.0.8",
-    "1.0.8.bcr.1"
+    "1.0.8.bcr.1",
+    "1.0.8.bcr.2"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
The sourceware HTTP repo is pretty consistently giving us 500s in our
CI environment. Use a mirror to prevent flakes.
