### PR TITLE
Load sh_test from rules_shell

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,6 +8,7 @@ bazel_dep(name = "aspect_rules_js", version = "2.3.3")
 bazel_dep(name = "buildozer", version = "8.0.3")
 bazel_dep(name = "rules_nodejs", version = "6.3.5")
 bazel_dep(name = "rules_python", version = "1.3.0")
+bazel_dep(name = "rules_shell", version = "0.4.1")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -2,6 +2,7 @@ load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@pip//:requirements.bzl", "requirement")
 load("@python_versions//3.11:defs.bzl", compile_pip_requirements_3_11 = "compile_pip_requirements")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 npm_link_all_packages(name = "node_modules")
 
@@ -106,6 +107,9 @@ py_binary(
 py_binary(
     name = "module_analyzer",
     srcs = ["module_analyzer.py"],
+    data = [
+        "@buildozer_binary//:buildozer.exe",
+    ],
     deps = [
         ":module_selector",
         requirement("networkx"),
@@ -113,9 +117,6 @@ py_binary(
         requirement("scipy"),
         requirement("bazel-runfiles"),
     ],
-    data = [
-        "@buildozer_binary//:buildozer.exe",
-    ]
 )
 
 genrule(


### PR DESCRIPTION
For modules we test with https://github.com/bazelbuild/bazel-central-registry/blob/bd6000574b1908998f503acbcb69111487a72b32/docs/README.md#L180 to prepare https://github.com/bazelbuild/bazel/issues/23043, hence we should also do this for this repo itself and load the starlark rules.