### PR TITLE
Add sdformat v15.3.0

### DIFF
--- a/modules/sdformat/15.3.0/MODULE.bazel
+++ b/modules/sdformat/15.3.0/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 )
 bazel_dep(name = "buildifier_prebuilt", version = "6.1.2")
 bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "rules_python", version = "0.40.0")
 bazel_dep(name = "rules_license", version = "0.0.8")
 bazel_dep(name = "tinyxml2", version = "10.0.0")
 bazel_dep(name = "rules_gazebo", version = "0.0.2")

--- a/modules/sdformat/15.3.0/MODULE.bazel
+++ b/modules/sdformat/15.3.0/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "sdformat",
+    version = "15.3.0",
+    compatibility_level = 0,
+)
+bazel_dep(name = "buildifier_prebuilt", version = "6.1.2")
+bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "rules_license", version = "0.0.8")
+bazel_dep(name = "tinyxml2", version = "10.0.0")
+bazel_dep(name = "rules_gazebo", version = "0.0.2")
+bazel_dep(name = "gz-utils", version = "3.1.0")
+bazel_dep(name = "gz-math", version = "8.1.1")

--- a/modules/sdformat/15.3.0/patches/fix_clang_build.patch
+++ b/modules/sdformat/15.3.0/patches/fix_clang_build.patch
@@ -1,0 +1,64 @@
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -1,6 +1,7 @@
+ load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
+ load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header")
+ load("@rules_license//rules:license.bzl", "license")
++load("@rules_python//python:py_binary.bzl", "py_binary")
+ 
+ package(
+     default_applicable_licenses = [":license"],
+@@ -101,7 +102,7 @@ cc_library(
+             # Bazel does not generate top-level includes, so exclude the redirect
+             "include/sdf/sdf.hh",
+         ],
+-    ),
++    ) + ["include/sdf/config.hh"],
+     data = [
+         "sdf",
+     ],
+@@ -116,7 +117,6 @@ cc_library(
+     ],
+     visibility = ["//visibility:public"],
+     deps = [
+-        ":Config",
+         ":Export",
+         ":urdf_parser",
+         "@gz-math",
+@@ -147,12 +147,20 @@ test_sources = glob(
+     cc_test(
+         name = src.replace("/", "_").replace(".cc", "").replace("src_", ""),
+         srcs = [src],
++        copts = [
++            # Some tests are for private headers
++            "-Wno-private-header",
++        ],
+         deps = [
+             ":sdformat",
+             "//test:test_utils",
+             "@googletest//:gtest",
+             "@googletest//:gtest_main",
++            "@gz-math",
++            "@gz-utils//:Environment",
+             "@gz-utils//:ExtraTestMacros",
++            "@gz-utils//:SuppressWarning",
++            "@tinyxml2",
+         ],
+     )
+     for src in test_sources
+@@ -161,6 +169,7 @@ test_sources = glob(
+ cc_test(
+     name = "Converter_TEST",
+     srcs = [
++        "include/sdf/config.hh",
+         "src/Converter.hh",
+         "src/Converter_TEST.cc",
+         "src/XmlUtils.hh",
+@@ -177,6 +186,7 @@ cc_test(
+         "//test:test_utils",
+         "@googletest//:gtest",
+         "@googletest//:gtest_main",
++        "@tinyxml2",
+     ],
+ )
+ 

--- a/modules/sdformat/15.3.0/patches/module_dot_bazel.patch
+++ b/modules/sdformat/15.3.0/patches/module_dot_bazel.patch
@@ -1,6 +1,6 @@
 --- MODULE.bazel
 +++ MODULE.bazel
-@@ -1,27 +1,12 @@
+@@ -1,27 +1,13 @@
 -## MODULE.bazel
  module(
      name = "sdformat",
@@ -11,6 +11,7 @@
 -
  bazel_dep(name = "buildifier_prebuilt", version = "6.1.2")
  bazel_dep(name = "googletest", version = "1.14.0")
++bazel_dep(name = "rules_python", version = "0.40.0")
  bazel_dep(name = "rules_license", version = "0.0.8")
  bazel_dep(name = "tinyxml2", version = "10.0.0")
 -

--- a/modules/sdformat/15.3.0/patches/module_dot_bazel.patch
+++ b/modules/sdformat/15.3.0/patches/module_dot_bazel.patch
@@ -1,0 +1,34 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,27 +1,12 @@
+-## MODULE.bazel
+ module(
+     name = "sdformat",
+-    repo_name = "org_gazebosim_sdformat",
++    version = "15.3.0",
++    compatibility_level = 0,
+ )
+-
+ bazel_dep(name = "buildifier_prebuilt", version = "6.1.2")
+ bazel_dep(name = "googletest", version = "1.14.0")
+ bazel_dep(name = "rules_license", version = "0.0.8")
+ bazel_dep(name = "tinyxml2", version = "10.0.0")
+-
+-# Gazebo Dependencies
+ bazel_dep(name = "rules_gazebo", version = "0.0.2")
+-bazel_dep(name = "gz-utils")
+-bazel_dep(name = "gz-math")
+-
+-archive_override(
+-    module_name = "gz-utils",
+-    strip_prefix = "gz-utils-gz-utils3",
+-    urls = ["https://github.com/gazebosim/gz-utils/archive/refs/heads/gz-utils3.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-math",
+-    strip_prefix = "gz-math-gz-math8",
+-    urls = ["https://github.com/gazebosim/gz-math/archive/refs/heads/gz-math8.tar.gz"],
+-)
++bazel_dep(name = "gz-utils", version = "3.1.0")
++bazel_dep(name = "gz-math", version = "8.1.1")

--- a/modules/sdformat/15.3.0/presubmit.yml
+++ b/modules/sdformat/15.3.0/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@sdformat'
+    - '@sdformat//:urdf_parser'

--- a/modules/sdformat/15.3.0/source.json
+++ b/modules/sdformat/15.3.0/source.json
@@ -4,6 +4,7 @@
     "strip_prefix": "sdformat-sdformat15_15.3.0",
     "patch_strip": 0,
     "patches": {
-        "module_dot_bazel.patch": "sha256-62CFVd/eF/5g6JcYYYpb5D/yYHEKnqfHvHVtWqVe//4="
+        "fix_clang_build.patch": "sha256-biY/DjWB7Tt0FcM5kNaFpTadeqT1tvCrJ5RDFQGQgrc=",
+        "module_dot_bazel.patch": "sha256-4m7ytFybzAaLIL1XhlITXyqkJdj2SUpjEKGhhrg7Jsw="
     }
 }

--- a/modules/sdformat/15.3.0/source.json
+++ b/modules/sdformat/15.3.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat15_15.3.0.tar.gz",
+    "integrity": "sha256-sYfaeiGm4PXipF9rQCahpp/Tnj9Q3ibwKDE1laHBDP0=",
+    "strip_prefix": "sdformat-sdformat15_15.3.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-62CFVd/eF/5g6JcYYYpb5D/yYHEKnqfHvHVtWqVe//4="
+    }
+}

--- a/modules/sdformat/metadata.json
+++ b/modules/sdformat/metadata.json
@@ -18,7 +18,8 @@
         "github:gazebosim/sdformat"
     ],
     "versions": [
-        "15.1.1"
+        "15.1.1",
+        "15.3.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Also update presubmit.yml to drop bazel 6 and specify build verification targets explicitly.

Some bazel changes had to be patched in to pass presubmits, which will be part of the next upstream release in sdformat.