### PR TITLE
Fixed how `librdkafka` files can be included in other C/C++ files.

### DIFF
--- a/modules/librdkafka/2.8.0.bcr.1/MODULE.bazel
+++ b/modules/librdkafka/2.8.0.bcr.1/MODULE.bazel
@@ -1,0 +1,15 @@
+module(
+    name = "librdkafka",
+    version = "2.8.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],  # need support for "overlay" directory
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "curl", version = "8.8.0.bcr.3")
+bazel_dep(name = "lz4", version = "1.9.4")
+bazel_dep(name = "openssl", version = "3.3.1.bcr.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
+bazel_dep(name = "zstd", version = "1.5.7")

--- a/modules/librdkafka/2.8.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/librdkafka/2.8.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,288 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Targets are based on the CMakeLists.txt files.
+
+bool_flag(
+    name = "with_curl",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "with_curl_setting",
+    flag_values = {":with_curl": "true"},
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "with_ssl",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "with_ssl_setting",
+    flag_values = {":with_ssl": "true"},
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "with_zlib",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "with_zlib_setting",
+    flag_values = {":with_zlib": "true"},
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "with_zstd",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "with_zstd_setting",
+    flag_values = {":with_zstd": "true"},
+    visibility = ["//visibility:public"],
+)
+
+# This is only used for unix systems. Windows hardcodes defines in
+# src/win32_config.h.
+expand_template(
+    name = "config_h",
+    out = "config.h",
+    substitutions = {
+        "#cmakedefine01 WITHOUT_OPTIMIZATION": "#define WITHOUT_OPTIMIZATION 0",
+        "#cmakedefine01 ENABLE_DEVEL": "#define ENABLE_DEVEL 0",
+        "#cmakedefine01 ENABLE_REFCNT_DEBUG": "#define ENABLE_REFCNT_DEBUG 0",
+        "#cmakedefine01 HAVE_ATOMICS_32_SYNC": "#define HAVE_ATOMICS_32_SYNC 0",
+        "#cmakedefine01 HAVE_ATOMICS_32": "#define HAVE_ATOMICS_32 0",
+        "#cmakedefine01 HAVE_ATOMICS_64_SYNC": "#define HAVE_ATOMICS_64_SYNC 0",
+        "#cmakedefine01 HAVE_ATOMICS_64": "#define HAVE_ATOMICS_64 0",
+        "#cmakedefine01 WITH_PKGCONFIG": "#define WITH_PKGCONFIG 0",
+        "#cmakedefine01 WITH_HDRHISTOGRAM": "#define WITH_HDRHISTOGRAM 1",
+        "#cmakedefine01 WITH_ZLIB": "#define WITH_ZLIB 0",
+        "#cmakedefine01 WITH_CURL": "#define WITH_CURL 0",
+        "#cmakedefine01 WITH_ZSTD": "#define WITH_ZSTD 0",
+        "#cmakedefine01 WITH_LIBDL": "#define WITH_LIBDL 1",
+        "#cmakedefine01 WITH_PLUGINS": "#define WITH_PLUGINS 1",
+        "#cmakedefine01 WITH_SSL": "#define WITH_SSL 0",
+        "#cmakedefine01 WITH_LZ4_EXT": "#define WITH_LZ4_EXT 1",
+        "#cmakedefine01 HAVE_REGEX": "#define HAVE_REGEX 1",
+        "#cmakedefine01 HAVE_STRNDUP": "#define HAVE_STRNDUP 1",
+        "#cmakedefine01 HAVE_RAND_R": "#define HAVE_RAND_R 1",
+        "#cmakedefine01 HAVE_PTHREAD_SETNAME_GNU": "#define HAVE_PTHREAD_SETNAME_GNU 0",
+        "#cmakedefine01 HAVE_PTHREAD_SETNAME_DARWIN": "#define HAVE_PTHREAD_SETNAME_DARWIN 0",
+        "#cmakedefine01 WITH_C11THREADS": "#define WITH_C11THREADS 0",
+        "#cmakedefine01 WITH_CRC32C_HW": "#define WITH_CRC32C_HW 0",
+        "${CMAKE_SHARED_LIBRARY_SUFFIX}": ".so",
+        "${BUILT_WITH}": "bazel",
+        # We don't support FreeBSD for now.
+        "#cmakedefine01 HAVE_PTHREAD_SETNAME_FREEBSD": "#define HAVE_PTHREAD_SETNAME_FREEBSD 0",
+        # SASL is not in the BCR.
+        "#cmakedefine01 WITH_OAUTHBEARER_OIDC": "#define WITH_OAUTHBEARER_OIDC 0",
+        "#cmakedefine01 WITH_SASL_SCRAM": "#define WITH_SASL_SCRAM 0",
+        "#cmakedefine01 WITH_SASL_OAUTHBEARER": "#define WITH_SASL_OAUTHBEARER 0",
+        "#cmakedefine01 WITH_SASL_CYRUS": "#define WITH_SASL_CYRUS 0",
+        "#cmakedefine01 WITH_SASL": "#define WITH_SASL 0",
+    } | selects.with_or({
+        ("@platforms//cpu:arm64", "@platforms//cpu:x86_64"): {
+            "#cmakedefine01 HAVE_ATOMICS_64_SYNC": "#define HAVE_ATOMICS_64_SYNC 1",
+            "#cmakedefine01 HAVE_ATOMICS_64": "#define HAVE_ATOMICS_64 1",
+        },
+        "@platforms//cpu:arm": {
+            "#cmakedefine01 HAVE_ATOMICS_32_SYNC": "1",
+            "#cmakedefine01 HAVE_ATOMICS_32": "1",
+        },
+    }) | select({
+        "@platforms//os:linux": {
+            "#cmakedefine01 HAVE_PTHREAD_SETNAME_GNU": "#define HAVE_PTHREAD_SETNAME_GNU 1",
+            "#cmakedefine01 WITH_C11THREADS": "#define WITH_C11THREADS 1",
+        },
+        "@platforms//os:macos": {
+            "#cmakedefine01 HAVE_PTHREAD_SETNAME_DARWIN": "#define HAVE_PTHREAD_SETNAME_DARWIN 1",
+        },
+    }) | select({
+        ":with_curl_setting": {"#cmakedefine01 WITH_CURL": "#define WITH_CURL 1"},
+        "//conditions:default": {},
+    }) | select({
+        ":with_ssl_setting": {"#cmakedefine01 WITH_SSL": "#define WITH_SSL 1"},
+        "//conditions:default": {},
+    }) | select({
+        ":with_zlib_setting": {"#cmakedefine01 WITH_ZLIB": "#define WITH_ZLIB 1"},
+        "//conditions:default": {},
+    }) | select({
+        ":with_zstd_setting": {"#cmakedefine01 WITH_ZSTD": "#define WITH_ZSTD 1"},
+        "//conditions:default": {},
+    }),
+    template = "packaging/cmake/config.h.in",
+)
+
+cc_library(
+    name = "rdkafka",
+    srcs = glob(
+        ["src/**/*.c"],
+        exclude = [
+            # Exclude all the feature related srcs to be added only if the
+            # feature is enabled.
+            "src/rdhttp.c",
+            "src/rdkafka_ssl.c",
+            "src/rdgz.c",
+            "src/rdkafka_zstd.c",
+            # Exclude files for SASL feature, since cyrus-sasl is currently not
+            # in the BCR.
+            "src/rdkafka_sasl_win32.c",
+            "src/rdkafka_sasl_cyrus.c",
+            "src/rdkafka_sasl_scram.c",
+            "src/rdkafka_sasl_oauthbearer.c",
+            "src/rdkafka_sasl_oauthbearer_oidc.c",
+        ],
+    ) + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [":config_h"],
+    }) + select({
+        ":with_curl_setting": ["src/rdhttp.c"],
+        "//conditions:default": [],
+    }) + select({
+        ":with_ssl_setting": ["src/rdkafka_ssl.c"],
+        "//conditions:default": [],
+    }) + select({
+        ":with_zlib_setting": ["src/rdgz.c"],
+        "//conditions:default": [],
+    }) + select({
+        ":with_zstd_setting": ["src/rdkafka_zstd.c"],
+        "//conditions:default": [],
+    }),
+    hdrs = glob(["src/**/*.h"]),
+    include_prefix = "librdkafka",
+    includes = ["src"],
+    strip_include_prefix = "src",
+    deps = [
+        "@lz4//:lz4_hc",
+    ] + select({
+        ":with_curl_setting": ["@curl"],
+        "//conditions:default": [],
+    }) + select({
+        ":with_ssl_setting": [
+            "@openssl//:crypto",
+            "@openssl//:ssl",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        ":with_zlib_setting": ["@zlib"],
+        "//conditions:default": [],
+    }) + select({
+        ":with_zstd_setting": ["@zstd"],
+        "//conditions:default": [],
+    }),
+)
+
+alias(
+    name = "librdkafka",
+    actual = ":rdkafka",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "rdkafka_cpp",
+    srcs = glob(["src-cpp/*.cpp"]),
+    hdrs = glob(["src-cpp/*.h"]),
+    include_prefix = "librdkafka",
+    includes = ["src-cpp"],
+    strip_include_prefix = "src-cpp",
+    deps = [":rdkafka"],
+)
+
+alias(
+    name = "librdkafka_cpp",
+    actual = ":rdkafka_cpp",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "rdkafka_test_lib",
+    testonly = True,
+    srcs = glob(
+        [
+            "tests/*-*.c",
+            "tests/*-*.cpp",
+        ],
+        exclude = [
+            "tests/xxxx-assign_partition.c",
+            "tests/xxxx-metadata.cpp",
+        ],
+    ) + [
+        "tests/interceptor_test/interceptor_test.c",
+        "tests/rusage.c",
+        "tests/testcpp.cpp",
+    ] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "tests/sockem.c",
+            "tests/sockem_ctrl.c",
+        ],
+    }),
+    hdrs = [
+        "tests/interceptor_test/interceptor_test.h",
+        "tests/test.h",
+        "tests/testcpp.h",
+        "tests/testshared.h",
+    ] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "tests/sockem.h",
+            "tests/sockem_ctrl.h",
+        ],
+    }),
+    deps = [
+        ":rdkafka",
+        ":rdkafka_cpp",
+    ],
+)
+
+# Most of rdkafka's tests require a local cluster to be running, see
+# https://github.com/confluentinc/librdkafka/tree/master/tests#automated-broker-cluster-setup-using-trivup.
+# We'll just run some that don't require this and should be good enough as a
+# sanity check.
+
+cc_test(
+    name = "0000_unittests_test",
+    srcs = ["tests/test.c"],
+    env = {"TESTS": "0000"},
+    deps = [":rdkafka_test_lib"],
+)
+
+cc_test(
+    name = "0004_conf_test",
+    srcs = ["tests/test.c"],
+    env = {"TESTS": "0004"},
+    deps = [":rdkafka_test_lib"],
+)
+
+cc_test(
+    name = "0006_symbols_test",
+    srcs = ["tests/test.c"],
+    env = {"TESTS": "0006"},
+    deps = [":rdkafka_test_lib"],
+)
+
+cc_test(
+    name = "0009_mock_cluster_test",
+    srcs = ["tests/test.c"],
+    env = {"TESTS": "0009"},
+    deps = [":rdkafka_test_lib"],
+)
+
+cc_test(
+    name = "0025_timers_test",
+    srcs = ["tests/test.c"],
+    env = {"TESTS": "0025"},
+    deps = [":rdkafka_test_lib"],
+)

