### PR TITLE
Fix tinyxml url

### DIFF
--- a/modules/tinyxml/2.6.2/source.json
+++ b/modules/tinyxml/2.6.2/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "http://archive.ubuntu.com/ubuntu/pool/universe/t/tinyxml/tinyxml_2.6.2.orig.tar.gz",
+    "url": "https://netcologne.dl.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz",
     "integrity": "sha256-Fb39zsWKfaMK3IesKweORBfb5TkvOvtxn5um0GJkVZM=",
     "overlay": {
         "BUILD.bazel": "sha256-4/TJ3JLPA8lIU9RT5VssXDTVNgBH3HnMcDpzhqCKB/0=",


### PR DESCRIPTION
QUESTION: Are there any issues with updating the URL as I did in this PR?
Or do I need to create a *.bcr.1 release?

The old url appears to no longer exist. It gives a 404 and the file is missing when browsing
https://archive.ubuntu.com/ubuntu/pool/universe/t/tinyxml/

The fix is to download the tar.gz from the sourceforge location. The hash is unchanged.