### PR TITLE
Disable --noincompatible_enable_deprecated_label_apis in incompatible_flags.yml

### DIFF
--- a/incompatible_flags.yml
+++ b/incompatible_flags.yml
@@ -19,9 +19,10 @@ incompatible_flags:
     - 8.x
   # https://github.com/bazelbuild/bazel/issues/23144
   # This flag will be flipped to false
-  "--noincompatible_enable_deprecated_label_apis":
-    - 7.x
-    - 8.x
+  # TODO: enable this after fixing https://github.com/bazelbuild/bazel/issues/23144#issuecomment-2793072689
+  # "--noincompatible_enable_deprecated_label_apis":
+  #   - 7.x
+  #   - 8.x
   # https://github.com/bazelbuild/bazel/issues/25755
   "--incompatible_disable_autoloads_in_main_repo":
     - last_green


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/23144#issuecomment-2793072689