### PR TITLE
Add new module xacro

### DIFF
--- a/modules/xacro/2.0.12/MODULE.bazel
+++ b/modules/xacro/2.0.12/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "xacro",
+    version = "2.0.12",
+    compatibility_level = 0,
+)

--- a/modules/xacro/2.0.12/MODULE.bazel
+++ b/modules/xacro/2.0.12/MODULE.bazel
@@ -1,5 +1,39 @@
 module(
-    name = "xacro",
-    version = "2.0.12",
-    compatibility_level = 0,
+  name = "xacro",
+  version = "2.0.12",
+  compatibility_level = 0,
 )
+
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_python", version = "0.40.0")
+
+PYTHON_VERSIONS = [
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+]
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+
+[
+    python.toolchain(
+        is_default = python_version == PYTHON_VERSIONS[-1],
+        python_version = python_version,
+    )
+    for python_version in PYTHON_VERSIONS
+]
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
+[
+    pip.parse(
+        hub_name = "xacro_python_dependencies",
+        python_version = python_version,
+        requirements_lock = "//bazel:requirements_lock.txt",
+    )
+    for python_version in PYTHON_VERSIONS
+]
+
+use_repo(pip, "xacro_python_dependencies")

--- a/modules/xacro/2.0.12/patches/module_dot_bazel.patch
+++ b/modules/xacro/2.0.12/patches/module_dot_bazel.patch
@@ -1,8 +1,12 @@
---- MODULE.bazel
-+++ MODULE.bazel
-@@ -0,0 +1,5 @@
+--- MODULE.bazel	2025-02-14 21:44:02.566594988 +0000
++++ MODULE.bazel	2025-02-19 16:32:19.920235441 +0000
+@@ -1,4 +1,8 @@
+-module(name = "xacro")
 +module(
-+    name = "xacro",
-+    version = "2.0.12",
-+    compatibility_level = 0,
++  name = "xacro",
++  version = "2.0.12",
++  compatibility_level = 0,
 +)
+ 
+ bazel_dep(name = "rules_license", version = "1.0.0")
+ bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/modules/xacro/2.0.12/patches/module_dot_bazel.patch
+++ b/modules/xacro/2.0.12/patches/module_dot_bazel.patch
@@ -1,12 +1,9 @@
---- MODULE.bazel	2025-02-14 21:44:02.566594988 +0000
-+++ MODULE.bazel	2025-02-19 16:32:19.920235441 +0000
-@@ -1,4 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1 +1,5 @@
 -module(name = "xacro")
 +module(
 +  name = "xacro",
 +  version = "2.0.12",
 +  compatibility_level = 0,
 +)
- 
- bazel_dep(name = "rules_license", version = "1.0.0")
- bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/modules/xacro/2.0.12/patches/module_dot_bazel.patch
+++ b/modules/xacro/2.0.12/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "xacro",
++    version = "2.0.12",
++    compatibility_level = 0,
++)

--- a/modules/xacro/2.0.12/patches/module_dot_bazel.patch
+++ b/modules/xacro/2.0.12/patches/module_dot_bazel.patch
@@ -1,9 +1,12 @@
 --- MODULE.bazel
 +++ MODULE.bazel
-@@ -1 +1,5 @@
+@@ -1,4 +1,8 @@
 -module(name = "xacro")
 +module(
 +  name = "xacro",
 +  version = "2.0.12",
 +  compatibility_level = 0,
 +)
+ 
+ bazel_dep(name = "rules_license", version = "1.0.0")
+ bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/modules/xacro/2.0.12/presubmit.yml
+++ b/modules/xacro/2.0.12/presubmit.yml
@@ -2,13 +2,9 @@ matrix:
   platform:
   - debian10
   - ubuntu2004
-  - macos
-  - macos_arm64
-  - windows
   bazel:
   - 8.x
   - 7.x
-  - 6.x
 tasks:
   verify_targets:
     name: Verify build targets
@@ -22,13 +18,9 @@ bcr_test_module:
     platform:
     - debian10
     - ubuntu2004
-    - macos
-    - macos_arm64
-    - windows
     bazel:
     - 8.x
     - 7.x
-    - 6.x
   tasks:
     run_test_module:
       name: Run test module

--- a/modules/xacro/2.0.12/presubmit.yml
+++ b/modules/xacro/2.0.12/presubmit.yml
@@ -16,7 +16,6 @@ tasks:
     bazel: ${{ bazel }}
     build_targets:
     - '@xacro//:xacro'
-    - '@xacro//bazel:defs'
 bcr_test_module:
   module_path: bazel/integration_test
   matrix:

