### PR TITLE
[boost.test] Split the library targets into a header-only version and a sources version.

### DIFF
--- a/modules/boost.test/1.87.0.bcr.1/MODULE.bazel
+++ b/modules/boost.test/1.87.0.bcr.1/MODULE.bazel
@@ -1,0 +1,30 @@
+module(
+    name = "boost.test",
+    version = "1.87.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 108700,
+)
+
+bazel_dep(name = "boost.algorithm", version = "1.87.0")
+bazel_dep(name = "boost.assert", version = "1.87.0")
+bazel_dep(name = "boost.bind", version = "1.87.0")
+bazel_dep(name = "boost.config", version = "1.87.0")
+bazel_dep(name = "boost.core", version = "1.87.0")
+bazel_dep(name = "boost.detail", version = "1.87.0")
+bazel_dep(name = "boost.exception", version = "1.87.0")
+bazel_dep(name = "boost.function", version = "1.87.0")
+bazel_dep(name = "boost.io", version = "1.87.0")
+bazel_dep(name = "boost.iterator", version = "1.87.0")
+bazel_dep(name = "boost.mpl", version = "1.87.0")
+bazel_dep(name = "boost.numeric_conversion", version = "1.87.0")
+bazel_dep(name = "boost.optional", version = "1.87.0")
+bazel_dep(name = "boost.preprocessor", version = "1.87.0")
+bazel_dep(name = "boost.smart_ptr", version = "1.87.0")
+bazel_dep(name = "boost.static_assert", version = "1.87.0")
+bazel_dep(name = "boost.type_traits", version = "1.87.0")
+bazel_dep(name = "boost.utility", version = "1.87.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+
+# For tests.
+bazel_dep(name = "boost.lexical_cast", version = "1.87.0")
+bazel_dep(name = "boost.thread", version = "1.87.0")

--- a/modules/boost.test/1.87.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.test/1.87.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,64 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "hdrs",
+    hdrs = glob([
+        "include/**/*.hpp",
+        "include/**/*.ipp",
+    ]),
+    defines = ["BOOST_TEST_NO_LIB"],
+    includes = ["include"],
+    deps = [
+        "@boost.algorithm",
+        "@boost.assert",
+        "@boost.bind",
+        "@boost.config",
+        "@boost.core",
+        "@boost.detail",
+        "@boost.exception",
+        "@boost.function",
+        "@boost.io",
+        "@boost.iterator",
+        "@boost.mpl",
+        "@boost.numeric_conversion",
+        "@boost.optional",
+        "@boost.preprocessor",
+        "@boost.smart_ptr",
+        "@boost.static_assert",
+        "@boost.type_traits",
+        "@boost.utility",
+    ],
+)
+
+cc_library(
+    name = "boost.test",
+    srcs = glob(
+        ["src/*.cpp"],
+        exclude = [
+            "src/cpp_main.cpp",
+            "src/test_main.cpp",
+            "src/unit_test_main.cpp",
+        ],
+    ),
+    deps = [":hdrs"],
+)
+
+cc_library(
+    name = "cpp_main",
+    srcs = ["src/cpp_main.cpp"],
+    deps = [":boost.test"],
+)
+
+cc_library(
+    name = "test_main",
+    srcs = ["src/test_main.cpp"],
+    deps = [":boost.test"],
+)
+
+cc_library(
+    name = "unit_test_main",
+    srcs = ["src/unit_test_main.cpp"],
+    deps = [":boost.test"],
+)

--- a/modules/boost.test/1.87.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/boost.test/1.87.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/boost.test/1.87.0.bcr.1/overlay/test/baseline-outputs/BUILD.bazel
+++ b/modules/boost.test/1.87.0.bcr.1/overlay/test/baseline-outputs/BUILD.bazel
@@ -1,0 +1,7 @@
+package(default_visibility = ["//:__subpackages__"])
+
+filegroup(
+    name = "baseline-outputs",
+    testonly = True,
+    srcs = glob(["*"]),
+)

