### PR TITLE
Updated integrity for gz-math

### DIFF
--- a/modules/gz-math/8.1.0/source.json
+++ b/modules/gz-math/8.1.0/source.json
@@ -1,6 +1,6 @@
 {
     "url": "https://github.com/gazebosim/gz-math/archive/refs/tags/gz-math8_8.1.0.tar.gz",
-    "integrity": "sha256-DyfIYAi30joNmOWNGYeAGtK6BemZmNCtFDrTme5H50U=",
+    "integrity": "sha256-0AaWP/B1VLP07kzni2uhWDo39HmYcqfA2Bi69UqOQ0E=",
     "strip_prefix": "gz-math-gz-math8_8.1.0",
     "patch_strip": 0,
     "patches": {

--- a/modules/gz-math/metadata.json
+++ b/modules/gz-math/metadata.json
@@ -4,8 +4,8 @@
         {
             "email": "mjcarroll@intrinsic.ai",
             "github": "mjcarroll",
-            "name": "Michael Carroll",
-            "github_user_id": 279701
+            "github_user_id": 279701,
+            "name": "Michael Carroll"
         }
     ],
     "repository": [


### PR DESCRIPTION
Upstream shasum changed for github generated tar.

I ran
```
$ bazel run tools:update_integrity -- gz-math
```

@bazel-io skip_check unstable_url