### PR TITLE
Set required SLSA_VERIFIER_EXPERIMENTAL env var

### DIFF
--- a/tools/slsa.py
+++ b/tools/slsa.py
@@ -113,6 +113,8 @@ class Verifier:
             [self._executable, cmd] + args,
             capture_output=True,
             encoding="utf-8",
+            # TODO(fweikert): remove once GH attestation support is stable.
+            env={"SLSA_VERIFIER_EXPERIMENTAL": "1", **os.environ},
         )
 
         if result.returncode:


### PR DESCRIPTION
Currently "slsa-verifier verify-github-attestation" requires experimental mode (https://github.com/slsa-framework/slsa-verifier/pull/840/files)