### PR TITLE
Implement compatibility_level check

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ Validations performed in the scripts are:
 - Verify the source archive URL is stable if it comes from GitHub. (See [this discussion](https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1029861300)). Comment `@bazel-io skip_check unstable_url` to skip this check.
 - Verify the integrity values of the source archive and patch files (if any) are correct.
 - Verify the checked-in `MODULE.bazel` file matches the one in the extracted and patched source tree.
+- Verify the `compatibility_level` in `MODULE.bazel` matches the previous version. If the bump is intentional, you can comment `@bazel-io skip_check compatibility_level` in the PR to skip this check.
 - Check if the module is new or the `presubmit.yml` file is changed compared to the last version, if so a BCR maintainer review will be required to run jobs specified in `presubmit.yml`.
 
 Additional validations implemented in the [bcr_presubmit.py](https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazel-central-registry/bcr_presubmit.py) script:

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -601,14 +601,13 @@ class BcrValidator:
         index = versions.index(version)
         if check_compatibility_level and index > 0:
             pre_version = versions[index - 1]
-            previous_module_dot_bazel = self.registry.get_module_dot_bazel(module_name, pre_version)
+            previous_module_dot_bazel = self.registry.get_module_dot_bazel_path(module_name, pre_version)
             current_compatibility_level = BcrValidator.extract_attribute_from_module(bcr_module_dot_bazel, "compatibility_level", 0)
             previous_compatibility_level = BcrValidator.extract_attribute_from_module(previous_module_dot_bazel, "compatibility_level", 0)
             if current_compatibility_level != previous_compatibility_level:
                 self.report(
                     BcrValidationResult.FAILED,
-                    "The compatibility_level in the new module version doesn't match the previous version. " \
-                    "If this is intentional, please add label `skip-compatibility-level-check` for the PR",
+                    f"The compatibility_level in the new module version ({current_compatibility_level}) doesn't match the previous version ({previous_compatibility_level}). " \
                 )
 
         shutil.rmtree(tmp_dir)

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -602,12 +602,16 @@ class BcrValidator:
         if check_compatibility_level and index > 0:
             pre_version = versions[index - 1]
             previous_module_dot_bazel = self.registry.get_module_dot_bazel_path(module_name, pre_version)
-            current_compatibility_level = BcrValidator.extract_attribute_from_module(bcr_module_dot_bazel, "compatibility_level", 0)
-            previous_compatibility_level = BcrValidator.extract_attribute_from_module(previous_module_dot_bazel, "compatibility_level", 0)
+            current_compatibility_level = BcrValidator.extract_attribute_from_module(
+                bcr_module_dot_bazel, "compatibility_level", 0
+            )
+            previous_compatibility_level = BcrValidator.extract_attribute_from_module(
+                previous_module_dot_bazel, "compatibility_level", 0
+            )
             if current_compatibility_level != previous_compatibility_level:
                 self.report(
                     BcrValidationResult.FAILED,
-                    f"The compatibility_level in the new module version ({current_compatibility_level}) doesn't match the previous version ({previous_compatibility_level}). " \
+                    f"The compatibility_level in the new module version ({current_compatibility_level}) doesn't match the previous version ({previous_compatibility_level}). ",
                 )
 
         shutil.rmtree(tmp_dir)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -38,6 +38,7 @@ GREEN = "\x1b[32m"
 RESET = "\x1b[0m"
 
 PRESUBMIT_YML = "presubmit.yml"
+MODULE_DOT_BAZEL = "MODULE.bazel"
 
 
 def log(msg):
@@ -580,3 +581,10 @@ class ModuleSnapshot:
         raw = self._download_if_exists("attestations.json")
         if raw:
             return json.loads(raw)
+
+    def module_dot_bazel(self):
+        raw = self._download_if_exists(MODULE_DOT_BAZEL)
+        if not raw:
+            return None
+
+        return raw.decode("utf-8")


### PR DESCRIPTION
To prevent accidentally bumping compatibility_level of a module: https://github.com/bazelbuild/bazel-central-registry/pull/4145#discussion_r2044252199

To bypass this check, assign `skip-compatibility-level-check` label to the PR, which can be done by commenting `@bazel-io skip_check compatibility_level`