--- a/modules/librdkafka/2.8.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/librdkafka/2.8.0.bcr.1/overlay/BUILD.bazel
@@ -163,6 +163,11 @@ cc_library(
     hdrs = glob(["src/**/*.h"]),
     include_prefix = "librdkafka",
     includes = ["src"],
+    linkopts = [
+        # Needed for Debian.
+        "-ldl",
+        "-lpthread",
+    ],
     strip_include_prefix = "src",
     deps = [
         "@lz4//:lz4_hc",

--- a/modules/librdkafka/2.8.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/librdkafka/2.8.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/librdkafka/2.8.0.bcr.1/overlay/test/MODULE.bazel
+++ b/modules/librdkafka/2.8.0.bcr.1/overlay/test/MODULE.bazel
@@ -1,0 +1,7 @@
+bazel_dep(name = "librdkafka", version = "2.8.0.bcr.1")
+local_path_override(
+    module_name = "librdkafka",
+    path = "..",
+)
+
+bazel_dep(name = "curl", version = "8.8.0.bcr.3")

--- a/modules/librdkafka/2.8.0.bcr.1/patches/src-cpp_rdkafkacpp_int.h.patch
+++ b/modules/librdkafka/2.8.0.bcr.1/patches/src-cpp_rdkafkacpp_int.h.patch
@@ -1,0 +1,11 @@
+--- src-cpp/rdkafkacpp_int.h
++++ src-cpp/rdkafkacpp_int.h
+@@ -46,7 +46,7 @@ extern "C" {
+ #include "../src/win32_config.h"
+ #else
+ /* POSIX / UNIX based systems */
+-#include "../config.h" /* mklove output */
++#include "config.h" /* mklove output */
+ #endif
+
+ #ifdef _MSC_VER

--- a/modules/librdkafka/2.8.0.bcr.1/patches/src_rd.h.patch
+++ b/modules/librdkafka/2.8.0.bcr.1/patches/src_rd.h.patch
@@ -1,0 +1,11 @@
+--- src/rd.h
++++ src/rd.h
+@@ -62,7 +62,7 @@
+ #include "win32_config.h"
+ #else
+ /* POSIX / UNIX based systems */
+-#include "../config.h" /* mklove output */
++#include "config.h" /* mklove output */
+ #endif
+
+ #ifdef _WIN32

--- a/modules/librdkafka/2.8.0.bcr.1/patches/src_tinycthread.h.patch
+++ b/modules/librdkafka/2.8.0.bcr.1/patches/src_tinycthread.h.patch
@@ -1,0 +1,11 @@
+--- src/tinycthread.h
++++ src/tinycthread.h
+@@ -29,7 +29,7 @@ freely, subject to the following restrictions:
+ #ifdef _WIN32
+ #include "win32_config.h"
+ #else
+-#include "../config.h"
++#include "config.h"
+ #endif
+
+ #if WITH_C11THREADS

--- a/modules/librdkafka/2.8.0.bcr.1/patches/tests_testcpp.h.patch
+++ b/modules/librdkafka/2.8.0.bcr.1/patches/tests_testcpp.h.patch
@@ -1,0 +1,11 @@
+--- tests/testcpp.h
++++ tests/testcpp.h
+@@ -38,7 +38,7 @@ extern "C" {
+ #include "../src/win32_config.h"
+ #include "../src/rdwin32.h"
+ #else
+-#include "../config.h"
++#include "config.h"
+ /* POSIX / UNIX based systems */
+ #include "../src/rdposix.h"
+ #endif

--- a/modules/librdkafka/2.8.0.bcr.1/presubmit.yml
+++ b/modules/librdkafka/2.8.0.bcr.1/presubmit.yml
@@ -1,0 +1,50 @@
+bcr_test_module:
+  module_path: test
+  matrix:
+    # Currently does not build in Windows due to the Windows defines being
+    # hardcoded in src/win32_config.h with all features enabled, so we cannot
+    # disable building with OpenSSL (the BCR OpenSSL does not support Windows)
+    # without patching this file to use something like #ifndef instead.
+    unix_platform:
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - ubuntu2404
+      - macos
+      - macos_arm64
+    bazel: [7.x, 8.x, rolling]
+  tasks:
+    verify_targets_unix:
+      platform: ${{ unix_platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        # So we don't have any boringssl/openssl conflicts (BCR curl defaults to
+        # boringssl).
+        - "--@curl//:ssl_lib=openssl"
+      build_targets:
+        - "@librdkafka//:librdkafka"
+        - "@librdkafka//:librdkafka_cpp"
+      test_flags:
+        # So we don't have any boringssl/openssl conflicts (BCR curl defaults to
+        # boringssl).
+        - "--@curl//:ssl_lib=openssl"
+      test_targets:
+        - "@librdkafka//:all"
+    verify_targets_no_features_unix:
+      platform: ${{ unix_platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--@librdkafka//:with_curl=false"
+        - "--@librdkafka//:with_ssl=false"
+        - "--@librdkafka//:with_zlib=false"
+        - "--@librdkafka//:with_zstd=false"
+      build_targets:
+        - "@librdkafka//:librdkafka"
+        - "@librdkafka//:librdkafka_cpp"
+      test_flags:
+        - "--@librdkafka//:with_curl=false"
+        - "--@librdkafka//:with_ssl=false"
+        - "--@librdkafka//:with_zlib=false"
+        - "--@librdkafka//:with_zstd=false"
+      test_targets:
+        - "@librdkafka//:all"

--- a/modules/librdkafka/2.8.0.bcr.1/source.json
+++ b/modules/librdkafka/2.8.0.bcr.1/source.json
@@ -1,0 +1,17 @@
+{
+    "url": "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.8.0.tar.gz",
+    "integrity": "sha256-W9HEb2MmXzHGv87c3nhwP3fSgjjq3yOCHCtD/DC+PiU=",
+    "strip_prefix": "librdkafka-2.8.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-H/JoBoujgSi8SWsciwXa5PHtevcdBaMHEpgBFG+T/ok=",
+        "MODULE.bazel": "sha256-4yVAS9MJ+CnVMoQWQswjNevuWipm0xiFfumTJ758nkU=",
+        "test/MODULE.bazel": "sha256-qIG365+t+l/d74di56qKKFZKFkmI0qxTUn6aEoBmWvA="
+    },
+    "patch_strip": 0,
+    "patches": {
+        "src-cpp_rdkafkacpp_int.h.patch": "sha256-2jKbC/v3rD2JnBYLzIOI0YlXH+8Vj8jSWl0Gw64ighM=",
+        "src_rd.h.patch": "sha256-2V7q6rr5B4QkfTvEkMIwC9yJL35NZkggs70BHecg2lo=",
+        "src_tinycthread.h.patch": "sha256-5cf9SXy35+x6qjiNy8lLyGSGWzgmrqYfPwnj2E0qmvM=",
+        "tests_testcpp.h.patch": "sha256-CriMImYBcoBE8ibDz2Bjncexm+V/3ZkKghW5JLMnZPE="
+    }
+}

--- a/modules/librdkafka/2.8.0.bcr.1/source.json
+++ b/modules/librdkafka/2.8.0.bcr.1/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-W9HEb2MmXzHGv87c3nhwP3fSgjjq3yOCHCtD/DC+PiU=",
     "strip_prefix": "librdkafka-2.8.0",
     "overlay": {
-        "BUILD.bazel": "sha256-H/JoBoujgSi8SWsciwXa5PHtevcdBaMHEpgBFG+T/ok=",
+        "BUILD.bazel": "sha256-8xyE7yXZiGKmC0VZijB754iwFR/1kq4x03dupt0UxMY=",
         "MODULE.bazel": "sha256-4yVAS9MJ+CnVMoQWQswjNevuWipm0xiFfumTJ758nkU=",
         "test/MODULE.bazel": "sha256-qIG365+t+l/d74di56qKKFZKFkmI0qxTUn6aEoBmWvA="
     },

--- a/modules/librdkafka/metadata.json
+++ b/modules/librdkafka/metadata.json
@@ -11,7 +11,8 @@
         "github:confluentinc/librdkafka"
     ],
     "versions": [
-        "2.8.0"
+        "2.8.0",
+        "2.8.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Fixed `librdkafka` so it can be included as either:

```c
#include <rdkafka.h>
```

or

```c
#include <librdkafka/rdkafka.h>
```

In order to do this I needed to add `strip_include_prefix` and add an `include_prefix` to the `librdkafka` lib. Also needed to split the lib into a `cpp` version and a `c` version due to it having two different source directories.