### PR TITLE
CI: Replace CentOS 7 with Rocky Linux 8

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -86,7 +86,7 @@ For example, in `zlib@1.2.13`'s [presubmit.yml](https://github.com/bazelbuild/ba
 ```yaml
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -126,7 +126,7 @@ bcr_test_module:
   module_path: examples/bzlmod
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/abseil-cpp/20210324.2/presubmit.yml
+++ b/modules/abseil-cpp/20210324.2/presubmit.yml
@@ -3,10 +3,8 @@ build_targets: &build_targets
 - '@abseil-cpp//absl/flags:flag'
 
 platforms:
-  # The current version of centos on Bazel CI still uses gcc 4.8.5
-  # Re-enable this platform when the gcc version is upgraded.
-  # centos7:
-  #   build_targets: *build_targets
+  rockylinux8:
+    build_targets: *build_targets
   debian10:
     build_targets: *build_targets
   macos:

--- a/modules/abseil-cpp/20211102.0/presubmit.yml
+++ b/modules/abseil-cpp/20211102.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20220623.1/presubmit.yml
+++ b/modules/abseil-cpp/20220623.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20230125.1/presubmit.yml
+++ b/modules/abseil-cpp/20230125.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20230802.0.bcr.1/presubmit.yml
+++ b/modules/abseil-cpp/20230802.0.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20230802.0/presubmit.yml
+++ b/modules/abseil-cpp/20230802.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20230802.1/presubmit.yml
+++ b/modules/abseil-cpp/20230802.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20240116.0/presubmit.yml
+++ b/modules/abseil-cpp/20240116.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20240116.1/presubmit.yml
+++ b/modules/abseil-cpp/20240116.1/presubmit.yml
@@ -3,7 +3,7 @@ matrix:
   - 6.x
   - 7.x
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20240116.2/presubmit.yml
+++ b/modules/abseil-cpp/20240116.2/presubmit.yml
@@ -3,7 +3,7 @@ matrix:
   - 6.x
   - 7.x
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20240116.3/presubmit.yml
+++ b/modules/abseil-cpp/20240116.3/presubmit.yml
@@ -3,7 +3,7 @@ matrix:
   - 6.x
   - 7.x
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20240722.0.bcr.1/presubmit.yml
+++ b/modules/abseil-cpp/20240722.0.bcr.1/presubmit.yml
@@ -2,7 +2,7 @@ matrix:
   bazel:
   - 7.x
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20240722.0.bcr.2/presubmit.yml
+++ b/modules/abseil-cpp/20240722.0.bcr.2/presubmit.yml
@@ -3,7 +3,7 @@ matrix:
   - 7.x
   - 8.0.0rc6
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20240722.0/presubmit.yml
+++ b/modules/abseil-cpp/20240722.0/presubmit.yml
@@ -2,7 +2,7 @@ matrix:
   bazel:
   - 7.x
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-cpp/20240722.1/presubmit.yml
+++ b/modules/abseil-cpp/20240722.1/presubmit.yml
@@ -3,7 +3,7 @@ matrix:
   - 7.x
   - 8.0.0rc6
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/abseil-py/1.4.0/presubmit.yml
+++ b/modules/abseil-py/1.4.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/ape/1.0.0-alpha.5/presubmit.yml
+++ b/modules/ape/1.0.0-alpha.5/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.11/presubmit.yml
+++ b/modules/ape/1.0.0-beta.11/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.12/presubmit.yml
+++ b/modules/ape/1.0.0-beta.12/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.13/presubmit.yml
+++ b/modules/ape/1.0.0-beta.13/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.14/presubmit.yml
+++ b/modules/ape/1.0.0-beta.14/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.15/presubmit.yml
+++ b/modules/ape/1.0.0-beta.15/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.16/presubmit.yml
+++ b/modules/ape/1.0.0-beta.16/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc4
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.17/presubmit.yml
+++ b/modules/ape/1.0.0-beta.17/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.2/presubmit.yml
+++ b/modules/ape/1.0.0-beta.2/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.3/presubmit.yml
+++ b/modules/ape/1.0.0-beta.3/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.4/presubmit.yml
+++ b/modules/ape/1.0.0-beta.4/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.6/presubmit.yml
+++ b/modules/ape/1.0.0-beta.6/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.0-beta.7/presubmit.yml
+++ b/modules/ape/1.0.0-beta.7/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/ape/1.0.1/presubmit.yml
+++ b/modules/ape/1.0.1/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/apple_rules_lint/0.2.0/presubmit.yml
+++ b/modules/apple_rules_lint/0.2.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/apple_rules_lint/0.3.2/presubmit.yml
+++ b/modules/apple_rules_lint/0.3.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/apple_support/0.11.0/presubmit.yml
+++ b/modules/apple_support/0.11.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/0.13.0/presubmit.yml
+++ b/modules/apple_support/0.13.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.0.0/presubmit.yml
+++ b/modules/apple_support/1.0.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.10.0/presubmit.yml
+++ b/modules/apple_support/1.10.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.10.1/presubmit.yml
+++ b/modules/apple_support/1.10.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.11.0/presubmit.yml
+++ b/modules/apple_support/1.11.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.11.1/presubmit.yml
+++ b/modules/apple_support/1.11.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.12.0/presubmit.yml
+++ b/modules/apple_support/1.12.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ["6.x", "7.x", "rolling"]
 
 tasks:

--- a/modules/apple_support/1.13.0/presubmit.yml
+++ b/modules/apple_support/1.13.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ["6.x", "7.x", "rolling"]
 
 tasks:

--- a/modules/apple_support/1.3.1/presubmit.yml
+++ b/modules/apple_support/1.3.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.3.2/presubmit.yml
+++ b/modules/apple_support/1.3.2/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.4.0/presubmit.yml
+++ b/modules/apple_support/1.4.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.4.1/presubmit.yml
+++ b/modules/apple_support/1.4.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.5.0/presubmit.yml
+++ b/modules/apple_support/1.5.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.6.0/presubmit.yml
+++ b/modules/apple_support/1.6.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.7.0/presubmit.yml
+++ b/modules/apple_support/1.7.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.7.1/presubmit.yml
+++ b/modules/apple_support/1.7.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.8.0/presubmit.yml
+++ b/modules/apple_support/1.8.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.8.1/presubmit.yml
+++ b/modules/apple_support/1.8.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/apple_support/1.9.0/presubmit.yml
+++ b/modules/apple_support/1.9.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/asio/1.21.0/presubmit.yml
+++ b/modules/asio/1.21.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/asio/1.24.0/presubmit.yml
+++ b/modules/asio/1.24.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/asio/1.28.2/presubmit.yml
+++ b/modules/asio/1.28.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/asio/1.31.0/presubmit.yml
+++ b/modules/asio/1.31.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/asio/1.32.0/presubmit.yml
+++ b/modules/asio/1.32.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/aspect_bazel_lib/0.11.0/presubmit.yml
+++ b/modules/aspect_bazel_lib/0.11.0/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
 - '@aspect_bazel_lib//lib/tests:expand_template_test'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/aspect_bazel_lib/0.11.4/presubmit.yml
+++ b/modules/aspect_bazel_lib/0.11.4/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
   - "@aspect_bazel_lib//lib/tests:expand_template_test"
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/aspect_bazel_lib/0.12.1/presubmit.yml
+++ b/modules/aspect_bazel_lib/0.12.1/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
   - "@aspect_bazel_lib//lib/tests:expand_template_test"
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/aspect_bazel_lib/0.4.2/presubmit.yml
+++ b/modules/aspect_bazel_lib/0.4.2/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
 - '@aspect_bazel_lib//lib/tests:expand_template_test'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/aspect_bazel_lib/1.0.0/presubmit.yml
+++ b/modules/aspect_bazel_lib/1.0.0/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
   - "@aspect_bazel_lib//lib/tests:expand_template_test"
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/aspect_bazel_lib/1.1.0/presubmit.yml
+++ b/modules/aspect_bazel_lib/1.1.0/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
   - "@aspect_bazel_lib//lib/tests:expand_template_test"
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/aspect_rules_js/0.3.2/presubmit.yml
+++ b/modules/aspect_rules_js/0.3.2/presubmit.yml
@@ -2,7 +2,7 @@ test_targets: &test_targets
 - '@aspect_rules_js//js/...'
 
 platforms:
-  centos7:
+  rockylinux8:
     test_targets: *test_targets
   debian10:
     test_targets: *test_targets

--- a/modules/aspect_rules_swc/0.3.0/presubmit.yml
+++ b/modules/aspect_rules_swc/0.3.0/presubmit.yml
@@ -6,10 +6,8 @@ test_targets: &test_targets
 - '@aspect_rules_swc//swc/...'
 
 platforms:
-  # Wrong libc version here
-  # Error: /lib64/libc.so.6: version `GLIBC_2.18' not found (required by /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/e805867cdad67fe4cf21a67a5735d7fa/external/aspect_rules_swc.0.3.0.swc.default_swc_linux-x64-gnu/swc.linux-x64-gnu.node)
-  #centos7:
-  #  test_targets: *test_targets
+  rockylinux8:
+    test_targets: *test_targets
   debian10:
     test_targets: *test_targets
   macos:

