### PR TITLE
chore: yank rules_js 2.3.2

### DIFF
--- a/modules/aspect_rules_js/metadata.json
+++ b/modules/aspect_rules_js/metadata.json
@@ -132,5 +132,7 @@
         "2.3.2",
         "2.3.3"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "2.3.2": "It contains a bug that breaks the js_image_layer rule: https://github.com/aspect-build/rules_js/pull/2145"
+    }
 }


### PR DESCRIPTION
rules_js 2.3.2 is faulty version that breaks the public api for js_image_layer and therefore should not be used.

https://github.com/aspect-build/rules_js/pull/2145
https://github.com/aspect-build/rules_js/pull/2143
https://github.com/aspect-build/rules_js/pull/2142
https://github.com/aspect-build/rules_js/pull/2141