### PR TITLE
Add patch to fix liburing compilation

### DIFF
--- a/modules/liburing/2.5/patches/working_build.patch
+++ b/modules/liburing/2.5/patches/working_build.patch
@@ -1,0 +1,19 @@
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -50,7 +50,7 @@
+         "src/arch/**/*.h",
+         "src/*.h",
+     ]),
+-    hdrs = glob(["src/include/**/*.h"]),
++    hdrs = ["config-host.h"] + glob(["src/include/**/*.h"]),
+ 
+     # cflags aligned with upstream:
+     # https://github.com/axboe/liburing/blob/master/src/Makefile#L13
+@@ -63,7 +63,6 @@
+         "-Wall",
+         "-Wextra",
+         "-fno-stack-protector",
+-        "-include config-host.h",
+     ],
+     includes = ["src/include"],
+     visibility = ["//visibility:public"],

--- a/modules/liburing/2.5/source.json
+++ b/modules/liburing/2.5/source.json
@@ -4,7 +4,8 @@
     "strip_prefix": "liburing-liburing-2.5",
     "patches": {
         "add_build_file.patch": "sha256-bSFDyIEyJYYP0sXNNePKjbnLKGMveouIm6pZ6fRY9Yc=",
-        "module_dot_bazel.patch": "sha256-YB8pxLkYyg8znqTewNFcc9D/bPjQ30plU+xoLEKWSco="
+        "module_dot_bazel.patch": "sha256-YB8pxLkYyg8znqTewNFcc9D/bPjQ30plU+xoLEKWSco=",
+        "working_build.patch": "sha256-iw9693Gy1OykmyhrbwIAiyEs0DCzzTToRN94SwxhM58="
     },
     "patch_strip": 1
 }


### PR DESCRIPTION
The current `liburing` module does not compile correctly. It outputs the following error:

```
(16:52:32) ERROR: /home/etched/.cache/bazel/_bazel_etched/83d6b42fdd7694af99a348063b73be17/external/liburing~/BUILD.bazel:38:11: Compiling src/queue.c failed: undeclared inclusion(s) in rule '@@liburing~//:uring':
this rule is missing dependency declarations for the following files included by 'src/queue.c':
  'external/liburing~/config-host.h'
Target //host/linux/driver/sohu/test/iouring_flatbuffer:test_app failed to build
Use --verbose_failures to see the command lines of failed build steps.
(16:52:32) INFO: Elapsed time: 15.339s, Critical Path: 0.46s
(16:52:32) INFO: 9 processes: 7 internal, 2 local.
(16:52:32) ERROR: Build did NOT complete successfully

``` 

This is due to the inclusion of an `-include` flag in the `copts` list. By removing the flag and moving the header into the `hdrs` list everything compiles correctly now!