### PR TITLE
Update migration tool - Find direct deps and resolve them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 tools/__pycache__
 tools/node_modules
+tools/bzlmod_migration_test_examples/*/bazel-*
+tools/bzlmod_migration_test_examples/*/__pycache__
 /bazel-*
 MODULE.bazel.lock
 temp_test_repos

--- a/tools/bzlmod_migration_test_examples/simple_module_deps/.bazelrc
+++ b/tools/bzlmod_migration_test_examples/simple_module_deps/.bazelrc
@@ -1,0 +1,1 @@
+build --java_runtime_version=21

--- a/tools/bzlmod_migration_test_examples/simple_module_deps/BUILD
+++ b/tools/bzlmod_migration_test_examples/simple_module_deps/BUILD
@@ -1,0 +1,30 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
+load("@rules_java//java:defs.bzl", "java_library", "java_binary")
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+
+cc_library(
+    name = "cc_lib",
+    srcs = ["test.cc"],
+    visibility = ["//visibility:public"], 
+)
+
+cc_binary(
+    name = "cc_bin",
+    deps = [
+        ":cc_lib", 
+    ],
+)
+
+java_library(
+    name = "java_lib",
+    srcs = ["Test.java"],
+    visibility = ["//visibility:public"],
+)
+
+java_binary(
+    name = "java_bin",
+    main_class = "Test",
+    runtime_deps = [":java_lib"],
+)
+
+sh_library(name='sh_lib')

--- a/tools/bzlmod_migration_test_examples/simple_module_deps/Test.java
+++ b/tools/bzlmod_migration_test_examples/simple_module_deps/Test.java
@@ -1,0 +1,4 @@
+public class Test {
+    public static void main(String[] args) {
+    }
+}

--- a/tools/bzlmod_migration_test_examples/simple_module_deps/migration_test.py
+++ b/tools/bzlmod_migration_test_examples/simple_module_deps/migration_test.py
@@ -1,0 +1,84 @@
+import unittest
+import subprocess
+import os
+from unittest import main
+
+
+class BazelBuildTest(unittest.TestCase):
+    """
+    A test suite for verifying Bzlmod migration tool for simple module deps.
+    """
+
+    _CREATED_FILES = [
+        "MODULE.bazel",
+        "MODULE.bazel.lock",
+        "WORKSPACE.bzlmod",
+        "migration_info.md",
+        "query_direct_deps",
+        "resolved_deps.py",
+    ]
+
+    def _cleanup_created_files(self):
+        """
+        Remove files which were created by migration tool.
+        """
+        for file_name in self._CREATED_FILES:
+            file_path = os.path.join(os.getcwd(), file_name)
+            if os.path.exists(file_path):
+                os.remove(file_path)
+
+    def _run_command(self, command):
+        """
+        Helper function to run a command and return its result.
+        It captures `stdout`, `stderr` and `returncode` for debugging.
+        """
+        try:
+            result = subprocess.run(command, capture_output=True, text=True, check=True)
+            return result
+        except FileNotFoundError:
+            self.fail("Command not found.")
+        except subprocess.CalledProcessError as e:
+            self.fail(
+                f"Command failed with exit code {e.returncode}:\n"
+                f"STDOUT:\n{e.stdout}\n"
+                f"STDERR:\n{e.stderr}"
+            )
+
+    def _print_success(self):
+        GREEN = "\033[92m"
+        RESET = "\033[0m"
+        print(f"{GREEN}Success{RESET}")
+
+    def test_migration_of_module_deps(self):
+        self._cleanup_created_files()
+
+        # Verify bazel build is successful with enabled workspace
+        print("\n--- Running bazel build with enabled workspace ---")
+        result = self._run_command(
+            ["bazel", "build", "--enable_workspace", "--noenable_bzlmod", "//..."]
+        )
+        assert result.returncode == 0
+        self._print_success()
+
+        # Run migration script
+        print("\n--- Running migration script ---")
+        result = self._run_command(["../../migrate_to_bzlmod.py", "-t=/..."])
+        assert result.returncode == 0
+        assert os.path.exists(
+            "migration_info.md"
+        ), f"File 'migration_info.md' should be created during migration, but it doesn't exist."
+        self._print_success()
+
+        # Verify MODULE.bazel was created successfully
+        print("\n--- Running bazel build with enabled bzlmod ---")
+        result = self._run_command(
+            ["bazel", "build", "--noenable_workspace", "--enable_bzlmod", "//..."]
+        )
+        assert result.returncode == 0
+        self._print_success()
+
+        self._cleanup_created_files()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bzlmod_migration_test_examples/simple_module_deps/test.cc
+++ b/tools/bzlmod_migration_test_examples/simple_module_deps/test.cc
@@ -1,0 +1,5 @@
+#include <iostream>
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
This PR updates migration tool with:
1. Finds direct deps via bazel query (parsing with `@{repo_name}` and first `/external/{repo_name}/`),
2. Resolves those direct deps in the similar way as before,
3. Mixes new (this) version with old version. It first tries resolving direct deps added in this PR (new behaviour), and then tries resolving errors gathered from parsing potentially failed bazel build command (old behaviour),
4. Adds test environment for simple module_deps and tests it (more tests will be added shortly, e.g. for extensions). 