--- a/modules/boost.test/1.87.0.bcr.1/overlay/test/execution_monitor-ts/BUILD.bazel
+++ b/modules/boost.test/1.87.0.bcr.1/overlay/test/execution_monitor-ts/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "boost_exception_test",
+    srcs = ["boost_exception-test.cpp"],
+    deps = ["//:unit_test_main"],
+)
+
+cc_test(
+    name = "custom_exception_test",
+    srcs = ["custom-exception-test.cpp"],
+    deps = ["//:unit_test_main"],
+)
+
+cc_test(
+    name = "errors_handling_test",
+    srcs = ["errors-handling-test.cpp"],
+    args = [
+        "--",
+        "$(rootpath //test/baseline-outputs:errors-handling-test.pattern)",
+        "$(rootpath //test/baseline-outputs:errors-handling-test.pattern2)",
+    ],
+    data = [
+        "//test/baseline-outputs:errors-handling-test.pattern",
+        "//test/baseline-outputs:errors-handling-test.pattern2",
+    ],
+    deps = [
+        "//:unit_test_main",
+        "//test/framework-ts:logger_for_tests",
+    ],
+)

--- a/modules/boost.test/1.87.0.bcr.1/overlay/test/framework-ts/BUILD.bazel
+++ b/modules/boost.test/1.87.0.bcr.1/overlay/test/framework-ts/BUILD.bazel
@@ -1,10 +1,9 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
 
-package(default_visibility = ["//:__subpackages__"])
-
 cc_library(
     name = "logger_for_tests",
     hdrs = ["logger-for-tests.hpp"],
+    visibility = ["//:__subpackages__"],
 )
 
 cc_test(

--- a/modules/boost.test/1.87.0.bcr.1/overlay/test/framework-ts/BUILD.bazel
+++ b/modules/boost.test/1.87.0.bcr.1/overlay/test/framework-ts/BUILD.bazel
@@ -1,0 +1,121 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+package(default_visibility = ["//:__subpackages__"])
+
+cc_library(
+    name = "logger_for_tests",
+    hdrs = ["logger-for-tests.hpp"],
+)
+
+cc_test(
+    name = "check_streams_on_exit_test",
+    srcs = ["check-streams-on-exit.cpp"],
+    deps = ["//:hdrs"],
+)
+
+cc_test(
+    name = "decorators_datatestcase_test",
+    srcs = ["decorators-datatestcase-test.cpp"],
+    deps = ["//:unit_test_main"],
+)
+
+cc_test(
+    name = "log_count_skipped_test",
+    srcs = ["log-count-skipped-test.cpp"],
+    args = [
+        "--",
+        "$(rootpath //test/baseline-outputs:log-count-skipped-tests.pattern)",
+    ],
+    data = ["//test/baseline-outputs:log-count-skipped-tests.pattern"],
+    deps = [
+        ":logger_for_tests",
+        "//:hdrs",
+    ],
+)
+
+cc_test(
+    name = "log_formatter_test",
+    srcs = ["log-formatter-test.cpp"],
+    args = [
+        "--",
+        "$(rootpath //test/baseline-outputs:log-formatter-test.pattern)",
+        "$(rootpath //test/baseline-outputs:log-formatter-test.pattern.junit)",
+        "$(rootpath //test/baseline-outputs:log-formatter-context-test.pattern)",
+    ],
+    data = [
+        "//test/baseline-outputs:log-formatter-context-test.pattern",
+        "//test/baseline-outputs:log-formatter-test.pattern",
+        "//test/baseline-outputs:log-formatter-test.pattern.junit",
+    ],
+    deps = [
+        ":logger_for_tests",
+        "//:unit_test_main",
+        "@boost.lexical_cast",
+    ],
+)
+
+# master-test-suite-non-copyable-test.cpp is not written in a way that works out
+# of the box for a Bazel cc_test, so we skip it.
+
+cc_test(
+    name = "message_in_datatestcase_test",
+    srcs = [
+        "message-in-datatestcase-test.cpp",
+    ],
+    args = [
+        "--",
+        "$(rootpath //test/baseline-outputs:messages-in-datasets-test.pattern)",
+    ],
+    data = ["//test/baseline-outputs:messages-in-datasets-test.pattern"],
+    deps = [
+        ":logger_for_tests",
+        "//:unit_test_main",
+    ],
+)
+
+cc_test(
+    name = "result_report_test",
+    srcs = ["result-report-test.cpp"],
+    args = [
+        "--",
+        "$(rootpath //test/baseline-outputs:result-report-test.pattern)",
+        "$(rootpath //test/baseline-outputs:result_report_test.pattern.default_behaviour)",
+    ],
+    data = [
+        "//test/baseline-outputs:result-report-test.pattern",
+        "//test/baseline-outputs:result_report_test.pattern.default_behaviour",
+    ],
+    deps = [
+        ":logger_for_tests",
+        "//:unit_test_main",
+        "@boost.lexical_cast",
+    ],
+)
+
+cc_test(
+    name = "run_by_name_or_label_test",
+    srcs = ["run-by-name-or-label-test.cpp"],
+    deps = ["//:unit_test_main"],
+)
+
+# This test has memory leaks.
+cc_test(
+    name = "macro_global_fixture_test",
+    srcs = ["test-macro-global-fixture.cpp"],
+    args = [
+        "--",
+        "$(rootpath //test/baseline-outputs:global-fixtures-test.pattern)",
+    ],
+    data = ["//test/baseline-outputs:global-fixtures-test.pattern"],
+    deps = [
+        ":logger_for_tests",
+        "//:unit_test_main",
+        "@boost.lexical_cast",
+    ],
+)
+
+cc_test(
+    name = "version_uses_module_name_test",
+    srcs = ["version-uses-module-name.cpp"],
+    deps = ["//:hdrs"],
+)

--- a/modules/boost.test/1.87.0.bcr.1/overlay/test/multithreading-ts/BUILD.bazel
+++ b/modules/boost.test/1.87.0.bcr.1/overlay/test/multithreading-ts/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "sync_access_test",
+    srcs = ["sync-access-test.cpp"],
+    deps = [
+        "//:unit_test_main",
+        "@boost.thread",
+    ],
+)

