### PR TITLE
add patchelf 0.16.1

### DIFF
--- a/modules/patchelf/0.16.1/MODULE.bazel
+++ b/modules/patchelf/0.16.1/MODULE.bazel
@@ -3,3 +3,5 @@ module(
     version = "0.16.1",
     compatibility_level = 0,
 )
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/patchelf/0.16.1/MODULE.bazel
+++ b/modules/patchelf/0.16.1/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "patchelf",
+    version = "0.16.1",
+    compatibility_level = 0,
+)

--- a/modules/patchelf/0.16.1/patches/0001-Add-MODULE.bazel.patch
+++ b/modules/patchelf/0.16.1/patches/0001-Add-MODULE.bazel.patch
@@ -1,8 +1,10 @@
 --- /dev/null
 +++ b/MODULE.bazel
-@@ -0,0 +1,5 @@
+@@ -0,0 +1,7 @@
 +module(
 +    name = "patchelf",
 +    version = "0.16.1",
 +    compatibility_level = 0,
 +)
++
++bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/patchelf/0.16.1/patches/0001-Add-MODULE.bazel.patch
+++ b/modules/patchelf/0.16.1/patches/0001-Add-MODULE.bazel.patch
@@ -1,0 +1,8 @@
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "patchelf",
++    version = "0.16.1",
++    compatibility_level = 0,
++)

--- a/modules/patchelf/0.16.1/patches/0002-Add-BUILD.bazel.patch
+++ b/modules/patchelf/0.16.1/patches/0002-Add-BUILD.bazel.patch
@@ -1,0 +1,20 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 0000000..1c12aa9
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,14 @@
++cc_binary(
++    name = "patchelf",
++    srcs = glob([
++        "src/*.cc",
++        "src/*.h",
++    ]),
++    copts = [
++        "-std=c++17",
++    ],
++    local_defines = [
++        "D_FILE_OFFSET_BITS=64",
++    ],
++    visibility = ["//visibility:public"],
++)

--- a/modules/patchelf/0.16.1/patches/0002-Add-BUILD.bazel.patch
+++ b/modules/patchelf/0.16.1/patches/0002-Add-BUILD.bazel.patch
@@ -3,7 +3,9 @@ new file mode 100644
 index 0000000..1c12aa9
 --- /dev/null
 +++ b/BUILD.bazel
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,16 @@
++load("@rules_cc//cc:defs.bzl", "cc_binary")
++
 +cc_binary(
 +    name = "patchelf",
 +    srcs = glob([

--- a/modules/patchelf/0.16.1/presubmit.yml
+++ b/modules/patchelf/0.16.1/presubmit.yml
@@ -1,0 +1,9 @@
+matrix:
+  platform: ["macos", "ubuntu2004"]
+  bazel: ["6.x", "7.x"]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@patchelf//:patchelf'

--- a/modules/patchelf/0.16.1/presubmit.yml
+++ b/modules/patchelf/0.16.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform: ["macos", "ubuntu2004"]
-  bazel: ["6.x", "7.x"]
+  bazel: ["6.x", "7.x", "8.x"]
 tasks:
   verify_targets:
     platform: ${{ platform }}

--- a/modules/patchelf/0.16.1/source.json
+++ b/modules/patchelf/0.16.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-GlYu0osW+KAEVrX57lc7sa98OcG+6gHZT8DHsyVrBAY=",
+    "strip_prefix": "patchelf-0.16.1",
+    "url": "https://github.com/NixOS/patchelf/releases/download/0.16.1/patchelf-0.16.1.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "0001-Add-MODULE.bazel.patch": "sha256-1wDvn/TO63bYOlgMdz4nUS5kONEbtEvWYZbL4mcilNI=",
+        "0002-Add-BUILD.bazel.patch": "sha256-H/tH14FO0cEmkl7Ff8vhIYCVfhLFGab2RJHMoEymQPE="
+    }
+}

--- a/modules/patchelf/0.16.1/source.json
+++ b/modules/patchelf/0.16.1/source.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/NixOS/patchelf/releases/download/0.16.1/patchelf-0.16.1.tar.gz",
     "patch_strip": 1,
     "patches": {
-        "0001-Add-MODULE.bazel.patch": "sha256-1wDvn/TO63bYOlgMdz4nUS5kONEbtEvWYZbL4mcilNI=",
-        "0002-Add-BUILD.bazel.patch": "sha256-H/tH14FO0cEmkl7Ff8vhIYCVfhLFGab2RJHMoEymQPE="
+        "0001-Add-MODULE.bazel.patch": "sha256-yNKPYrLOFvVNyBCK0kE7q0A1/1ggelSwsCk6PrZteW4=",
+        "0002-Add-BUILD.bazel.patch": "sha256-YnkSaGFyQqRMnTcbOSHEj7zXuTcKcVnsmOSIkU8GW5U="
     }
 }

--- a/modules/patchelf/0.18.0/presubmit.yml
+++ b/modules/patchelf/0.18.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform: ["macos", "ubuntu2004"]
-  bazel: ["6.x", "7.x"]
+  bazel: ["6.x", "7.x", "8.x"]
 tasks:
   verify_targets:
     platform: ${{ platform }}

--- a/modules/patchelf/metadata.json
+++ b/modules/patchelf/metadata.json
@@ -10,6 +10,7 @@
     "github:NixOS/patchelf"
   ],
   "versions": [
+    "0.16.1",
     "0.18.0"
   ],
   "yanked_versions": {}

--- a/modules/patchelf/metadata.json
+++ b/modules/patchelf/metadata.json
@@ -1,17 +1,17 @@
 {
-  "homepage": "https://github.com/NixOS/patchelf",
-  "maintainers": [
-    {
-      "email": "keithbsmiley@gmail.com",
-      "name": "Keith Smiley"
-    }
-  ],
-  "repository": [
-    "github:NixOS/patchelf"
-  ],
-  "versions": [
-    "0.16.1",
-    "0.18.0"
-  ],
-  "yanked_versions": {}
+    "homepage": "https://github.com/NixOS/patchelf",
+    "maintainers": [
+        {
+            "email": "keithbsmiley@gmail.com",
+            "name": "Keith Smiley"
+        }
+    ],
+    "repository": [
+        "github:NixOS/patchelf"
+    ],
+    "versions": [
+        "0.16.1",
+        "0.18.0"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
The 0.18.0 version has a known bug. https://github.com/NixOS/patchelf/issues/492. Until the fixed version is released, 0.16.1 is a working alternative.