### PR TITLE
Add opencensus-proto 0.4.1.bcr.2

### DIFF
--- a/modules/opencensus-proto/0.4.1.bcr.2/MODULE.bazel
+++ b/modules/opencensus-proto/0.4.1.bcr.2/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "opencensus-proto",
+    version = "0.4.1.bcr.2",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "grpc", version = "1.41.0", repo_name = "com_github_grpc_grpc")
+bazel_dep(name = "protobuf", version = "25.6", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_go", version = "0.45.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_proto", version = "5.3.0-21.7")

--- a/modules/opencensus-proto/0.4.1.bcr.2/overlay/MODULE.bazel
+++ b/modules/opencensus-proto/0.4.1.bcr.2/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/opencensus-proto/0.4.1.bcr.2/patches/py-proto-library.patch
+++ b/modules/opencensus-proto/0.4.1.bcr.2/patches/py-proto-library.patch
@@ -1,0 +1,52 @@
+diff --git a/src/opencensus/proto/resource/v1/BUILD.bazel b/src/opencensus/proto/resource/v1/BUILD.bazel
+index b6ec91e..5e0c01b 100644
+--- a/src/opencensus/proto/resource/v1/BUILD.bazel
++++ b/src/opencensus/proto/resource/v1/BUILD.bazel
+@@ -17,7 +17,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
+ package(default_visibility = ["//visibility:public"])
+ 
+ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+-load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
++load("@com_google_protobuf//bazel:py_proto_library.bzl", "py_proto_library")
+ 
+ proto_library(
+     name = "resource_proto",
+@@ -42,5 +42,5 @@ go_proto_library(
+ 
+ py_proto_library(
+     name = "resource_proto_py",
+-    srcs = ["resource.proto"],
++    deps = ["resource.proto"],
+ )
+diff --git a/src/opencensus/proto/trace/v1/BUILD.bazel b/src/opencensus/proto/trace/v1/BUILD.bazel
+index 0beb6d8..351b850 100644
+--- a/src/opencensus/proto/trace/v1/BUILD.bazel
++++ b/src/opencensus/proto/trace/v1/BUILD.bazel
+@@ -18,7 +18,7 @@ package(default_visibility = ["//visibility:public"])
+ 
+ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+ load("@io_bazel_rules_go//go:def.bzl", "go_library")
+-load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
++load("@com_google_protobuf//bazel:py_proto_library.bzl", "py_proto_library")
+ 
+ proto_library(
+     name = "trace_proto",
+@@ -74,16 +74,12 @@ go_proto_library(
+ 
+ py_proto_library(
+     name = "trace_proto_py",
+-    srcs = ["trace.proto"],
+-    deps = [
+-        "//opencensus/proto/resource/v1:resource_proto_py",
+-        "@com_google_protobuf//:protobuf_python",
+-    ],
++    deps = ["trace.proto"],
+ )
+ 
+ py_proto_library(
+     name = "trace_config_proto_py",
+-    srcs = ["trace_config.proto"],
++    deps = ["trace_config.proto"],
+ )
+ 
+ # This a workaround because `trace_proto_go` and `trace_config_proto_go` have

--- a/modules/opencensus-proto/0.4.1.bcr.2/presubmit.yml
+++ b/modules/opencensus-proto/0.4.1.bcr.2/presubmit.yml
@@ -1,0 +1,26 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++14'
+    build_targets:
+    - '@opencensus-proto//opencensus/proto/agent/common/v1:common_proto'
+    - '@opencensus-proto//opencensus/proto/agent/metrics/v1:metrics_service_proto'
+    - '@opencensus-proto//opencensus/proto/agent/trace/v1:trace_service_proto'
+    - '@opencensus-proto//opencensus/proto/metrics/v1:metrics_proto'
+    - '@opencensus-proto//opencensus/proto/resource/v1:resource_proto'
+    - '@opencensus-proto//opencensus/proto/stats/v1:stats_proto'
+    - '@opencensus-proto//opencensus/proto/trace/v1:trace_proto'
+    - '@opencensus-proto//opencensus/proto/trace/v1:trace_config_proto'

--- a/modules/opencensus-proto/0.4.1.bcr.2/source.json
+++ b/modules/opencensus-proto/0.4.1.bcr.2/source.json
@@ -1,0 +1,12 @@
+{
+    "url": "https://github.com/census-instrumentation/opencensus-proto/archive/refs/tags/v0.4.1.tar.gz",
+    "integrity": "sha256-49iff57YTJtu7oGMLpMGlQUZQCv4A2mLFcMQt3yi8PM=",
+    "strip_prefix": "opencensus-proto-0.4.1/src",
+    "patches": {
+        "py-proto-library.patch": "sha256-CZCdIqmnl+ZncUmGl59JVBwUSdxMmJnrQ/ZxBR544yU="
+    },
+    "patch_strip": 2,
+    "overlay": {
+        "MODULE.bazel": "sha256-eJcGpxSFX5LFyM/PHvMru2Tc07fJBmdWrXmG7FlwnSk="
+    }
+}

--- a/modules/opencensus-proto/metadata.json
+++ b/modules/opencensus-proto/metadata.json
@@ -11,7 +11,8 @@
     ],
     "versions": [
         "0.4.1",
-        "0.4.1.bcr.1"
+        "0.4.1.bcr.1",
+        "0.4.1.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This fixes compatibility with newer versions of protobuf by using the new implementation of py_proto_library.