--- a/modules/bazel_features/0.0.1/presubmit.yml
+++ b/modules/bazel_features/0.0.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/bazel_features/0.1.0/presubmit.yml
+++ b/modules/bazel_features/0.1.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/bazel_features/0.2.0/presubmit.yml
+++ b/modules/bazel_features/0.2.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/bazel_features/1.0.0/presubmit.yml
+++ b/modules/bazel_features/1.0.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/bazel_features/1.1.0/presubmit.yml
+++ b/modules/bazel_features/1.1.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/bazel_features/1.1.1/presubmit.yml
+++ b/modules/bazel_features/1.1.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/bazel_features/1.10.0/presubmit.yml
+++ b/modules/bazel_features/1.10.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.11.0/presubmit.yml
+++ b/modules/bazel_features/1.11.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.12.0/presubmit.yml
+++ b/modules/bazel_features/1.12.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.13.0/presubmit.yml
+++ b/modules/bazel_features/1.13.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.14.0/presubmit.yml
+++ b/modules/bazel_features/1.14.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.15.0/presubmit.yml
+++ b/modules/bazel_features/1.15.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.16.0/presubmit.yml
+++ b/modules/bazel_features/1.16.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.17.0/presubmit.yml
+++ b/modules/bazel_features/1.17.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.18.0/presubmit.yml
+++ b/modules/bazel_features/1.18.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.19.0/presubmit.yml
+++ b/modules/bazel_features/1.19.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.2.0/presubmit.yml
+++ b/modules/bazel_features/1.2.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/bazel_features/1.20.0/presubmit.yml
+++ b/modules/bazel_features/1.20.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.21.0/presubmit.yml
+++ b/modules/bazel_features/1.21.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.22.0/presubmit.yml
+++ b/modules/bazel_features/1.22.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.23.0/presubmit.yml
+++ b/modules/bazel_features/1.23.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.24.0/presubmit.yml
+++ b/modules/bazel_features/1.24.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.25.0/presubmit.yml
+++ b/modules/bazel_features/1.25.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.26.0/presubmit.yml
+++ b/modules/bazel_features/1.26.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.27.0/presubmit.yml
+++ b/modules/bazel_features/1.27.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.28.0/presubmit.yml
+++ b/modules/bazel_features/1.28.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.29.0/presubmit.yml
+++ b/modules/bazel_features/1.29.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.3.0/presubmit.yml
+++ b/modules/bazel_features/1.3.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/bazel_features/1.4.1/presubmit.yml
+++ b/modules/bazel_features/1.4.1/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.5.0/presubmit.yml
+++ b/modules/bazel_features/1.5.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.6.0/presubmit.yml
+++ b/modules/bazel_features/1.6.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.7.0/presubmit.yml
+++ b/modules/bazel_features/1.7.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.7.1/presubmit.yml
+++ b/modules/bazel_features/1.7.1/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.8.0/presubmit.yml
+++ b/modules/bazel_features/1.8.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.9.0/presubmit.yml
+++ b/modules/bazel_features/1.9.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_features/1.9.1/presubmit.yml
+++ b/modules/bazel_features/1.9.1/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: test/bcr_test
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/bazel_skylib/1.0.3/presubmit.yml
+++ b/modules/bazel_skylib/1.0.3/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@bazel_skylib//...'
   debian10:

--- a/modules/bazel_skylib/1.1.1/presubmit.yml
+++ b/modules/bazel_skylib/1.1.1/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@bazel_skylib//...'
   debian10:

--- a/modules/bazel_skylib/1.2.0/presubmit.yml
+++ b/modules/bazel_skylib/1.2.0/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@bazel_skylib//...'
   debian10:

--- a/modules/bazel_skylib/1.2.1/presubmit.yml
+++ b/modules/bazel_skylib/1.2.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib/1.3.0/presubmit.yml
+++ b/modules/bazel_skylib/1.3.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib/1.4.0/presubmit.yml
+++ b/modules/bazel_skylib/1.4.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib/1.4.1/presubmit.yml
+++ b/modules/bazel_skylib/1.4.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib/1.4.2/presubmit.yml
+++ b/modules/bazel_skylib/1.4.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib/1.5.0/presubmit.yml
+++ b/modules/bazel_skylib/1.5.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib/1.6.0/presubmit.yml
+++ b/modules/bazel_skylib/1.6.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib/1.6.1/presubmit.yml
+++ b/modules/bazel_skylib/1.6.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib/1.7.0/presubmit.yml
+++ b/modules/bazel_skylib/1.7.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib/1.7.1/presubmit.yml
+++ b/modules/bazel_skylib/1.7.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/bazel_skylib_gazelle_plugin/1.4.0/presubmit.yml
+++ b/modules/bazel_skylib_gazelle_plugin/1.4.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib_gazelle_plugin/1.4.1/presubmit.yml
+++ b/modules/bazel_skylib_gazelle_plugin/1.4.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib_gazelle_plugin/1.4.2/presubmit.yml
+++ b/modules/bazel_skylib_gazelle_plugin/1.4.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib_gazelle_plugin/1.5.0/presubmit.yml
+++ b/modules/bazel_skylib_gazelle_plugin/1.5.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib_gazelle_plugin/1.6.0/presubmit.yml
+++ b/modules/bazel_skylib_gazelle_plugin/1.6.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib_gazelle_plugin/1.6.1/presubmit.yml
+++ b/modules/bazel_skylib_gazelle_plugin/1.6.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib_gazelle_plugin/1.7.0/presubmit.yml
+++ b/modules/bazel_skylib_gazelle_plugin/1.7.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bazel_skylib_gazelle_plugin/1.7.1/presubmit.yml
+++ b/modules/bazel_skylib_gazelle_plugin/1.7.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/blake3/1.5.1.bcr.1/presubmit.yml
+++ b/modules/blake3/1.5.1.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - fedora39
   - ubuntu2004

--- a/modules/blake3/1.5.1/presubmit.yml
+++ b/modules/blake3/1.5.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - fedora39
   - ubuntu2004

--- a/modules/blake3/1.5.4.bcr.1/presubmit.yml
+++ b/modules/blake3/1.5.4.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - fedora39
   - ubuntu2004

--- a/modules/blake3/1.5.4/presubmit.yml
+++ b/modules/blake3/1.5.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - fedora39
   - ubuntu2004

--- a/modules/boringssl/0.0.0-20211025-d4f1ab9/presubmit.yml
+++ b/modules/boringssl/0.0.0-20211025-d4f1ab9/presubmit.yml
@@ -3,10 +3,8 @@ build_targets: &build_targets
 - '@boringssl//:ssl'
 
 platforms:
-  # The current version of centos on Bazel CI still uses gcc 4.8.5
-  # Re-enable this platform when the gcc version is upgraded.
-  # centos7:
-  #   build_targets: *build_targets
+  rockylinux8:
+    build_targets: *build_targets
   debian10:
     build_targets: *build_targets
   macos:

--- a/modules/boringssl/0.0.0-20230215-5c22014/presubmit.yml
+++ b/modules/boringssl/0.0.0-20230215-5c22014/presubmit.yml
@@ -3,10 +3,8 @@ build_targets: &build_targets
 - '@boringssl//:ssl'
 
 platforms:
-  # The current version of centos on Bazel CI still uses gcc 4.8.5
-  # Re-enable this platform when the gcc version is upgraded.
-  # centos7:
-  #   build_targets: *build_targets
+  rockylinux8:
+    build_targets: *build_targets
   debian10:
     build_targets: *build_targets
   macos:

--- a/modules/boringssl/0.0.0-20240126-22d349c/presubmit.yml
+++ b/modules/boringssl/0.0.0-20240126-22d349c/presubmit.yml
@@ -4,7 +4,7 @@ build_targets: &build_targets
 
 matrix:
   platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian11
     - ubuntu2204
     - windows

--- a/modules/boringssl/0.0.0-20240530-2db0eb3/presubmit.yml
+++ b/modules/boringssl/0.0.0-20240530-2db0eb3/presubmit.yml
@@ -4,7 +4,7 @@ build_targets: &build_targets
 
 matrix:
   platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian11
     - ubuntu2204
     - windows

--- a/modules/boringssl/0.20240913.0/presubmit.yml
+++ b/modules/boringssl/0.20240913.0/presubmit.yml
@@ -4,7 +4,7 @@ build_targets: &build_targets
 
 matrix: &matrix
   non_macos_platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian11
     - ubuntu2204
     - windows

--- a/modules/boringssl/0.20240930.0/presubmit.yml
+++ b/modules/boringssl/0.20240930.0/presubmit.yml
@@ -4,7 +4,7 @@ build_targets: &build_targets
 
 matrix: &matrix
   non_macos_platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian11
     - ubuntu2204
     - windows

--- a/modules/boringssl/0.20241024.0/presubmit.yml
+++ b/modules/boringssl/0.20241024.0/presubmit.yml
@@ -4,7 +4,7 @@ build_targets: &build_targets
 
 matrix: &matrix
   non_macos_platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian11
     - ubuntu2204
     - windows

--- a/modules/bzip2/1.0.8.bcr.1/presubmit.yml
+++ b/modules/bzip2/1.0.8.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bzip2/1.0.8.bcr.2/presubmit.yml
+++ b/modules/bzip2/1.0.8.bcr.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/bzip2/1.0.8/presubmit.yml
+++ b/modules/bzip2/1.0.8/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/c-ares/1.15.0/presubmit.yml
+++ b/modules/c-ares/1.15.0/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@c-ares//:ares'
   debian10:

--- a/modules/c-ares/1.16.1/presubmit.yml
+++ b/modules/c-ares/1.16.1/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@c-ares//:ares'
   debian10:

--- a/modules/capnp-cpp/1.1.0/presubmit.yml
+++ b/modules/capnp-cpp/1.1.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/circl/1.3.3/presubmit.yml
+++ b/modules/circl/1.3.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/circl/1.3.7/presubmit.yml
+++ b/modules/circl/1.3.7/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/circl/1.3.8/presubmit.yml
+++ b/modules/circl/1.3.8/presubmit.yml
@@ -2,7 +2,7 @@ matrix:
   bazel:
     - 7.x
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/contrib_rules_jvm/0.13.0/presubmit.yml
+++ b/modules/contrib_rules_jvm/0.13.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/download_utils/1.0.0-beta.2/presubmit.yml
+++ b/modules/download_utils/1.0.0-beta.2/presubmit.yml
@@ -6,7 +6,7 @@ bcr_test_module:
     platform:
       # TODO: Enable when we can fallback to an older `coreutils` in testing
       # `uutils/coreutils` only goes back to `glibc@2.18`
