### PR TITLE
Don't allow symlinks in module overlay

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -498,7 +498,6 @@ class BcrValidator:
                     f"{module_file} should be a symlink to `../MODULE.bazel`.",
                 )
 
-            version_dir = self.registry.get_version_dir(module_name, version)
             for overlay_file, expected_integrity in source["overlay"].items():
                 overlay_src = overlay_dir / overlay_file
                 if overlay_src != module_file and overlay_src.is_symlink():

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -488,6 +488,12 @@ class BcrValidator:
                         f"The patch file `{patch_file}` has expected integrity value `{expected_integrity}`, "
                         f"but the real integrity value is `{actual_integrity}`.",
                     )
+                if patch_file.is_symlink():
+                    self.report(
+                        BcrValidationResult.FAILED,
+                        f"The patch file `{patch_name}` is a symlink to `{patch_file.readlink()}`, "
+                        "which is not allowed because https://raw.githubusercontent.com/ will not follow it.",
+                    )
                 apply_patch(source_root, source["patch_strip"], str(patch_file.resolve()))
         if "overlay" in source:
             overlay_dir = self.registry.get_overlay_dir(module_name, version)
@@ -503,10 +509,9 @@ class BcrValidator:
                 if overlay_src != module_file and overlay_src.is_symlink():
                     self.report(
                         BcrValidationResult.FAILED,
-                        f"The overlay file path `{overlay_file}` is a symlink to `{overlay_src.readlink()}`, "
+                        f"The overlay file `{overlay_file}` is a symlink to `{overlay_src.readlink()}`, "
                         "which is not allowed because https://raw.githubusercontent.com/ will not follow it.",
                     )
-                    continue
                 overlay_dst = source_root / overlay_file
                 try:
                     overlay_dst.resolve().relative_to(source_root.resolve())

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -501,12 +501,11 @@ class BcrValidator:
             version_dir = self.registry.get_version_dir(module_name, version)
             for overlay_file, expected_integrity in source["overlay"].items():
                 overlay_src = overlay_dir / overlay_file
-                try:
-                    overlay_src.resolve().relative_to(version_dir.resolve())
-                except ValueError as e:
+                if overlay_src != module_file and overlay_src.is_symlink():
                     self.report(
                         BcrValidationResult.FAILED,
-                        f"The overlay file path `{overlay_file}` must point to a file inside the same module version dir.\n {e}",
+                        f"The overlay file path `{overlay_file}` is a symlink to `{overlay_src.readlink()}`, "
+                        "which is not allowed because https://raw.githubusercontent.com/ will not follow it.",
                     )
                     continue
                 overlay_dst = source_root / overlay_file

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -498,8 +498,17 @@ class BcrValidator:
                     f"{module_file} should be a symlink to `../MODULE.bazel`.",
                 )
 
+            version_dir = self.registry.get_version_dir(module_name, version)
             for overlay_file, expected_integrity in source["overlay"].items():
                 overlay_src = overlay_dir / overlay_file
+                try:
+                    overlay_src.resolve().relative_to(version_dir.resolve())
+                except ValueError as e:
+                    self.report(
+                        BcrValidationResult.FAILED,
+                        f"The overlay file path `{overlay_file}` must point to a file inside the same module version dir.\n {e}",
+                    )
+                    continue
                 overlay_dst = source_root / overlay_file
                 try:
                     overlay_dst.resolve().relative_to(source_root.resolve())


### PR DESCRIPTION
Using symlinks in module overlay dirs is problematic because GitHub doesn't follow them.

