### PR TITLE
Verify github user id in metadata.json

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ The BCR follows the format of a regular [Bazel registry](https://bazel.build/ext
 - Extra metadata.json fields (see [JSON schema](https://github.com/bazelbuild/bazel-central-registry/blob/main/metadata.schema.json)):
   - `maintainers`: an array of JSON objects, each representing a module maintainer. Each object can have the following fields:
     - `github`: a string, the maintainer's GitHub username. This is used to `@`-ping the maintainer when a PR updating the module is sent, and determines whether a GitHub user has approval rights for a PR (see [approval and submission](#approval-and-submission) below).
-    - `github_user_id`: a number, the maintainer's GitHub ID number. This is used to verify the maintainer's identity in case of GitHub username change or deletion.
+    - `github_user_id`: a number, the maintainer's GitHub ID number. This is used to verify the maintainer's identity in case of GitHub username change or deletion. Run `bazel run //tools:bcr_validation -- --check_metadata=foo --fix` to get it updated.
     - `name`: a string, the maintainer's name. Purely informational.
     - `email`: a string, the maintainer's email address. Purely informational.
     - `do_not_notify`: a boolean. When set to `true`, the maintainer will still have approval rights, but will not be `@`-pinged when a PR for the module is sent.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ The BCR follows the format of a regular [Bazel registry](https://bazel.build/ext
 - Extra metadata.json fields (see [JSON schema](https://github.com/bazelbuild/bazel-central-registry/blob/main/metadata.schema.json)):
   - `maintainers`: an array of JSON objects, each representing a module maintainer. Each object can have the following fields:
     - `github`: a string, the maintainer's GitHub username. This is used to `@`-ping the maintainer when a PR updating the module is sent, and determines whether a GitHub user has approval rights for a PR (see [approval and submission](#approval-and-submission) below).
-    - `github_user_id`: a number, the maintainer's GitHub ID number. This is used to verify the maintainer's identity in case of GitHub username change or deletion. Run `bazel run //tools:bcr_validation -- --check_metadata=foo --fix` to get it updated.
+    - `github_user_id`: a number, the maintainer's GitHub ID number. This is used to verify the maintainer's identity in case of GitHub username change or deletion. Run `bazel run //tools:bcr_validation -- --check_metadata=foo --fix` to update it for the module `foo`.
     - `name`: a string, the maintainer's name. Purely informational.
     - `email`: a string, the maintainer's email address. Purely informational.
     - `do_not_notify`: a boolean. When set to `true`, the maintainer will still have approval rights, but will not be `@`-pinged when a PR for the module is sent.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ The BCR follows the format of a regular [Bazel registry](https://bazel.build/ext
 - Extra metadata.json fields (see [JSON schema](https://github.com/bazelbuild/bazel-central-registry/blob/main/metadata.schema.json)):
   - `maintainers`: an array of JSON objects, each representing a module maintainer. Each object can have the following fields:
     - `github`: a string, the maintainer's GitHub username. This is used to `@`-ping the maintainer when a PR updating the module is sent, and determines whether a GitHub user has approval rights for a PR (see [approval and submission](#approval-and-submission) below).
+    - `github_user_id`: a number, the maintainer's GitHub ID number. This is used to verify the maintainer's identity in case of GitHub username change or deletion.
     - `name`: a string, the maintainer's name. Purely informational.
     - `email`: a string, the maintainer's email address. Purely informational.
     - `do_not_notify`: a boolean. When set to `true`, the maintainer will still have approval rights, but will not be `@`-pinged when a PR for the module is sent.

--- a/metadata.schema.json
+++ b/metadata.schema.json
@@ -17,6 +17,11 @@
               "description": "maintainer's github username",
               "pattern": "^[-a-zA-Z0-9]*$"
             },
+            "github_user_id": {
+              "type": "integer",
+              "description": "maintainer's github user id",
+              "pattern": "^[0-9]*$"
+            },
             "email": {
               "type": "string",
               "description": "maintainer's email address"

--- a/modules/aspect_rules_js/metadata.json
+++ b/modules/aspect_rules_js/metadata.json
@@ -4,17 +4,20 @@
         {
             "name": "Alex Eagle",
             "email": "alex@aspect.build",
-            "github": "alexeagle"
+            "github": "alexeagle",
+            "github_user_id": 47395
         },
         {
             "name": "Greg Magolan",
             "email": "greg@aspect.build",
-            "github": "gregmagolan"
+            "github": "gregmagolan",
+            "github_user_id": 520826
         },
         {
             "name": "Jason Bedard",
             "email": "jason@aspect.build",
-            "github": "jbedard"
+            "github": "jbedard",
+            "github_user_id": 89246
         }
     ],
     "repository": [

--- a/modules/cel-spec/metadata.json
+++ b/modules/cel-spec/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "cel-lang-discuss@googlegroups.com",
             "github": "cel-expr",
-            "name": "CEL Team"
+            "name": "CEL Team",
+            "github_user_id": 186625994
         }
     ],
     "repository": [

--- a/modules/cjson/metadata.json
+++ b/modules/cjson/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "dev@rdxip.com",
             "github": "Attempt3035",
-            "name": "Luke Aguilar"
+            "name": "Luke Aguilar",
+            "github_user_id": 118163872
         }
     ],
     "repository": [

--- a/modules/cudd/metadata.json
+++ b/modules/cudd/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "emahintorabi@gmail.com",
             "github": "QuantamHD",
-            "name": "Ethan Mahintorabi"
+            "name": "Ethan Mahintorabi",
+            "github_user_id": 3784748
         },
         {
             "email": "h.zeller@acm.org",

--- a/modules/fastjson/metadata.json
+++ b/modules/fastjson/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "dev@rdxip.com",
             "github": "Attempt3035",
-            "name": "Luke Aguilar"
+            "name": "Luke Aguilar",
+            "github_user_id": 118163872
         }
     ],
     "repository": [

--- a/modules/gason/metadata.json
+++ b/modules/gason/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "dev@rdxip.com",
             "github": "Attempt3035",
-            "name": "Luke Aguilar"
+            "name": "Luke Aguilar",
+            "github_user_id": 118163872
         }
     ],
     "repository": [

--- a/modules/jsmn/metadata.json
+++ b/modules/jsmn/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "dev@rdxip.com",
             "github": "Attempt3035",
-            "name": "Luke Aguilar"
+            "name": "Luke Aguilar",
+            "github_user_id": 118163872
         }
     ],
     "repository": [

--- a/modules/json11/metadata.json
+++ b/modules/json11/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "dev@rdxip.com",
             "github": "Attempt3035",
-            "name": "Luke Aguilar"
+            "name": "Luke Aguilar",
+            "github_user_id": 118163872
         }
     ],
     "repository": [

--- a/modules/libcap/metadata.json
+++ b/modules/libcap/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "johnor@users.noreply.github.com",
             "github": "johnor",
-            "name": "Johan Norberg"
+            "name": "Johan Norberg",
+            "github_user_id": 6647461
         }
     ],
     "repository": [

--- a/modules/prodrive_technologies_bazel_latex/metadata.json
+++ b/modules/prodrive_technologies_bazel_latex/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "julian.amann@tum.de",
             "github": "Vertexwahn",
-            "name": "Julian Amann"
+            "name": "Julian Amann",
+            "github_user_id": 3775001
         }
     ],
     "repository": [

--- a/modules/rules_uv/metadata.json
+++ b/modules/rules_uv/metadata.json
@@ -4,12 +4,14 @@
         {
             "email": "123787712+mark-thm@users.noreply.github.com",
             "github": "mark-thm",
-            "name": "Mark Elliot"
+            "name": "Mark Elliot",
+            "github_user_id": 123787712
         },
         {
             "email": "bazel-maintainers@theoremlp.com",
             "github": "theoremlp",
-            "name": "Theorem Bazel Maintainers"
+            "name": "Theorem Bazel Maintainers",
+            "github_user_id": 84351796
         }
     ],
     "repository": [

--- a/modules/sajson/metadata.json
+++ b/modules/sajson/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "dev@rdxip.com",
             "github": "Attempt3035",
-            "name": "Luke Aguilar"
+            "name": "Luke Aguilar",
+            "github_user_id": 118163872
         }
     ],
     "repository": [

--- a/modules/saru/metadata.json
+++ b/modules/saru/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "dev@rdxip.com",
             "github": "Attempt3035",
-            "name": "Luke Aguilar"
+            "name": "Luke Aguilar",
+            "github_user_id": 118163872
         }
     ],
     "repository": [

--- a/modules/ultrajson/metadata.json
+++ b/modules/ultrajson/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "dev@rdxip.com",
             "github": "Attempt3035",
-            "name": "Luke Aguilar"
+            "name": "Luke Aguilar",
+            "github_user_id": 118163872
         }
     ],
     "repository": [

--- a/modules/unittest-cpp/metadata.json
+++ b/modules/unittest-cpp/metadata.json
@@ -4,7 +4,8 @@
         {
             "email": "dev@rdxip.com",
             "github": "Attempt3035",
-            "name": "Luke Aguilar"
+            "name": "Luke Aguilar",
+            "github_user_id": 118163872
         }
     ],
     "repository": [

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -641,12 +641,10 @@ class BcrValidator:
         self.verify_module_dot_bazel(module_name, version)
         self.verify_attestations(module_name, version)
 
-
     def validate_metadata(self, modules):
         print_expanded_group(f"Validating metadata.json files for {modules}")
         for module_name in modules:
             self.verify_metadata_json(module_name)
-
 
     def verify_metadata_json(self, module_name):
         """Verify the metadata.json file is valid."""
@@ -698,7 +696,7 @@ class BcrValidator:
                     self.report(
                         BcrValidationResult.FAILED,
                         f"{module_name}'s metadata.json file has an invalid GitHub user ID for {github_username}\n"
-                        + f"Please add `\"github_user_id\": {github_user_id}` to the maintainer entry by running `bazel run //tools:bcr_validation -- --check_metadata={module_name} --fix`.",
+                        + f'Please add `"github_user_id": {github_user_id}` to the maintainer entry by running `bazel run //tools:bcr_validation -- --check_metadata={module_name} --fix`.',
                     )
                     if self.should_fix:
                         maintainer["github_user_id"] = github_user_id
@@ -708,7 +706,6 @@ class BcrValidator:
                         BcrValidationResult.GOOD,
                         f"{module_name}'s metadata.json file has a valid GitHub user ID for {github_username}",
                     )
