### PR TITLE
Bump Bazel CI commit for setup_presubmit_repos

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,7 +38,7 @@ use_repo(npm, "npm")
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
-BAZEL_CI_COMMIT = "c12a4c95c302ad6fee34c1229714dcf9d314cd60"
+BAZEL_CI_COMMIT = "3c2bc5dc463e7d35b0d14faca4e1aa0b2c04bfa9"
 
 http_file(
     name = "bazelci_py_file",


### PR DESCRIPTION
Getting https://github.com/bazelbuild/continuous-integration/commit/3c2bc5dc463e7d35b0d14faca4e1aa0b2c04bfa9