### PR TITLE
Updated integrity of `setup_presubmit_repos` files after `BAZEL_CI_COMMIT` was bumped.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -42,14 +42,14 @@ BAZEL_CI_COMMIT = "3c2bc5dc463e7d35b0d14faca4e1aa0b2c04bfa9"
 
 http_file(
     name = "bazelci_py_file",
-    integrity = "sha256-nkB6rJrq0w2T/yLxjgL9jR0JB07nGNtzY5aDQ1qrMeY=",
+    integrity = "sha256-7RzwSiBqmEUM87qAgPpAKA28v1MWWmjP22FLp8qSU0s=",
     downloaded_file_path = "bazelci.py",
     urls = ["https://raw.githubusercontent.com/bazelbuild/continuous-integration/%s/buildkite/bazelci.py" % BAZEL_CI_COMMIT],
 )
 
 http_file(
     name = "bcr_presubmit_py_file",
-    integrity = "sha256-I3t2q/kMAHLDmiIqy+UUoUmWkHN+0bz9IwqikO7btDg=",
+    integrity = "sha256-ksWL3Jl4IOcGs1f5uZpvtw/Qb/F5EWEL6khv3G5ATcA=",
     downloaded_file_path = "bcr_presubmit.py",
     urls = ["https://raw.githubusercontent.com/bazelbuild/continuous-integration/%s/buildkite/bazel-central-registry/bcr_presubmit.py" % BAZEL_CI_COMMIT],
 )


### PR DESCRIPTION
Fixes `//tools:setup_presubmit_repos`.

Bumped in https://github.com/bazelbuild/bazel-central-registry/pull/3848, but forgot to update integrity.