--- a/modules/boost.test/1.87.0.bcr.1/overlay/test/smoke-ts/BUILD.bazel
+++ b/modules/boost.test/1.87.0.bcr.1/overlay/test/smoke-ts/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "basic_smoke_test",
+    srcs = ["basic-smoke-test.cpp"],
+    deps = ["//:hdrs"],
+)
+
+cc_test(
+    name = "basic_smoke_test2",
+    srcs = ["basic-smoke-test2.cpp"],
+    deps = ["//:hdrs"],
+)
+
+# basic-smoke-test3.cpp and basic-smoke-test4.cpp are not written in a way that
+# works out of the box for a Bazel cc_test, so we skip them.

--- a/modules/boost.test/1.87.0.bcr.1/presubmit.yml
+++ b/modules/boost.test/1.87.0.bcr.1/presubmit.yml
@@ -27,14 +27,14 @@ tasks:
     bazel: ${{ bazel }}
     build_flags:
       - --copt=-fsanitize=address
-      - -c dbg
+      - --compilation_mode=dbg
       - --copt=-fno-omit-frame-pointer
       - --linkopt=-fsanitize=address
     build_targets:
       - "@boost.test//..."
     test_flags:
       - --copt=-fsanitize=address
-      - -c dbg
+      - --compilation_mode=dbg
       - --copt=-fno-omit-frame-pointer
       - --linkopt=-fsanitize=address
     test_targets:

--- a/modules/boost.test/1.87.0.bcr.1/presubmit.yml
+++ b/modules/boost.test/1.87.0.bcr.1/presubmit.yml
@@ -1,16 +1,23 @@
 matrix:
-  platform:
+  platform_unix:
     - debian11
     - ubuntu2004
     - ubuntu2204
     - ubuntu2404
     - macos
     - macos_arm64
-    - windows
   bazel: [7.x, 8.x, rolling]
 tasks:
   verify_targets:
