### PR TITLE
Add helly25_mbo@0.4.0-rc.1

### DIFF
--- a/modules/helly25_mbo/0.4.0-rc.1/MODULE.bazel
+++ b/modules/helly25_mbo/0.4.0-rc.1/MODULE.bazel
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) The helly25/mbo authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Due to flag and test references to the repo name we use the old name for now.
+module(name = "helly25_mbo", version = "0.4.0-rc.1", repo_name = "com_helly25_mbo")
+
+# For local development we include LLVM and Hedron-Compile-Commands.
+# For bazelmod usage these have to be provided by the main module - if necessary.
+# include("//bazelmod:hedron.MODULE.bazel")
+# include("//bazelmod:llvm.MODULE.bazel")
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+
+bazel_dep(name = "abseil-cpp", version = "20250127.0", repo_name = "com_google_absl")
+bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")
+bazel_dep(name = "googletest", version = "1.16.0", repo_name = "com_google_googletest")
+bazel_dep(name = "google_benchmark", version = "1.9.1", repo_name = "com_github_google_benchmark")
+# In Bazelmod we do not need to specify the protobuf version yet.
+# bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")

--- a/modules/helly25_mbo/0.4.0-rc.1/patches/bazelmod.patch
+++ b/modules/helly25_mbo/0.4.0-rc.1/patches/bazelmod.patch
@@ -1,0 +1,28 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index c298a32..658794e 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -18,8 +18,8 @@ module(name = "helly25_mbo", version = "0.4.0", repo_name = "com_helly25_mbo")
+ 
+ # For local development we include LLVM and Hedron-Compile-Commands.
+ # For bazelmod usage these have to be provided by the main module - if necessary.
+-include("//bazelmod:hedron.MODULE.bazel")
+-include("//bazelmod:llvm.MODULE.bazel")
++# include("//bazelmod:hedron.MODULE.bazel")
++# include("//bazelmod:llvm.MODULE.bazel")
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.7.1")
+ bazel_dep(name = "rules_cc", version = "0.1.1")
+diff --git a/mbo/mope/mope.bzl b/mbo/mope/mope.bzl
+index d80d788..7aeac41 100644
+--- a/mbo/mope/mope.bzl
++++ b/mbo/mope/mope.bzl
+@@ -35,7 +35,7 @@ load("//mbo/diff:diff.bzl", "diff_test")
+ #    c) `$(which "clang_format")`
+ #    d) `clang-format-23` ... `clang-format-15`, `clang-format`
+ #    e) If even (d) fails, then we will just copy the file.
+-_CLANG_FORMAT_BINARY = ""  # Ignore clang-format from repo with: "clang-format-auto"
++_CLANG_FORMAT_BINARY = "clang-format-auto"  # Ignore clang-format from repo with: "clang-format-auto"
+ 
+ def _get_clang_format(ctx):
+     """Get the selected clang-format from `--//mbo/mope:clang_format` bazel flag."""

--- a/modules/helly25_mbo/0.4.0-rc.1/patches/bcr.bazelmod-version.patch
+++ b/modules/helly25_mbo/0.4.0-rc.1/patches/bcr.bazelmod-version.patch
@@ -1,0 +1,13 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index bb91a62..1d31850 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -14,7 +14,7 @@
+ # limitations under the License.
+ 
+ # Due to flag and test references to the repo name we use the old name for now.
+-module(name = "helly25_mbo", version = "0.4.0", repo_name = "com_helly25_mbo")
++module(name = "helly25_mbo", version = "0.4.0-rc.1", repo_name = "com_helly25_mbo")
+ 
+ # For local development we include LLVM and Hedron-Compile-Commands.
+ # For bazelmod usage these have to be provided by the main module - if necessary.

--- a/modules/helly25_mbo/0.4.0-rc.1/presubmit.yml
+++ b/modules/helly25_mbo/0.4.0-rc.1/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  bazel:
+  - 7.x
+  - 8.x
+  platform:
+  - debian11
+  - ubuntu2404
+  - macos
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++20'
+    #bazel query 'kind(cc_binary,//...) - rdeps(//mbo/mope:mope,//...)'
+    build_targets:
+      - '@helly25_mbo//mbo/container:limited_set_benchmark'
+      - '@helly25_mbo//mbo/diff:unified_diff'
+      - '@helly25_mbo//mbo/file:glob'

--- a/modules/helly25_mbo/0.4.0-rc.1/presubmit.yml
+++ b/modules/helly25_mbo/0.4.0-rc.1/presubmit.yml
@@ -3,7 +3,6 @@ matrix:
   - 7.x
   - 8.x
   platform:
-  - debian11
   - ubuntu2404
   - macos
 tasks:

--- a/modules/helly25_mbo/0.4.0-rc.1/source.json
+++ b/modules/helly25_mbo/0.4.0-rc.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/helly25/mbo/releases/download/0.4.0-rc.1/mbo-0.4.0-rc.1.tar.gz",
+    "integrity": "sha256-OgLf2eAFxyqSZ6Xv6GDrbWjBQVoLBhtBozPtT1lCq5I=",
+    "strip_prefix": "mbo-0.4.0-rc.1",
+    "patches": {
+        "bazelmod.patch": "sha256-9puSa8FNS4PP0RFLa5As0qyNPeyQ8xGjekm0rxNvaFo=",
+        "bcr.bazelmod-version.patch": "sha256-2eRAQ4CC1Pp1qAmtC7n83paDr8zGjgAFvDQ3QajzmXY="
+    },
+    "patch_strip": 1
+}

--- a/modules/helly25_mbo/metadata.json
+++ b/modules/helly25_mbo/metadata.json
@@ -12,7 +12,6 @@
     ],
     "versions": [
         "0.4.0-rc.1",
-        "0.4.0"
     ],
     "yanked_versions": {}
 }

--- a/modules/helly25_mbo/metadata.json
+++ b/modules/helly25_mbo/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "http://github.com/helly25/mbo",
+    "maintainers": [
+        {
+            "email": "marcus.boerger@gmail.com",
+            "github": "helly25",
+            "name": "helly25"
+        }
+    ],
+    "repository": [
+        "github:helly25/mbo"
+    ],
+    "versions": [
+        "0.4.0-rc.1",
+        "0.4.0"
+    ],
+    "yanked_versions": {}
+}

--- a/modules/helly25_mbo/metadata.json
+++ b/modules/helly25_mbo/metadata.json
@@ -11,7 +11,7 @@
         "github:helly25/mbo"
     ],
     "versions": [
-        "0.4.0-rc.1",
+        "0.4.0-rc.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Add helly25_mbo@0.4.0-rc.1

Version 0.3.0 failed in https://github.com/bazelbuild/bazel-central-registry/pull/3813
This version addresses the fundamental problem of the toolchains_llvm dependency in two ways:
* It is used as a dev dependency only
* That dependency occurs in includes which are commented out through a patch for the bcr release
* The `presubmit.yml`:
  * tests are limited (only actual binaries that do not use clang-format)
    * though technically the project should now work without that as well
  * windows platform is not present (some code & tooling won't work there)
  * c++20 compilation flag is set