-      # - centos7_java11_devtoolset10
+      # - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/download_utils/1.0.0-beta.4/presubmit.yml
+++ b/modules/download_utils/1.0.0-beta.4/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/download_utils/1.0.0-beta.5/presubmit.yml
+++ b/modules/download_utils/1.0.0-beta.5/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc4
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/download_utils/1.0.1/presubmit.yml
+++ b/modules/download_utils/1.0.1/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/gazelle/0.26.0/presubmit.yml
+++ b/modules/gazelle/0.26.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/gazelle/0.27.0/presubmit.yml
+++ b/modules/gazelle/0.27.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/gazelle/0.28.0/presubmit.yml
+++ b/modules/gazelle/0.28.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/gazelle/0.29.0/presubmit.yml
+++ b/modules/gazelle/0.29.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/gazelle/0.30.0/presubmit.yml
+++ b/modules/gazelle/0.30.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/gazelle/0.31.0/presubmit.yml
+++ b/modules/gazelle/0.31.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/gazelle/0.31.1/presubmit.yml
+++ b/modules/gazelle/0.31.1/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/gazelle/0.32.0/presubmit.yml
+++ b/modules/gazelle/0.32.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/gazelle/0.33.0/presubmit.yml
+++ b/modules/gazelle/0.33.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/gflags/2.2.2/presubmit.yml
+++ b/modules/gflags/2.2.2/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@gflags//:gflags'
   debian10:

--- a/modules/glog/0.5.0/presubmit.yml
+++ b/modules/glog/0.5.0/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@glog//:glog'
   debian10:

--- a/modules/glog/0.6.0/presubmit.yml
+++ b/modules/glog/0.6.0/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@glog//:glog'
   debian10:

--- a/modules/glog/0.7.1/presubmit.yml
+++ b/modules/glog/0.7.1/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: [6.x, 7.x, rolling]
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - debian11
     - macos

--- a/modules/googletest/1.11.0/presubmit.yml
+++ b/modules/googletest/1.11.0/presubmit.yml
@@ -1,8 +1,7 @@
 platforms:
-  # The compiler on centos7 is not modern enough.
-  # centos7:
-  #   build_targets:
-  #   - '@googletest//:gtest'
+  rockylinux8:
+    build_targets:
+    - '@googletest//:gtest'
   debian10:
     build_targets:
     - '@googletest//:gtest'

--- a/modules/googletest/1.12.1/presubmit.yml
+++ b/modules/googletest/1.12.1/presubmit.yml
@@ -1,8 +1,7 @@
 platforms:
-  # The compiler on centos7 is not modern enough.
-  # centos7:
-  #   build_targets:
-  #   - '@googletest//:gtest'
+  rockylinux8:
+    build_targets:
+    - '@googletest//:gtest'
   debian10:
     build_targets:
     - '@googletest//:gtest'

--- a/modules/googletest/1.13.0/presubmit.yml
+++ b/modules/googletest/1.13.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/googletest/1.14.0.bcr.1/presubmit.yml
+++ b/modules/googletest/1.14.0.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/googletest/1.14.0/presubmit.yml
+++ b/modules/googletest/1.14.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/grpc/1.41.0/presubmit.yml
+++ b/modules/grpc/1.41.0/presubmit.yml
@@ -5,10 +5,8 @@ build_targets: &build_targets
 - '@grpc//src/compiler:grpc_cpp_plugin'
 
 platforms:
-  # The current version of centos on Bazel CI still uses gcc 4.8.5
-  # Re-enable this platform when the gcc version is upgraded.
-  # centos7:
-  #   build_targets: *build_targets
+  rockylinux8:
+    build_targets: *build_targets
   debian10:
     build_targets: *build_targets
   macos:

--- a/modules/imath/3.1.9/presubmit.yml
+++ b/modules/imath/3.1.9/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/jsoncons/0.177.0/presubmit.yml
+++ b/modules/jsoncons/0.177.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/jsoncons/1.0.0/presubmit.yml
+++ b/modules/jsoncons/1.0.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/libpfm/4.11.0.bcr.1/presubmit.yml
+++ b/modules/libpfm/4.11.0.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   bazel:

--- a/modules/libpfm/4.11.0/presubmit.yml
+++ b/modules/libpfm/4.11.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
 tasks:

--- a/modules/libpng/1.6.40/presubmit.yml
+++ b/modules/libpng/1.6.40/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/libpng/1.6.41/presubmit.yml
+++ b/modules/libpng/1.6.41/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - debian11
   - macos

--- a/modules/libpng/1.6.42/presubmit.yml
+++ b/modules/libpng/1.6.42/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - debian11
     - macos

--- a/modules/libpng/1.6.43/presubmit.yml
+++ b/modules/libpng/1.6.43/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - debian11
     - macos

--- a/modules/libpng/1.6.44/presubmit.yml
+++ b/modules/libpng/1.6.44/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - debian11
     - macos

--- a/modules/libpng/1.6.45/presubmit.yml
+++ b/modules/libpng/1.6.45/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - debian11
     - macos

--- a/modules/libpng/1.6.46/presubmit.yml
+++ b/modules/libpng/1.6.46/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - debian11
     - macos

--- a/modules/libpng/1.6.47.bcr.1/presubmit.yml
+++ b/modules/libpng/1.6.47.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - debian11
     - macos

--- a/modules/libpng/1.6.47/presubmit.yml
+++ b/modules/libpng/1.6.47/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - debian11
     - macos

--- a/modules/lmdb/0.9.29/presubmit.yml
+++ b/modules/lmdb/0.9.29/presubmit.yml
@@ -6,7 +6,7 @@ build_targets: &build_targets
 - '@lmdb//:mdb_stat'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/nlohmann_json/3.11.2/presubmit.yml
+++ b/modules/nlohmann_json/3.11.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/nlohmann_json/3.11.3.bcr.1/presubmit.yml
+++ b/modules/nlohmann_json/3.11.3.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/nlohmann_json/3.11.3/presubmit.yml
+++ b/modules/nlohmann_json/3.11.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/nlohmann_json/3.12.0/presubmit.yml
+++ b/modules/nlohmann_json/3.12.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian11
     - ubuntu2204
     - ubuntu2404

--- a/modules/nlohmann_json/3.6.1/presubmit.yml
+++ b/modules/nlohmann_json/3.6.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.3.7/presubmit.yml
+++ b/modules/ofiuco/0.3.7/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.4.1/presubmit.yml
+++ b/modules/ofiuco/0.4.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.4.4/presubmit.yml
+++ b/modules/ofiuco/0.4.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.4.5/presubmit.yml
+++ b/modules/ofiuco/0.4.5/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.4.6/presubmit.yml
+++ b/modules/ofiuco/0.4.6/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/openapi_tools_generator_bazel/0.2.0/presubmit.yml
+++ b/modules/openapi_tools_generator_bazel/0.2.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: "internal/test/bcr"
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/pigz/2.7/presubmit.yml
+++ b/modules/pigz/2.7/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/pigz/2.8/presubmit.yml
+++ b/modules/pigz/2.8/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - debian11
   - ubuntu2004

--- a/modules/platforms/0.0.4/presubmit.yml
+++ b/modules/platforms/0.0.4/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@platforms//...'
   debian10:

--- a/modules/platforms/0.0.5/presubmit.yml
+++ b/modules/platforms/0.0.5/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@platforms//...'
   debian10:

--- a/modules/platforms/0.0.6/presubmit.yml
+++ b/modules/platforms/0.0.6/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@platforms//...'
   debian10:

--- a/modules/platforms/0.0.7/presubmit.yml
+++ b/modules/platforms/0.0.7/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@platforms//...'
   debian10:

--- a/modules/platforms/0.0.8/presubmit.yml
+++ b/modules/platforms/0.0.8/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@platforms//...'
   debian10:

--- a/modules/procps-ng/4.0.5/presubmit.yml
+++ b/modules/procps-ng/4.0.5/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: [centos7, debian11, ubuntu2404]
+  platform: [rockylinux8, debian11, ubuntu2404]
   bazel: [7.x, 8.x]
 tasks:
   verify_targets:

--- a/modules/protobuf/21.7/presubmit.yml
+++ b/modules/protobuf/21.7/presubmit.yml
@@ -15,7 +15,7 @@ tasks:
 bcr_test_module:
   module_path: "examples"
   matrix:
