### PR TITLE
portaudio@19.7.0.bcr.1

### DIFF
--- a/modules/portaudio/19.7.0.bcr.1/MODULE.bazel
+++ b/modules/portaudio/19.7.0.bcr.1/MODULE.bazel
@@ -1,0 +1,11 @@
+"""https://www.portaudio.com/"""
+
+module(
+    name = "portaudio",
+    version = "19.7.0.bcr.1",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "alsa_lib", version = "1.2.9")

--- a/modules/portaudio/19.7.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/portaudio/19.7.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,178 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+exports_files(["LICENSE.txt"])
+
+bool_flag(
+    name = "pa_use_alsa",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "pa_use_alsa_setting",
+    flag_values = {":pa_use_alsa": "true"},
+    visibility = ["//visibility:public"],
+)
+
+selects.config_setting_group(
+    name = "linux_pa_use_alsa_setting",
+    match_all = [
+        "@platforms//os:linux",
+        ":pa_use_alsa_setting",
+    ],
+)
+
+bool_flag(
+    name = "pa_use_jack",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "pa_use_jack_setting",
+    flag_values = {":pa_use_jack": "true"},
+    visibility = ["//visibility:public"],
+)
+
+selects.config_setting_group(
+    name = "linux_pa_use_jack_setting",
+    match_all = [
+        "@platforms//os:linux",
+        ":pa_use_jack_setting",
+    ],
+)
+
+filegroup(
+    name = "linux_srcs",
+    srcs = glob([
+        "src/os/unix/*.c",
+    ]) + select({
+        ":pa_use_jack_setting": glob([
+            "src/hostapi/jack/*.c",
+        ]),
+        "//conditions:default": [],
+    }) + select({
+        ":pa_use_alsa_setting": glob([
+            "src/hostapi/alsa/*.c",
+        ]),
+        "//conditions:default": [],
+    }),
+)
+
+cc_library(
+    name = "jack",
+    linkopts = ["-ljack"],
+    tags = ["manual"],
+)
+
+LINUX_DEFINES = select({
+    ":linux_pa_use_alsa_setting": ["PA_USE_ALSA=1"],
+    ":linux_pa_use_jack_setting": ["PA_USE_JACK=1"],
+    "//conditions:default": [],
+})
+
+cc_library(
+    name = "portaudio",
+    srcs = glob([
+        "src/common/*.c",
+    ]) + select({
+        "@platforms//os:linux": [":linux_srcs"],
+        "@platforms//os:macos": glob([
+            "src/hostapi/coreaudio/*.c",
+            "src/os/unix/*.c",
+        ]),
+        "@platforms//os:windows": glob([
+            "src/hostapi/wmme/*.c",
+            "src/os/win/*.c",
+        ]),
+        "//conditions:default": [],
+    }),
+    hdrs = ["include/portaudio.h"],
+    copts = ["-w"],
+    defines = LINUX_DEFINES + select({
+        "@platforms//os:macos": ["PA_USE_COREAUDIO=1"],
+        "@platforms//os:windows": ["PA_USE_WMME=1"],
+        "//conditions:default": [],
+    }),
+    includes = [
+        "include",
+        "src/common",
+    ] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["src/os/unix"],
+    }),
+    linkopts = select({
+        "@platforms//os:linux": [
+            "-lpthread",
+        ],
+        "@platforms//os:macos": [
+            "-framework AudioUnit",
+            "-framework CoreAudio",
+            "-framework AudioToolbox",
+            "-framework Carbon",
+        ],
+        "//conditions:default": [],
+    }),
+    textual_hdrs = glob([
+        "src/common/*.h",
+        "include/*.h",
+    ]) + select({
+        "@platforms//os:linux": glob([
+            "src/os/unix/*.h",
+        ]),
+        "@platforms//os:macos": glob([
+            "src/hostapi/coreaudio/*.h",
+            "src/os/unix/*.h",
+        ]),
+        "@platforms//os:windows": glob([
+            "src/os/win/*.h",
+        ]),
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = select({
+        ":linux_pa_use_alsa_setting": ["@alsa_lib//:asound"],
+        "//conditions:default": [],
+    }) + select({
+        ":linux_pa_use_jack_setting": [":jack"],
+        "//conditions:default": [],
+    }),
+)
+
+[
+    cc_test(
+        name = test[:-len(".c")],
+        srcs = [test],
+        deps = [":portaudio"],
+    )
+    for test in glob(
+        include = [
+            "test/*.c",
+        ],
+        exclude = [
+            "test/pa_minlat.c",
+            "test/patest_converters.c",
+            "test/patest_dsound_find_best_latency_params.c",
+            "test/patest_dsound_low_level_latency_params.c",
+            "test/patest_dsound_surround.c",
+            "test/patest_jack_wasapi.c",
+            "test/patest_latency.c",
+            "test/patest_mono.c",
+            "test/patest_read_record.c",
+            "test/patest_sine_channelmaps.c",
+            "test/patest_sine_formats.c",
+            "test/patest_stop_playout.c",
+            "test/patest_suggested_vs_streaminfo_latency.c",
+            "test/patest_timing.c",
+            "test/patest_unplug.c",
+            "test/patest_wire.c",
+            "test/patest_wmme_find_best_latency_params.c",
+            "test/patest_wmme_low_level_latency_params.c",
+            "test/patest_write_stop_hang_illegal.c",
+            "test/patest_write_stop.c",
+            "test/patest1.c",
+        ],
+    )
+]

--- a/modules/portaudio/19.7.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/portaudio/19.7.0.bcr.1/overlay/BUILD.bazel
@@ -62,6 +62,13 @@ filegroup(
 )
 
 cc_library(
+    name = "alsa",
+    linkopts = ["-ldl"],
+    deps = ["@alsa_lib//:asound"],
+    tags = ["manual"],
+)
+
+cc_library(
     name = "jack",
     linkopts = ["-ljack"],
     tags = ["manual"],
@@ -133,7 +140,7 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = select({
-        ":linux_pa_use_alsa_setting": ["@alsa_lib//:asound"],
+        ":linux_pa_use_alsa_setting": [":alsa"],
         "//conditions:default": [],
     }) + select({
         ":linux_pa_use_jack_setting": [":jack"],

--- a/modules/portaudio/19.7.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/portaudio/19.7.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/portaudio/19.7.0.bcr.1/presubmit.yml
+++ b/modules/portaudio/19.7.0.bcr.1/presubmit.yml
@@ -1,0 +1,14 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform: ["macos_arm64", "ubuntu2004"]
+    bazel: ["7.x", "8.x"]
+  tasks:
+    verify_targets:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - "//..."
+      test_targets:
+      - "//..."

--- a/modules/portaudio/19.7.0.bcr.1/source.json
+++ b/modules/portaudio/19.7.0.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz",
+    "strip_prefix": "portaudio",
+    "integrity": "sha256-R++/Qsd8GaBdIuYn1Chz6ZHsDBNXIZwNdM5qKUjLLe8=",
+    "overlay": {
+        "BUILD.bazel": "sha256-xABMdG7DaoKnFiyU6a5dfYm1oJAF338FfRfZCU9n5Ho=",
+        "MODULE.bazel": "sha256-3gWUZGvoQ3v8aWh3ZVtISAQRIhyjJoGOaubc4MXN8WE="
+    }
+}

--- a/modules/portaudio/19.7.0.bcr.1/source.json
+++ b/modules/portaudio/19.7.0.bcr.1/source.json
@@ -3,7 +3,7 @@
     "strip_prefix": "portaudio",
     "integrity": "sha256-R++/Qsd8GaBdIuYn1Chz6ZHsDBNXIZwNdM5qKUjLLe8=",
     "overlay": {
-        "BUILD.bazel": "sha256-xABMdG7DaoKnFiyU6a5dfYm1oJAF338FfRfZCU9n5Ho=",
+        "BUILD.bazel": "sha256-EhMEKvawi/KxR+COXCo8AGBWiBjUKVuq2L0Xcij+i3g=",
         "MODULE.bazel": "sha256-3gWUZGvoQ3v8aWh3ZVtISAQRIhyjJoGOaubc4MXN8WE="
     }
 }

--- a/modules/portaudio/metadata.json
+++ b/modules/portaudio/metadata.json
@@ -12,7 +12,8 @@
         "github:PortAudio/portaudio"
     ],
     "versions": [
-        "19.7.0"
+        "19.7.0",
+        "19.7.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
With `asound` now available (https://github.com/bazelbuild/bazel-central-registry/pull/4121) this flag can be enabled for linux.