### PR TITLE
Git ignored `temp_test_repos`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ tools/__pycache__
 tools/node_modules
 /bazel-*
 MODULE.bazel.lock
+temp_test_repos
 
 # CLion
 /.clwb/


### PR DESCRIPTION
This folder is generated by `//tools:setup_presubmit_repos` when doing local testing, so we should ignore it.