### PR TITLE
jsonnet_go: publish v0.21.0-rc2

### DIFF
--- a/modules/jsonnet_go/0.21.0-rc2/MODULE.bazel
+++ b/modules/jsonnet_go/0.21.0-rc2/MODULE.bazel
@@ -1,0 +1,49 @@
+module(name = "jsonnet_go", version = "0.21.0-rc2")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# NB: update_cpp_jsonnet.sh looks for these.
+CPP_JSONNET_SHA256 = "c19ca480c1d9d74d18e3e3c872bf1761eba09c9b7e4029bf3862046e73d191f6"
+CPP_JSONNET_GITHASH = "5ad56d2c07610f502f5ca4eef1a478adbfd7e13b"
+CPP_JSONNET_RELEASE_VERSION = "v0.21.0-rc2"
+
+CPP_JSONNET_STRIP_PREFIX = (
+    "jsonnet-" + (
+        CPP_JSONNET_RELEASE_VERSION if CPP_JSONNET_RELEASE_VERSION else CPP_JSONNET_GITHASH
+    )
+)
+CPP_JSONNET_URL = (
+    "https://github.com/google/jsonnet/releases/download/%s/jsonnet-%s.tar.gz" % (
+        CPP_JSONNET_RELEASE_VERSION,
+        CPP_JSONNET_RELEASE_VERSION,
+    ) if CPP_JSONNET_RELEASE_VERSION else "https://github.com/google/jsonnet/archive/%s.tar.gz" % CPP_JSONNET_GITHASH
+)
+
+# We don't use a normal bazel_dep reference for the cpp_jsonnet module,
+# because we want to pin to the specific jsonnet commit (which might not
+# even exactly match a released version).
+http_archive(
+    name = "cpp_jsonnet",
+    sha256 = CPP_JSONNET_SHA256,
+    strip_prefix = CPP_JSONNET_STRIP_PREFIX,
+    urls = [CPP_JSONNET_URL],
+)
+
+bazel_dep(name = "gazelle", version = "0.42.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", version = "0.53.0", repo_name = "io_bazel_rules_go")
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(
+    name = "go_sdk",
+    version = "1.23.7",
+)
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "@jsonnet_go//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_fatih_color",
+    "com_github_sergi_go_diff",
+    "io_k8s_sigs_yaml",
+    "org_golang_x_crypto",
+)

--- a/modules/jsonnet_go/0.21.0-rc2/presubmit.yml
+++ b/modules/jsonnet_go/0.21.0-rc2/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@jsonnet_go//...'

--- a/modules/jsonnet_go/0.21.0-rc2/source.json
+++ b/modules/jsonnet_go/0.21.0-rc2/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/google/go-jsonnet/releases/download/v0.21.0-rc2/go-jsonnet-v0.21.0-rc2.tar.gz",
+    "integrity": "sha256-0QojPYJEaKgt+hORPZH18yH6FCMPesbyQMvoPUD+I4o=",
+    "strip_prefix": "go-jsonnet-v0.21.0-rc2"
+}

--- a/modules/jsonnet_go/metadata.json
+++ b/modules/jsonnet_go/metadata.json
@@ -1,16 +1,17 @@
 {
-  "homepage": "https://github.com/google/go-jsonnet",
-  "maintainers": [
-    {
-      "email": "bcr-maintainers@bazel.build",
-      "name": "No Maintainer Specified"
-    }
-  ],
-  "repository": [
-    "github:google/go-jsonnet"
-  ],
-  "versions": [
-    "0.20.0"
-  ],
-  "yanked_versions": {}
+    "homepage": "https://github.com/google/go-jsonnet",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:google/go-jsonnet"
+    ],
+    "versions": [
+        "0.20.0",
+        "0.21.0-rc2"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Add jsonnet_go 0.21.0-rc2.

The release is here: https://github.com/google/go-jsonnet/releases/tag/v0.21.0-rc2