-
 
     def verify_attestations(self, module_name, version):
         print_expanded_group("Verifying attestations")

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -698,7 +698,7 @@ class BcrValidator:
                     self.report(
                         BcrValidationResult.FAILED,
                         f"{module_name}'s metadata.json file has an invalid GitHub user ID for {github_username}\n"
-                        + f"Please add `\"github_user_id\": {github_user_id}` to the maintainer entry.",
+                        + f"Please add `\"github_user_id\": {github_user_id}` to the maintainer entry by running `bazel run //tools:bcr_validation -- --check_metadata={module_name} --fix`.",
                     )
                     if self.should_fix:
                         maintainer["github_user_id"] = github_user_id

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -208,6 +208,27 @@ def check_github_url(repo_path, source_url):
     return reference and is_ref_in_original_repo(repo_path, reference)
 
 
+def get_github_user_id(github_username):
+    """
+    Get the GitHub user ID for a given GitHub username.
+
+    Args:
+        github_username: The GitHub username to look up.
+
+    Returns:
+        The GitHub user ID if found, otherwise None.
+    """
+    url = f"https://api.github.com/users/{github_username}"
+    headers = {}
+    github_token = os.getenv("GITHUB_TOKEN")
+    if github_token:
+        headers["Authorization"] = f"token {github_token}"
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        return response.json().get("id")
+    return None
+
+
 class BcrValidationException(Exception):
     """
     Raised whenever we should stop the validation immediately.
@@ -620,50 +641,74 @@ class BcrValidator:
         self.verify_module_dot_bazel(module_name, version)
         self.verify_attestations(module_name, version)
 
-    def validate_all_metadata(self):
-        print_expanded_group("Validating all metadata.json files")
-        has_error = False
-        for module_name in self.registry.get_all_modules():
-            try:
-                metadata = self.registry.get_metadata(module_name)
-            except json.JSONDecodeError as e:
+
+    def validate_metadata(self, modules):
+        print_expanded_group(f"Validating metadata.json files for {modules}")
+        for module_name in modules:
+            self.verify_metadata_json(module_name)
+
+
+    def verify_metadata_json(self, module_name):
+        """Verify the metadata.json file is valid."""
+        try:
+            metadata = self.registry.get_metadata(module_name)
+        except json.JSONDecodeError as e:
+            self.report(
+                BcrValidationResult.FAILED,
+                f"Failed to load {module_name}'s metadata.json file: " + str(e),
+            )
+            return
+
+        sorted_versions = sorted(metadata["versions"], key=Version)
+        if sorted_versions != metadata["versions"]:
+            self.report(
+                BcrValidationResult.FAILED,
+                f"{module_name}'s metadata.json file is not sorted by version.\n "
+                f"Sorted versions: {sorted_versions}.\n "
+                f"Original versions: {metadata['versions']}",
+            )
+
+        for version in metadata["versions"]:
+            if not self.registry.contains(module_name, version):
                 self.report(
                     BcrValidationResult.FAILED,
-                    f"Failed to load {module_name}'s metadata.json file: " + str(e),
+                    f"{module_name}@{version} doesn't exist, "
+                    f"but it's recorded in {module_name}'s metadata.json file.",
                 )
-                has_error = True
-                continue
 
-            sorted_versions = sorted(metadata["versions"], key=Version)
-            if sorted_versions != metadata["versions"]:
-                self.report(
-                    BcrValidationResult.FAILED,
-                    f"{module_name}'s metadata.json file is not sorted by version.\n "
-                    f"Sorted versions: {sorted_versions}.\n "
-                    f"Original versions: {metadata['versions']}",
-                )
-                has_error = True
+        latest_version = metadata["versions"][-1]
+        if not metadata.get("deprecated") and latest_version in metadata.get("yanked_versions", {}):
+            self.report(
+                BcrValidationResult.FAILED,
+                f"The latest version ({latest_version}) of {module_name} should not be yanked, "
+                f"please make sure a newer version is available before yanking it.",
+            )
 
-            for version in metadata["versions"]:
-                if not self.registry.contains(module_name, version):
+        maintainers = metadata.get("maintainers", [])
+        for maintainer in maintainers:
+            if "github" in maintainer:
+                github_username = maintainer["github"]
+                print("checking github user id for %s" % github_username)
+                github_user_id = get_github_user_id(github_username)
+                if github_user_id is None:
+                    raise BcrValidationException(
+                        f"Failed to get GitHub user ID for {github_username}. Please check the username."
+                    )
+                if github_user_id != maintainer.get("github_user_id"):
                     self.report(
                         BcrValidationResult.FAILED,
-                        f"{module_name}@{version} doesn't exist, "
-                        f"but it's recorded in {module_name}'s metadata.json file.",
+                        f"{module_name}'s metadata.json file has an invalid GitHub user ID for {github_username}\n"
+                        + f"Please add `\"github_user_id\": {github_user_id}` to the maintainer entry.",
                     )
-                    has_error = True
+                    if self.should_fix:
+                        maintainer["github_user_id"] = github_user_id
+                        self.registry.get_metadata_path(module_name).write_text(json.dumps(metadata, indent=4) + "\n")
+                else:
+                    self.report(
+                        BcrValidationResult.GOOD,
+                        f"{module_name}'s metadata.json file has a valid GitHub user ID for {github_username}",
+                    )
 
-            latest_version = metadata["versions"][-1]
-            if not metadata.get("deprecated") and latest_version in metadata.get("yanked_versions", {}):
-                self.report(
-                    BcrValidationResult.FAILED,
-                    f"The latest version ({latest_version}) of {module_name} should not be yanked, "
-                    f"please make sure a newer version is available before yanking it.",
-                )
-                has_error = True
-
-        if not has_error:
-            self.report(BcrValidationResult.GOOD, "All metadata.json files are valid.")
 
     def verify_attestations(self, module_name, version):
         print_expanded_group("Verifying attestations")
@@ -774,6 +819,11 @@ def main(argv=None):
         help="Check all Bazel modules in the registry, ignore other --check flags.",
     )
     parser.add_argument(
+        "--check_metadata",
+        action="append",
+        help="Check metadata for given modules in the registry.",
+    )
+    parser.add_argument(
         "--check_all_metadata",
         action="store_true",
         help="Check all Bazel module metadata in the registry.",
@@ -796,7 +846,7 @@ def main(argv=None):
 
     args = parser.parse_args(argv)
 
-    if not args.check_all and not args.check and not args.check_all_metadata:
+    if not args.check_all and not args.check and not args.check_all_metadata and not args.check_metadata:
         parser.print_help()
         return -1
 
@@ -818,7 +868,12 @@ def main(argv=None):
         validator.validate_module(name, version, args.skip_validation)
 
     if args.check_all_metadata:
-        validator.validate_all_metadata()
+        # Validate all metadata.json
+        validator.validate_metadata(validator.registry.get_all_modules())
+    else:
+        # Validate metadata.json for given modules and all modified modules.
+        modules_to_validate = set(args.check_metadata + [name for name, _ in module_versions])
+        validator.validate_metadata(list(modules_to_validate))
 
     # Perform some global checks
     validator.global_checks()


### PR DESCRIPTION
Whenever a module is added or its metadata is changed, verify the github handle of the module maintainer matches the previously recorded github user id. This is to prevent security risk in case of module maintainer's github username change or deletion which will make the previous username available for take over. 