### PR TITLE
Set `ignore_root_user_error = True` for python toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,6 +12,7 @@ python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
     is_default = True,
     python_version = "3.11",
+    ignore_root_user_error = True,
 )
 use_repo(python, "python_3_11", "python_versions")
 


### PR DESCRIPTION
Avoid the root user error in Docker container