-    platform: ${{ platform }}
+    platform: ${{ platform_unix }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@boost.test//..."
+    test_targets:
+      - "@boost.test//..."
+
+  verify_targets:
+    platform: windows
     bazel: ${{ bazel }}
     build_targets:
       - "@boost.test//..."
@@ -18,6 +25,7 @@ tasks:
       - --enable_runfiles # required for rootpath to work on Windows
     test_targets:
       - "@boost.test//..."
+
   # boost.test has a header-only version and a source version. If you include
   # boost.test using "boost/test/included" and link the source version, you will
   # get an odr-violation if compiling with ASan. Without ASan it will compile,
@@ -25,7 +33,7 @@ tasks:
   # the BCR boost.test library always provides both a header-only target and a
   # sources target.
   verify_targets_asan:
-    platform: ${{ platform }}
+    platform: ${{ platform_unix }}  # doesn't work on Windows
     bazel: ${{ bazel }}
     build_flags:
       - --copt=-fsanitize=address
@@ -35,7 +43,6 @@ tasks:
     build_targets:
       - "@boost.test//..."
     test_flags:
-      - --enable_runfiles # required for rootpath to work on Windows
       - --copt=-fsanitize=address
       - --compilation_mode=dbg
       - --copt=-fno-omit-frame-pointer

--- a/modules/boost.test/1.87.0.bcr.1/presubmit.yml
+++ b/modules/boost.test/1.87.0.bcr.1/presubmit.yml
@@ -1,0 +1,42 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@boost.test//..."
+    test_targets:
+      - "@boost.test//..."
+  # boost.test has a header-only version and a source version. If you include
+  # boost.test using "boost/test/included" and link the source version, you will
+  # get an odr-violation if compiling with ASan. Without ASan it will compile,
+  # but the BCR CI tests seem to run with some form of ASan. These tests ensure
+  # the BCR boost.test library always provides both a header-only target and a
+  # sources target.
+  verify_targets_asan:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - --copt=-fsanitize=address
+      - -c dbg
+      - --copt=-fno-omit-frame-pointer
+      - --linkopt=-fsanitize=address
+    build_targets:
+      - "@boost.test//..."
+    test_flags:
+      - --copt=-fsanitize=address
+      - -c dbg
+      - --copt=-fno-omit-frame-pointer
+      - --linkopt=-fsanitize=address
+    test_targets:
+      # The macro_global_fixture_test has memory leaks, so skip it for ASan.
+      - "@boost.test//... -@boost.test//test/framework-ts:macro_global_fixture_test"

--- a/modules/boost.test/1.87.0.bcr.1/presubmit.yml
+++ b/modules/boost.test/1.87.0.bcr.1/presubmit.yml
@@ -38,5 +38,6 @@ tasks:
       - --copt=-fno-omit-frame-pointer
       - --linkopt=-fsanitize=address
     test_targets:
+      - "@boost.test//..."
       # The macro_global_fixture_test has memory leaks, so skip it for ASan.
-      - "@boost.test//... -@boost.test//test/framework-ts:macro_global_fixture_test"
+      - "-@boost.test//test/framework-ts:macro_global_fixture_test"

--- a/modules/boost.test/1.87.0.bcr.1/presubmit.yml
+++ b/modules/boost.test/1.87.0.bcr.1/presubmit.yml
@@ -14,6 +14,8 @@ tasks:
     bazel: ${{ bazel }}
     build_targets:
       - "@boost.test//..."
+    test_flags:
+      - --enable_runfiles # required for rootpath to work on Windows
     test_targets:
       - "@boost.test//..."
   # boost.test has a header-only version and a source version. If you include
@@ -33,11 +35,13 @@ tasks:
     build_targets:
       - "@boost.test//..."
     test_flags:
+      - --enable_runfiles # required for rootpath to work on Windows
       - --copt=-fsanitize=address
       - --compilation_mode=dbg
       - --copt=-fno-omit-frame-pointer
       - --linkopt=-fsanitize=address
     test_targets:
       - "@boost.test//..."
-      # The macro_global_fixture_test has memory leaks, so skip it for ASan.
+      # These tests have memory leaks, so skip it for ASan.
       - "-@boost.test//test/framework-ts:macro_global_fixture_test"
+      - "-@boost.test//test/framework-ts:result_report_test"

--- a/modules/boost.test/1.87.0.bcr.1/source.json
+++ b/modules/boost.test/1.87.0.bcr.1/source.json
@@ -8,7 +8,7 @@
         "MODULE.bazel": "sha256-5403BpOX3eN6KI+P7gMXt28bEWJsRZ/RWEnnaYR6LA0=",
         "test/baseline-outputs/BUILD.bazel": "sha256-BdhMXETvFGxtawIqOyuhKsqr0qCWlU375uqQOfxBz8A=",
         "test/execution_monitor-ts/BUILD.bazel": "sha256-DXhtrmwYwYwkx7uDiT6q7FuQdhh/XVrCxzaM8VaqDtM=",
-        "test/framework-ts/BUILD.bazel": "sha256-IjwhKNlJGeylTsGokK3mbTzoJhHsczNRTfDRVP+hVxc=",
+        "test/framework-ts/BUILD.bazel": "sha256-qfjWz15C59ZfUcD5H8sgnv05LT8QSNyyg3dumD7BafA=",
         "test/multithreading-ts/BUILD.bazel": "sha256-Udx0p1oe+JxLS1B74js4ffnpKOHxgLimew7dAr2lYwc=",
         "test/smoke-ts/BUILD.bazel": "sha256-fV+CCJIkLY9uJllshSsqgYcrdamPkqHC4a+N4+fCOW8="
     }

