### PR TITLE
Read upstream registry data from GCS mirror

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -77,6 +77,8 @@ COLOR = {
     BcrValidationResult.FAILED: RED,
 }
 
+UPSTREAM_MODULES_DIR_URL = "https://storage.googleapis.com/bcr.bazel.build/modules"
+
 # TODO(fweikert): switch to a stable release that contains https://github.com/slsa-framework/slsa-verifier/pull/840
 DEFAULT_SLSA_VERIFIER_VERSION = "v2.7.1-rc.1"
 
@@ -922,7 +924,7 @@ def main(argv=None):
             print(f"{name}@{version}")
 
     # TODO: Read org etc from flags to support forks.
-    upstream = UpstreamRegistry()
+    upstream = UpstreamRegistry(modules_dir_url=UPSTREAM_MODULES_DIR_URL)
 
     # Validate given module version.
     validator = BcrValidator(registry, upstream, args.fix)

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -77,7 +77,7 @@ COLOR = {
     BcrValidationResult.FAILED: RED,
 }
 
-UPSTREAM_MODULES_DIR_URL = "https://storage.googleapis.com/bcr.bazel.build/modules"
+UPSTREAM_MODULES_DIR_URL = "https://bcr.bazel.build/modules"
 
 # TODO(fweikert): switch to a stable release that contains https://github.com/slsa-framework/slsa-verifier/pull/840
 DEFAULT_SLSA_VERIFIER_VERSION = "v2.7.1-rc.1"

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -923,7 +923,7 @@ def main(argv=None):
         for name, version in module_versions:
             print(f"{name}@{version}")
 
-    # TODO: Read org etc from flags to support forks.
+    # TODO: Read url from flags to support forks.
     upstream = UpstreamRegistry(modules_dir_url=UPSTREAM_MODULES_DIR_URL)
 
     # Validate given module version.

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -547,8 +547,8 @@ def _download_if_exists(url):
 
 
 class UpstreamRegistry:
-    def __init__(self, org="bazelbuild", repo="bazel-central-registry", branch="main"):
-        self._root_url = f"https://raw.githubusercontent.com/{org}/{repo}/refs/heads/{branch}/modules"
+    def __init__(self, modules_dir_url):
+        self._root_url = modules_dir_url
 
     def get_latest_module_version(self, module_name):
         metadata_url = posixpath.join(self._root_url, module_name, "metadata.json")


### PR DESCRIPTION
GitHub has started to throttle unauthenticated traffic, which has caused the attestation presubmit check to fail: https://buildkite.com/bazel/bcr-presubmit/builds/14065#0196d96c-b03d-472d-9b36-2083763d1db0/257