### PR TITLE
boost.asio@1.87.0.bcr.1 : Add the missing openssl dependency

### DIFF
--- a/modules/boost.asio/1.87.0.bcr.1/MODULE.bazel
+++ b/modules/boost.asio/1.87.0.bcr.1/MODULE.bazel
@@ -7,6 +7,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "boringssl", version = "0.20240913.0")
+bazel_dep(name = "openssl", version = "3.3.1.bcr.1")
 bazel_dep(name = "boost.align", version = "1.87.0")
 bazel_dep(name = "boost.array", version = "1.87.0")
 bazel_dep(name = "boost.assert", version = "1.87.0")


### PR DESCRIPTION
Add the missing openssl dependency to boost.asio@1.87.0.bcr.1 to solve the below error while building asio with openssl settings enabled
`The repository '@@[unknown repo 'openssl' requested from @@boost.asio+]' could not be resolved: No repository visible as '@openssl' from repository '@@boost.asio+'`