### PR TITLE
Add openconfig_bootz@0.5.0

### DIFF
--- a/modules/openconfig_bootz/0.5.0/MODULE.bazel
+++ b/modules/openconfig_bootz/0.5.0/MODULE.bazel
@@ -1,0 +1,24 @@
+module(
+    name = "openconfig_bootz",
+    version = "0.5.0",
+)
+
+bazel_dep(name = "gazelle", version = "0.41.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "grpc", version = "1.69.0", repo_name = "com_github_grpc_grpc")
+bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_go", version = "0.51.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "openconfig_gnmi", version = "0.14.1")
+bazel_dep(name = "openconfig_gnsi", version = "1.9.0")
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.24.1")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(go_deps, "com_github_coredhcp_coredhcp", "com_github_golang_glog", "com_github_google_go_cmp", "com_github_h_fam_errdiff", "com_github_insomniacslk_dhcp", "org_golang_google_grpc", "org_golang_google_grpc_cmd_protoc_gen_go_grpc", "org_golang_google_protobuf", "org_mozilla_go_pkcs7")
+
+go_deps_dev = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
+go_deps_dev.gazelle_override(
+    build_file_generation = "clean",
+    path = "github.com/h-fam/errdiff",
+)

--- a/modules/openconfig_bootz/0.5.0/patches/module_dot_bazel.patch
+++ b/modules/openconfig_bootz/0.5.0/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "openconfig_bootz",
+-    version = "0.0.0",
++    version = "0.5.0",
+ )
+ 
+ bazel_dep(name = "gazelle", version = "0.41.0", repo_name = "bazel_gazelle")

--- a/modules/openconfig_bootz/0.5.0/presubmit.yml
+++ b/modules/openconfig_bootz/0.5.0/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@openconfig_bootz//...'

--- a/modules/openconfig_bootz/0.5.0/source.json
+++ b/modules/openconfig_bootz/0.5.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/openconfig/bootz/archive/refs/tags/v0.5.0.tar.gz",
+    "integrity": "sha256-SzhleyKp2mSUStsiCnRV3vRP2xzKiKkqv0exq1uYlJc=",
+    "strip_prefix": "bootz-0.5.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-1fvURvHpBDP120cpc5mewSooCBsItNR1mdTWyvVfTIE="
+    }
+}

--- a/modules/openconfig_bootz/metadata.json
+++ b/modules/openconfig_bootz/metadata.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://github.com/openconfig/bootz",
+    "maintainers": [
+        {
+            "email": "bstoll@google.com",
+            "github": "bstoll",
+            "github_user_id": 6945781,
+            "name": "Brandon Stoll"
+        },
+        {
+            "email": "hines@google.com",
+            "github": "marcushines",
+            "github_user_id": 80116818,
+            "name": "Marcus Hines"
+        }
+    ],
+    "repository": [
+        "github:openconfig/bootz"
+    ],
+    "versions": [
+        "0.5.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add BCR package for github.com/openconfig/bootz.

I think incompatible_flags will fail because of the GRPC dep - I don't see any version of GRPC that has the issue fixed though. I confirmed if I explicitly pin a newer grpc/rules_foreign_cc it passes.