### PR TITLE
Add 4.3.5.bcr.2 version for libzmq with updated cmake options

### DIFF
--- a/modules/libzmq/4.3.5.bcr.2/MODULE.bazel
+++ b/modules/libzmq/4.3.5.bcr.2/MODULE.bazel
@@ -1,0 +1,13 @@
+"""
+The ZeroMQ lightweight messaging kernel is a library which extends the 
+standard socket interfaces with features traditionally provided by 
+specialised messaging middleware products.
+"""
+
+module(
+    name = "libzmq",
+    version = "4.3.5.bcr.1",
+    compatibility_level = 4,
+)
+
+bazel_dep(name = "rules_foreign_cc", version = "0.10.1")

--- a/modules/libzmq/4.3.5.bcr.2/MODULE.bazel
+++ b/modules/libzmq/4.3.5.bcr.2/MODULE.bazel
@@ -6,7 +6,7 @@ specialised messaging middleware products.
 
 module(
     name = "libzmq",
-    version = "4.3.5.bcr.1",
+    version = "4.3.5.bcr.2",
     compatibility_level = 4,
 )
 

--- a/modules/libzmq/4.3.5.bcr.2/patches/add_build_file.patch
+++ b/modules/libzmq/4.3.5.bcr.2/patches/add_build_file.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ BUILD.bazel
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,36 @@
 +""" Builds libzmq.
 +"""
 +load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")

--- a/modules/libzmq/4.3.5.bcr.2/patches/add_build_file.patch
+++ b/modules/libzmq/4.3.5.bcr.2/patches/add_build_file.patch
@@ -1,0 +1,39 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,37 @@
++""" Builds libzmq.
++"""
++load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
++
++filegroup(
++    name = "srcs",
++    srcs = glob(
++        ["**"],
++        exclude = ["bazel-*"],
++    ),
++)
++
++cmake(
++    name = "libzmq",
++    cache_entries = {
++        # Perftools fail to link on some Linux distributions and turning off
++        # shared library build also disables perftools from building.
++        "BUILD_SHARED": "OFF",
++        # Tests fail to link on some Linux distributions.
++        "ZMQ_BUILD_TESTS": "OFF",
++        # Gnu TLS is not available in BCR.
++        "WITH_TLS": "OFF",
++    },
++    env = {"CMAKE_BUILD_TYPE": "Release"},
++    lib_source = ":srcs",
++    out_include_dir = "include",
++    out_static_libs = ["libzmq.a"],
++    visibility = ["//visibility:public"],
++)
++
++cc_library(
++    name = "libzmq_headers_only",
++    hdrs = glob(["include/*.h"]),
++    strip_include_prefix = "include",
++    visibility = ["//visibility:public"],
++)

--- a/modules/libzmq/4.3.5.bcr.2/patches/module_dot_bazel.patch
+++ b/modules/libzmq/4.3.5.bcr.2/patches/module_dot_bazel.patch
@@ -1,0 +1,16 @@
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,13 @@
++"""
++The ZeroMQ lightweight messaging kernel is a library which extends the 
++standard socket interfaces with features traditionally provided by 
++specialised messaging middleware products.
++"""
++
++module(
++    name = "libzmq",
++    version = "4.3.5.bcr.2",
++    compatibility_level = 4,
++)
++
++bazel_dep(name = "rules_foreign_cc", version = "0.10.1")

--- a/modules/libzmq/4.3.5.bcr.2/presubmit.yml
+++ b/modules/libzmq/4.3.5.bcr.2/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  # - macos_arm64
+  # - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@libzmq'

--- a/modules/libzmq/4.3.5.bcr.2/source.json
+++ b/modules/libzmq/4.3.5.bcr.2/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz",
+    "integrity": "sha256-ZlPvWRDxeVSGH+cjMuaLA8puTZxxYOs6jeWlqRO/q0M=",
+    "strip_prefix": "zeromq-4.3.5",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-YpAn1nkWTR2mna+Cgx9TtHG6Y7mMum3nAVa73RJhFbQ=",
+        "module_dot_bazel.patch": "sha256-qBWgWwH10wWBjANRdTK8/Z9HoDTiFS87qoios+T7dO8="
+    }
+}

--- a/modules/libzmq/4.3.5.bcr.2/source.json
+++ b/modules/libzmq/4.3.5.bcr.2/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "zeromq-4.3.5",
     "patch_strip": 0,
     "patches": {
-        "add_build_file.patch": "sha256-YpAn1nkWTR2mna+Cgx9TtHG6Y7mMum3nAVa73RJhFbQ=",
-        "module_dot_bazel.patch": "sha256-qBWgWwH10wWBjANRdTK8/Z9HoDTiFS87qoios+T7dO8="
+        "add_build_file.patch": "sha256-+Nx72lstolRYXYX6npejBvWf9LoUZ7TwGMy2h7lVzto=",
+        "module_dot_bazel.patch": "sha256-6+oldDFIC+2bj0ezyrngCX/IHw2SR4NG+SiU/xmOAfM="
     }
 }

--- a/modules/libzmq/metadata.json
+++ b/modules/libzmq/metadata.json
@@ -11,7 +11,8 @@
   ],
   "versions": [
     "4.3.5",
-    "4.3.5.bcr.1"
+    "4.3.5.bcr.1",
+    "4.3.5.bcr.2"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
lib-zmq fails to compile and link correctly on some Linux distributions with the default Cmake options. This change adds a new package version that strips out a few non-essential components from the build (shared lib, tests and GnuTLS dependency) to compile successfully.