### PR TITLE
PEGTL bzlmod entry

### DIFF
--- a/modules/pegtl/3.2.8/MODULE.bazel
+++ b/modules/pegtl/3.2.8/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "pegtl",
+    version = "3.2.8",
+    compatibility_level = 0,
+)

--- a/modules/pegtl/3.2.8/overlay/BUILD.bazel
+++ b/modules/pegtl/3.2.8/overlay/BUILD.bazel
@@ -1,0 +1,6 @@
+cc_library(
+    name = "pegtl",
+    hdrs = glob(["include/**/*.hpp"]),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)

--- a/modules/pegtl/3.2.8/overlay/src/example/pegtl/BUILD.bazel
+++ b/modules/pegtl/3.2.8/overlay/src/example/pegtl/BUILD.bazel
@@ -1,0 +1,251 @@
+cc_binary(
+    name = "abnf2pegtl",
+    srcs = ["abnf2pegtl.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "analyze",
+    srcs = ["analyze.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "calculator",
+    srcs = ["calculator.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "chomsky_hierarchy",
+    srcs = ["chomsky_hierarchy.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "csv1",
+    srcs = ["csv1.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "csv2",
+    srcs = ["csv2.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "dynamic_match",
+    srcs = ["dynamic_match.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "expression",
+    srcs = ["expression.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "hello_world",
+    srcs = ["hello_world.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "indent_aware",
+    srcs = ["indent_aware.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "iri",
+    srcs = ["iri.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "json_analyze",
+    srcs = ["json_analyze.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "json_ast",
+    srcs = ["json_ast.cpp", "json_errors.hpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "json_build",
+    srcs = ["json_build.cpp", "json_classes.hpp", "json_errors.hpp", "json_unescape.hpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "json_count",
+    srcs = ["json_count.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "json_coverage",
+    srcs = ["json_coverage.cpp", "json_errors.hpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "json_parse",
+    srcs = ["json_parse.cpp", "json_errors.hpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "json_print_debug",
+    srcs = ["json_print_debug.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "json_print_names",
+    srcs = ["json_print_names.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "json_trace",
+    srcs = ["json_trace.cpp", "json_errors.hpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "lua53_analyze",
+    srcs = ["lua53_analyze.cpp", "lua53.hpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "lua53_parse",
+    srcs = ["lua53_parse.cpp", "lua53.hpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "modulus_match",
+    srcs = ["modulus_match.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "parse_tree",
+    srcs = ["parse_tree.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "parse_tree_user_state",
+    srcs = ["parse_tree_user_state.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "proto3",
+    srcs = ["proto3.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "recover",
+    srcs = ["recover.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "s_expression",
+    srcs = ["s_expression.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "sum",
+    srcs = ["sum.cpp", "double.hpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "symbol_table",
+    srcs = ["symbol_table.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "token_input",
+    srcs = ["token_input.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "unescape",
+    srcs = ["unescape.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "uri",
+    srcs = ["uri.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "uri_print_debug",
+    srcs = ["uri_print_debug.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "uri_print_names",
+    srcs = ["uri_print_names.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)
+
+cc_binary(
+    name = "uri_trace",
+    srcs = ["uri_trace.cpp"],
+    visibility = ["//visibility:public"],
+    deps = ["//:pegtl"],
+)

--- a/modules/pegtl/3.2.8/patches/module_dot_bazel.patch
+++ b/modules/pegtl/3.2.8/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "pegtl",
++    version = "3.2.8",
++    compatibility_level = 0,
++)

--- a/modules/pegtl/3.2.8/presubmit.yml
+++ b/modules/pegtl/3.2.8/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   bazel: [7.x, 8.x]
-  unix_platform: ["macos", "macos_arm64", "ubuntu2004", "debian10"]
+  unix_platform: ["macos", "macos_arm64", "ubuntu2004", "debian11"]
 
 tasks:
   unix_test:

--- a/modules/pegtl/3.2.8/presubmit.yml
+++ b/modules/pegtl/3.2.8/presubmit.yml
@@ -17,3 +17,11 @@ tasks:
       - '--cxxopt=/std:c++17'
     build_targets:
       - '@pegtl//...'
+verify_debian10_targets:
+    platform: debian10
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--cxxopt=-std=c++17"
+      - "--linkopt=-lstdc++fs"
+    build_targets:
+      - '@pegtl//...'

--- a/modules/pegtl/3.2.8/presubmit.yml
+++ b/modules/pegtl/3.2.8/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  bazel: [7.x, 8.x]
+  unix_platform: ["macos", "macos_arm", "ubuntu2004", "debian10"]
+
+tasks:
+  unix_test:
+    platform: ${{ unix_platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--cxxopt=-std=c++17'
+    build_targets:
+      - '@pegtl//...'
+  windows_test:
+    platform: windows
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--cxxopt=/std:c++17'
+    build_targets:
+      - '@pegtl//...'

--- a/modules/pegtl/3.2.8/presubmit.yml
+++ b/modules/pegtl/3.2.8/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   bazel: [7.x, 8.x]
-  unix_platform: ["macos", "macos_arm", "ubuntu2004", "debian10"]
+  unix_platform: ["macos", "macos_arm64", "ubuntu2004", "debian10"]
 
 tasks:
   unix_test:

--- a/modules/pegtl/3.2.8/presubmit.yml
+++ b/modules/pegtl/3.2.8/presubmit.yml
@@ -17,7 +17,7 @@ tasks:
       - '--cxxopt=/std:c++17'
     build_targets:
       - '@pegtl//...'
-verify_debian10_targets:
+  debian10_test:
     platform: debian10
     bazel: ${{ bazel }}
     build_flags:

--- a/modules/pegtl/3.2.8/source.json
+++ b/modules/pegtl/3.2.8/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://github.com/taocpp/PEGTL/archive/refs/tags/3.2.8.tar.gz",
+    "integrity": "sha256-MZ6CONrrw6Fj9gyIx4kiqAEncgdv3WSo2vr1YZzWR3M=",
+    "strip_prefix": "PEGTL-3.2.8",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-HBybFkj8WdhtVyUr6NNBou6/9cfj46sjgYsiO9Kjftk="
+    },
+    "overlay": {
+        "BUILD.bazel": "sha256-bEHE2A5r/1vktGnn62ORBlfi7AcWahEYuUe4+f9z+1I=",
+        "src/example/pegtl/BUILD.bazel": "sha256-Z3Gf5nxCzzBeIUJ4uNxEHJjy8ZhFUeDI4+p4dFoHjGg="
+    }
+}

--- a/modules/pegtl/metadata.json
+++ b/modules/pegtl/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/taocpp/PEGTL",
+    "maintainers": [
+        {
+            "email": "github@danieldeptford.com",
+            "github": "redmercury",
+            "name": "Daniel Deptford"
+        }
+    ],
+    "repository": [
+        "github:taocpp/PEGTL"
+    ],
+    "versions": [
+        "3.2.8"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
PEGTL is a header-only library for parsing expression grammars.

This bzlmod entry adds a target for the header-only pegtl library, as well as cc_binary targets for the examples subdirectory, some of which are useful in their own right.