### PR TITLE
Use Ubuntu 22.04 in bazelci presubmit

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,7 +2,7 @@
 tasks:
   linux:
     name: ubuntu
-    platform: ubuntu2004
+    platform: ubuntu2204
     test_targets:
     # NB: we must avoid //... because some modules contain BUILD files in overlays folders
     # and those cannot be analyzed because their load() statements aren't functional here


### PR DESCRIPTION
Ubuntu 20.04 is EOL so we should use at least 22.04