### PR TITLE
Add gz-math module version 8.1.1

### DIFF
--- a/modules/gz-math/8.1.1/MODULE.bazel
+++ b/modules/gz-math/8.1.1/MODULE.bazel
@@ -6,6 +6,6 @@ module(
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 bazel_dep(name = "googletest", version = "1.14.0")
 bazel_dep(name = "rules_license", version = "1.0.0")
-bazel_dep(name = "eigen", version = "3.4.0")
+bazel_dep(name = "eigen", version = "3.4.0.bcr.3")  # workaround for https://github.com/bazelbuild/bazel-central-registry/issues/4355
 bazel_dep(name = "rules_gazebo", version = "0.0.2")
 bazel_dep(name = "gz-utils", version = "3.1.0")

--- a/modules/gz-math/8.1.1/MODULE.bazel
+++ b/modules/gz-math/8.1.1/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "gz-math",
+    version = "8.1.1",
+    compatibility_level = 0,
+)
+bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
+bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "eigen", version = "3.4.0")
+bazel_dep(name = "rules_gazebo", version = "0.0.2")
+bazel_dep(name = "gz-utils", version = "3.1.0")

--- a/modules/gz-math/8.1.1/patches/fix_clang_build.patch
+++ b/modules/gz-math/8.1.1/patches/fix_clang_build.patch
@@ -1,0 +1,18 @@
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -74,6 +74,7 @@ cc_library(
+     deps = [
+         "@gz-utils//:ImplPtr",
+         "@gz-utils//:NeverDestroyed",
++        "@gz-utils//:SuppressWarning",
+     ],
+ )
+ 
+@@ -113,6 +114,7 @@ test_sources = glob(
+             ":gz-math",
+             "@googletest//:gtest",
+             "@googletest//:gtest_main",
++            "@gz-utils//:SuppressWarning",
+         ],
+     )
+     for src in test_sources

--- a/modules/gz-math/8.1.1/patches/module_dot_bazel.patch
+++ b/modules/gz-math/8.1.1/patches/module_dot_bazel.patch
@@ -12,9 +12,10 @@
  bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
  bazel_dep(name = "googletest", version = "1.14.0")
  bazel_dep(name = "rules_license", version = "1.0.0")
- bazel_dep(name = "eigen", version = "3.4.0")
+-bazel_dep(name = "eigen", version = "3.4.0")
 -
 -# Gazebo Dependencies
++bazel_dep(name = "eigen", version = "3.4.0.bcr.3")  # workaround for https://github.com/bazelbuild/bazel-central-registry/issues/4355
  bazel_dep(name = "rules_gazebo", version = "0.0.2")
 -bazel_dep(name = "gz-utils")
 -archive_override(

--- a/modules/gz-math/8.1.1/patches/module_dot_bazel.patch
+++ b/modules/gz-math/8.1.1/patches/module_dot_bazel.patch
@@ -1,0 +1,25 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,19 +1,11 @@
+-## MODULE.bazel
+ module(
+     name = "gz-math",
+-    repo_name = "org_gazebosim_gz-math",
++    version = "8.1.1",
++    compatibility_level = 0,
+ )
+-
+ bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
+ bazel_dep(name = "googletest", version = "1.14.0")
+ bazel_dep(name = "rules_license", version = "1.0.0")
+ bazel_dep(name = "eigen", version = "3.4.0")
+-
+-# Gazebo Dependencies
+ bazel_dep(name = "rules_gazebo", version = "0.0.2")
+-bazel_dep(name = "gz-utils")
+-archive_override(
+-    module_name = "gz-utils",
+-    strip_prefix = "gz-utils-gz-utils3",
+-    urls = ["https://github.com/gazebosim/gz-utils/archive/refs/heads/gz-utils3.tar.gz"],
+-)
++bazel_dep(name = "gz-utils", version = "3.1.0")

--- a/modules/gz-math/8.1.1/presubmit.yml
+++ b/modules/gz-math/8.1.1/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@gz-math//:*'

--- a/modules/gz-math/8.1.1/presubmit.yml
+++ b/modules/gz-math/8.1.1/presubmit.yml
@@ -5,8 +5,8 @@ matrix:
   - macos
   - macos_arm64
   bazel:
+  - 8.x
   - 7.x
-  - 6.x
 tasks:
   verify_targets:
     name: Verify build targets

--- a/modules/gz-math/8.1.1/source.json
+++ b/modules/gz-math/8.1.1/source.json
@@ -4,6 +4,7 @@
     "strip_prefix": "gz-math-gz-math8_8.1.1",
     "patch_strip": 0,
     "patches": {
-        "module_dot_bazel.patch": "sha256-Yr6C89IoxFn39prD4ZrappAn7kfC6MKHEkeZkqFno5A="
+        "fix_clang_build.patch": "sha256-Pa4QeFqu9HsSnIHiKRwffiPeFFWqBi9nkTmXrTkfDR8=",
+        "module_dot_bazel.patch": "sha256-fVB2/b7HtwyQAOCTxDdl+G0Lg4AtixuGypgGzjNhDoU="
     }
 }

--- a/modules/gz-math/8.1.1/source.json
+++ b/modules/gz-math/8.1.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/gazebosim/gz-math/archive/refs/tags/gz-math8_8.1.1.tar.gz",
+    "integrity": "sha256-BFWyQGnGEXK2JcVTSPOnImUgWCYkIgGRdtD/Q1UfcJM=",
+    "strip_prefix": "gz-math-gz-math8_8.1.1",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-Yr6C89IoxFn39prD4ZrappAn7kfC6MKHEkeZkqFno5A="
+    }
+}

--- a/modules/gz-math/metadata.json
+++ b/modules/gz-math/metadata.json
@@ -12,7 +12,8 @@
         "github:gazebosim/gz-math"
     ],
     "versions": [
-        "8.1.0"
+        "8.1.0",
+        "8.1.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Clang build fails layering check. This will be fixed upstream in v8.1.2, but I pulled in the fix with a patch here to unblock adding downstream packages that depend on v8.1.1 to BCR (e.g. https://github.com/bazelbuild/bazel-central-registry/pull/4557).

Also bumped eigen dep version from `3.4.0` to `3.4.0.bcr.3` which sources an archive with more stable integrity (https://github.com/bazelbuild/bazel-central-registry/issues/4355)