### PR TITLE
ncurses@6.4.20221231.bcr.6

### DIFF
--- a/modules/ncurses/6.4.20221231.bcr.6/MODULE.bazel
+++ b/modules/ncurses/6.4.20221231.bcr.6/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "ncurses",
+    version = "6.4.20221231.bcr.6",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_perl", version = "0.2.5")

--- a/modules/ncurses/6.4.20221231.bcr.6/overlay/BUILD.bazel
+++ b/modules/ncurses/6.4.20221231.bcr.6/overlay/BUILD.bazel
@@ -1,0 +1,635 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The ncurses C library and unit test.
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//bazel:automake_substitution.bzl", "automake_substitution")
+load("//bazel:pseudo_configure.bzl", "pseudo_configure")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+exports_files([
+    "LICENSE",
+    "include/Caps",
+])
+
+NCURSES_COPTS = [
+    "-w",
+    "-DTRACE",
+    "-DHAVE_CONFIG_H",
+    "-D_GNU_SOURCE",
+    "-DNDEBUG",
+]
+
+CAPLIST = [
+    "include/Caps",
+    "include/Caps-ncurses",
+]
+
+CAPLIST_LOCATIONS = " ".join(["$(execpath :" + cap + ")" for cap in CAPLIST])
+
+AUTOMAKE_SUBSTITUTIONS_COMMON = {
+    "BROKEN_LINKER": "0",
+    "EXP_WIN32_DRIVER": "0",
+    "GENERATED_EXT_FUNCS": "generated",
+    "HAVE_BTOWC": "1",
+    "HAVE_MBLEN": "1",
+    "HAVE_MBRLEN": "1",
+    "HAVE_MBRTOWC": "1",
+    "HAVE_MBSRTOWCS": "1",
+    "HAVE_MBSTOWCS": "1",
+    "HAVE_MBTOWC": "1",
+    "HAVE_PUTWC": "1",
+    "HAVE_STDINT_H": "1",
+    "HAVE_STDNORETURN_H": "1",
+    "HAVE_TCGETATTR": "1",
+    "HAVE_TERMIOS_H": "1",
+    "HAVE_TERMIO_H": "1",
+    "HAVE_VSSCANF": "1",
+    "HAVE_WCHAR_H": "1",
+    "HAVE_WCSRTOMBS": "1",
+    "HAVE_WCSTOMBS": "1",
+    "HAVE_WCTOB": "1",
+    "HAVE_WCTOMB": "1",
+    "HAVE_WCTYPE_H": "1",
+    "HAVE_WMEMCHR": "1",
+    "NCURSES_CCHARW_MAX": "5",
+    "NCURSES_CH_T": "cchar_t",
+    "NCURSES_CONST": "const",
+    "NCURSES_EXT_COLORS": "0",
+    "NCURSES_EXT_FUNCS": "1",
+    "NCURSES_INLINE": "inline",
+    "NCURSES_INTEROP_FUNCS": "1",
+    "NCURSES_LIBUTF8": "0",
+    "NCURSES_MAJOR": "6",
+    "NCURSES_MBSTATE_T": "1",
+    "NCURSES_MINOR": "4",
+    "NCURSES_MOUSE_VERSION": "2",
+    "NCURSES_OK_WCHAR_T": "",
+    "NCURSES_OPAQUE": "0",
+    "NCURSES_OPAQUE_FORM": "0",
+    "NCURSES_OPAQUE_MENU": "0",
+    "NCURSES_OPAQUE_PANEL": "0",
+    "NCURSES_OSPEED": "short",
+    "NCURSES_PATCH": "20221231",
+    "NCURSES_SBOOL": "char",
+    "NCURSES_SIZE_T": "short",
+    "NCURSES_SP_FUNCS": "1",
+    "NCURSES_TPARM_ARG": "intptr_t",
+    "NCURSES_TPARM_VARARGS": "1",
+    "NCURSES_USE_DATABASE": "1",
+    "NCURSES_USE_TERMCAP": "0",
+    "NCURSES_WATTR_MACROS": "1",
+    "NCURSES_WCHAR_T": "0",
+    "NCURSES_WCWIDTH_GRAPHICS": "1",
+    "NCURSES_WIDECHAR": "1",
+    "NCURSES_WINT_T": "0",
+    "NCURSES_WRAP_PREFIX": "_nc_",
+    "NCURSES_XNAMES": "1",
+    "NEED_WCHAR_H": "1",
+    "USE_CXX_BOOL": "defined(__cplusplus)",
+    "USE_WIDEC_SUPPORT": "1",
+    "cf_cv_1UL": "1U",
+    "cf_cv_enable_lp64": "1",
+    "cf_cv_enable_reentrant": "0",
+    "cf_cv_header_stdbool_h": "1",
+    "cf_cv_type_of_bool": "unsigned char",
+    "cf_cv_typeof_chtype": "cchar_t",
+    "cf_cv_typeof_mmask_t": "unsigned",
+}
+
+AUTOMAKE_SUBSTITUTIONS = select({
+    "@platforms//cpu:armv7": AUTOMAKE_SUBSTITUTIONS_COMMON | {
+        "HAVE_STDNORETURN_H": "0",
+        "HAVE_WCHAR_H": "0",
+        "NCURSES_CH_T": "chtype",
+        "NCURSES_WATTR_MACROS": "0",
+        "NCURSES_WIDECHAR": "0",
+        "NEED_WCHAR_H": "0",
+        "USE_WIDEC_SUPPORT": "0",
+        "cf_cv_typeof_chtype": "uint32_t",
+        "cf_cv_typeof_mmask_t": "uint32_t",
+    },
+    "//conditions:default": AUTOMAKE_SUBSTITUTIONS_COMMON,
+})
+
+cc_library(
+    name = "ncurses_headers",
+    hdrs = glob(["include/*"]) + [
+        # Generated files are not found by glob.
+        "include/hashsize.h",
+        "include/ncurses_cfg.h",
+        "include/ncurses_def.h",
+        "include/parametrized.h",
+        "include/curses.h",
+        "include/term.h",
+        "include/ncurses_dll.h",
+        "include/unctrl.h",
+        "include/termcap.h",
+        # Various source files include these, so call them headers.
+        "ncurses/tinfo/doalloc.c",
+        "ncurses/names.c",
+    ],
+    includes = [
+        "include",
+        "ncurses",
+    ],
+)
+
+NCURSES_SRCS = glob(
+    [
+        "ncurses/base/*.c",
+        "ncurses/*.c",
+        "ncurses/*.h",
+        "ncurses/tinfo/*.c",
+        "ncurses/trace/*.c",
+        "ncurses/tty/*.c",
+    ],
+    exclude = [
+        "ncurses/base/lib_driver.c",
+        "ncurses/base/sigaction.c",
+        "ncurses/tinfo/make_keys.c",
+        "ncurses/tinfo/tinfo_driver.c",
+        "ncurses/tinfo/make_hash.c",
+        "ncurses/report_offsets.c",
+        "ncurses/report_hashing.c",
+    ],
+) + [
+    # Generated files are not found by glob.
+    "ncurses/codes.c",
+    "ncurses/comp_captab.c",
+    "ncurses/comp_userdefs.c",
+    "ncurses/fallback.c",
+    "ncurses/init_keytry.h",
+    "ncurses/lib_gen.c",
+    "ncurses/lib_keyname.c",
+    "ncurses/names.c",
+    "ncurses/unctrl.c",
+]
+
+cc_library(
+    name = "ncurses",
+    srcs = select({
+        "@platforms//cpu:armv7": NCURSES_SRCS,
+        "//conditions:default": NCURSES_SRCS + glob([
+            "ncurses/widechar/*.c",
+        ]),
+    }),
+    copts = NCURSES_COPTS,
+    deps = [":ncurses_headers"],
+)
+
+# Common headers between form and menu.
+cc_library(
+    name = "mf_common",
+    hdrs = [
+        "menu/eti.h",
+        "menu/mf_common.h",
+    ],
+    includes = ["menu"],
+)
+
+cc_library(
+    name = "form",
+    srcs = glob(["form/*.c"]) + [
+        "form/form.priv.h",
+        "ncurses/curses.priv.h",
+    ],
+    hdrs = ["form/form.h"],
+    copts = NCURSES_COPTS,
+    deps = [
+        ":mf_common",
+        ":ncurses",
+    ],
+)
+
+cc_library(
+    name = "menu",
+    srcs = glob(["menu/*.c"]) + [
+        "menu/menu.priv.h",
+        "ncurses/curses.priv.h",
+    ],
+    hdrs = ["menu/menu.h"],
+    copts = NCURSES_COPTS,
+    deps = [
+        ":mf_common",
+        ":ncurses",
+    ],
+)
+
+cc_library(
+    name = "panel",
+    srcs = glob(["panel/*.c"]) + [
+        "ncurses/curses.priv.h",
+        "panel/panel.priv.h",
+    ],
+    hdrs = [
+        "panel/panel.h",
+    ],
+    copts = NCURSES_COPTS,
+    deps = [":ncurses"],
+)
+
+genrule(
+    name = "fallback_c",
+    srcs = ["misc/terminfo.src"],
+    outs = ["ncurses/fallback.c"],
+    cmd = "$(execpath :ncurses/tinfo/MKfallback.sh) /usr/share/terminfo $(execpath :misc/terminfo.src) $$(which tic) $$(which infocmp) > $@",
+    tools = ["ncurses/tinfo/MKfallback.sh"],
+)
+
+cc_binary(
+    name = "make_hash",
+    srcs = [
+        "ncurses/build.priv.h",
+        "ncurses/curses.priv.h",
+        "ncurses/tinfo/make_hash.c",
+    ],
+    copts = NCURSES_COPTS,
+    deps = [":ncurses_headers"],
+)
+
+genrule(
+    name = "comp_captab_c",
+    srcs = [
+        "ncurses/tinfo/MKcaptab.awk",
+        "include/Caps",
+    ],
+    outs = ["ncurses/comp_captab.c"],
+    cmd = "cp -f $(execpath :make_hash) . && $(execpath :ncurses/tinfo/MKcaptab.sh) $$(which awk) 1 $(execpath :ncurses/tinfo/MKcaptab.awk) $(execpath :include/Caps) > $@",
+    tools = [
+        "ncurses/tinfo/MKcaptab.sh",
+        ":make_hash",
+    ],
+)
+
+genrule(
+    name = "comp_userdefs_c",
+    srcs = ["include/hashsize.h"] + CAPLIST,
+    outs = ["ncurses/comp_userdefs.c"],
+    cmd = "cp -f $(execpath :make_hash) . && $(execpath ncurses/tinfo/MKuserdefs.sh) $$(which awk) 1 " + CAPLIST_LOCATIONS + " > $@",
+    tools = [
+        "ncurses/tinfo/MKuserdefs.sh",
+        ":make_hash",
+    ],
+)
+
+genrule(
+    name = "codes_c",
+    srcs = [
+        "ncurses/tinfo/MKcodes.awk",
+        "include/Caps",
+    ],
+    outs = ["ncurses/codes.c"],
+    cmd = "/usr/bin/env awk -f $(execpath ncurses/tinfo/MKcodes.awk) bigstrings=1 $(execpath :include/Caps) > $@",
+)
+
+genrule(
+    name = "names_c",
+    srcs = [
+        "ncurses/tinfo/MKnames.awk",
+        "include/Caps",
+    ],
+    outs = ["ncurses/names.c"],
+    cmd = "/usr/bin/env awk -f $(execpath :ncurses/tinfo/MKnames.awk) bigstrings=1 $(execpath :include/Caps) > $@",
+)
+
+genrule(
+    name = "unctrl_c",
+    srcs = [
+        "ncurses/base/MKunctrl.awk",
+    ],
+    outs = ["ncurses/unctrl.c"],
+    cmd = "/usr/bin/env awk -f $(execpath :ncurses/base/MKunctrl.awk) bigstrings=1 > $@",
+)
+
+cc_binary(
+    name = "make_keys",
+    srcs = [
+        "ncurses/build.priv.h",
+        "ncurses/curses.priv.h",
+        "ncurses/tinfo/make_keys.c",
+    ],
+    copts = NCURSES_COPTS,
+    deps = [":ncurses_headers"],
+)
+
+genrule(
+    name = "keys_list",
+    srcs = ["include/Caps"],
+    outs = ["keys.list"],
+    cmd = "$(execpath :ncurses/tinfo/MKkeys_list.sh) $(execpath :include/Caps) | LC_ALL=C sort > $@",
+    tools = ["ncurses/tinfo/MKkeys_list.sh"],
+)
+
+genrule(
+    name = "lib_keyname_c",
+    srcs = [
+        "ncurses/base/MKkeyname.awk",
+        "keys.list",
+    ],
+    outs = ["ncurses/lib_keyname.c"],
+    cmd = "/usr/bin/env awk -f $(execpath :ncurses/base/MKkeyname.awk) bigstrings=1 $(execpath :keys.list) > $@",
+)
+
+automake_substitution(
+    name = "curses_head",
+    src = "include/curses.h.in",
+    out = "include/curses.head",
+    substitutions = AUTOMAKE_SUBSTITUTIONS,
+)
+
+automake_substitution(
+    name = "curses_dll",
+    src = "include/ncurses_dll.h.in",
+    out = "include/ncurses_dll.h",
+    substitutions = AUTOMAKE_SUBSTITUTIONS,
+)
+
+automake_substitution(
+    name = "unctrl_h",
+    src = "include/unctrl.h.in",
+    out = "include/unctrl.h",
+    substitutions = AUTOMAKE_SUBSTITUTIONS,
+)
+
+automake_substitution(
+    name = "termcap_h",
+    src = "include/termcap.h.in",
+    out = "include/termcap.h",
+    substitutions = AUTOMAKE_SUBSTITUTIONS,
+)
+
+genrule(
+    name = "curses_h",
+    srcs = [
+        "include/curses.head",
+        "include/curses.tail",
+        "include/curses.wide",
+    ] + CAPLIST,
+    outs = ["include/curses.h"],
+    cmd = select({
+        "@platforms//cpu:armv7": "cat $(execpath :include/curses.head) > $@ && AWK=$$(which awk) $(execpath :include/MKkey_defs.sh) " + CAPLIST_LOCATIONS + " >> $@ && cat $(execpath :include/curses.tail) >> $@",
+        "//conditions:default": "cat $(execpath :include/curses.head) > $@ && AWK=$$(which awk) $(execpath :include/MKkey_defs.sh) " + CAPLIST_LOCATIONS + " >> $@ && cat $(execpath :include/curses.wide) $(execpath :include/curses.tail) >> $@",
+    }),
+    tools = ["include/MKkey_defs.sh"],
+)
+
+genrule(
+    name = "lib_gen_c",
+    srcs = [
+        "include/curses.h",
+        "include/ncurses_cfg.h",
+        "include/ncurses_def.h",
+    ],
+    outs = ["ncurses/lib_gen.c"],
+    cmd = "$(execpath :ncurses/base/MKlib_gen.sh) \"$(CC) -E -isystem $$(dirname $(execpath :include/ncurses_cfg.h))\" $$(which awk) generated < $(execpath :include/curses.h) > $@",
+    toolchains = ["@rules_cc//cc:current_cc_toolchain"],
+    tools = ["ncurses/base/MKlib_gen.sh"],
+)
+
+genrule(
+    name = "hashsize_h",
+    srcs = ["include/Caps"],
+    outs = ["include/hashsize.h"],
+    cmd = "$(execpath :include/MKhashsize.sh) $(execpath :include/Caps) > $@",
+    tools = ["include/MKhashsize.sh"],
+)
+
+genrule(
+    name = "init_keytry_h",
+    srcs = ["keys.list"],
+    outs = ["ncurses/init_keytry.h"],
+    cmd = "$(execpath :make_keys) $(execpath :keys.list) > $@",
+    tools = [":make_keys"],
+)
+
+automake_substitution(
+    name = "mkterm_h_awk",
+    src = "include/MKterm.h.awk.in",
+    out = "include/MKterm.h.awk",
+    substitutions = AUTOMAKE_SUBSTITUTIONS,
+)
+
+genrule(
+    name = "term_h",
+    srcs = [
+        "include/MKterm.h.awk",
+        "include/Caps",
+    ],
+    outs = ["include/term.h"],
+    cmd = "/usr/bin/env awk -f $(execpath :include/MKterm.h.awk) $(execpath :include/Caps) > $@",
+)
+
+genrule(
+    name = "parametrized_h",
+    srcs = ["include/Caps"],
+    outs = ["include/parametrized.h"],
+    cmd = "(cd $$(dirname $(execpath :include/MKparametrized.sh)) && ./MKparametrized.sh) > $@",
+    tools = ["include/MKparametrized.sh"],
+)
+
+genrule(
+    name = "ncurses_def_h",
+    srcs = ["include/ncurses_defs"],
+    outs = ["include/ncurses_def.h"],
+    cmd = "(cd $$(dirname $(execpath :include/MKncurses_def.sh)) && ./MKncurses_def.sh) > $@",
+    tools = ["include/MKncurses_def.sh"],
+)
+
+DEFS_COMMON = [
+    "HAVE_LONG_FILE_NAMES",
+    "MIXEDCASE_FILENAMES",
+    "HAVE_BIG_CORE",
+    "PURE_TERMINFO",
+    "USE_HOME_TERMINFO",
+    "USE_ROOT_ENVIRON",
+    "HAVE_UNISTD_H",
+    "HAVE_REMOVE",
+    "HAVE_UNLINK",
+    "HAVE_LINK",
+    "HAVE_SYMLINK",
+    "USE_LINKS",
+    "HAVE_LANGINFO_CODESET",
+    "HAVE_FSEEKO",
+    "STDC_HEADERS",
+    "HAVE_SYS_TYPES_H",
+    "HAVE_SYS_STAT_H",
+    "HAVE_STDLIB_H",
+    "HAVE_STRING_H",
+    "HAVE_MEMORY_H",
+    "HAVE_STRINGS_H",
+    "HAVE_INTTYPES_H",
+    "HAVE_STDINT_H",
+    "HAVE_UNISTD_H",
+    "SIZEOF_SIGNED_CHAR",
+    "NCURSES_EXT_FUNCS",
+    "HAVE_ASSUME_DEFAULT_COLORS",
+    "HAVE_CURSES_VERSION",
+    "HAVE_HAS_KEY",
+    "HAVE_RESIZETERM",
+    "HAVE_RESIZE_TERM",
+    "HAVE_TERM_ENTRY_H",
+    "HAVE_USE_DEFAULT_COLORS",
+    "HAVE_USE_EXTENDED_NAMES",
+    "HAVE_USE_SCREEN",
+    "HAVE_USE_WINDOW",
+    "HAVE_WRESIZE",
+    "NCURSES_SP_FUNCS",
+    "HAVE_TPUTS_SP",
+    "NCURSES_EXT_PUTWIN",
+    "NCURSES_NO_PADDING",
+    "USE_SIGWINCH",
+    "USE_ASSUMED_COLOR",
+    "USE_HASHMAP",
+    "GCC_SCANF",
+    "GCC_PRINTF",
+    "HAVE_NC_ALLOC_H",
+    "HAVE_GETTIMEOFDAY",
+    "STDC_HEADERS",
+    "HAVE_DIRENT_H",
+    "TIME_WITH_SYS_TIME",
+    "HAVE_REGEX_H_FUNCS",
+    "HAVE_FCNTL_H",
+    "HAVE_GETOPT_H",
+    "HAVE_LIMITS_H",
+    "HAVE_LOCALE_H",
+    "HAVE_MATH_H",
+    "HAVE_POLL_H",
+    "HAVE_SYS_IOCTL_H",
+    "HAVE_SYS_PARAM_H",
+    "HAVE_SYS_POLL_H",
+    "HAVE_SYS_SELECT_H",
+    "HAVE_SYS_TIME_H",
+    "HAVE_SYS_TIMES_H",
+    "HAVE_TTYENT_H",
+    "HAVE_UNISTD_H",
+    "HAVE_WCTYPE_H",
+    "HAVE_UNISTD_H",
+    "HAVE_GETOPT_H",
+    "HAVE_GETOPT_HEADER",
+    "DECL_ENVIRON",
+    "HAVE_ENVIRON",
+    "HAVE_PUTENV",
+    "HAVE_SETENV",
+    "HAVE_STRDUP",
+    "HAVE_SYS_TIME_SELECT",
+    "HAVE_GETCWD",
+    "HAVE_GETEGID",
+    "HAVE_GETEUID",
+    "HAVE_GETOPT",
+    "HAVE_GETTTYNAM",
+    "HAVE_LOCALECONV",
+    "HAVE_POLL",
+    "HAVE_PUTENV",
+    "HAVE_REMOVE",
+    "HAVE_SELECT",
+    "HAVE_SETBUF",
+    "HAVE_SETBUFFER",
+    "HAVE_SETENV",
+    "HAVE_SETVBUF",
+    "HAVE_SIGACTION",
+    "HAVE_STRDUP",
+    "HAVE_STRSTR",
+    "HAVE_SYSCONF",
+    "HAVE_TCGETPGRP",
+    "HAVE_TIMES",
+    "HAVE_TSEARCH",
+    "HAVE_VSNPRINTF",
+    "HAVE_ISASCII",
+    "HAVE_NANOSLEEP",
+    "HAVE_TERMIO_H",
+    "HAVE_TERMIOS_H",
+    "HAVE_UNISTD_H",
+    "HAVE_SYS_IOCTL_H",
+    "HAVE_TCGETATTR",
+    "HAVE_VSSCANF",
+    "HAVE_UNISTD_H",
+    "HAVE_MKSTEMP",
+    "HAVE_SIZECHANGE",
+    "HAVE_WORKING_POLL",
+    "HAVE_VA_COPY",
+    "HAVE_UNISTD_H",
+    "HAVE_FORK",
+    "HAVE_VFORK",
+    "HAVE_WORKING_VFORK",
+    "HAVE_WORKING_FORK",
+    "USE_FOPEN_BIN_R",
+    "USE_XTERM_PTY",
+    "HAVE_TYPEINFO",
+    "HAVE_IOSTREAM",
+    "IOSTREAM_NAMESPACE",
+    "CPP_HAS_STATIC_CAST",
+    "HAVE_SLK_COLOR",
+    "HAVE_PANEL_H",
+    "HAVE_LIBPANEL",
+    "HAVE_MENU_H",
+    "HAVE_LIBMENU",
+    "HAVE_FORM_H",
+    "HAVE_LIBFORM",
+    "NCURSES_OSPEED_COMPAT",
+    "HAVE_CURSES_DATA_BOOLNAMES",
+    "HAVE_PUTWC",
+    "HAVE_BTOWC",
+    "HAVE_WCTOB",
+    "HAVE_WMEMCHR",
+    "HAVE_MBTOWC",
+    "HAVE_WCTOMB",
+    "HAVE_MBLEN",
+    "HAVE_MBRLEN",
+    "HAVE_MBRTOWC",
+    "HAVE_WCSRTOMBS",
+    "HAVE_MBSRTOWCS",
+    "HAVE_WCSTOMBS",
+    "HAVE_MBSTOWCS",
+]
+
+pseudo_configure(
+    name = "ncurses_cfg_h",
+    src = "include/ncurses_cfg.hin",
+    out = "include/ncurses_cfg.h",
+    defs = select({
+        "@platforms//cpu:armv7": DEFS_COMMON,
+        "//conditions:default": DEFS_COMMON + [
+            "HAVE_WCHAR_H",
+            "NEED_WCHAR_H",
+            "USE_WIDEC_SUPPORT",
+            "NCURSES_WIDECHAR",
+            "HAVE_WCTYPE_H",
+        ],
+    }),
+    mappings = {
+        "GCC_NORETURN": "__attribute__((noreturn))",
+        "GCC_PRINTFLIKE(fmt,var)": "__attribute__((format(printf,fmt,var)))",
+        "GCC_SCANFLIKE(fmt,var)": "__attribute__((format(scanf,fmt,var)))",
+        "GCC_UNUSED": "__attribute__((unused))",
+        "NCURSES_PATCHDATE": "20200212",
+        "NCURSES_PATHSEP": "0x3a",
+        "NCURSES_VERSION": '"6.4"',
+        "NCURSES_VERSION_STRING": '"6.4.20221231"',
+        "NCURSES_WRAP_PREFIX": '"_nc_"',
+        "NC_CONFIG_H": "",
+        "PACKAGE": '"ncurses"',
+        "RGB_PATH": r'"\/usr\/share\/X11\/rgb.txt"',
+        "SIG_ATOMIC_T": "volatile sig_atomic_t",
+        "SYSTEM_NAME": '"linux-gnu"',
+        "TERMINFO": r'"\/usr\/share\/terminfo"',
+        "TERMINFO_DIRS": r'"\/usr\/share\/terminfo"',
+        "USE_OPENPTY_HEADER": "<pty.h>",
+    },
+)

