### PR TITLE
Bump libzip to 1.11.4

### DIFF
--- a/modules/libzip/1.11.4/MODULE.bazel
+++ b/modules/libzip/1.11.4/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "libzip",
+    version = "1.11.4",
+)
+bazel_dep(name = "boringssl", version = "0.20250514.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_foreign_cc", version = "0.14.0")
+bazel_dep(name = "zstd", version = "1.5.7")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.6")

--- a/modules/libzip/1.11.4/patches/add-build-file.patch
+++ b/modules/libzip/1.11.4/patches/add-build-file.patch
@@ -1,0 +1,60 @@
+diff --git a/BUILD b/BUILD
+new file mode 100644
+index 00000000..991cb183
+--- a/BUILD
++++ b/BUILD
+@@ -0,0 +1,53 @@
++load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
++load("@rules_license//rules:license.bzl", "license")
++
++package(
++    default_applicable_licenses = [":license"],
++    default_visibility = ["//visibility:public"],
++)
++
++license(
++    name = "license",
++    package_name = "libzip",
++)
++
++filegroup(
++    name = "all_srcs",
++    srcs = glob(["**"]),
++)
++
++cmake(
++    name = "libzip",
++    build_args = [
++        "-j4",
++    ],
++    cache_entries = {
++        "BUILD_SHARED_LIBS": "OFF",
++        "BUILD_DOC": "OFF",
++        "BUILD_EXAMPLES": "OFF",
++        "BUILD_OSSFUZZ": "OFF",
++        "BUILD_REGRESS": "OFF",
++        "BUILD_TOOLS": "OFF",
++        "ENABLE_BZIP2": "OFF",
++        "ENABLE_COMMONCRYPTO": "OFF",
++        "ENABLE_GNUTLS": "OFF",
++        "ENABLE_LZMA": "OFF",
++        "ENABLE_MBEDTLS": "OFF",
++        "ENABLE_WINDOWS_CRYPTO": "OFF",
++    },
++    env = {
++        "CMAKE_BUILD_TYPE": "Release",
++        "CMAKE_BUILD_PARALLEL_LEVEL": "4",
++    },
++    includes = [
++      ".",
++      "lib",
++    ],
++    lib_source = ":all_srcs",
++    out_static_libs = ["libzip.a"],
++    deps = [
++      "@boringssl//:crypto",
++      "@zstd",
++      "@zlib",
++    ],
++)
+\ No newline at end of file

--- a/modules/libzip/1.11.4/patches/module_dot_bazel.patch
+++ b/modules/libzip/1.11.4/patches/module_dot_bazel.patch
@@ -1,0 +1,12 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -0,0 +1,9 @@
++module(
++    name = "libzip",
++    version = "1.11.4",
++)
++bazel_dep(name = "boringssl", version = "0.20250514.0")
++bazel_dep(name = "rules_license", version = "1.0.0")
++bazel_dep(name = "rules_foreign_cc", version = "0.14.0")
++bazel_dep(name = "zstd", version = "1.5.7")
++bazel_dep(name = "zlib", version = "1.3.1.bcr.6")

--- a/modules/libzip/1.11.4/presubmit.yml
+++ b/modules/libzip/1.11.4/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@libzip//:libzip'

--- a/modules/libzip/1.11.4/presubmit.yml
+++ b/modules/libzip/1.11.4/presubmit.yml
@@ -11,5 +11,8 @@ tasks:
     name: Verify build targets
     platform: ${{ platform }}
     bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
     build_targets:
     - '@libzip//:libzip'

--- a/modules/libzip/1.11.4/source.json
+++ b/modules/libzip/1.11.4/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/nih-at/libzip/releases/download/v1.11.4/libzip-1.11.4.tar.gz",
+    "integrity": "sha256-guny8kIfnXwkZrvDFzzQlZWojqN9sNVZqdCi3GDcci4=",
+    "strip_prefix": "libzip-1.11.4",
+    "patch_strip": 1,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-FxW4Z8Qez/LB+LGGAiadF6gIfrU2Cpcm+psbYRogD2g=",
+        "add-build-file.patch": "sha256-6A7P76GJufd3SVJHcaLqAyH3wxGL82U3DziOAhm1uzk="
+    }
+}

--- a/modules/libzip/metadata.json
+++ b/modules/libzip/metadata.json
@@ -10,7 +10,8 @@
         "github:nih-at/libzip"
     ],
     "versions": [
-        "1.10.1"
+        "1.10.1",
+        "1.11.4"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Also,
- Set cmake `ENABLE_LZMA` to off to fix linker errors
- Bump version for all dependencies in MODULE.bazel
- Add bazel 8.x coverage in presubmits
- Add MacOS coverage in presubmits