### PR TITLE
fmt@1.2.0

### DIFF
--- a/modules/fmt/11.2.0/MODULE.bazel
+++ b/modules/fmt/11.2.0/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "fmt",
+    version = "11.2.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 10,
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/fmt/11.2.0/overlay/BUILD.bazel
+++ b/modules/fmt/11.2.0/overlay/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+)
+
+exports_files([
+    "LICENSE",
+])
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "LICENSE",
+)
+
+cc_library(
+    name = "fmt",
+    srcs = [
+        #"src/fmt.cc", # No C++ module support, yet in Bazel (https://github.com/bazelbuild/bazel/pull/19940)
+        "src/format.cc",
+        "src/os.cc",
+    ],
+    hdrs = glob([
+        "include/fmt/*.h",
+    ]),
+    copts = select({
+        "@rules_cc/cc/compiler:msvc-cl": ["-utf-8"],
+        "//conditions:default": [],
+    }),
+    includes = ["include"],
+    strip_include_prefix = "include",  # workaround: only needed on some macOS systems (see https://github.com/bazelbuild/bazel-central-registry/issues/1537)
+    visibility = ["//visibility:public"],
+)

--- a/modules/fmt/11.2.0/overlay/MODULE.bazel
+++ b/modules/fmt/11.2.0/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/fmt/11.2.0/presubmit.yml
+++ b/modules/fmt/11.2.0/presubmit.yml
@@ -1,0 +1,28 @@
+matrix:
+  unix_platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2004_arm64
+    - ubuntu2204
+    - ubuntu2404
+  windows_test:
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  unix_test:
+    name: Verify build targets
+    platform: ${{ unix_platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@fmt//:fmt'
+  windows_test:
+    name: Verify build targets
+    platform: ${{ windows_test }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - --cxxopt=/utf-8
+    build_targets:
+      - '@fmt//:fmt'

--- a/modules/fmt/11.2.0/source.json
+++ b/modules/fmt/11.2.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/fmtlib/fmt/releases/download/11.2.0/fmt-11.2.0.zip",
+    "integrity": "sha256-ID606KoNdGxi2PkD31jgQZ43UVkbtT/5cQluqg69TsM=",
+    "strip_prefix": "fmt-11.2.0",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-VxCwUXId/jtF27t6aStV0ig/pLvCIW01YVYDaUECJUY=",
+        "MODULE.bazel": "sha256-uyzvR/IhY+I6o5/3gSz+jOyFrbYzdJP+ONH6A5Ezylw="
+    }
+}

--- a/modules/fmt/metadata.json
+++ b/modules/fmt/metadata.json
@@ -4,8 +4,8 @@
         {
             "email": "julian.amann@tum.de",
             "github": "Vertexwahn",
-            "name": "Julian Amann",
-            "github_user_id": 3775001
+            "github_user_id": 3775001,
+            "name": "Julian Amann"
         }
     ],
     "repository": [
@@ -28,7 +28,8 @@
         "11.1.1",
         "11.1.2",
         "11.1.3",
-        "11.1.4"
+        "11.1.4",
+        "11.2.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Add fmt 1.2.0

Changes to `BUILD.bazel` file compared to previous version:
- Switching from `"@platforms//os:windows": ["-utf-8"]` to "@rules_cc/cc/compiler:msvc-cl": ["-utf-8"],
- Get rid of direct `platforms` dependency