### PR TITLE
Add release 0.1.0 of rules_abs

### DIFF
--- a/modules/rules_abs/0.1.0/MODULE.bazel
+++ b/modules/rules_abs/0.1.0/MODULE.bazel
@@ -1,0 +1,83 @@
+module(
+    name = "rules_abs",
+    version = "0.1.0",
+    compatibility_level = 0,
+)
+
+# ✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂
+# only dev_dependencies below this line - rules_abs is lean
+# ✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂
+
+bazel_dep(
+    name = "tweag-credential-helper",
+    version = "0.0.5",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.7.1",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "rules_bazel_integration_test",
+    version = "0.32.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "rules_java",
+    version = "8.11.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "rules_proto",
+    version = "7.1.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "rules_testing",
+    version = "0.8.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "stardoc",
+    version = "0.8.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "toolchains_protoc",
+    version = "0.3.7",
+    dev_dependency = True,
+)
+
+protoc = use_extension(
+    "@toolchains_protoc//protoc:extensions.bzl",
+    "protoc",
+    dev_dependency = True,
+)
+protoc.toolchain(
+    google_protobuf = "com_google_protobuf",
+    version = "v27.0",
+)
+
+http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+
+http_jar(
+    name = "protobuf-java",
+    sha256 = "9072e60fe66cff5d6c0f11a1df21d8f3e4b29b5ee782b45c3fc75f59fbe2b839",
+    urls = ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/4.27.0/protobuf-java-4.27.0.jar"],
+    dev_dependency = True,
+)
+
+register_toolchains(
+    "//docs/lang_toolchains:all",
+    dev_dependency = True,
+)
+
+bazel_binaries = use_extension(
+    "@rules_bazel_integration_test//:extensions.bzl",
+    "bazel_binaries",
+    dev_dependency = True,
+)
+bazel_binaries.download(version = "7.1.0")
+bazel_binaries.download(version = "8.1.1")
+use_repo(bazel_binaries, "bazel_binaries", "bazel_binaries_bazelisk", "build_bazel_bazel_7_1_0", "build_bazel_bazel_8_1_1")

--- a/modules/rules_abs/0.1.0/presubmit.yml
+++ b/modules/rules_abs/0.1.0/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004"]
+    bazel: ['7.x', '8.x']
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_abs/0.1.0/source.json
+++ b/modules/rules_abs/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-wmWept9sSwUTDmT3SVZCYni313cQ8VkdR+sHNgYFCgs=",
+    "strip_prefix": "rules_abs-0.1.0",
+    "url": "https://github.com/michaeljs1990/rules_abs/releases/download/0.1.0/rules_abs-0.1.0.tar"
+}

--- a/modules/rules_abs/metadata.json
+++ b/modules/rules_abs/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/michaeljs1990/rules_abs",
+    "maintainers": [
+        {
+            "name": "Michael Schuett",
+            "email": "michaeljs1990@gmail.com",
+            "github": "michaeljs1990",
+            "github_user_id": 2604634
+        }
+    ],
+    "repository": [
+        "github:michaeljs1990/rules_abs"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This adds rules_abs which is heavily based on rules_gcs and rules_s3 but supports using the azure blob store.