### PR TITLE
Fix print_all_src_urls.py

### DIFF
--- a/tools/print_all_src_urls.py
+++ b/tools/print_all_src_urls.py
@@ -26,7 +26,12 @@ from registry import RegistryClient
 def main():
     client = RegistryClient(".")
     for name, version in client.get_all_module_versions(include_yanked=False):
-        print(client.get_source(name, version)["url"])
+        source = client.get_source(name, version)
+        if "url" in source:
+            print(source["url"])
+        elif "urls" in source:
+            for url in source["urls"]:
+                print(url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Check "url" or "urls" attribute actually exists since BCR also supports `git_repository` now in source.json