### PR TITLE
Add ng-log 0.8.0-rc1

### DIFF
--- a/modules/ng-log/0.8.0-rc1/MODULE.bazel
+++ b/modules/ng-log/0.8.0-rc1/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "ng-log",
+    version = "0.8.0-rc1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "gflags", version = "2.2.2")
+bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.12")
+
+# Required for Windows clang-cl build: --extra_toolchains=@local_config_cc//:cc-toolchain-arm64_windows
+cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")
+use_repo(cc_configure, "local_config_cc")

--- a/modules/ng-log/0.8.0-rc1/patches/module_dot_bazel.patch
+++ b/modules/ng-log/0.8.0-rc1/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,5 +1,6 @@
+ module(
+-    name = "glog",
++    name = "ng-log",
++    version = "0.8.0-rc1",
+     compatibility_level = 1,
+ )
+

--- a/modules/ng-log/0.8.0-rc1/presubmit.yml
+++ b/modules/ng-log/0.8.0-rc1/presubmit.yml
@@ -8,7 +8,6 @@ matrix:
   bazel:
   - 8.x
   - 7.x
-  - 6.x
 tasks:
   verify_targets:
     name: Verify build targets

--- a/modules/ng-log/0.8.0-rc1/presubmit.yml
+++ b/modules/ng-log/0.8.0-rc1/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - macos
+  - macos_arm64
+  - ubuntu2204
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@ng-log//:ng-log'

--- a/modules/ng-log/0.8.0-rc1/source.json
+++ b/modules/ng-log/0.8.0-rc1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/ng-log/ng-log/archive/refs/tags/v0.8.0-rc1.tar.gz",
+    "integrity": "sha256-A6DHF2KQ8Vw/wfOCa4/8LHo+m5lrQrxZkDj+SVRsvlM=",
+    "strip_prefix": "ng-log-0.8.0-rc1",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-OJsyulDmnhU3ubjU/uu2vKtfYlKrCel3VY1x+Db1PpI="
+    }
+}

--- a/modules/ng-log/metadata.json
+++ b/modules/ng-log/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/ng-log/ng-log",
+    "maintainers": [
+        {
+            "email": "rodrigoq@intrinsic.ai",
+            "github": "drigz",
+            "name": "drigz"
+        }
+    ],
+    "repository": [
+        "github:ng-log/ng-log"
+    ],
+    "versions": [
+        "0.8.0-rc1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This is the new name for "glog", as that project is no longer maintained
by Google.