For example https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/refs/heads/main/modules/boost.asio/1.87.0/overlay/BUILD.bazel
is a symlink and indeed this causes issues like `Java.io.IOException: Error downloading [https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main/modules/boost.asio/1.87.0/overlay/BUILD.bazel] to /home/laltenmueller/.cache/bazel/_bazel_laltenmueller/5f48ff965103b174f3c248651ebad24d/external/boost.asio~/BUILD.bazel: Checksum was sha256-vBvC/W9TQ9vRetDZWdnElvq8fuVlhV+T0Lkv9mw/lJk= but wanted sha256-7dsPuPevCutp/EdPRxhW0dlbB1wNJFseGx4b35TS2WA=` (see https://github.com/bazelbuild/bazel-central-registry/pull/3991, https://github.com/bazelbuild/bazel-central-registry/pull/4080, https://github.com/bazelbuild/bazel-central-registry/pull/3633, https://github.com/bazelbuild/bazel-central-registry/issues/3631)

This PR adds a bcr_validation check against this.
`modules/boost.asio/1.87.0/overlay/BUILD.bazel` would have been flagged.
```console
❯ bazel run //tools:bcr_validation -- --check boost.asio@1.87.0 --skip_validation url_stability
(...)
BcrValidationResult.GOOD: The presubmit.yml file is valid.
BcrValidationResult.FAILED: The overlay file path `BUILD.bazel` is a symlink to `../../1.83.0.bcr.1/overlay/BUILD.bazel`, which is not allowed because raw.githubusercontent.com will not follow it.
BcrValidationResult.GOOD: Checked in MODULE.bazel matches the sources.
(...)
```

`modules/boost.asio/1.87.0.bcr.1/overlay/BUILD.bazel` is not a symlink anymore and is green:
```console
❯ bazel run //tools:bcr_validation -- --check boost.asio@1.87.0.bcr.1 --skip_validation url_stability
(...)
BcrValidationResult.GOOD: The presubmit.yml file is valid.
BcrValidationResult.GOOD: Checked in MODULE.bazel matches the sources.
(...)
```

I am actually curious how other people use the BCR as they don't seem to run into this (@Vertexwahn ?).

Also disallows symlinked patch files:
```console
❯ bzr //tools:bcr_validation -- --check glib@2.82.2.bcr.2 --skip_validation url_stability
(...)
BcrValidationResult.GOOD: The presubmit.yml file is valid.
BcrValidationResult.FAILED: The patch file `test_portability.patch` is a symlink to `../../2.82.2.bcr.1/patches/test_portability.patch`, which is not allowed because https://raw.githubusercontent.com/ will not follow it.
patching file glib/tests/date.c
patching file glib/tests/environment.c
patching file glib/tests/gdatetime.c
patching file glib/tests/gdatetime.c
Hunk #1 succeeded at 2930 (offset -1 lines).
Hunk #2 succeeded at 2954 (offset -1 lines).
BcrValidationResult.FAILED: The overlay file `BUILD.bazel` is a symlink to `../../2.82.2.bcr.1/overlay/BUILD.bazel`, which is not allowed because https://raw.githubusercontent.com/ will not follow it.
BcrValidationResult.FAILED: The overlay file `config.h-macos` is a symlink to `../../2.82.2.bcr.1/overlay/config.h-macos`, which is not allowed because https://raw.githubusercontent.com/ will not follow it.
BcrValidationResult.FAILED: The overlay file `glib/glibconfig.h.in-posix` is a symlink to `../../../2.82.2.bcr.1/overlay/glib/glibconfig.h.in-posix`, which is not allowed because https://raw.githubusercontent.com/ will not follow it.
BcrValidationResult.FAILED: The overlay file `glib/stub_libintl/libintl.h` is a symlink to `../../../../2.82.2.bcr.1/overlay/glib/stub_libintl/libintl.h`, which is not allowed because https://raw.githubusercontent.com/ will not follow it.
BcrValidationResult.FAILED: The overlay file `glib/tests/BUILD.bazel` is a symlink to `../../../../2.82.2.bcr.1/overlay/glib/tests/BUILD.bazel`, which is not allowed because https://raw.githubusercontent.com/ will not follow it.
BcrValidationResult.GOOD: Checked in MODULE.bazel matches the sources.
(...)
```