### PR TITLE
add rules_cc_hdrs_map@0.1.0

### DIFF
--- a/modules/rules_cc_hdrs_map/0.1.0/MODULE.bazel
+++ b/modules/rules_cc_hdrs_map/0.1.0/MODULE.bazel
@@ -1,0 +1,30 @@
+module(
+    name = "rules_cc_hdrs_map",
+    version = "0.1.0",
+)
+
+bazel_dep(
+    name = "rules_cc",
+    version = "0.1.1",
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.11",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "aspect_bazel_lib",
+    version = "2.14.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.7.1",
+    dev_dependency = True,
+)
+
+register_execution_platforms(
+    "@rules_cc_hdrs_map//:x86_64_linux_remote",
+    dev_dependency = True,
+)

--- a/modules/rules_cc_hdrs_map/0.1.0/presubmit.yml
+++ b/modules/rules_cc_hdrs_map/0.1.0/presubmit.yml
@@ -1,0 +1,16 @@
+bcr_test_module:
+  module_path: examples
+  matrix:
+    platform:
+    - centos7
+    - debian10
+    - ubuntu2004
+    bazel:
+    - 8.x
+  tasks:
+    build_test_module:
+      name: Build test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - "//..."

--- a/modules/rules_cc_hdrs_map/0.1.0/source.json
+++ b/modules/rules_cc_hdrs_map/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/AleksanderGondek/rules_cc_hdrs_map/releases/download/v0.1.0/rules_cc_hdrs_map-v0.1.0.tar.gz",
+    "integrity": "sha256-V6EqRQbtuCgUFdLz40Tj2ylH4DlBgj1QtfE3gxDM538=",
+    "strip_prefix": "rules_cc_hdrs_map-0.1.0"
+}

--- a/modules/rules_cc_hdrs_map/metadata.json
+++ b/modules/rules_cc_hdrs_map/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/AleksanderGondek/rules_cc_hdrs_map",
+    "maintainers": [
+        {
+            "email": "github@other-songs.eu",
+            "github": "AleksanderGondek",
+            "name": "Aleksander Gondek",
+            "github_user_id": 6681509
+        }
+    ],
+    "repository": [
+        "github:AleksanderGondek/rules_cc_hdrs_map"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Introduce rules extending the CC compilation capabilities with headers map and exposing cc_common compilation functionality in form of Bazel subrules.