### PR TITLE
add libxml2-go module

### DIFF
--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/MODULE.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/MODULE.bazel
@@ -1,0 +1,15 @@
+module(name = "libxml2-go", version = "0.0.0-20250331-c934e3f")
+
+bazel_dep(name = "rules_go", version = "0.51.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "libxml2", version = "2.13.5")
+
+bazel_dep(name = "gazelle", version = "0.42.0")
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+
+use_repo(
+    go_deps,
+    "com_github_pkg_errors",
+    "com_github_stretchr_testify",
+    "in_gopkg_xmlpath_v1",
+)

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/BUILD.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "libxml2",
+    srcs = [
+        "html.go",
+        "libxml2.go",
+        "parser.go",
+    ],
+    importpath = "github.com/lestrrat-go/libxml2",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//clib",
+        "//dom",
+        "//parser",
+        "//types",
+        "@com_github_pkg_errors//:errors",
+    ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":libxml2",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/MODULE.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/clib/BUILD.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/clib/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "clib",
+    srcs = [
+        "clib.go",
+        "interface.go",
+        "link_dynamic.go",
+    ],
+    cdeps = [
+        "@libxml2//:libxml2",
+    ],
+    cgo = True,
+    importpath = "github.com/lestrrat-go/libxml2/clib",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//internal/debug",
+        "//internal/option",
+        "@com_github_pkg_errors//:errors",
+    ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":clib",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/dom/BUILD.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/dom/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "dom",
+    srcs = [
+        "dom.go",
+        "interface.go",
+        "node.go",
+        "node_attr.go",
+        "node_document.go",
+        "node_element.go",
+        "node_namespace.go",
+        "node_text.go",
+        "node_wrap.go",
+        "serialize.go",
+    ],
+    importpath = "github.com/lestrrat-go/libxml2/dom",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//clib",
+        "//types",
+        "//xpath",
+        "@com_github_pkg_errors//:errors",
+    ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":dom",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/internal/cmd/genwrapnode/BUILD.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/internal/cmd/genwrapnode/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "genwrapnode_lib",
+    srcs = ["genwrapnode.go"],
+    importpath = "github.com/lestrrat-go/libxml2/internal/cmd/genwrapnode",
+    visibility = ["//visibility:private"],
+    deps = ["@com_github_pkg_errors//:errors"],
+)
+
+go_binary(
+    name = "genwrapnode",
+    embed = [":genwrapnode_lib"],
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/internal/debug/BUILD.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/internal/debug/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "debug",
+    srcs = ["debug_off.go"],
+    importpath = "github.com/lestrrat-go/libxml2/internal/debug",
+    visibility = ["//:__subpackages__"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":debug",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/internal/option/BUILD.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/internal/option/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "option",
+    srcs = [
+        "interface.go",
+        "option.go",
+    ],
+    importpath = "github.com/lestrrat-go/libxml2/internal/option",
+    visibility = ["//:__subpackages__"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":option",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/parser/BUILD.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/parser/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "parser",
+    srcs = [
+        "interface.go",
+        "parser.go",
+    ],
+    importpath = "github.com/lestrrat-go/libxml2/parser",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//clib",
+        "//dom",
+        "//types",
+        "@com_github_pkg_errors//:errors",
+    ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":parser",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/types/BUILD.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/types/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "types",
+    srcs = [
+        "interface.go",
+        "types.go",
+    ],
+    importpath = "github.com/lestrrat-go/libxml2/types",
+    visibility = ["//visibility:public"],
+    deps = ["//clib"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":types",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/xpath/BUILD.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/xpath/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "xpath",
+    srcs = [
+        "interface.go",
+        "iterator.go",
+        "util.go",
+        "xpath.go",
+    ],
+    importpath = "github.com/lestrrat-go/libxml2/xpath",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//clib",
+        "//types",
+        "@com_github_pkg_errors//:errors",
+    ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":xpath",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/xsd/BUILD.bazel
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/overlay/xsd/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "xsd",
+    srcs = [
+        "interface.go",
+        "option.go",
+        "xsd.go",
+    ],
+    importpath = "github.com/lestrrat-go/libxml2/xsd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//clib",
+        "//internal/option",
+        "//types",
+        "@com_github_pkg_errors//:errors",
+    ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":xsd",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/presubmit.yml
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/presubmit.yml
@@ -16,5 +16,5 @@ tasks:
     bazel: ${{ bazel }}
     build_targets:
     - '@libxml2-go//:go_default_library'
-    # - '@libxml2-go//clib:go_default_library'
+    - '@libxml2-go//clib:go_default_library'
     - '@libxml2-go//xsd:go_default_library'

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/presubmit.yml
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/presubmit.yml
@@ -4,11 +4,9 @@ matrix:
   - ubuntu2004
   - macos
   - macos_arm64
-  - windows
   bazel:
   - 8.x
   - 7.x
-  - 6.x
 tasks:
   verify_targets:
     name: Verify build targets

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/presubmit.yml
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@libxml2-go//:go_default_library'
+    # - '@libxml2-go//clib:go_default_library'
+    - '@libxml2-go//xsd:go_default_library'

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/source.json
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/source.json
@@ -1,0 +1,18 @@
+{
+    "url": "https://github.com/lestrrat-go/libxml2/archive/c934e3fcb9d356b6842830761f72b4802d40c60a.zip",
+    "integrity": "sha256-kOKyAjEhWaxyipNuOoSg8JfOZxnzxGabMKVo/3Vzr0A=",
+    "strip_prefix": "libxml2-c934e3fcb9d356b6842830761f72b4802d40c60a",
+    "overlay": {
+        "clib/BUILD.bazel": "sha256-xizPLOHX9Me8La5GOVZa3z2nxZN57RZ19GcTrIfJGH4=",
+        "dom/BUILD.bazel": "sha256-FrwsWDlljnPXKOsDhTIYDzndpWtvgiUYnRRjq+6K6jk=",
+        "xpath/BUILD.bazel": "sha256-/McHIWeLX3CKh6OD9UHyK7oVxQlFAKVnhR233s69yLA=",
+        "parser/BUILD.bazel": "sha256-DrTMO9KD+kMR8hnAxkkarciaMa4UhsilMMmeSqYZMso=",
+        "types/BUILD.bazel": "sha256-9N5aoDML2NvvObyFwB8ZDxgTXrOeTbsqoN1BhYJOQw4=",
+        "internal/debug/BUILD.bazel": "sha256-6hJe54n9iAKazmKG2kWXQytfppDXEvfffiE50Jp6z10=",
+        "internal/cmd/genwrapnode/BUILD.bazel": "sha256-jGDaMchwx41jyg9NpbBS6/VUg1bi9erJ08OgGcLEBhk=",
+        "internal/option/BUILD.bazel": "sha256-ZTXTXEIT7evjXsqSkwkj/EgBt7ZROmZCjfmsk7/WEGc=",
+        "MODULE.bazel": "sha256-+ipf6JmzLILTHnbAV3rO1VsbVOHPmxMIQQlCUYzBFow=",
+        "xsd/BUILD.bazel": "sha256-fTJ+5bbvGurmYoXErmU9sDhcFHGwyl7veYV9cW0ESwM=",
+        "BUILD.bazel": "sha256-wIl8jMEV1fR9MFjk64zoW31EuglovJQG7reHytLsYlY="
+    }
+}

--- a/modules/libxml2-go/0.0.0-20250331-c934e3f/source.json
+++ b/modules/libxml2-go/0.0.0-20250331-c934e3f/source.json
@@ -3,16 +3,16 @@
     "integrity": "sha256-kOKyAjEhWaxyipNuOoSg8JfOZxnzxGabMKVo/3Vzr0A=",
     "strip_prefix": "libxml2-c934e3fcb9d356b6842830761f72b4802d40c60a",
     "overlay": {
+        "BUILD.bazel": "sha256-wIl8jMEV1fR9MFjk64zoW31EuglovJQG7reHytLsYlY=",
         "clib/BUILD.bazel": "sha256-xizPLOHX9Me8La5GOVZa3z2nxZN57RZ19GcTrIfJGH4=",
         "dom/BUILD.bazel": "sha256-FrwsWDlljnPXKOsDhTIYDzndpWtvgiUYnRRjq+6K6jk=",
-        "xpath/BUILD.bazel": "sha256-/McHIWeLX3CKh6OD9UHyK7oVxQlFAKVnhR233s69yLA=",
+        "internal/cmd/genwrapnode/BUILD.bazel": "sha256-jGDaMchwx41jyg9NpbBS6/VUg1bi9erJ08OgGcLEBhk=",
+        "internal/debug/BUILD.bazel": "sha256-6hJe54n9iAKazmKG2kWXQytfppDXEvfffiE50Jp6z10=",
+        "internal/option/BUILD.bazel": "sha256-ZTXTXEIT7evjXsqSkwkj/EgBt7ZROmZCjfmsk7/WEGc=",
+        "MODULE.bazel": "sha256-6RKz1/ylh9FB4p1C1+vHPIZgRHd00BHgMCgqHXh4cKk=",
         "parser/BUILD.bazel": "sha256-DrTMO9KD+kMR8hnAxkkarciaMa4UhsilMMmeSqYZMso=",
         "types/BUILD.bazel": "sha256-9N5aoDML2NvvObyFwB8ZDxgTXrOeTbsqoN1BhYJOQw4=",
-        "internal/debug/BUILD.bazel": "sha256-6hJe54n9iAKazmKG2kWXQytfppDXEvfffiE50Jp6z10=",
-        "internal/cmd/genwrapnode/BUILD.bazel": "sha256-jGDaMchwx41jyg9NpbBS6/VUg1bi9erJ08OgGcLEBhk=",
-        "internal/option/BUILD.bazel": "sha256-ZTXTXEIT7evjXsqSkwkj/EgBt7ZROmZCjfmsk7/WEGc=",
-        "MODULE.bazel": "sha256-+ipf6JmzLILTHnbAV3rO1VsbVOHPmxMIQQlCUYzBFow=",
-        "xsd/BUILD.bazel": "sha256-fTJ+5bbvGurmYoXErmU9sDhcFHGwyl7veYV9cW0ESwM=",
-        "BUILD.bazel": "sha256-wIl8jMEV1fR9MFjk64zoW31EuglovJQG7reHytLsYlY="
+        "xpath/BUILD.bazel": "sha256-/McHIWeLX3CKh6OD9UHyK7oVxQlFAKVnhR233s69yLA=",
+        "xsd/BUILD.bazel": "sha256-fTJ+5bbvGurmYoXErmU9sDhcFHGwyl7veYV9cW0ESwM="
     }
 }

--- a/modules/libxml2-go/metadata.json
+++ b/modules/libxml2-go/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/lestrrat-go/libxml2",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No maintainer specified"
+        }
+    ],
+    "repository": [
+        "github:lestrrat-go/libxml2"
+    ],
+    "versions": [
+        "0.0.0-20250331-c934e3f"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Using peudo-version 0.0.0-20250331-c934e3f (0.0.0-<date>-<latest commit id>) since the original repo doesn't have any official versioning.

Also using overlay, since the original repo has been set read-only.