--- a/modules/boost.test/1.87.0.bcr.1/source.json
+++ b/modules/boost.test/1.87.0.bcr.1/source.json
@@ -1,0 +1,15 @@
+{
+    "integrity": "sha256-+J+aA2euxv9QAU13sr8UrhEcjDiyU1qRFaY4QEWcSxs=",
+    "strip_prefix": "test-boost-1.87.0",
+    "url": "https://github.com/boostorg/test/archive/refs/tags/boost-1.87.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-ktchGtjNhAAZMSGbJY2HNze3onxUYWrFqU9C5OGM+8U=",
+        "MODULE.bazel": "sha256-5403BpOX3eN6KI+P7gMXt28bEWJsRZ/RWEnnaYR6LA0=",
+        "test/baseline-outputs/BUILD.bazel": "sha256-BdhMXETvFGxtawIqOyuhKsqr0qCWlU375uqQOfxBz8A=",
+        "test/execution_monitor-ts/BUILD.bazel": "sha256-DXhtrmwYwYwkx7uDiT6q7FuQdhh/XVrCxzaM8VaqDtM=",
+        "test/framework-ts/BUILD.bazel": "sha256-IjwhKNlJGeylTsGokK3mbTzoJhHsczNRTfDRVP+hVxc=",
+        "test/multithreading-ts/BUILD.bazel": "sha256-Udx0p1oe+JxLS1B74js4ffnpKOHxgLimew7dAr2lYwc=",
+        "test/smoke-ts/BUILD.bazel": "sha256-fV+CCJIkLY9uJllshSsqgYcrdamPkqHC4a+N4+fCOW8="
+    }
+}

--- a/modules/boost.test/metadata.json
+++ b/modules/boost.test/metadata.json
@@ -4,14 +4,20 @@
         {
             "email": "daisuke.nishimatsu1021@gmail.com",
             "github": "wep21",
-            "name": "Daisuke Nishimatsu",
-            "github_user_id": 42202095
+            "github_user_id": 42202095,
+            "name": "Daisuke Nishimatsu"
         },
         {
             "email": "julian.amann@tum.de",
             "github": "Vertexwahn",
-            "name": "Julian Amann",
-            "github_user_id": 3775001
+            "github_user_id": 3775001,
+            "name": "Julian Amann"
+        },
+        {
+            "email": "vtsao@openai.com",
+            "github": "vtsao-openai",
+            "github_user_id": 176426301,
+            "name": "Vincent Tsao"
         }
     ],
     "repository": [
@@ -20,7 +26,8 @@
     "versions": [
         "1.83.0",
         "1.83.0.bcr.1",
-        "1.87.0"
+        "1.87.0",
+        "1.87.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Boost.Test is meant to provide a header-only version and a source version of the library (https://sourcegraph.com/github.com/boostorg/test/-/blob/test/CMakeLists.txt).

When including Boost.Test with `#include <boost/test/included/unit_test.hpp>` you do not want to link in the `.cpp` sources, you want to link in the headers only, otherwise you get an `odr-violation` if compiling with ASan ([example](https://gist.github.com/vtsao-openai/2515a13f96989b4279b87219bea9e3c3)).

Normally this is fine as most people don't compile with ASan, but the BCR CI tests seem to run with some form of ASan, so BCR CI tests will fail due to this. This PR provides a `@boost.test//:hdrs` target so anybody including with `#include <boost/test/included/unit_test.hpp>` can use that target to avoid getting `odr-violation` errors.

I also added some of the Boost.Test tests to help verify this.