### PR TITLE
Publish tar.bzl@0.2.1

### DIFF
--- a/modules/tar.bzl/0.2.1/MODULE.bazel
+++ b/modules/tar.bzl/0.2.1/MODULE.bazel
@@ -1,0 +1,19 @@
+"Bazel dependencies"
+
+module(
+    name = "tar.bzl",
+    version = "0.2.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.0.3", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
+
+bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
+use_repo(bazel_lib_toolchains, "bsd_tar_toolchains")
+
+register_toolchains("@bsd_tar_toolchains//:all")

--- a/modules/tar.bzl/0.2.1/attestations.json
+++ b/modules/tar.bzl/0.2.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/bazel-contrib/tar.bzl/releases/download/v0.2.1/source.json.intoto.jsonl",
+            "integrity": "sha256-mSyCiOoq7O5hmH5StqwVD2itT/QzaD2u6S5sWyIImsQ="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/bazel-contrib/tar.bzl/releases/download/v0.2.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-dt4loGmPVSBaNKnRp2+3lx6OLanGK8eQO0233HMNC6A="
+        },
+        "tar.bzl-v0.2.1.tar.gz": {
+            "url": "https://github.com/bazel-contrib/tar.bzl/releases/download/v0.2.1/tar.bzl-v0.2.1.tar.gz.intoto.jsonl",
+            "integrity": "sha256-FnUcN9WzIG0M3dd7vLXVFE19Ss1CycpHQaPoBGFm44o="
+        }
+    }
+}

--- a/modules/tar.bzl/0.2.1/patches/module_dot_bazel_version.patch
+++ b/modules/tar.bzl/0.2.1/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,9 +1,9 @@
+ "Bazel dependencies"
+ 
+ module(
+     name = "tar.bzl",
+-    version = "0.0.0",
++    version = "0.2.1",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")

--- a/modules/tar.bzl/0.2.1/presubmit.yml
+++ b/modules/tar.bzl/0.2.1/presubmit.yml
@@ -1,0 +1,14 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    # TODO(alex): add windows.
+    # bazel-lib was only testing e2e/smoke on windows, which is missing tar coverage
+    platform: ["debian10", "macos", "ubuntu2004"]
+    bazel: ["rolling", "8.x", "7.x", "6.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/tar.bzl/0.2.1/presubmit.yml
+++ b/modules/tar.bzl/0.2.1/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     # TODO(alex): add windows.
     # bazel-lib was only testing e2e/smoke on windows, which is missing tar coverage
     platform: ["debian10", "macos", "ubuntu2004"]
-    bazel: ["rolling", "8.x", "7.x", "6.x"]
+    bazel: ["rolling", "8.x", "7.x"]
   tasks:
     run_tests:
       name: "Run test module"

--- a/modules/tar.bzl/0.2.1/presubmit.yml
+++ b/modules/tar.bzl/0.2.1/presubmit.yml
@@ -12,3 +12,5 @@ bcr_test_module:
       bazel: ${{ bazel }}
       test_targets:
         - "//..."
+      test_flags:
+        - "--enable_bzlmod"

--- a/modules/tar.bzl/0.2.1/source.json
+++ b/modules/tar.bzl/0.2.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-nHby+lRAdZewEsheWBPYJZtp5q/Lmx76J6bMcg0I40c=",
+    "strip_prefix": "tar.bzl-0.2.1",
+    "url": "https://github.com/bazel-contrib/tar.bzl/releases/download/v0.2.1/tar.bzl-v0.2.1.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-xetqVa4/Au1nRw7RoYbk5psb+NBGveJKw54MdzrfOZ0="
+    },
+    "patch_strip": 1
+}

--- a/modules/tar.bzl/metadata.json
+++ b/modules/tar.bzl/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/alexeagle/tar.bzl",
+    "homepage": "https://github.com/bazel-contrib/tar.bzl",
     "maintainers": [
         {
             "email": "alex@aspect.build",
@@ -15,10 +15,11 @@
         }
     ],
     "repository": [
-        "github:alexeagle/tar.bzl"
+        "github:bazel-contrib/tar.bzl"
     ],
     "versions": [
-        "0.2.0"
+        "0.2.0",
+        "0.2.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/bazel-contrib/tar.bzl/releases/tag/v0.2.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_