### PR TITLE
Add cppzmq version 4.10.0.bcr.1 to fix build on Ubuntu Noble

### DIFF
--- a/modules/cppzmq/4.10.0.bcr.1/MODULE.bazel
+++ b/modules/cppzmq/4.10.0.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+"""cppzmq is a C++ binding for libzmq."""
+
+module(
+    name = "cppzmq",
+    version = "4.10.0.bcr.1",
+    compatibility_level = 4,
+)
+
+bazel_dep(name = "libzmq", version = "4.3.5.bcr.2")

--- a/modules/cppzmq/4.10.0.bcr.1/patches/add_build_file.patch
+++ b/modules/cppzmq/4.10.0.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,11 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,8 @@
++""" Builds cppzmq."""
++cc_library(
++    name = "cppzmq",
++    hdrs = glob(["*.hpp"]),
++    includes = ["."],
++    visibility = ["//visibility:public"],
++    deps = ["@libzmq//:libzmq_headers_only"],
++)

--- a/modules/cppzmq/4.10.0.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/cppzmq/4.10.0.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,12 @@
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,9 @@
++"""cppzmq is a C++ binding for libzmq."""
++
++module(
++    name = "cppzmq",
++    version = "4.10.0.bcr.1",
++    compatibility_level = 4,
++)
++
++bazel_dep(name = "libzmq", version = "4.3.5.bcr.2")

--- a/modules/cppzmq/4.10.0.bcr.1/presubmit.yml
+++ b/modules/cppzmq/4.10.0.bcr.1/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@cppzmq'

--- a/modules/cppzmq/4.10.0.bcr.1/source.json
+++ b/modules/cppzmq/4.10.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/zeromq/cppzmq/archive/refs/tags/v4.10.0.tar.gz",
+  "integrity": "sha256-yByBu6inZEyEkyIl8Bi1CIdDoimZxtgqK19c0eaUK3Q=",
+  "strip_prefix": "cppzmq-4.10.0",
+  "patch_strip": 0,
+  "patches": {
+      "add_build_file.patch": "sha256-X3kVzLVQJWWzruTh+PphnUyFp3Yj6oGGXKmZZ1vFDBg=",
+      "module_dot_bazel.patch": "sha256-IayFzbPw6yJdCGoKApq1knEI466m44Kf06g2AlpS6lA="
+  }
+}

--- a/modules/cppzmq/metadata.json
+++ b/modules/cppzmq/metadata.json
@@ -10,7 +10,8 @@
     "github:zeromq/cppzmq"
   ],
   "versions": [
-    "4.10.0"
+    "4.10.0",
+    "4.10.0.bcr.1"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
Build fails for version 4.10.0 on Ubuntu 24.04 (Noble) for depending packages with
```
src/Discovery.cc:18:10: fatal error: zmq.hpp: No such file or directory
   18 | #include <zmq.hpp>
```

This is because the `cppzmq` target does not declare any `includes`. I have added a new version `4.10.0.bcr.1` to address this issue.