-    platform: ["centos7", "debian10", "macos", "ubuntu2004"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004"]
   tasks:
     run_test_module:
       name: "Run test module"

--- a/modules/protobuf/3.19.0/presubmit.yml
+++ b/modules/protobuf/3.19.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:
@@ -14,7 +14,7 @@ tasks:
 bcr_test_module:
   module_path: "examples"
   matrix:
-    platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_test_module:
       name: "Run test module"

--- a/modules/protobuf/3.19.2/presubmit.yml
+++ b/modules/protobuf/3.19.2/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:
@@ -14,7 +14,7 @@ tasks:
 bcr_test_module:
   module_path: "examples"
   matrix:
-    platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_test_module:
       name: "Run test module"

--- a/modules/protobuf/3.19.6/presubmit.yml
+++ b/modules/protobuf/3.19.6/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:
@@ -14,7 +14,7 @@ tasks:
 bcr_test_module:
   module_path: "examples"
   matrix:
-    platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_test_module:
       name: "Run test module"

--- a/modules/pybind11_bazel/2.11.1.bzl.1/presubmit.yml
+++ b/modules/pybind11_bazel/2.11.1.bzl.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/pybind11_bazel/2.11.1.bzl.2/presubmit.yml
+++ b/modules/pybind11_bazel/2.11.1.bzl.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/pybind11_bazel/2.11.1.bzl.3/presubmit.yml
+++ b/modules/pybind11_bazel/2.11.1.bzl.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/pybind11_bazel/2.11.1/presubmit.yml
+++ b/modules/pybind11_bazel/2.11.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/pybind11_bazel/2.12.0/presubmit.yml
+++ b/modules/pybind11_bazel/2.12.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rapidjson/1.1.0.bcr.20241007/presubmit.yml
+++ b/modules/rapidjson/1.1.0.bcr.20241007/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -19,7 +19,7 @@ bcr_test_module:
 
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rapidjson/1.1.0/presubmit.yml
+++ b/modules/rapidjson/1.1.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/re2/2021-09-01/presubmit.yml
+++ b/modules/re2/2021-09-01/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@re2//...'
     test_targets:

--- a/modules/re2/2023-06-02/presubmit.yml
+++ b/modules/re2/2023-06-02/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/re2/2023-08-01/presubmit.yml
+++ b/modules/re2/2023-08-01/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/re2/2023-09-01/presubmit.yml
+++ b/modules/re2/2023-09-01/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -18,7 +18,7 @@ bcr_test_module:
 
   matrix:
     platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/re2/2023-11-01/presubmit.yml
+++ b/modules/re2/2023-11-01/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -18,7 +18,7 @@ bcr_test_module:
 
   matrix:
     platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/re2/2024-02-01/presubmit.yml
+++ b/modules/re2/2024-02-01/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -22,7 +22,7 @@ bcr_test_module:
 
   matrix:
     platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/re2/2024-03-01/presubmit.yml
+++ b/modules/re2/2024-03-01/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -23,7 +23,7 @@ bcr_test_module:
 
   matrix:
     platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/re2/2024-04-01/presubmit.yml
+++ b/modules/re2/2024-04-01/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -23,7 +23,7 @@ bcr_test_module:
 
   matrix:
     platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/re2/2024-05-01/presubmit.yml
+++ b/modules/re2/2024-05-01/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -23,7 +23,7 @@ bcr_test_module:
 
   matrix:
     platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/re2/2024-06-01/presubmit.yml
+++ b/modules/re2/2024-06-01/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -23,7 +23,7 @@ bcr_test_module:
 
   matrix:
     platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/re2/2024-07-01/presubmit.yml
+++ b/modules/re2/2024-07-01/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -23,7 +23,7 @@ bcr_test_module:
 
   matrix:
     platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/re2/2024-07-02.bcr.1/presubmit.yml
+++ b/modules/re2/2024-07-02.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -24,7 +24,7 @@ bcr_test_module:
 
   matrix:
     platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/re2/2024-07-02/presubmit.yml
+++ b/modules/re2/2024-07-02/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7_java11_devtoolset10
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -23,7 +23,7 @@ bcr_test_module:
 
   matrix:
     platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/roaring/4.2.1/presubmit.yml
+++ b/modules/roaring/4.2.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/robin-map/1.2.1/presubmit.yml
+++ b/modules/robin-map/1.2.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_android/0.1.1/presubmit.yml
+++ b/modules/rules_android/0.1.1/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@rules_android//...'
   debian10:

--- a/modules/rules_bison/0.2.2/presubmit.yml
+++ b/modules/rules_bison/0.2.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_bison/0.3.1/presubmit.yml
+++ b/modules/rules_bison/0.3.1/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: ["7.x"]
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_bison/0.3.2/presubmit.yml
+++ b/modules/rules_bison/0.3.2/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: ["7.x"]
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_bison/0.3/presubmit.yml
+++ b/modules/rules_bison/0.3/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: ["7.x"]
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_bison/0.4/presubmit.yml
+++ b/modules/rules_bison/0.4/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: ["7.x"]
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_bzip2/1.0.0-beta.1/presubmit.yml
+++ b/modules/rules_bzip2/1.0.0-beta.1/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_bzip2/1.0.0-beta.2/presubmit.yml
+++ b/modules/rules_bzip2/1.0.0-beta.2/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_bzip2/1.0.0-beta.3/presubmit.yml
+++ b/modules/rules_bzip2/1.0.0-beta.3/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_bzip2/1.0.0-beta.5/presubmit.yml
+++ b/modules/rules_bzip2/1.0.0-beta.5/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_bzip2/1.0.0-beta.6/presubmit.yml
+++ b/modules/rules_bzip2/1.0.0-beta.6/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc4
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_bzip2/1.0.0/presubmit.yml
+++ b/modules/rules_bzip2/1.0.0/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_cc/0.0.1/presubmit.yml
+++ b/modules/rules_cc/0.0.1/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@rules_cc//cc/...'
     - '@rules_cc//tools/runfiles'

--- a/modules/rules_cc/0.0.10/presubmit.yml
+++ b/modules/rules_cc/0.0.10/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
 tasks:

--- a/modules/rules_cc/0.0.11/presubmit.yml
+++ b/modules/rules_cc/0.0.11/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
 tasks:

--- a/modules/rules_cc/0.0.12/presubmit.yml
+++ b/modules/rules_cc/0.0.12/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
 tasks:

--- a/modules/rules_cc/0.0.13/presubmit.yml
+++ b/modules/rules_cc/0.0.13/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
 tasks:

--- a/modules/rules_cc/0.0.14/presubmit.yml
+++ b/modules/rules_cc/0.0.14/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
 tasks:

--- a/modules/rules_cc/0.0.15/presubmit.yml
+++ b/modules/rules_cc/0.0.15/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
 tasks:

--- a/modules/rules_cc/0.0.16/presubmit.yml
+++ b/modules/rules_cc/0.0.16/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
 tasks:

--- a/modules/rules_cc/0.0.17/presubmit.yml
+++ b/modules/rules_cc/0.0.17/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
 tasks:

--- a/modules/rules_cc/0.0.2/presubmit.yml
+++ b/modules/rules_cc/0.0.2/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_targets:
     name: "Verify build targets"

--- a/modules/rules_cc/0.0.4/presubmit.yml
+++ b/modules/rules_cc/0.0.4/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_targets:
     name: "Verify build targets"

--- a/modules/rules_cc/0.0.5/presubmit.yml
+++ b/modules/rules_cc/0.0.5/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_targets:
     name: "Verify build targets"

--- a/modules/rules_cc/0.0.6/presubmit.yml
+++ b/modules/rules_cc/0.0.6/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_targets:
     name: "Verify build targets"

--- a/modules/rules_cc/0.0.8/presubmit.yml
+++ b/modules/rules_cc/0.0.8/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_targets:
     name: "Verify build targets"

--- a/modules/rules_cc/0.0.9/presubmit.yml
+++ b/modules/rules_cc/0.0.9/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_targets:
     name: "Verify build targets"

--- a/modules/rules_cc/0.1.0/presubmit.yml
+++ b/modules/rules_cc/0.1.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
 tasks:

--- a/modules/rules_cc/0.1.1/presubmit.yml
+++ b/modules/rules_cc/0.1.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
   - 8.x

--- a/modules/rules_cc_hdrs_map/0.1.0/presubmit.yml
+++ b/modules/rules_cc_hdrs_map/0.1.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: examples
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     bazel:

--- a/modules/rules_codeowners/0.2.1/presubmit.yml
+++ b/modules/rules_codeowners/0.2.1/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
 - '@rules_codeowners//tests:github_codeowners'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_coreutils/1.0.0-alpha.8/presubmit.yml
+++ b/modules/rules_coreutils/1.0.0-alpha.8/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_coreutils/1.0.0-beta.1/presubmit.yml
+++ b/modules/rules_coreutils/1.0.0-beta.1/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_coreutils/1.0.0-beta.3/presubmit.yml
+++ b/modules/rules_coreutils/1.0.0-beta.3/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_coreutils/1.0.0-beta.4/presubmit.yml
+++ b/modules/rules_coreutils/1.0.0-beta.4/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_coreutils/1.0.0-beta.6/presubmit.yml
+++ b/modules/rules_coreutils/1.0.0-beta.6/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_coreutils/1.0.0-beta.7/presubmit.yml
+++ b/modules/rules_coreutils/1.0.0-beta.7/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_coreutils/1.0.0-beta.8/presubmit.yml
+++ b/modules/rules_coreutils/1.0.0-beta.8/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_coreutils/1.0.1/presubmit.yml
+++ b/modules/rules_coreutils/1.0.1/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_cue/0.10.0/presubmit.yml
+++ b/modules/rules_cue/0.10.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.11.0/presubmit.yml
+++ b/modules/rules_cue/0.11.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.12.0/presubmit.yml
+++ b/modules/rules_cue/0.12.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.2.0/presubmit.yml
+++ b/modules/rules_cue/0.2.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.2.1/presubmit.yml
+++ b/modules/rules_cue/0.2.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.2.2/presubmit.yml
+++ b/modules/rules_cue/0.2.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.3.0/presubmit.yml
+++ b/modules/rules_cue/0.3.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.4.0/presubmit.yml
+++ b/modules/rules_cue/0.4.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.4.1/presubmit.yml
+++ b/modules/rules_cue/0.4.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.4.2/presubmit.yml
+++ b/modules/rules_cue/0.4.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.5.0/presubmit.yml
+++ b/modules/rules_cue/0.5.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.7.0/presubmit.yml
+++ b/modules/rules_cue/0.7.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.8.1/presubmit.yml
+++ b/modules/rules_cue/0.8.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.8.2/presubmit.yml
+++ b/modules/rules_cue/0.8.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.8.3/presubmit.yml
+++ b/modules/rules_cue/0.8.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_cue/0.9.0/presubmit.yml
+++ b/modules/rules_cue/0.9.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_curl/1.0.0-alpha.13/presubmit.yml
+++ b/modules/rules_curl/1.0.0-alpha.13/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc4
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_curl/1.0.0-alpha.7/presubmit.yml
+++ b/modules/rules_curl/1.0.0-alpha.7/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_curl/1.0.0-alpha.8/presubmit.yml
+++ b/modules/rules_curl/1.0.0-alpha.8/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_diff/1.0.0-beta.2/presubmit.yml
+++ b/modules/rules_diff/1.0.0-beta.2/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_diff/1.0.0-beta.3/presubmit.yml
+++ b/modules/rules_diff/1.0.0-beta.3/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_diff/1.0.0-beta.4/presubmit.yml
+++ b/modules/rules_diff/1.0.0-beta.4/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_diff/1.0.0-beta.5/presubmit.yml
+++ b/modules/rules_diff/1.0.0-beta.5/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_diff/1.0.0-beta.6/presubmit.yml
+++ b/modules/rules_diff/1.0.0-beta.6/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc4
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_diff/1.0.0/presubmit.yml
+++ b/modules/rules_diff/1.0.0/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_flex/0.2.1/presubmit.yml
+++ b/modules/rules_flex/0.2.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_flex/0.3.1/presubmit.yml
+++ b/modules/rules_flex/0.3.1/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: ["6.x", "7.x"]
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_flex/0.3.2/presubmit.yml
+++ b/modules/rules_flex/0.3.2/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: ["6.x", "7.x"]
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_flex/0.3/presubmit.yml
+++ b/modules/rules_flex/0.3/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: ["6.x", "7.x"]
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_flex/0.4/presubmit.yml
+++ b/modules/rules_flex/0.4/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: ["6.x", "7.x"]
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_foreign_cc/0.10.1/presubmit.yml
+++ b/modules/rules_foreign_cc/0.10.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/rules_foreign_cc/0.11.1/presubmit.yml
+++ b/modules/rules_foreign_cc/0.11.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ["6.x", "7.x"]
 
 tasks:

--- a/modules/rules_foreign_cc/0.12.0/presubmit.yml
+++ b/modules/rules_foreign_cc/0.12.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ["6.x", "7.x"]
 
 tasks:

--- a/modules/rules_foreign_cc/0.13.0/presubmit.yml
+++ b/modules/rules_foreign_cc/0.13.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ["6.x", "7.x"]
 
 tasks:

--- a/modules/rules_foreign_cc/0.14.0/presubmit.yml
+++ b/modules/rules_foreign_cc/0.14.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ["7.x"]
 
 tasks:

--- a/modules/rules_foreign_cc/0.8.0/presubmit.yml
+++ b/modules/rules_foreign_cc/0.8.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/rules_foreign_cc/0.9.0/presubmit.yml
+++ b/modules/rules_foreign_cc/0.9.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   verify_targets:

--- a/modules/rules_go/0.33.0/presubmit.yml
+++ b/modules/rules_go/0.33.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_go/0.34.0/presubmit.yml
+++ b/modules/rules_go/0.34.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_go/0.35.0/presubmit.yml
+++ b/modules/rules_go/0.35.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_go/0.36.0/presubmit.yml
+++ b/modules/rules_go/0.36.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_go/0.37.0/presubmit.yml
+++ b/modules/rules_go/0.37.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_go/0.38.0/presubmit.yml
+++ b/modules/rules_go/0.38.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_go/0.38.1/presubmit.yml
+++ b/modules/rules_go/0.38.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_go/0.39.0/presubmit.yml
+++ b/modules/rules_go/0.39.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_go/0.39.1/presubmit.yml
+++ b/modules/rules_go/0.39.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_go/0.40.0/presubmit.yml
+++ b/modules/rules_go/0.40.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_go/0.40.1/presubmit.yml
+++ b/modules/rules_go/0.40.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_go/0.41.0/presubmit.yml
+++ b/modules/rules_go/0.41.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_go/0.42.0/presubmit.yml
+++ b/modules/rules_go/0.42.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos
@@ -16,7 +16,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_gzip/1.0.0-beta.1/presubmit.yml
+++ b/modules/rules_gzip/1.0.0-beta.1/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_gzip/1.0.0-beta.2/presubmit.yml
+++ b/modules/rules_gzip/1.0.0-beta.2/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_gzip/1.0.0-beta.3/presubmit.yml
+++ b/modules/rules_gzip/1.0.0-beta.3/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_gzip/1.0.0-beta.5/presubmit.yml
+++ b/modules/rules_gzip/1.0.0-beta.5/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_gzip/1.0.0-beta.6/presubmit.yml
+++ b/modules/rules_gzip/1.0.0-beta.6/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc4
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_gzip/1.0.0/presubmit.yml
+++ b/modules/rules_gzip/1.0.0/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_java/4.0.0/presubmit.yml
+++ b/modules/rules_java/4.0.0/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@rules_java//...'
   debian10:

--- a/modules/rules_java/5.0.0/presubmit.yml
+++ b/modules/rules_java/5.0.0/presubmit.yml
@@ -1,6 +1,6 @@
 ---
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@rules_java//examples/...'
   debian10:

--- a/modules/rules_java/5.1.0/presubmit.yml
+++ b/modules/rules_java/5.1.0/presubmit.yml
@@ -1,6 +1,6 @@
 ---
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@rules_java//examples/...'
   debian10:

--- a/modules/rules_java/5.3.5/presubmit.yml
+++ b/modules/rules_java/5.3.5/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/5.4.0/presubmit.yml
+++ b/modules/rules_java/5.4.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/5.4.1/presubmit.yml
+++ b/modules/rules_java/5.4.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/5.5.0/presubmit.yml
+++ b/modules/rules_java/5.5.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/5.5.1/presubmit.yml
+++ b/modules/rules_java/5.5.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.0.0/presubmit.yml
+++ b/modules/rules_java/6.0.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.1.0/presubmit.yml
+++ b/modules/rules_java/6.1.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.1.1/presubmit.yml
+++ b/modules/rules_java/6.1.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.2.2/presubmit.yml
+++ b/modules/rules_java/6.2.2/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.3.0/presubmit.yml
+++ b/modules/rules_java/6.3.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.3.1/presubmit.yml
+++ b/modules/rules_java/6.3.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.3.2/presubmit.yml
+++ b/modules/rules_java/6.3.2/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.3.3/presubmit.yml
+++ b/modules/rules_java/6.3.3/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.4.0/presubmit.yml
+++ b/modules/rules_java/6.4.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.5.0/presubmit.yml
+++ b/modules/rules_java/6.5.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.5.1/presubmit.yml
+++ b/modules/rules_java/6.5.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/6.5.2/presubmit.yml
+++ b/modules/rules_java/6.5.2/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/7.0.0/presubmit.yml
+++ b/modules/rules_java/7.0.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/7.0.6/presubmit.yml
+++ b/modules/rules_java/7.0.6/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/7.1.0/presubmit.yml
+++ b/modules/rules_java/7.1.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/7.10.0/presubmit.yml
+++ b/modules/rules_java/7.10.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.11.0/presubmit.yml
+++ b/modules/rules_java/7.11.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.11.1/presubmit.yml
+++ b/modules/rules_java/7.11.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.12.0/presubmit.yml
+++ b/modules/rules_java/7.12.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.12.1/presubmit.yml
+++ b/modules/rules_java/7.12.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.12.2/presubmit.yml
+++ b/modules/rules_java/7.12.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.12.3/presubmit.yml
+++ b/modules/rules_java/7.12.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.12.4/presubmit.yml
+++ b/modules/rules_java/7.12.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.12.5/presubmit.yml
+++ b/modules/rules_java/7.12.5/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.2.0/presubmit.yml
+++ b/modules/rules_java/7.2.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/7.3.0/presubmit.yml
+++ b/modules/rules_java/7.3.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/7.3.1/presubmit.yml
+++ b/modules/rules_java/7.3.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/7.3.2/presubmit.yml
+++ b/modules/rules_java/7.3.2/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_java/7.4.0/presubmit.yml
+++ b/modules/rules_java/7.4.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.5.0/presubmit.yml
+++ b/modules/rules_java/7.5.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.6.0/presubmit.yml
+++ b/modules/rules_java/7.6.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.6.1/presubmit.yml
+++ b/modules/rules_java/7.6.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.6.2/presubmit.yml
+++ b/modules/rules_java/7.6.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.6.3/presubmit.yml
+++ b/modules/rules_java/7.6.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.6.4/presubmit.yml
+++ b/modules/rules_java/7.6.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.6.5/presubmit.yml
+++ b/modules/rules_java/7.6.5/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.7.0/presubmit.yml
+++ b/modules/rules_java/7.7.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.7.2/presubmit.yml
+++ b/modules/rules_java/7.7.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.8.0/presubmit.yml
+++ b/modules/rules_java/7.8.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.9.0/presubmit.yml
+++ b/modules/rules_java/7.9.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/7.9.1/presubmit.yml
+++ b/modules/rules_java/7.9.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.0.0-rc1/presubmit.yml
+++ b/modules/rules_java/8.0.0-rc1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.0.0-rc2/presubmit.yml
+++ b/modules/rules_java/8.0.0-rc2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.0.0/presubmit.yml
+++ b/modules/rules_java/8.0.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.0.1/presubmit.yml
+++ b/modules/rules_java/8.0.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.1.0/presubmit.yml
+++ b/modules/rules_java/8.1.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.10.0/presubmit.yml
+++ b/modules/rules_java/8.10.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.11.0/presubmit.yml
+++ b/modules/rules_java/8.11.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.2.0/presubmit.yml
+++ b/modules/rules_java/8.2.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.3.0/presubmit.yml
+++ b/modules/rules_java/8.3.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.3.1/presubmit.yml
+++ b/modules/rules_java/8.3.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.3.2/presubmit.yml
+++ b/modules/rules_java/8.3.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.4.0/presubmit.yml
+++ b/modules/rules_java/8.4.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.5.0-rc1/presubmit.yml
+++ b/modules/rules_java/8.5.0-rc1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.5.0-rc2/presubmit.yml
+++ b/modules/rules_java/8.5.0-rc2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.5.0/presubmit.yml
+++ b/modules/rules_java/8.5.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.5.1/presubmit.yml
+++ b/modules/rules_java/8.5.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.6.0/presubmit.yml
+++ b/modules/rules_java/8.6.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.6.1/presubmit.yml
+++ b/modules/rules_java/8.6.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.6.2/presubmit.yml
+++ b/modules/rules_java/8.6.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.6.3/presubmit.yml
+++ b/modules/rules_java/8.6.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.7.0/presubmit.yml
+++ b/modules/rules_java/8.7.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.7.1/presubmit.yml
+++ b/modules/rules_java/8.7.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.7.2/presubmit.yml
+++ b/modules/rules_java/8.7.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.8.0/presubmit.yml
+++ b/modules/rules_java/8.8.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_java/8.9.0/presubmit.yml
+++ b/modules/rules_java/8.9.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_jni/0.10.1/presubmit.yml
+++ b/modules/rules_jni/0.10.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   bazel: [6.x, 7.x]
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   build_targets:
@@ -14,7 +14,7 @@ bcr_test_module:
   module_path: "tests"
   matrix:
     bazel: [6.x, 7.x]
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_tests:
       name: "Run test module"
@@ -22,13 +22,4 @@ bcr_test_module:
       platform: ${{ platform }}
       test_targets:
         - "//..."
-    # The CentOS image does not set JAVA_HOME. To make the tests work, we set it
-    # manually.
-    run_tests_centos7:
-      name: "Run test module"
-      bazel: ${{ bazel }}
-      platform: centos7
-      environment:
-        JAVA_HOME: /usr/lib/jvm/zulu21
-      test_targets:
-        - "//..."
+

--- a/modules/rules_jni/0.10.3/presubmit.yml
+++ b/modules/rules_jni/0.10.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   bazel: [6.x, 7.x, 8.0.0rc4]
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   build_targets:
@@ -14,7 +14,7 @@ bcr_test_module:
   module_path: "tests"
   matrix:
     bazel: [6.x, 7.x, 8.0.0rc4]
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_tests:
       name: "Run test module"
@@ -22,13 +22,4 @@ bcr_test_module:
       platform: ${{ platform }}
       test_targets:
         - "//..."
-    # The CentOS image does not set JAVA_HOME. To make the tests work, we set it
-    # manually.
-    run_tests_centos7:
-      name: "Run test module"
-      bazel: ${{ bazel }}
-      platform: centos7
-      environment:
-        JAVA_HOME: /usr/lib/jvm/zulu21
-      test_targets:
-        - "//..."
+

--- a/modules/rules_jni/0.11.0/presubmit.yml
+++ b/modules/rules_jni/0.11.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   bazel: [7.x, 8.x]
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   build_targets:
@@ -14,21 +14,11 @@ bcr_test_module:
   module_path: "tests"
   matrix:
     bazel: [7.x, 8.x]
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_tests:
       name: "Run test module"
       bazel: ${{ bazel }}
       platform: ${{ platform }}
-      test_targets:
-        - "//..."
-    # The CentOS image does not set JAVA_HOME. To make the tests work, we set it
-    # manually.
-    run_tests_centos7:
-      name: "Run test module"
-      bazel: ${{ bazel }}
-      platform: centos7
-      environment:
-        JAVA_HOME: /usr/lib/jvm/zulu21
       test_targets:
         - "//..."

--- a/modules/rules_jni/0.3.1/presubmit.yml
+++ b/modules/rules_jni/0.3.1/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@rules_jni//jni/...'
   debian10:

--- a/modules/rules_jni/0.4.0/presubmit.yml
+++ b/modules/rules_jni/0.4.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   build_targets:
@@ -11,19 +11,10 @@ tasks:
 bcr_test_module:
   module_path: "tests"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
-      test_targets:
-      - "//..."
-    # The CentOS image does not set JAVA_HOME. To make the tests work, we set it
-    # manually.
-    run_tests_centos7:
-      name: "Run test module"
-      platform: centos7
-      environment:
-        JAVA_HOME: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.302.b08-0.el7_9.x86_64
       test_targets:
       - "//..."

--- a/modules/rules_jni/0.6.0/presubmit.yml
+++ b/modules/rules_jni/0.6.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   build_targets:
@@ -11,19 +11,10 @@ tasks:
 bcr_test_module:
   module_path: "tests"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
-      test_targets:
-        - "//..."
-    # The CentOS image does not set JAVA_HOME. To make the tests work, we set it
-    # manually.
-    run_tests_centos7:
-      name: "Run test module"
-      platform: centos7
-      environment:
-        JAVA_HOME: /usr/lib/jvm/java-1.8.0
       test_targets:
         - "//..."

--- a/modules/rules_jni/0.6.1/presubmit.yml
+++ b/modules/rules_jni/0.6.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   build_targets:
@@ -11,19 +11,10 @@ tasks:
 bcr_test_module:
   module_path: "tests"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
-      test_targets:
-        - "//..."
-    # The CentOS image does not set JAVA_HOME. To make the tests work, we set it
-    # manually.
-    run_tests_centos7:
-      name: "Run test module"
-      platform: centos7
-      environment:
-        JAVA_HOME: /usr/lib/jvm/java-1.8.0
       test_targets:
         - "//..."

--- a/modules/rules_jni/0.7.0/presubmit.yml
+++ b/modules/rules_jni/0.7.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   build_targets:
@@ -11,19 +11,11 @@ tasks:
 bcr_test_module:
   module_path: "tests"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
       test_targets:
         - "//..."
-    # The CentOS image does not set JAVA_HOME. To make the tests work, we set it
-    # manually.
-    run_tests_centos7:
-      name: "Run test module"
-      platform: centos7
-      environment:
-        JAVA_HOME: /usr/lib/jvm/java-1.8.0
-      test_targets:
-        - "//..."
+

--- a/modules/rules_jni/0.8.0/presubmit.yml
+++ b/modules/rules_jni/0.8.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   build_targets:
@@ -11,19 +11,11 @@ tasks:
 bcr_test_module:
   module_path: "tests"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
       test_targets:
         - "//..."
-    # The CentOS image does not set JAVA_HOME. To make the tests work, we set it
-    # manually.
-    run_tests_centos7:
-      name: "Run test module"
-      platform: centos7
-      environment:
-        JAVA_HOME: /usr/lib/jvm/java-1.8.0
-      test_targets:
-        - "//..."
+

--- a/modules/rules_jni/0.9.1/presubmit.yml
+++ b/modules/rules_jni/0.9.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   build_targets:
@@ -11,19 +11,11 @@ tasks:
 bcr_test_module:
   module_path: "tests"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
       test_targets:
         - "//..."
-    # The CentOS image does not set JAVA_HOME. To make the tests work, we set it
-    # manually.
-    run_tests_centos7:
-      name: "Run test module"
-      platform: centos7
-      environment:
-        JAVA_HOME: /usr/lib/jvm/java-1.8.0
-      test_targets:
-        - "//..."
+

--- a/modules/rules_jsonnet/0.5.0/presubmit.yml
+++ b/modules/rules_jsonnet/0.5.0/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: examples
   matrix:
-    platform: ["centos7", "debian10", "macos", "ubuntu2004"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004"]
     bazel: ["7.x"]
   tasks:
     run_tests:

--- a/modules/rules_jsonnet/0.6.0/presubmit.yml
+++ b/modules/rules_jsonnet/0.6.0/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: examples
   matrix:
-    platform: ["centos7", "debian10", "macos", "ubuntu2004"]
+    platform: ["rockylinux8", "debian10", "macos", "ubuntu2004"]
     bazel: ["7.x"]
   tasks:
     run_tests:

--- a/modules/rules_jvm_external/4.4.2/presubmit.yml
+++ b/modules/rules_jvm_external/4.4.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -16,7 +16,7 @@ bcr_test_module:
   module_path: examples/bzlmod
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_jvm_external/4.5/presubmit.yml
+++ b/modules/rules_jvm_external/4.5/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -16,7 +16,7 @@ bcr_test_module:
   module_path: examples/bzlmod
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_jvm_external/5.1/presubmit.yml
+++ b/modules/rules_jvm_external/5.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -16,7 +16,7 @@ bcr_test_module:
   module_path: examples/bzlmod
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_jvm_external/5.2/presubmit.yml
+++ b/modules/rules_jvm_external/5.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -16,7 +16,7 @@ bcr_test_module:
   module_path: examples/bzlmod
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_kustomize/0.2.0/presubmit.yml
+++ b/modules/rules_kustomize/0.2.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.2.1/presubmit.yml
+++ b/modules/rules_kustomize/0.2.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.2.2/presubmit.yml
+++ b/modules/rules_kustomize/0.2.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.3.0/presubmit.yml
+++ b/modules/rules_kustomize/0.3.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.3.1/presubmit.yml
+++ b/modules/rules_kustomize/0.3.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.3.10/presubmit.yml
+++ b/modules/rules_kustomize/0.3.10/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.3.2/presubmit.yml
+++ b/modules/rules_kustomize/0.3.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.3.3/presubmit.yml
+++ b/modules/rules_kustomize/0.3.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.3.4/presubmit.yml
+++ b/modules/rules_kustomize/0.3.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.3.5/presubmit.yml
+++ b/modules/rules_kustomize/0.3.5/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.3.6/presubmit.yml
+++ b/modules/rules_kustomize/0.3.6/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.3.8/presubmit.yml
+++ b/modules/rules_kustomize/0.3.8/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.3.9/presubmit.yml
+++ b/modules/rules_kustomize/0.3.9/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_kustomize/0.4.0/presubmit.yml
+++ b/modules/rules_kustomize/0.4.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix: &matrix
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - ubuntu2004

--- a/modules/rules_license/0.0.2/presubmit.yml
+++ b/modules/rules_license/0.0.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_license/0.0.3/presubmit.yml
+++ b/modules/rules_license/0.0.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_license/0.0.4/presubmit.yml
+++ b/modules/rules_license/0.0.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_license/0.0.6/presubmit.yml
+++ b/modules/rules_license/0.0.6/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_license/0.0.7/presubmit.yml
+++ b/modules/rules_license/0.0.7/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_license/0.0.8/presubmit.yml
+++ b/modules/rules_license/0.0.8/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_m4/0.2.3/presubmit.yml
+++ b/modules/rules_m4/0.2.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_m4/0.2.4/presubmit.yml
+++ b/modules/rules_m4/0.2.4/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: ["6.x", "7.x"]
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_m4/0.2.5/presubmit.yml
+++ b/modules/rules_m4/0.2.5/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: ["6.x", "7.x"]
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_m4/0.3/presubmit.yml
+++ b/modules/rules_m4/0.3/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel: ["6.x", "7.x"]
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_nodejs/4.5.0/presubmit.yml
+++ b/modules/rules_nodejs/4.5.0/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
 - '@rules_nodejs//nodejs/...'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_nodejs/4.5.1/presubmit.yml
+++ b/modules/rules_nodejs/4.5.1/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
 - '@rules_nodejs//nodejs/...'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_nodejs/5.5.0/presubmit.yml
+++ b/modules/rules_nodejs/5.5.0/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
 - '@rules_nodejs//nodejs/...'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_nodejs/5.5.3/presubmit.yml
+++ b/modules/rules_nodejs/5.5.3/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
 - '@rules_nodejs//nodejs/...'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_nodejs/5.8.0/presubmit.yml
+++ b/modules/rules_nodejs/5.8.0/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
 - '@rules_nodejs//nodejs/...'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_nodejs/5.8.2/presubmit.yml
+++ b/modules/rules_nodejs/5.8.2/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
 - '@rules_nodejs//nodejs/...'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_nodejs/5.8.3/presubmit.yml
+++ b/modules/rules_nodejs/5.8.3/presubmit.yml
@@ -2,7 +2,7 @@ build_targets: &build_targets
 - '@rules_nodejs//nodejs/...'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_pkg/0.10.0/presubmit.yml
+++ b/modules/rules_pkg/0.10.0/presubmit.yml
@@ -5,7 +5,7 @@ build_targets: &build_targets
 - '-@rules_pkg//pkg:make_rpm'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_pkg/0.10.1/presubmit.yml
+++ b/modules/rules_pkg/0.10.1/presubmit.yml
@@ -5,7 +5,7 @@ build_targets: &build_targets
 - '-@rules_pkg//pkg:make_rpm'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_pkg/0.5.1/presubmit.yml
+++ b/modules/rules_pkg/0.5.1/presubmit.yml
@@ -4,7 +4,7 @@ build_targets: &build_targets
 - '-@rules_pkg//toolchains/...'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_pkg/0.7.0/presubmit.yml
+++ b/modules/rules_pkg/0.7.0/presubmit.yml
@@ -5,7 +5,7 @@ build_targets: &build_targets
 - '-@rules_pkg//pkg:make_rpm'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_pkg/0.8.1/presubmit.yml
+++ b/modules/rules_pkg/0.8.1/presubmit.yml
@@ -5,7 +5,7 @@ build_targets: &build_targets
 - '-@rules_pkg//pkg:make_rpm'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_pkg/0.9.0/presubmit.yml
+++ b/modules/rules_pkg/0.9.0/presubmit.yml
@@ -5,7 +5,7 @@ build_targets: &build_targets
 - '-@rules_pkg//pkg:make_rpm'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_pkg/0.9.1/presubmit.yml
+++ b/modules/rules_pkg/0.9.1/presubmit.yml
@@ -5,7 +5,7 @@ build_targets: &build_targets
 - '-@rules_pkg//pkg:make_rpm'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_poetry/0.1.0/presubmit.yml
+++ b/modules/rules_poetry/0.1.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_poetry/0.2.0/presubmit.yml
+++ b/modules/rules_poetry/0.2.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_poetry/0.3.0/presubmit.yml
+++ b/modules/rules_poetry/0.3.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_poetry/0.3.1/presubmit.yml
+++ b/modules/rules_poetry/0.3.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_poetry/0.3.2/presubmit.yml
+++ b/modules/rules_poetry/0.3.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_poetry/0.3.3/presubmit.yml
+++ b/modules/rules_poetry/0.3.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_poetry/0.3.4/presubmit.yml
+++ b/modules/rules_poetry/0.3.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_poetry/0.3.5/presubmit.yml
+++ b/modules/rules_poetry/0.3.5/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_poetry/0.3.6/presubmit.yml
+++ b/modules/rules_poetry/0.3.6/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_proto/4.0.0/presubmit.yml
+++ b/modules/rules_proto/4.0.0/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@rules_proto//proto/...'
     - '@rules_proto//tools/...'

--- a/modules/rules_proto/5.3.0-21.7/presubmit.yml
+++ b/modules/rules_proto/5.3.0-21.7/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_proto/6.0.0-rc1/presubmit.yml
+++ b/modules/rules_proto/6.0.0-rc1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 tasks:
   verify_build_targets:
     name: "Verify build targets"

--- a/modules/rules_proto/6.0.0-rc2/presubmit.yml
+++ b/modules/rules_proto/6.0.0-rc2/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ["6.x", "7.x"]
 tasks:
   verify_build_targets:

--- a/modules/rules_proto/6.0.0-rc3/presubmit.yml
+++ b/modules/rules_proto/6.0.0-rc3/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ['7.x', '6.x']
 tasks:
   verify_build_targets:

--- a/modules/rules_proto/6.0.0.bcr.1/presubmit.yml
+++ b/modules/rules_proto/6.0.0.bcr.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ['7.x', '6.x']
 tasks:
   verify_build_targets:

--- a/modules/rules_proto/6.0.0/presubmit.yml
+++ b/modules/rules_proto/6.0.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ['7.x', '6.x']
 tasks:
   verify_build_targets:

--- a/modules/rules_proto/6.0.2/presubmit.yml
+++ b/modules/rules_proto/6.0.2/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ['7.x', '6.x']
 tasks:
   verify_build_targets:

--- a/modules/rules_proto/7.0.0/presubmit.yml
+++ b/modules/rules_proto/7.0.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ['7.x', '6.x']
 tasks:
   verify_build_targets:

--- a/modules/rules_proto/7.0.1/presubmit.yml
+++ b/modules/rules_proto/7.0.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ['7.x', '6.x']
 tasks:
   verify_build_targets:

--- a/modules/rules_proto/7.0.2/presubmit.yml
+++ b/modules/rules_proto/7.0.2/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ['7.x', '6.x']
 tasks:
   verify_build_targets:

--- a/modules/rules_proto/7.1.0/presubmit.yml
+++ b/modules/rules_proto/7.1.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ['7.x', '8.x']
 tasks:
   verify_build_targets:

--- a/modules/rules_proto_grpc_buf/5.0.0-alpha2/presubmit.yml
+++ b/modules/rules_proto_grpc_buf/5.0.0-alpha2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_proto_grpc_c/5.0.0-alpha2/presubmit.yml
+++ b/modules/rules_proto_grpc_c/5.0.0-alpha2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_proto_grpc_cpp/5.0.0-alpha2/presubmit.yml
+++ b/modules/rules_proto_grpc_cpp/5.0.0-alpha2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_proto_grpc_doc/5.0.0-alpha2/presubmit.yml
+++ b/modules/rules_proto_grpc_doc/5.0.0-alpha2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_proto_grpc_go/5.0.0-alpha2/presubmit.yml
+++ b/modules/rules_proto_grpc_go/5.0.0-alpha2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_proto_grpc_grpc_gateway/5.0.0-alpha2/presubmit.yml
+++ b/modules/rules_proto_grpc_grpc_gateway/5.0.0-alpha2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_proto_grpc_objc/5.0.0-alpha2/presubmit.yml
+++ b/modules/rules_proto_grpc_objc/5.0.0-alpha2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_proto_grpc_python/5.0.0-alpha2/presubmit.yml
+++ b/modules/rules_proto_grpc_python/5.0.0-alpha2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_python/0.4.0/presubmit.yml
+++ b/modules/rules_python/0.4.0/presubmit.yml
@@ -5,7 +5,7 @@ build_targets: &build_targets
 - '@rules_python//python:requirements'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/rules_sh/0.2.0/patches/add_module_extension.patch
+++ b/modules/rules_sh/0.2.0/patches/add_module_extension.patch
@@ -5,7 +5,7 @@ index 0000000..8b8cbda
 +++ b/.bazelci/presubmit.yml
 @@ -0,0 +1,16 @@
 +platforms:
-+  centos7:
++  rockylinux8:
 +    build_targets:
 +    - '@rules_sh//...'
 +  debian10:

--- a/modules/rules_sh/0.2.0/patches/add_module_extension.patch
+++ b/modules/rules_sh/0.2.0/patches/add_module_extension.patch
@@ -5,7 +5,7 @@ index 0000000..8b8cbda
 +++ b/.bazelci/presubmit.yml
 @@ -0,0 +1,16 @@
 +platforms:
-+  rockylinux8:
++  centos7:
 +    build_targets:
 +    - '@rules_sh//...'
 +  debian10:

--- a/modules/rules_sh/0.2.0/presubmit.yml
+++ b/modules/rules_sh/0.2.0/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@rules_sh//...'
   debian10:

--- a/modules/rules_sh/0.3.0/presubmit.yml
+++ b/modules/rules_sh/0.3.0/presubmit.yml
@@ -1,7 +1,7 @@
 bazel: 6.x
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@rules_sh//...'
     - '-@rules_sh//tests/...'

--- a/modules/rules_shell/0.1.1/presubmit.yml
+++ b/modules/rules_shell/0.1.1/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_shell/0.1.2/presubmit.yml
+++ b/modules/rules_shell/0.1.2/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_shell/0.2.0/presubmit.yml
+++ b/modules/rules_shell/0.2.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_shell/0.3.0/presubmit.yml
+++ b/modules/rules_shell/0.3.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_shell/0.4.0/presubmit.yml
+++ b/modules/rules_shell/0.4.0/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_shell/0.4.1/presubmit.yml
+++ b/modules/rules_shell/0.4.1/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: tests/bcr
   matrix:
     platform:
-      - centos7
+      - rockylinux8
       - debian10
       - ubuntu2004
       - macos

--- a/modules/rules_shtk/1.7.0/presubmit.yml
+++ b/modules/rules_shtk/1.7.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos
@@ -15,7 +15,7 @@ bcr_test_module:
   module_path: examples/binary
   matrix:
     platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_squashfs/1.0.0-alpha.1/presubmit.yml
+++ b/modules/rules_squashfs/1.0.0-alpha.1/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian11
       - ubuntu2004
       - ubuntu2004_arm64

--- a/modules/rules_squashfs/1.0.0-alpha.2/presubmit.yml
+++ b/modules/rules_squashfs/1.0.0-alpha.2/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian11
       - ubuntu2004
       - ubuntu2004_arm64

--- a/modules/rules_squashfs/1.0.0-alpha.4/presubmit.yml
+++ b/modules/rules_squashfs/1.0.0-alpha.4/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc4
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_tar/1.0.0-beta.1/presubmit.yml
+++ b/modules/rules_tar/1.0.0-beta.1/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_tar/1.0.0-beta.2/presubmit.yml
+++ b/modules/rules_tar/1.0.0-beta.2/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_tar/1.0.0-beta.3/presubmit.yml
+++ b/modules/rules_tar/1.0.0-beta.3/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_tar/1.0.0-beta.4/presubmit.yml
+++ b/modules/rules_tar/1.0.0-beta.4/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_tar/1.0.0-beta.5/presubmit.yml
+++ b/modules/rules_tar/1.0.0-beta.5/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc4
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_tar/1.0.0/presubmit.yml
+++ b/modules/rules_tar/1.0.0/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_tar/1.0.1/presubmit.yml
+++ b/modules/rules_tar/1.0.1/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_testing/0.0.1/presubmit.yml
+++ b/modules/rules_testing/0.0.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/rules_xz/1.0.0-beta.1/presubmit.yml
+++ b/modules/rules_xz/1.0.0-beta.1/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_xz/1.0.0-beta.2/presubmit.yml
+++ b/modules/rules_xz/1.0.0-beta.2/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_xz/1.0.0-beta.3/presubmit.yml
+++ b/modules/rules_xz/1.0.0-beta.3/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_xz/1.0.0-beta.5/presubmit.yml
+++ b/modules/rules_xz/1.0.0-beta.5/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_xz/1.0.0-beta.6/presubmit.yml
+++ b/modules/rules_xz/1.0.0-beta.6/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc4
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_xz/1.0.0/presubmit.yml
+++ b/modules/rules_xz/1.0.0/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_xz/1.0.1/presubmit.yml
+++ b/modules/rules_xz/1.0.1/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_zstd/1.0.0-beta.1/presubmit.yml
+++ b/modules/rules_zstd/1.0.0-beta.1/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_zstd/1.0.0-beta.2/presubmit.yml
+++ b/modules/rules_zstd/1.0.0-beta.2/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_zstd/1.0.0-beta.3/presubmit.yml
+++ b/modules/rules_zstd/1.0.0-beta.3/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_zstd/1.0.0-beta.4/presubmit.yml
+++ b/modules/rules_zstd/1.0.0-beta.4/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_zstd/1.0.0-beta.6/presubmit.yml
+++ b/modules/rules_zstd/1.0.0-beta.6/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_zstd/1.0.0-beta.7/presubmit.yml
+++ b/modules/rules_zstd/1.0.0-beta.7/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc4
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/rules_zstd/1.0.0/presubmit.yml
+++ b/modules/rules_zstd/1.0.0/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/spdlog/1.10.0/presubmit.yml
+++ b/modules/spdlog/1.10.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/spdlog/1.11.0/presubmit.yml
+++ b/modules/spdlog/1.11.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/sqlite3/3.42.0.bcr.1/presubmit.yml
+++ b/modules/sqlite3/3.42.0.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/sqlite3/3.42.0/presubmit.yml
+++ b/modules/sqlite3/3.42.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/sqlite3/3.46.1/presubmit.yml
+++ b/modules/sqlite3/3.46.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/sqlite3/3.47.0/presubmit.yml
+++ b/modules/sqlite3/3.47.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/sqlite3/3.47.1/presubmit.yml
+++ b/modules/sqlite3/3.47.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/sqlite3/3.47.2/presubmit.yml
+++ b/modules/sqlite3/3.47.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/sqlite3/3.48.0/presubmit.yml
+++ b/modules/sqlite3/3.48.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/sqlite3/3.49.0.bcr.1/presubmit.yml
+++ b/modules/sqlite3/3.49.0.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/sqlite3/3.49.0/presubmit.yml
+++ b/modules/sqlite3/3.49.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/sqlite3/3.49.1/presubmit.yml
+++ b/modules/sqlite3/3.49.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/squashfs-tools/4.6.1/presubmit.yml
+++ b/modules/squashfs-tools/4.6.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7_java11_devtoolset10
+    - rockylinux8
     - debian11
     - ubuntu2004_arm64
     - ubuntu2204

--- a/modules/stardoc/0.5.0/presubmit.yml
+++ b/modules/stardoc/0.5.0/presubmit.yml
@@ -4,7 +4,7 @@ build_targets: &build_targets
 - '-@stardoc//stardoc:stardoc_doc'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/stardoc/0.5.1/presubmit.yml
+++ b/modules/stardoc/0.5.1/presubmit.yml
@@ -4,7 +4,7 @@ build_targets: &build_targets
 - '-@stardoc//stardoc:stardoc_doc'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/stardoc/0.5.3/presubmit.yml
+++ b/modules/stardoc/0.5.3/presubmit.yml
@@ -4,7 +4,7 @@ build_targets: &build_targets
 - '-@stardoc//stardoc:stardoc_doc'
 
 platforms:
-  centos7:
+  rockylinux8:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets

--- a/modules/stardoc/0.5.4/presubmit.yml
+++ b/modules/stardoc/0.5.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/stardoc/0.5.6/presubmit.yml
+++ b/modules/stardoc/0.5.6/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/toolchain_utils/1.0.0-beta.10/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.10/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.11/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.11/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.12/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.12/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.13/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.13/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.14/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.14/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.16/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.16/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc1
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.17/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.17/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.18/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.18/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.0.0rc2
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.2/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.2/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.3/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.3/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.4/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.4/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.6/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.6/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.0-beta.9/presubmit.yml
+++ b/modules/toolchain_utils/1.0.0-beta.9/presubmit.yml
@@ -4,7 +4,7 @@ bcr_test_module:
     bazel:
       - 7.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.0.2/presubmit.yml
+++ b/modules/toolchain_utils/1.0.2/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/toolchain_utils/1.2.0/presubmit.yml
+++ b/modules/toolchain_utils/1.2.0/presubmit.yml
@@ -5,7 +5,7 @@ bcr_test_module:
       - 7.x
       - 8.x
     platform:
-      - centos7_java11_devtoolset10
+      - rockylinux8
       - debian10
       - debian11
       - ubuntu2004

--- a/modules/tree-sitter-bazel/0.22.5/presubmit.yml
+++ b/modules/tree-sitter-bazel/0.22.5/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - macos_arm64

--- a/modules/tree-sitter-bazel/0.22.6/presubmit.yml
+++ b/modules/tree-sitter-bazel/0.22.6/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - macos_arm64

--- a/modules/tree-sitter-bazel/0.23.2/presubmit.yml
+++ b/modules/tree-sitter-bazel/0.23.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - macos_arm64

--- a/modules/tree-sitter-bazel/0.24.2/presubmit.yml
+++ b/modules/tree-sitter-bazel/0.24.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - macos_arm64

--- a/modules/tree-sitter-bazel/0.24.3/presubmit.yml
+++ b/modules/tree-sitter-bazel/0.24.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - macos_arm64

--- a/modules/tree-sitter-bazel/0.24.4/presubmit.yml
+++ b/modules/tree-sitter-bazel/0.24.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - macos_arm64

--- a/modules/tree-sitter-c-bazel/0.20.7/presubmit.yml
+++ b/modules/tree-sitter-c-bazel/0.20.7/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - macos_arm64

--- a/modules/tree-sitter-c-bazel/0.23.4/presubmit.yml
+++ b/modules/tree-sitter-c-bazel/0.23.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - macos
   - macos_arm64

--- a/modules/universal-robots-client-library/1.4.0.bcr.1/presubmit.yml
+++ b/modules/universal-robots-client-library/1.4.0.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   bazel:

--- a/modules/universal-robots-client-library/1.4.0/presubmit.yml
+++ b/modules/universal-robots-client-library/1.4.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   bazel:

--- a/modules/universal-robots-client-library/1.5.0.bcr.1/presubmit.yml
+++ b/modules/universal-robots-client-library/1.5.0.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   bazel:

--- a/modules/universal-robots-client-library/1.5.0/presubmit.yml
+++ b/modules/universal-robots-client-library/1.5.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   bazel:

--- a/modules/upb/0.0.0-20211020-160625a/presubmit.yml
+++ b/modules/upb/0.0.0-20211020-160625a/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@upb//:upb'
     - '@upb//:descriptor_upb_proto'

--- a/modules/zlib/1.2.11/presubmit.yml
+++ b/modules/zlib/1.2.11/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/zlib/1.2.12/presubmit.yml
+++ b/modules/zlib/1.2.12/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/zlib/1.2.13.bcr.1/presubmit.yml
+++ b/modules/zlib/1.2.13.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/zlib/1.2.13/presubmit.yml
+++ b/modules/zlib/1.2.13/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/zlib/1.3.1/presubmit.yml
+++ b/modules/zlib/1.3.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/zlib/1.3/presubmit.yml
+++ b/modules/zlib/1.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/zopfli/1.0.3.bcr.1/presubmit.yml
+++ b/modules/zopfli/1.0.3.bcr.1/presubmit.yml
@@ -4,7 +4,7 @@ matrix:
   - 7.x
   - rolling
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/zopfli/1.0.3/presubmit.yml
+++ b/modules/zopfli/1.0.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/zstd-jni/1.5.0-4/presubmit.yml
+++ b/modules/zstd-jni/1.5.0-4/presubmit.yml
@@ -1,5 +1,5 @@
 platforms:
-  centos7:
+  rockylinux8:
     build_targets:
     - '@zstd-jni//...'
   debian10:

--- a/modules/zstd-jni/1.5.2-3.bcr.1/presubmit.yml
+++ b/modules/zstd-jni/1.5.2-3.bcr.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/zstd-jni/1.5.2-3/presubmit.yml
+++ b/modules/zstd-jni/1.5.2-3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos

--- a/modules/zstd-jni/1.5.6-9/presubmit.yml
+++ b/modules/zstd-jni/1.5.6-9/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-  - centos7
+  - rockylinux8
   - debian10
   - ubuntu2004
   - macos


### PR DESCRIPTION
Bazel CI is migrating all CentOS 7 jobs to Rocky Linux 8 since the former has been EOL for almost a year now and will be removed from CI soon.

Part of https://github.com/bazelbuild/continuous-integration/issues/2272