### PR TITLE
Update source url for eigen 3.4.0 due to integrity change

### DIFF
--- a/modules/eigen/3.4.0.bcr.1/source.json
+++ b/modules/eigen/3.4.0.bcr.1/source.json
@@ -1,6 +1,6 @@
 {
-    "url": "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip",
-    "integrity": "sha256-HMqrv+hw9grz1qUZxT4J89z2MCBzId/6VTVkqOdcT8g=",
+    "url": "https://github.com/eigen-mirror/eigen/archive/refs/tags/3.4.0.zip",
+    "integrity": "sha256-bqakNLoGOgJ12+Gh3O9cJv4mJtfPjp3nqUi1z4E4JoQ=",
     "strip_prefix": "eigen-3.4.0",
     "patch_strip": 0,
     "patches": {

--- a/modules/eigen/3.4.0.bcr.2/source.json
+++ b/modules/eigen/3.4.0.bcr.2/source.json
@@ -1,6 +1,6 @@
 {
-    "url": "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip",
-    "integrity": "sha256-HMqrv+hw9grz1qUZxT4J89z2MCBzId/6VTVkqOdcT8g=",
+    "url": "https://github.com/eigen-mirror/eigen/archive/refs/tags/3.4.0.zip",
+    "integrity": "sha256-bqakNLoGOgJ12+Gh3O9cJv4mJtfPjp3nqUi1z4E4JoQ=",
     "strip_prefix": "eigen-3.4.0",
     "overlay": {
         "BUILD.bazel": "sha256-DhWxn3iDrOwF4b2Jd87eKfqOTs4LIVWfhTbpSuuZAGk=",

--- a/modules/eigen/3.4.0/source.json
+++ b/modules/eigen/3.4.0/source.json
@@ -1,6 +1,6 @@
 {
-    "url": "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip",
-    "integrity": "sha256-HMqrv+hw9grz1qUZxT4J89z2MCBzId/6VTVkqOdcT8g=",
+    "url": "https://github.com/eigen-mirror/eigen/archive/refs/tags/3.4.0.zip",
+    "integrity": "sha256-bqakNLoGOgJ12+Gh3O9cJv4mJtfPjp3nqUi1z4E4JoQ=",
     "strip_prefix": "eigen-3.4.0",
     "patch_strip": 0,
     "patches": {


### PR DESCRIPTION
Due to [instability](https://gitlab.com/libeigen/eigen/-/issues/2919#note_2458857762) / change of the checksum for version 3.4.0 on the gitlab eigen repo, this change to use the github mirror instead.

Fixes https://github.com/bazelbuild/bazel-central-registry/issues/4355

If there is a better way to make this update, let me know. I am not sure about name change practices when the original is broken and when there are already 3 different versions to update.