### PR TITLE
Fixed include paths for `fasttext` and `exprtk`.

### DIFF
--- a/modules/exprtk/0.0.3.bcr.1/MODULE.bazel
+++ b/modules/exprtk/0.0.3.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "exprtk",
+    version = "0.0.3.bcr.1",
+    bazel_compatibility = [">=7.2.1"],  # need support for "overlay" directory
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/exprtk/0.0.3.bcr.1/overlay/BUILD.bazel
+++ b/modules/exprtk/0.0.3.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "exprtk",
+    hdrs = ["exprtk.hpp"],
+    features = ["parse_headers"],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "exprtk_test",
+    srcs = ["exprtk_test.cpp"],
+    data = [
+        "exprtk_functional_ext_test.txt",
+        "exprtk_functional_test.txt",
+    ],
+    deps = [":exprtk"],
+)

--- a/modules/exprtk/0.0.3.bcr.1/overlay/BUILD.bazel
+++ b/modules/exprtk/0.0.3.bcr.1/overlay/BUILD.bazel
@@ -4,7 +4,8 @@ cc_library(
     name = "exprtk",
     hdrs = ["exprtk.hpp"],
     features = ["parse_headers"],
-    includes = ["."],
+    include_prefix = "exprtk",
+    includes = [""],
     visibility = ["//visibility:public"],
 )
 

--- a/modules/exprtk/0.0.3.bcr.1/overlay/MODULE.bazel
+++ b/modules/exprtk/0.0.3.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/exprtk/0.0.3.bcr.1/presubmit.yml
+++ b/modules/exprtk/0.0.3.bcr.1/presubmit.yml
@@ -1,0 +1,25 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+  # Tests don't all pass out of the box on Windows and Mac, skip them for now.
+  build_only_platform:
+    - macos
+    - macos_arm64
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@exprtk//:exprtk"
+    test_targets:
+      - "@exprtk//:exprtk_test"
+  verify_targets_build_only:
+    platform: ${{ build_only_platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@exprtk//:exprtk"

--- a/modules/exprtk/0.0.3.bcr.1/source.json
+++ b/modules/exprtk/0.0.3.bcr.1/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-+d7Gl16GxwIDPWplupoDaOujGmG4nXTytdJEV8AshDk=",
     "strip_prefix": "exprtk-0.0.3",
     "overlay": {
-        "BUILD.bazel": "sha256-dB+l1yQBj3fwHuP4FgJlpiaRrbDfDYGA+MngDP4L/Rk=",
+        "BUILD.bazel": "sha256-vjWW9jPKdghkOvBjLpc0S4NHS6AsMgVfSyzAru/RT0g=",
         "MODULE.bazel": "sha256-zHB2Ntt4PKRqgeqyf0wgalQq6TjXmWES6U7GCZPPaVM="
     }
 }

--- a/modules/exprtk/0.0.3.bcr.1/source.json
+++ b/modules/exprtk/0.0.3.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/ArashPartow/exprtk/archive/refs/tags/0.0.3.tar.gz",
+    "integrity": "sha256-+d7Gl16GxwIDPWplupoDaOujGmG4nXTytdJEV8AshDk=",
+    "strip_prefix": "exprtk-0.0.3",
+    "overlay": {
+        "BUILD.bazel": "sha256-dB+l1yQBj3fwHuP4FgJlpiaRrbDfDYGA+MngDP4L/Rk=",
+        "MODULE.bazel": "sha256-zHB2Ntt4PKRqgeqyf0wgalQq6TjXmWES6U7GCZPPaVM="
+    }
+}

--- a/modules/exprtk/metadata.json
+++ b/modules/exprtk/metadata.json
@@ -11,7 +11,8 @@
         "github:ArashPartow/exprtk"
     ],
     "versions": [
-        "0.0.3"
+        "0.0.3",
+        "0.0.3.bcr.1"
     ],
     "yanked_versions": {}
 }

--- a/modules/fasttext/0.10.0-bcr.20240313-1142dc4.bcr.1/MODULE.bazel
+++ b/modules/fasttext/0.10.0-bcr.20240313-1142dc4.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "fasttext",
+    version = "0.10.0-bcr.20240313-1142dc4.bcr.1",
+    bazel_compatibility = [">=7.2.1"],  # need support for "overlay" directory
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/fasttext/0.10.0-bcr.20240313-1142dc4.bcr.1/overlay/BUILD.bazel
+++ b/modules/fasttext/0.10.0-bcr.20240313-1142dc4.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+cc_library(
+    name = "fasttext",
+    srcs = glob(
+        ["src/**/*.cc"],
+        exclude = ["src/main.cc"],
+    ),
+    hdrs = glob(
+        ["src/**/*.h"],
+        exclude = ["src/aligned.h"],
+    ),
+    copts = ["-std=c++17"],
+    features = ["parse_headers"],
+    include_prefix = "fasttext",
+    includes = ["src"],
+    strip_include_prefix = "src",
+    textual_hdrs = ["src/aligned.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "fasttext_cli",
+    srcs = ["src/main.cc"],
+    copts = ["-std=c++17"],
+    visibility = ["//visibility:public"],
+    deps = [":fasttext"],
+)

--- a/modules/fasttext/0.10.0-bcr.20240313-1142dc4.bcr.1/overlay/MODULE.bazel
+++ b/modules/fasttext/0.10.0-bcr.20240313-1142dc4.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/fasttext/0.10.0-bcr.20240313-1142dc4.bcr.1/presubmit.yml
+++ b/modules/fasttext/0.10.0-bcr.20240313-1142dc4.bcr.1/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@fasttext//:fasttext"

--- a/modules/fasttext/0.10.0-bcr.20240313-1142dc4.bcr.1/source.json
+++ b/modules/fasttext/0.10.0-bcr.20240313-1142dc4.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/facebookresearch/fastText/archive/1142dc4c4ecbc19cc16eee5cdd28472e689267e6.tar.gz",
+    "integrity": "sha256-yLbPFGg5onFmWPpVF6CBC+7Ugsry/AvS9j3xAIjY1Qc=",
+    "strip_prefix": "fastText-1142dc4c4ecbc19cc16eee5cdd28472e689267e6",
+    "overlay": {
+        "BUILD.bazel": "sha256-qd0dON3rFIDumrEQytIxZJiAk8rxTaNNxdL1PwTuXLY=",
+        "MODULE.bazel": "sha256-08KCL2yBTVGzbvSm11rKKH8Ixgks1B/dXt+DHZXIOKo="
+    }
+}

--- a/modules/fasttext/metadata.json
+++ b/modules/fasttext/metadata.json
@@ -11,7 +11,8 @@
         "github:facebookresearch/fastText"
     ],
     "versions": [
-        "0.10.0-bcr.20240313-1142dc4"
+        "0.10.0-bcr.20240313-1142dc4",
+        "0.10.0-bcr.20240313-1142dc4.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Similar to https://github.com/bazelbuild/bazel-central-registry/pull/3954.

Both these projects don't have a typical `include/<lib_name>` directory, so we have to use `strip_include_prefix` and/or `include_prefix` to make their include paths match what users expect.

This allows these deps to be included using angle brackets and with or without the lib name prefix. E.g.,

```c++
#include <fasttext/fasttext.h>
#include <exprtk/exprtk.hpp>
```

or

```c++
#include <fasttext.h>
#include <exprtk.hpp>
```