### PR TITLE
Updated `azure-core-cpp` `1.14.1` to only add OpenSSL as a dep if not on Windows.

### DIFF
--- a/modules/azure-core-cpp/1.14.1.bcr.1/MODULE.bazel
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/MODULE.bazel
@@ -1,0 +1,13 @@
+module(
+    name = "azure-core-cpp",
+    version = "1.14.1.bcr.1",
+    bazel_compatibility = [">=7.2.1"],  # need support for "overlay" directory
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "curl", version = "8.8.0.bcr.3")
+bazel_dep(name = "googletest", version = "1.16.0")
+bazel_dep(name = "openssl", version = "3.3.1.bcr.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/azure-core-cpp/1.14.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/overlay/BUILD.bazel
@@ -102,9 +102,8 @@ cc_library(
     }),
     linkopts = select({
         "@platforms//os:windows": [
-            "-lbcrypt",
-            "-lcrypt32",
-            "-ladvapi32",
+            "bcrypt.lib",
+            "crypt32.lib",
         ],
         "//conditions:default": [],
     }),

--- a/modules/azure-core-cpp/1.14.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/overlay/BUILD.bazel
@@ -100,6 +100,10 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
+    linkopts = select({
+        "@platforms//os:windows": ["-lbcrypt"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/modules/azure-core-cpp/1.14.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/overlay/BUILD.bazel
@@ -101,7 +101,11 @@ cc_library(
         "//conditions:default": [],
     }),
     linkopts = select({
-        "@platforms//os:windows": ["-lbcrypt"],
+        "@platforms//os:windows": [
+            "-lbcrypt",
+            "-lcrypt32",
+            "-ladvapi32",
+        ],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],

--- a/modules/azure-core-cpp/1.14.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,145 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+bool_flag(
+    name = "build_transport_curl",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "build_transport_curl_setting",
+    flag_values = {":build_transport_curl": "true"},
+)
+
+config_setting(
+    name = "not_build_transport_curl_setting",
+    flag_values = {":build_transport_curl": "false"},
+)
+
+# If we're building azure_core_cpp with Curl as a transport, we must ensure curl
+# was built with OpenSSL and not another SSL lib, as azure_core_cpp only
+# supports OpenSSL.
+selects.config_setting_group(
+    name = "build_transport_curl_openssl",
+    match_all = [
+        ":build_transport_curl_setting",
+        "@curl//:use_openssl",
+    ],
+)
+
+bool_flag(
+    name = "build_transport_winhttp",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "build_transport_winhttp_setting",
+    flag_values = {":build_transport_winhttp": "true"},
+)
+
+cc_library(
+    name = "azure_core_cpp",
+    hdrs = glob(
+        ["inc/**/*.hpp"],
+        exclude = [
+            "inc/azure/core/http/curl_transport.hpp",
+            "inc/azure/core/http/win_http_transport.hpp",
+        ],
+    ) + select({
+        ":build_transport_curl_setting": ["inc/azure/core/http/curl_transport.hpp"],
+        "//conditions:default": [],
+    }) + select({
+        ":build_transport_winhttp_setting": ["inc/azure/core/http/win_http_transport.hpp"],
+        "//conditions:default": [],
+    }),
+    features = ["parse_headers"],
+    includes = ["inc"],
+    textual_hdrs = glob(
+        ["src/private/**/*.hpp"]
+    ) + select({
+        ":build_transport_curl_setting": glob(["src/http/curl/**/*.hpp"]),
+        "//conditions:default": [],
+    }) + select({
+        ":build_transport_winhttp_setting": ["src/http/winhttp/win_http_request.hpp"],
+        "//conditions:default": [],
+    }),
+    srcs = glob(
+        ["src/**/*.cpp"],
+        exclude = [
+            "src/http/curl/**/*.cpp",
+            "src/http/winhttp/**/*.cpp",
+        ],
+    ) + select({
+        ":build_transport_curl_setting": glob(["src/http/curl/**/*.cpp"]),
+        "//conditions:default": [],
+    }) + select({
+        ":build_transport_winhttp_setting": glob(["src/http/winhttp/**/*.cpp"]),
+        "//conditions:default": [],
+    }),
+    deps = select({
+        # azure-core-cpp uses bcrypt on Windows and OpenSSL otherwise for
+        # hashing.
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "@openssl//:crypto",
+            "@openssl//:ssl",
+        ],
+    }) + select(
+        {
+            ":build_transport_curl_openssl": ["@curl//:curl"],
+            ":not_build_transport_curl_setting": [],
+        },
+        no_match_error = "azure_core_cpp must be built with --@curl//:ssl_lib=openssl when Curl is enabled as a transport",
+    ) + select({
+        ":build_transport_winhttp_setting": [
+            # TODO: add wil as a dep here when it's in the BCR:
+            # https://github.com/bazelbuild/bazel-central-registry/issues/3807
+        ],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "azure_core_cpp_test",
+    srcs = glob(
+        [
+            "test/ut/*.cpp",
+            "test/ut/*.hpp",
+        ],
+        # TODO: exclude tests that fail out of the box for now.
+        exclude = [
+            "test/ut/azure_libcurl_core_main_test.cpp",
+            "test/ut/bodystream_test.cpp",
+            "test/ut/curl_options_test.cpp",
+            "test/ut/retry_policy_test.cpp",
+            "test/ut/telemetry_policy_test.cpp",
+            "test/ut/transport_adapter_base_test.cpp",
+            "test/ut/transport_policy_options.cpp",
+        ] + [
+            # Exclude Curl tests so we only add them in when building with Curl
+            # transport.
+            "test/ut/curl_connection_pool_test.cpp",
+            "test/ut/curl_session_test.hpp",
+            "test/ut/curl_session_test_test.cpp",
+        ],
+    ) + select({
+        ":build_transport_curl_setting": [
+            "test/ut/curl_connection_pool_test.cpp",
+            "test/ut/curl_session_test.hpp",
+            "test/ut/curl_session_test_test.cpp",
+        ],
+        "//conditions:default": [],
+    }),
+    includes = ["src"],
+    deps = [
+        ":azure_core_cpp",
+        "@googletest//:gtest",
+    ],
+    local_defines = [
+        "_azure_TESTING_BUILD",
+    ],
+)

--- a/modules/azure-core-cpp/1.14.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/overlay/BUILD.bazel
@@ -104,6 +104,7 @@ cc_library(
         "@platforms//os:windows": [
             "bcrypt.lib",
             "crypt32.lib",
+            "advapi32.lib",
         ],
         "//conditions:default": [],
     }),

--- a/modules/azure-core-cpp/1.14.1.bcr.1/overlay/MODULE.bazel
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/azure-core-cpp/1.14.1.bcr.1/overlay/test/MODULE.bazel
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/overlay/test/MODULE.bazel
@@ -1,0 +1,7 @@
+bazel_dep(name = "azure-core-cpp", version = "1.14.1")
+local_path_override(
+    module_name = "azure-core-cpp",
+    path = "..",
+)
+
+bazel_dep(name = "curl", version = "8.8.0.bcr.3")

--- a/modules/azure-core-cpp/1.14.1.bcr.1/overlay/test/MODULE.bazel
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/overlay/test/MODULE.bazel
@@ -1,4 +1,4 @@
-bazel_dep(name = "azure-core-cpp", version = "1.14.1")
+bazel_dep(name = "azure-core-cpp", version = "1.14.1.bcr.1")
 local_path_override(
     module_name = "azure-core-cpp",
     path = "..",

--- a/modules/azure-core-cpp/1.14.1.bcr.1/presubmit.yml
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/presubmit.yml
@@ -1,0 +1,75 @@
+bcr_test_module:
+  module_path: test
+  matrix:
+    platform:
+      - debian11
+      - macos
+      - macos_arm64
+      - ubuntu2004
+      - ubuntu2204
+      - ubuntu2404
+      # - windows
+    bazel: [7.x, 8.x, rolling]
+  tasks:
+    verify_targets_no_transport:
+      name: Build and test with no HTTP transport
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "@azure-core-cpp//:azure_core_cpp"
+      build_flags:
+        - "--@azure-core-cpp//:build_transport_curl=false"
+        - "--@azure-core-cpp//:build_transport_winhttp=false"
+      test_targets:
+        - "@azure-core-cpp//:azure_core_cpp_test"
+      test_flags:
+        - "--@azure-core-cpp//:build_transport_curl=false"
+        - "--@azure-core-cpp//:build_transport_winhttp=false"
+    verify_targets_curl_transport:
+      name: Build and test with Curl as HTTP transport
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "@azure-core-cpp//:azure_core_cpp"
+      build_flags:
+        - "--@curl//:ssl_lib=openssl"
+        - "--@azure-core-cpp//:build_transport_curl=true"
+        - "--@azure-core-cpp//:build_transport_winhttp=false"
+      test_targets:
+        - "@azure-core-cpp//:azure_core_cpp_test"
+      test_flags:
+        - "--@curl//:ssl_lib=openssl"
+        - "--@azure-core-cpp//:build_transport_curl=true"
+        - "--@azure-core-cpp//:build_transport_winhttp=false"
+    # Enable once wil is in the BCR:
+    #   https://github.com/bazelbuild/bazel-central-registry/issues/3807
+    # verify_targets_winhttp_transport:
+    #   name: Build and test with WinHTTP as HTTP transport
+    #   platform: ${{ platform }}
+    #   bazel: ${{ bazel }}
+    #   build_targets:
+    #     - "@azure-core-cpp//:azure_core_cpp"
+    #   build_flags:
+    #     - "--@azure-core-cpp//:build_transport_curl=false"
+    #     - "--@azure-core-cpp//:build_transport_winhttp=true"
+    #   test_targets:
+    #     - "@azure-core-cpp//:azure_core_cpp_test"
+    #   test_flags:
+    #     - "--@azure-core-cpp//:build_transport_curl=false"
+    #     - "--@azure-core-cpp//:build_transport_winhttp=true"
+    # verify_targets_all_transports:
+    #   name: Build and test with all HTTP transports
+    #   platform: ${{ platform }}
+    #   bazel: ${{ bazel }}
+    #   build_targets:
+    #     - "@azure-core-cpp//:azure_core_cpp"
+    #   build_flags:
+    #     - "--@curl//:ssl_lib=openssl"
+    #     - "--@azure-core-cpp//:build_transport_curl=true"
+    #     - "--@azure-core-cpp//:build_transport_winhttp=true"
+    #   test_targets:
+    #     - "@azure-core-cpp//:azure_core_cpp_test"
+    #   test_flags:
+    #     - "--@curl//:ssl_lib=openssl"
+    #     - "--@azure-core-cpp//:build_transport_curl=true"
+    #     - "--@azure-core-cpp//:build_transport_winhttp=true"

--- a/modules/azure-core-cpp/1.14.1.bcr.1/presubmit.yml
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/presubmit.yml
@@ -1,19 +1,18 @@
 bcr_test_module:
   module_path: test
   matrix:
-    platform:
+    unix_platform:
       - debian11
       - macos
       - macos_arm64
       - ubuntu2004
       - ubuntu2204
       - ubuntu2404
-      # - windows
     bazel: [7.x, 8.x, rolling]
   tasks:
-    verify_targets_no_transport:
-      name: Build and test with no HTTP transport
-      platform: ${{ platform }}
+    verify_targets_no_transport_unix:
+      name: Build and test with no HTTP transport on Unix platforms
+      platform: ${{ unix_platform }}
       bazel: ${{ bazel }}
       build_targets:
         - "@azure-core-cpp//:azure_core_cpp"
@@ -25,9 +24,9 @@ bcr_test_module:
       test_flags:
         - "--@azure-core-cpp//:build_transport_curl=false"
         - "--@azure-core-cpp//:build_transport_winhttp=false"
-    verify_targets_curl_transport:
-      name: Build and test with Curl as HTTP transport
-      platform: ${{ platform }}
+    verify_targets_curl_transport_unix:
+      name: Build and test with Curl as HTTP transport on Unix platforms
+      platform: ${{ unix_platform }}
       bazel: ${{ bazel }}
       build_targets:
         - "@azure-core-cpp//:azure_core_cpp"
@@ -41,35 +40,21 @@ bcr_test_module:
         - "--@curl//:ssl_lib=openssl"
         - "--@azure-core-cpp//:build_transport_curl=true"
         - "--@azure-core-cpp//:build_transport_winhttp=false"
-    # Enable once wil is in the BCR:
+    verify_targets_no_transport_windows:
+      name: Build and test with no HTTP transport on Windows
+      platform: windows
+      bazel: ${{ bazel }}
+      build_targets:
+        - "@azure-core-cpp//:azure_core_cpp"
+      build_flags:
+        - "--@azure-core-cpp//:build_transport_curl=false"
+        - "--@azure-core-cpp//:build_transport_winhttp=false"
+      test_targets:
+        - "@azure-core-cpp//:azure_core_cpp_test"
+      test_flags:
+        - "--@azure-core-cpp//:build_transport_curl=false"
+        - "--@azure-core-cpp//:build_transport_winhttp=false"
+    # Add this once wil is in the BCR:
     #   https://github.com/bazelbuild/bazel-central-registry/issues/3807
-    # verify_targets_winhttp_transport:
-    #   name: Build and test with WinHTTP as HTTP transport
-    #   platform: ${{ platform }}
-    #   bazel: ${{ bazel }}
-    #   build_targets:
-    #     - "@azure-core-cpp//:azure_core_cpp"
-    #   build_flags:
-    #     - "--@azure-core-cpp//:build_transport_curl=false"
-    #     - "--@azure-core-cpp//:build_transport_winhttp=true"
-    #   test_targets:
-    #     - "@azure-core-cpp//:azure_core_cpp_test"
-    #   test_flags:
-    #     - "--@azure-core-cpp//:build_transport_curl=false"
-    #     - "--@azure-core-cpp//:build_transport_winhttp=true"
-    # verify_targets_all_transports:
-    #   name: Build and test with all HTTP transports
-    #   platform: ${{ platform }}
-    #   bazel: ${{ bazel }}
-    #   build_targets:
-    #     - "@azure-core-cpp//:azure_core_cpp"
-    #   build_flags:
-    #     - "--@curl//:ssl_lib=openssl"
-    #     - "--@azure-core-cpp//:build_transport_curl=true"
-    #     - "--@azure-core-cpp//:build_transport_winhttp=true"
-    #   test_targets:
-    #     - "@azure-core-cpp//:azure_core_cpp_test"
-    #   test_flags:
-    #     - "--@curl//:ssl_lib=openssl"
-    #     - "--@azure-core-cpp//:build_transport_curl=true"
-    #     - "--@azure-core-cpp//:build_transport_winhttp=true"
+    # verify_targets_winhttp_transport_windows:
+    #   ...

--- a/modules/azure-core-cpp/1.14.1.bcr.1/source.json
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-4Bc6Z1NjRjxj9SohXks/G/soyQHXD+fupCC13Eqlkcs=",
     "strip_prefix": "azure-sdk-for-cpp-azure-core_1.14.1/sdk/core/azure-core",
     "overlay": {
-        "BUILD.bazel": "sha256-HOEwWV8MT9ImeSMjzETvzU1S8F68NQqDDLpdTzeOPJw=",
+        "BUILD.bazel": "sha256-arus7bLl7rLoBQf4mpFs9kW6ldpWlLX8ggAvSTeR7FQ=",
         "MODULE.bazel": "sha256-/zVpyhjzlzqxai0TXZ1sQFDM7PZaL61stPL7o7tMxts=",
         "test/MODULE.bazel": "sha256-JDkG4iOhVHMz3QSVOr/JT5IYWpKk/k3svUjUxgmolwE="
     }

--- a/modules/azure-core-cpp/1.14.1.bcr.1/source.json
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-4Bc6Z1NjRjxj9SohXks/G/soyQHXD+fupCC13Eqlkcs=",
     "strip_prefix": "azure-sdk-for-cpp-azure-core_1.14.1/sdk/core/azure-core",
     "overlay": {
-        "BUILD.bazel": "sha256-I0QPOLZ/+0bpvi+nN/h0HXcgzCpKodVjN+yrPCazt9g=",
+        "BUILD.bazel": "sha256-HOEwWV8MT9ImeSMjzETvzU1S8F68NQqDDLpdTzeOPJw=",
         "MODULE.bazel": "sha256-/zVpyhjzlzqxai0TXZ1sQFDM7PZaL61stPL7o7tMxts=",
         "test/MODULE.bazel": "sha256-JDkG4iOhVHMz3QSVOr/JT5IYWpKk/k3svUjUxgmolwE="
     }

--- a/modules/azure-core-cpp/1.14.1.bcr.1/source.json
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-core_1.14.1.tar.gz",
+    "integrity": "sha256-4Bc6Z1NjRjxj9SohXks/G/soyQHXD+fupCC13Eqlkcs=",
+    "strip_prefix": "azure-sdk-for-cpp-azure-core_1.14.1/sdk/core/azure-core",
+    "overlay": {
+        "BUILD.bazel": "sha256-DlexFB91+20aVyr3Rmq1+0xDuAZ1FRDSFzmkwQQZOrM=",
+        "MODULE.bazel": "sha256-/zVpyhjzlzqxai0TXZ1sQFDM7PZaL61stPL7o7tMxts=",
+        "test/MODULE.bazel": "sha256-7U1k/sU3wPNDBIgcmAfDU9u9VJbUIYu2OKdKGIJ2YEo="
+    }
+}

--- a/modules/azure-core-cpp/1.14.1.bcr.1/source.json
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/source.json
@@ -5,6 +5,6 @@
     "overlay": {
         "BUILD.bazel": "sha256-DlexFB91+20aVyr3Rmq1+0xDuAZ1FRDSFzmkwQQZOrM=",
         "MODULE.bazel": "sha256-/zVpyhjzlzqxai0TXZ1sQFDM7PZaL61stPL7o7tMxts=",
-        "test/MODULE.bazel": "sha256-7U1k/sU3wPNDBIgcmAfDU9u9VJbUIYu2OKdKGIJ2YEo="
+        "test/MODULE.bazel": "sha256-JDkG4iOhVHMz3QSVOr/JT5IYWpKk/k3svUjUxgmolwE="
     }
 }

--- a/modules/azure-core-cpp/1.14.1.bcr.1/source.json
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-4Bc6Z1NjRjxj9SohXks/G/soyQHXD+fupCC13Eqlkcs=",
     "strip_prefix": "azure-sdk-for-cpp-azure-core_1.14.1/sdk/core/azure-core",
     "overlay": {
-        "BUILD.bazel": "sha256-lzFd2zwShG8Etfzuar7SFMQrFbzXlM8EDqHEp+6G9zc=",
+        "BUILD.bazel": "sha256-I0QPOLZ/+0bpvi+nN/h0HXcgzCpKodVjN+yrPCazt9g=",
         "MODULE.bazel": "sha256-/zVpyhjzlzqxai0TXZ1sQFDM7PZaL61stPL7o7tMxts=",
         "test/MODULE.bazel": "sha256-JDkG4iOhVHMz3QSVOr/JT5IYWpKk/k3svUjUxgmolwE="
     }

--- a/modules/azure-core-cpp/1.14.1.bcr.1/source.json
+++ b/modules/azure-core-cpp/1.14.1.bcr.1/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-4Bc6Z1NjRjxj9SohXks/G/soyQHXD+fupCC13Eqlkcs=",
     "strip_prefix": "azure-sdk-for-cpp-azure-core_1.14.1/sdk/core/azure-core",
     "overlay": {
-        "BUILD.bazel": "sha256-DlexFB91+20aVyr3Rmq1+0xDuAZ1FRDSFzmkwQQZOrM=",
+        "BUILD.bazel": "sha256-lzFd2zwShG8Etfzuar7SFMQrFbzXlM8EDqHEp+6G9zc=",
         "MODULE.bazel": "sha256-/zVpyhjzlzqxai0TXZ1sQFDM7PZaL61stPL7o7tMxts=",
         "test/MODULE.bazel": "sha256-JDkG4iOhVHMz3QSVOr/JT5IYWpKk/k3svUjUxgmolwE="
     }

--- a/modules/azure-core-cpp/metadata.json
+++ b/modules/azure-core-cpp/metadata.json
@@ -11,7 +11,8 @@
         "github:Azure/azure-sdk-for-cpp"
     ],
     "versions": [
-        "1.14.1"
+        "1.14.1",
+        "1.14.1.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
*   Updated `azure_core_cpp_test` to enable some more tests.
*   Added a presubmit for Windows.