### PR TITLE
Shorten date in recommended pseudo version string

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -182,7 +182,7 @@ To ensure reproducibility, the BCR is add-only; that is, existing versions of a 
 
 ### Pseudo-versions
 
-If upstream hasn't released a new version in a long time (for example, due to project owner inactivity), but you'd still like to submit a version based on a main branch commit, the convention is to use a [pseudo-version](https://go.dev/ref/mod#pseudo-versions) similar to the one in the Go module system. Unlike in Go, such pseudo-versions are not semantically significant; they're just treated normally as any other version string. For example, if `foo`'s current version is `1.19.0`, you can submit a new version `1.19.1-20250305180549-abcdef`. This can also be combined with the `.bcr.<N>` suffix if necessary.
+If upstream hasn't released a new version in a long time (for example, due to project owner inactivity), but you'd still like to submit a version based on a main branch commit, the convention is to use a [pseudo-version](https://go.dev/ref/mod#pseudo-versions) similar to the one in the Go module system. Unlike in Go, such pseudo-versions are not semantically significant; they're just treated normally as any other version string. For example, if `foo`'s current version is `1.19.0`, you can submit a new version `1.19.1-20250305-abcdef`. This can also be combined with the `.bcr.<N>` suffix if necessary.
 
 ### Yank a module version
 


### PR DESCRIPTION
Large integers in version strings can cause some older Bazel releases to crash with a NumberFormatException.