### PR TITLE
Publish tar.bzl@0.2.0

### DIFF
--- a/modules/tar.bzl/0.2.0/MODULE.bazel
+++ b/modules/tar.bzl/0.2.0/MODULE.bazel
@@ -1,0 +1,19 @@
+"Bazel dependencies"
+
+module(
+    name = "tar.bzl",
+    version = "0.2.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.0.3", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
+
+bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
+use_repo(bazel_lib_toolchains, "bsd_tar_toolchains")
+
+register_toolchains("@bsd_tar_toolchains//:all")

--- a/modules/tar.bzl/0.2.0/attestations.json
+++ b/modules/tar.bzl/0.2.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/alexeagle/tar.bzl/releases/download/v0.2.0/source.json.intoto.jsonl",
+            "integrity": "sha256-cg/fCirZHVX1jBUT1CcrUkCJaLk9Z6X0kDi9YpBlb8k="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/alexeagle/tar.bzl/releases/download/v0.2.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-pD2bfAgB8+OG839HS35noWAZi7bjNiGPijQR+n6Zybc="
+        },
+        "tar.bzl-v0.2.0.tar.gz": {
+            "url": "https://github.com/alexeagle/tar.bzl/releases/download/v0.2.0/tar.bzl-v0.2.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-8RTpIntrKtnWKuvg9vem47NqHhSdQDTYUxoNlSd8zNg="
+        }
+    }
+}

--- a/modules/tar.bzl/0.2.0/patches/module_dot_bazel_version.patch
+++ b/modules/tar.bzl/0.2.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,9 +1,9 @@
+ "Bazel dependencies"
+ 
+ module(
+     name = "tar.bzl",
+-    version = "0.0.0",
++    version = "0.2.0",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")

--- a/modules/tar.bzl/0.2.0/presubmit.yml
+++ b/modules/tar.bzl/0.2.0/presubmit.yml
@@ -1,0 +1,14 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    # TODO(alex): add windows.
+    # bazel-lib was only testing e2e/smoke on windows, which is missing tar coverage
+    platform: ["debian10", "macos", "ubuntu2004"]
+    bazel: ["rolling", "8.x", "7.x", "6.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/tar.bzl/0.2.0/presubmit.yml
+++ b/modules/tar.bzl/0.2.0/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     # TODO(alex): add windows.
     # bazel-lib was only testing e2e/smoke on windows, which is missing tar coverage
     platform: ["debian10", "macos", "ubuntu2004"]
-    bazel: ["rolling", "8.x", "7.x", "6.x"]
+    bazel: ["rolling", "8.x", "7.x"]
   tasks:
     run_tests:
       name: "Run test module"

--- a/modules/tar.bzl/0.2.0/source.json
+++ b/modules/tar.bzl/0.2.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-hxBEOANJbhubW2b1auVapYYzjLCaTd65uz1t9ObaRMc=",
+    "strip_prefix": "tar.bzl-0.2.0",
+    "url": "https://github.com/alexeagle/tar.bzl/releases/download/v0.2.0/tar.bzl-v0.2.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-OpEqnLo+W4d0PdmaKty9PUZPbSYlh808xlacOgQKSm4="
+    },
+    "patch_strip": 1
+}

--- a/modules/tar.bzl/metadata.json
+++ b/modules/tar.bzl/metadata.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://github.com/alexeagle/tar.bzl",
+    "maintainers": [
+        {
+            "email": "alex@aspect.build",
+            "github": "alexeagle",
+            "name": "Alex Eagle",
+            "github_user_id": 47395
+        },
+        {
+            "email": "sahin@aspect.build",
+            "github": "thesayyn",
+            "name": "Şahin Yort",
+            "github_user_id": 20563340
+        }
+    ],
+    "repository": [
+        "github:alexeagle/tar.bzl"
+    ],
+    "versions": [
+        "0.2.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/alexeagle/tar.bzl/releases/tag/v0.2.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_