--- a/modules/ncurses/6.4.20221231.bcr.6/overlay/MODULE.bazel
+++ b/modules/ncurses/6.4.20221231.bcr.6/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/ncurses/6.4.20221231.bcr.6/overlay/bazel/BUILD.bazel
+++ b/modules/ncurses/6.4.20221231.bcr.6/overlay/bazel/BUILD.bazel
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:private"])

--- a/modules/ncurses/6.4.20221231.bcr.6/overlay/bazel/automake_substitution.bzl
+++ b/modules/ncurses/6.4.20221231.bcr.6/overlay/bazel/automake_substitution.bzl
@@ -1,0 +1,62 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides helper that replaces @VARIABLE_NAME@ occurrences with values, as
+specified by a provided map."""
+
+def _automake_substitution_impl(ctx):
+
+    substitutions = ctx.attr.substitutions
+    substitution_pipe = " ".join([
+        "| sed 's/@%s@/%s/g'" % (variable_name, value)
+        for variable_name, value in substitutions.items()
+    ])
+
+    output = ctx.outputs.out
+    ctx.actions.run_shell(
+        mnemonic = "NCursesAutomakeSubstitution",
+        inputs = [ctx.file.src],
+        outputs = [output],
+        command = "cat %s %s > %s" % (ctx.file.src.path, substitution_pipe, output.path),
+        use_default_shell_env = True,
+    )
+
+    return [DefaultInfo(
+        files = depset([output])
+    )]
+
+automake_substitution = rule(
+    doc = """\
+Replaces @VARIABLE_NAME@ occurrences with values.
+
+Note: The current implementation does not allow slashes in variable
+values.
+""",
+    implementation = _automake_substitution_impl,
+    attrs = {
+        "src": attr.label(
+            doc = "The source file to modify",
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "out": attr.output(
+            doc = "The output file.",
+            mandatory = True,
+        ),
+        "substitutions": attr.string_dict(
+            doc = "Substitutions to apply.",
+            default = {},
+        )
+    }
+)

--- a/modules/ncurses/6.4.20221231.bcr.6/overlay/bazel/pseudo_configure.bzl
+++ b/modules/ncurses/6.4.20221231.bcr.6/overlay/bazel/pseudo_configure.bzl
@@ -1,0 +1,93 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fake configuration step for hacky substitutions in ".in" files."""
+
+def _pseudo_configure_impl(ctx):
+    additional = ctx.attr.additional
+    mappings = ctx.attr.mappings
+    defs = ctx.attr.defs
+    out = ctx.outputs.out
+    src = ctx.file.src if ctx.attr.src else None
+    out = ctx.outputs.out
+
+    perl_toolchain = ctx.attr._current_perl_toolchain[platform_common.ToolchainInfo]
+    perl = perl_toolchain.perl_runtime.interpreter.path
+
+    cmd = ""
+
+    if src == None:
+        cmd += "echo '#pragma once' >> %s &&" % (out.path)
+
+    for k, v in additional.items():
+        cmd += "echo '#define %s %s' >> %s &&" % (k, v, out.path)
+
+    if src != None:
+        cmd += "cat " + src.path
+    else:
+        cmd += "echo"
+    all_defs = ""
+    for def_ in defs:
+        cmd += r"| " + perl + r" -p -e 's/#\s*undef \b(" + def_ + r")\b/#define $$1 1/'"
+        all_defs += "#define " + def_ + " 1\\n"
+    for key, value in mappings.items():
+        cmd += r"| " + perl + r" -p -e 's/#\s*undef \b" + key + r"\b/#define " + str(key) + " " + str(value) + "/'"
+        cmd += r"| " + perl + r" -p -e 's/#\s*define \b(" + key + r")\b 0/#define $$1 " + str(value) + "/'"
+        all_defs += "#define " + key + " " + value + "\\n"
+    cmd += r"| " + perl + r" -p -e 's/\@DEFS\@/" + all_defs + "/'"
+    cmd += " >> " + out.path
+
+    ctx.actions.run_shell(
+        mnemonic = "NCursesPseudoConfigure",
+        inputs = [src] if src != None else [],
+        outputs = [out],
+        command = cmd,
+        tools = perl_toolchain.perl_runtime.runtime,
+    )
+
+    return [DefaultInfo(
+        files = depset([out])
+    )]
+
+pseudo_configure = rule(
+    doc = "Perform a fake 'configure' step on a file.",
+    implementation = _pseudo_configure_impl,
+    attrs = {
+        "src": attr.label(
+            doc = "`.in` file to transform.",
+            allow_single_file = True,
+        ),
+        "out": attr.output(
+            doc = "Path to place the output file contents.",
+            mandatory = True,
+        ),
+        "defs": attr.string_list(
+            doc = "List of definitions to #define as `1`.",
+            default = [],
+        ),
+        "mappings": attr.string_dict(
+            doc = "Mapping of definitions with non-trivial values.",
+            default = {},
+        ),
+        "additional": attr.string_dict(
+            doc = "Optional mapping of definitions to prepend to the file.",
+            default = {},
+        ),
+        "_current_perl_toolchain": attr.label(
+            doc = "A perl toolchain in the exec configuration",
+            cfg = "exec",
+            default = Label("@rules_perl//:current_toolchain"),
+        )
+    },
+)

