### PR TITLE
Publish rules_oci@2.2.6

### DIFF
--- a/modules/rules_oci/2.2.6/MODULE.bazel
+++ b/modules/rules_oci/2.2.6/MODULE.bazel
@@ -1,0 +1,43 @@
+"bazel-contrib/rules_oci"
+
+module(
+    name = "rules_oci",
+    version = "2.2.6",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.2")
+bazel_dep(name = "bazel_features", version = "1.10.0")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "platforms", version = "0.0.8")
+
+oci = use_extension("//oci:extensions.bzl", "oci")
+oci.toolchains()
+use_repo(oci, "oci_crane_toolchains", "oci_regctl_toolchains")
+
+register_toolchains("@oci_crane_toolchains//:all", "@oci_regctl_toolchains//:all")
+
+# Workaround https://github.com/aspect-build/bazel-lib/pull/832
+zstd = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
+zstd.zstd()
+use_repo(zstd, "zstd_toolchains")
+
+register_toolchains("@zstd_toolchains//:all")
+
+bazel_lib = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
+bazel_lib.jq()
+bazel_lib.tar()
+use_repo(bazel_lib, "bsd_tar_toolchains", "jq_toolchains")
+
+# Dev dependencies
+
+bazel_dep(name = "rules_go", version = "0.46.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
+bazel_dep(name = "rules_multirun", version = "0.9.0", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
+bazel_dep(name = "rules_multitool", version = "0.9.0", dev_dependency = True)
+
+multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool", dev_dependency = True)
+multitool.hub(lockfile = "//tools:tools.lock.json")
+use_repo(multitool, "multitool")

--- a/modules/rules_oci/2.2.6/attestations.json
+++ b/modules/rules_oci/2.2.6/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.6/source.json.intoto.jsonl",
+            "integrity": "sha256-H9TKC1ramjqQfGFfoTZyJAA02tjgeUJ7MtkvxWJ1QfU="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.6/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-yEo1cHi6AgIBtKgTpjZyw2z7WtGqo4ito+Vy8tHXkcQ="
+        },
+        "rules_oci-v2.2.6.tar.gz": {
+            "url": "https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.6/rules_oci-v2.2.6.tar.gz.intoto.jsonl",
+            "integrity": "sha256-zuTbhM2/SCObmx3fi716U/wBl5T1icbPf0OnmGV4Rho="
+        }
+    }
+}

--- a/modules/rules_oci/2.2.6/patches/module_dot_bazel_version.patch
+++ b/modules/rules_oci/2.2.6/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,9 +1,9 @@
+ "bazel-contrib/rules_oci"
+ 
+ module(
+     name = "rules_oci",
+-    version = "0.0.0",
++    version = "2.2.6",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "aspect_bazel_lib", version = "2.7.2")

--- a/modules/rules_oci/2.2.6/presubmit.yml
+++ b/modules/rules_oci/2.2.6/presubmit.yml
@@ -1,0 +1,21 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    bazel: ["6.x", "7.x"]
+    # TODO(#97): add windows
+    platform: ["debian10", "ubuntu2004"]
+  tasks:
+    test_linux:
+      name: "Run test module"
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."
+    test_macos:
+      name: "Run test module"
+      bazel: ${{ bazel }}
+      platform: macos
+      test_targets:
+        - "//..."
+        # This test requires a docker daemon, not available on BCR CI
+        - "-//:test"

--- a/modules/rules_oci/2.2.6/presubmit.yml
+++ b/modules/rules_oci/2.2.6/presubmit.yml
@@ -11,11 +11,3 @@ bcr_test_module:
       platform: ${{ platform }}
       test_targets:
         - "//..."
-    test_macos:
-      name: "Run test module"
-      bazel: ${{ bazel }}
-      platform: macos
-      test_targets:
-        - "//..."
-        # This test requires a docker daemon, not available on BCR CI
-        - "-//:test"

--- a/modules/rules_oci/2.2.6/source.json
+++ b/modules/rules_oci/2.2.6/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-WZTsDo35LDGe9dpeH5tRRijOuPxYJLQjTy/mNau4zC4=",
+    "strip_prefix": "rules_oci-2.2.6",
+    "url": "https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.6/rules_oci-v2.2.6.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-eFJHKIc1K7MsEA7J+koJTV1wqdRSrvEndrUtGrCmbhk="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_oci/metadata.json
+++ b/modules/rules_oci/metadata.json
@@ -10,7 +10,7 @@
         {
             "email": "sahin@aspect.dev",
             "github": "thesayyn",
-            "name": "\u015eahin Yort",
+            "name": "Şahin Yort",
             "github_user_id": 20563340
         }
     ],
@@ -60,7 +60,8 @@
         "2.2.1",
         "2.2.2",
         "2.2.3",
-        "2.2.5"
+        "2.2.5",
+        "2.2.6"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/bazel-contrib/rules_oci/releases/tag/v2.2.6

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_