### PR TITLE
Fix rules_ytt@0.4.0 patch.

### DIFF
--- a/modules/rules_ytt/0.4.0/patches/module_dot_bazel.patch
+++ b/modules/rules_ytt/0.4.0/patches/module_dot_bazel.patch
@@ -7,3 +7,5 @@
 +    version = "0.4.0",
      compatibility_level = 0,
  )
+
+bazel_dep(name = "platforms", version = "0.0.11")

--- a/modules/rules_ytt/0.4.0/source.json
+++ b/modules/rules_ytt/0.4.0/source.json
@@ -4,6 +4,6 @@
     "strip_prefix": "rules_ytt-0.4.0",
     "patch_strip": 0,
     "patches": {
-        "module_dot_bazel.patch": "sha256-fvcmhkRImUFC+Za4/Ok0QQMMA4CnFAfkkbJhgz3UaFA="
+        "module_dot_bazel.patch": "sha256-3/YO9gSQgZ9dRgtZwhBzvhdcZ+Mvru6tAqnJXTGfh+c="
     }
 }


### PR DESCRIPTION
Without the last line patching fails during the build with the following error:

```
Error in patch: Error applying patch
.../external/rules_ytt~/.tmp_remote_patches/module_dot_bazel.patch: Expecting more chunk line at line 10
```