--- a/modules/ncurses/6.4.20221231.bcr.6/patches/change_mode.patch
+++ b/modules/ncurses/6.4.20221231.bcr.6/patches/change_mode.patch
@@ -1,0 +1,9 @@
+diff --git ncurses/tinfo/MKcaptab.sh ncurses/tinfo/MKcaptab.sh
+old mode 100644
+new mode 100755
+diff --git ncurses/tinfo/MKfallback.sh ncurses/tinfo/MKfallback.sh
+old mode 100644
+new mode 100755
+diff --git ncurses/tinfo/MKuserdefs.sh ncurses/tinfo/MKuserdefs.sh
+old mode 100644
+new mode 100755

--- a/modules/ncurses/6.4.20221231.bcr.6/patches/fail_on_error.patch
+++ b/modules/ncurses/6.4.20221231.bcr.6/patches/fail_on_error.patch
@@ -1,0 +1,50 @@
+diff --git ncurses/tinfo/MKcaptab.sh ncurses/tinfo/MKcaptab.sh
+--- ncurses/tinfo/MKcaptab.sh
++++ ncurses/tinfo/MKcaptab.sh
+@@ -29,6 +29,8 @@
+ ##############################################################################
+ # $Id: MKcaptab.sh,v 1.19 2020/02/02 23:34:34 tom Exp $
+ 
++set -e
++
+ if test $# != 0
+ then
+ 	AWK="$1"; shift 1
+diff --git ncurses/tinfo/MKfallback.sh ncurses/tinfo/MKfallback.sh
+--- ncurses/tinfo/MKfallback.sh
++++ ncurses/tinfo/MKfallback.sh
+@@ -37,6 +37,8 @@
+ # specified list of types generated in.
+ #
+ 
++set -e
++
+ terminfo_dir=$1
+ shift
+ 
+diff --git ncurses/tinfo/MKkeys_list.sh ncurses/tinfo/MKkeys_list.sh
+--- ncurses/tinfo/MKkeys_list.sh
++++ ncurses/tinfo/MKkeys_list.sh
+@@ -35,6 +35,9 @@
+ #
+ # Extract function-key names from the Caps file
+ #
++
++set -e
++
+ : ${AWK-awk}
+ if test $# != 0
+ then
+diff --git ncurses/tinfo/MKuserdefs.sh ncurses/tinfo/MKuserdefs.sh
+--- ncurses/tinfo/MKuserdefs.sh
++++ ncurses/tinfo/MKuserdefs.sh
+@@ -27,6 +27,9 @@
+ # authorization.                                                             #
+ ##############################################################################
+ # $Id: MKuserdefs.sh,v 1.10 2020/02/02 23:34:34 tom Exp $
++
++set -e
++
+ AWK=${1-awk}; shift 1
+ OPT1=${1-0}; shift 1
+ 