--- a/modules/xacro/2.0.12/presubmit.yml
+++ b/modules/xacro/2.0.12/presubmit.yml
@@ -1,0 +1,41 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@xacro//:xacro'
+    - '@xacro//bazel:defs'
+bcr_test_module:
+  module_path: bazel/integration_test
+  matrix:
+    platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    - windows
+    bazel:
+    - 8.x
+    - 7.x
+    - 6.x
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - //...
+      test_targets:
+      - //...

--- a/modules/xacro/2.0.12/source.json
+++ b/modules/xacro/2.0.12/source.json
@@ -3,6 +3,6 @@
     "integrity": "sha256-/Af66Yj7FPPokL4gEaXzKdSO5GzL4CHzWCJ9N0oAReU=",
     "patch_strip": 0,
     "patches": {
-        "module_dot_bazel.patch": "sha256-SaPEMQvbT2+MnIrlyOvTy3MqDLIeRc1t7EG2ZpcaEfE="
+        "module_dot_bazel.patch": "sha256-sX7V/iOW+SbQveXfxHAFTirdropFbRzZqW7HMb5RnxA="
     }
 }

--- a/modules/xacro/2.0.12/source.json
+++ b/modules/xacro/2.0.12/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/ros/xacro/archive/c7cc10afb5d1389bde6b7242b532de69bfbad8e7.zip",
+    "integrity": "sha256-qaKrlFbE5wdoVq90Y8O49a1KO1jRyVUR2ms3wBGX1uo=",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-SaPEMQvbT2+MnIrlyOvTy3MqDLIeRc1t7EG2ZpcaEfE="
+    }
+}

--- a/modules/xacro/2.0.12/source.json
+++ b/modules/xacro/2.0.12/source.json
@@ -3,6 +3,6 @@
     "integrity": "sha256-/Af66Yj7FPPokL4gEaXzKdSO5GzL4CHzWCJ9N0oAReU=",
     "patch_strip": 0,
     "patches": {
-        "module_dot_bazel.patch": "sha256-sX7V/iOW+SbQveXfxHAFTirdropFbRzZqW7HMb5RnxA="
+        "module_dot_bazel.patch": "sha256-ZPsNDJqfrndzCvWM3FdPWQzXM1jd7PQ+Xps6+8xDlrY="
     }
 }

--- a/modules/xacro/2.0.12/source.json
+++ b/modules/xacro/2.0.12/source.json
@@ -1,8 +1,9 @@
 {
     "url": "https://github.com/ros/xacro/archive/35e3c2ebc737ef3a0c2866101c08c90304d008bd.zip",
     "integrity": "sha256-/Af66Yj7FPPokL4gEaXzKdSO5GzL4CHzWCJ9N0oAReU=",
+    "strip_prefix": "xacro-35e3c2ebc737ef3a0c2866101c08c90304d008bd",
     "patch_strip": 0,
     "patches": {
-        "module_dot_bazel.patch": "sha256-ZPsNDJqfrndzCvWM3FdPWQzXM1jd7PQ+Xps6+8xDlrY="
+        "module_dot_bazel.patch": "sha256-154lQpbiJFvXviIU/TWvefTwsWiSRNDv3asmBH5FjGk="
     }
 }

--- a/modules/xacro/2.0.12/source.json
+++ b/modules/xacro/2.0.12/source.json
@@ -1,6 +1,6 @@
 {
-    "url": "https://github.com/ros/xacro/archive/c7cc10afb5d1389bde6b7242b532de69bfbad8e7.zip",
-    "integrity": "sha256-qaKrlFbE5wdoVq90Y8O49a1KO1jRyVUR2ms3wBGX1uo=",
+    "url": "https://github.com/ros/xacro/archive/35e3c2ebc737ef3a0c2866101c08c90304d008bd.zip",
+    "integrity": "sha256-/Af66Yj7FPPokL4gEaXzKdSO5GzL4CHzWCJ9N0oAReU=",
     "patch_strip": 0,
     "patches": {
         "module_dot_bazel.patch": "sha256-SaPEMQvbT2+MnIrlyOvTy3MqDLIeRc1t7EG2ZpcaEfE="

--- a/modules/xacro/metadata.json
+++ b/modules/xacro/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/ros/xacro",
+    "maintainers": [
+        {
+            "email": "mjcarroll@intrinsic.ai",
+            "github": "mjcarroll",
+            "name": "Michael Carroll"
+        }
+    ],
+    "repository": [
+        "github:ros/xacro"
+    ],
+    "versions": [
+        "2.0.12"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds a module for https://github.com/ros/xacro, a tool to expand xacro files (xml macros).

Upstream accepted patches for bzlmod support as well as rules for expanding these macro files at build-time with bazel.