### PR TITLE
spirv_headers@1.4.313-aa6cef1

### DIFF
--- a/modules/spirv_headers/1.4.313/MODULE.bazel
+++ b/modules/spirv_headers/1.4.313/MODULE.bazel
@@ -1,0 +1,8 @@
+"""SPIRV-Headers"""
+
+module(
+    name = "spirv_headers",
+    version = "1.4.313",
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/spirv_headers/1.4.313/patches/version.patch
+++ b/modules/spirv_headers/1.4.313/patches/version.patch
@@ -1,0 +1,13 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index ed7a2fb..e8633d1 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -2,7 +2,7 @@
+ 
+ module(
+     name = "spirv_headers",
+-    version = "0.0.0",
++    version = "1.4.313",
+ )
+ 
+ bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/spirv_headers/1.4.313/presubmit.yml
+++ b/modules/spirv_headers/1.4.313/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian10
+  - debian11
+  - ubuntu2004
+  - ubuntu2004_arm64
+  - ubuntu2204
+  - ubuntu2404
+  - macos
+  - macos_arm64
+  - windows
+  bazel: [7.x, 8.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@spirv_headers//...'

--- a/modules/spirv_headers/1.4.313/source.json
+++ b/modules/spirv_headers/1.4.313/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/KhronosGroup/SPIRV-Headers/archive/3786ee89d584f5ba46f31dc5253e6dfaa222e5c1.zip",
+    "strip_prefix": "SPIRV-Headers-3786ee89d584f5ba46f31dc5253e6dfaa222e5c1",
+    "patch_strip": 1,
+    "integrity": "sha256-rLgoALgpxJnpxgECWqlKaDCsny27MZp5M7Tu9tMn+aY=",
+    "patches": {
+        "version.patch": "sha256-/nrvcin+0JR+vio8Gs1LQQPccAqavqE8UzPtaDjmPd8="
+    }
+}

--- a/modules/spirv_headers/README.md
+++ b/modules/spirv_headers/README.md
@@ -1,0 +1,3 @@
+# spirv_headers
+
+Releases follow the `vulkan-sdk-*` tags.

--- a/modules/spirv_headers/metadata.json
+++ b/modules/spirv_headers/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/KhronosGroup/SPIRV-Headers",
+    "maintainers": [
+        {
+            "email": "26427366+UebelAndre@users.noreply.github.com",
+            "github": "UebelAndre",
+            "github_user_id": 26427366,
+            "name": "UebelAndre"
+        }
+    ],
+    "repository": [
+        "github:KhronosGroup/SPIRV-Headers"
+    ],
+    "versions": [
+        "1.4.313"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Note that this is off of the [vulkan-sdk-1.4.313](https://github.com/KhronosGroup/SPIRV-Headers/tree/vulkan-sdk-1.4.313) branch but includes BCR patches to bring in https://github.com/KhronosGroup/SPIRV-Headers/pull/511 (the BCR support).