### PR TITLE
Add nanobind_bazel v2.6.1

### DIFF
--- a/modules/nanobind_bazel/2.6.1/MODULE.bazel
+++ b/modules/nanobind_bazel/2.6.1/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "nanobind_bazel",
+    version = "2.6.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.16")
+bazel_dep(name = "rules_python", version = "0.40.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+
+# Creates a `http_archive` for nanobind and robin-map.
+internal_configure = use_extension("//:internal_configure.bzl", "internal_configure_extension")
+use_repo(internal_configure, "nanobind", "pypi__typing_extensions")

--- a/modules/nanobind_bazel/2.6.1/presubmit.yml
+++ b/modules/nanobind_bazel/2.6.1/presubmit.yml
@@ -1,0 +1,29 @@
+matrix:
+  bazel:
+    - 7.x
+    - 8.x
+  unix_platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+  win_platform:
+    - windows
+
+tasks:
+  unix_test:
+    name: Verify build targets on Unix
+    platform: ${{ unix_platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@nanobind_bazel//:nanobind'
+    build_flags:
+    - --cxxopt=-std=c++17
+  windows_test:
+    name: Verify build targets
+    platform: ${{ win_platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@nanobind_bazel//:nanobind'
+    build_flags:
+    - --cxxopt=/std:c++17

--- a/modules/nanobind_bazel/2.6.1/source.json
+++ b/modules/nanobind_bazel/2.6.1/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/nicholasjng/nanobind-bazel/releases/download/v2.6.1/nanobind-bazel-2.6.1.tar.gz",
+    "integrity": "sha256-rrtVgsnY5Ea2SEDp685U03mynmwCugvT11EZSs5Cbz0=",
+    "strip_prefix": "nanobind-bazel-2.6.1"
+}

--- a/modules/nanobind_bazel/metadata.json
+++ b/modules/nanobind_bazel/metadata.json
@@ -4,8 +4,8 @@
         {
             "email": "nicho.junge@gmail.com",
             "github": "nicholasjng",
-            "name": "Nicholas Junge",
-            "github_user_id": 54248170
+            "github_user_id": 54248170,
+            "name": "Nicholas Junge"
         }
     ],
     "repository": [
@@ -17,7 +17,8 @@
         "2.1.0",
         "2.2.0",
         "2.4.0",
-        "2.5.0"
+        "2.5.0",
+        "2.6.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
No new functionality, just an update to nanobind v2.6.1. Please note that nanobind v2.6.0 was yanked due to a regression, hence, there will be no nanobind_bazel v2.6.0 tag.