--- a/modules/ncurses/6.4.20221231.bcr.6/presubmit.yml
+++ b/modules/ncurses/6.4.20221231.bcr.6/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - ubuntu2004
+    - ubuntu2004_arm64
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@ncurses"

--- a/modules/ncurses/6.4.20221231.bcr.6/source.json
+++ b/modules/ncurses/6.4.20221231.bcr.6/source.json
@@ -1,0 +1,17 @@
+{
+    "url": "https://github.com/mirror/ncurses/archive/refs/tags/v6.4.tar.gz",
+    "integrity": "sha256-OYk4RhOVGObC0ArB01TUiJ8POUrNRIhdcLFOrvTiPo4=",
+    "strip_prefix": "ncurses-6.4",
+    "patch_strip": 0,
+    "patches": {
+        "change_mode.patch": "sha256-gXT4QnWB+cVCTg0YUJvNVOJPajQ4YTr4YN6qVgrwqvA=",
+        "fail_on_error.patch": "sha256-1S/L6K/pb+ruXwT2b8tzncHTwNvt+VNHaMcDqT7xTKY="
+    },
+    "overlay": {
+        "BUILD.bazel": "sha256-BJBrrFWJoJrfnwMxsc3SOCvKe27drc0sDfj/SF/fVIk=",
+        "MODULE.bazel": "sha256-a8W1dBzoEDHkbCDi7xAsxKz6az3mWwzJKXH+uiQ3hKY=",
+        "bazel/BUILD.bazel": "sha256-Zuz0VFa0seaXM4/wmRX865OGXbFWBw47EsurCzPRqss=",
+        "bazel/automake_substitution.bzl": "sha256-RSUxc8MnuPFLqKmfUKOtfuhBizR/8DSkjCY9k0vM/YA=",
+        "bazel/pseudo_configure.bzl": "sha256-M2W0YwiJ6L/9+pmhNk8mXX21adB5DksfJ8O4ckEtGws="
+    }
+}

--- a/modules/ncurses/metadata.json
+++ b/modules/ncurses/metadata.json
@@ -4,8 +4,8 @@
         {
             "email": "daisuke.nishimatsu1021@gmail.com",
             "github": "wep21",
-            "name": "Daisuke Nishimatsu",
-            "github_user_id": 42202095
+            "github_user_id": 42202095,
+            "name": "Daisuke Nishimatsu"
         }
     ],
     "repository": [
@@ -17,7 +17,8 @@
         "6.4.20221231.bcr.2",
         "6.4.20221231.bcr.3",
         "6.4.20221231.bcr.4",
-        "6.4.20221231.bcr.5"
+        "6.4.20221231.bcr.5",
+        "6.4.20221231.bcr.6"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Changes:
- Convert `automake_substitution` and `pseudo_configure` to rules.
- Adds support for armv7.