### PR TITLE
Publish toolchains_llvm_bootstrapped@0.1.9

### DIFF
--- a/modules/toolchains_llvm_bootstrapped/0.1.9/MODULE.bazel
+++ b/modules/toolchains_llvm_bootstrapped/0.1.9/MODULE.bazel
@@ -1,0 +1,191 @@
+module(
+    name = "toolchains_llvm_bootstrapped",
+    version = "0.1.9",
+    bazel_compatibility = [">=7.4.0"],
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "bazel_features", version = "1.24.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+
+RULES_CC_COMMIT = "bbc0814aa22f1748c60722ad8972d16812eb206d" # HEAD
+bazel_dep(name = "rules_cc", version = "0.1.1")
+archive_override(
+    module_name = "rules_cc",
+    urls = ["https://github.com/bazelbuild/rules_cc/archive/%s.tar.gz" % RULES_CC_COMMIT],
+    integrity = "sha256-f/9TYhNs+hvmZ3cH7RvDdZFFTOk2a6DBSZZRfdb50rk=",
+    strip_prefix = "rules_cc-%s" % RULES_CC_COMMIT,
+)
+
+bazel_dep(name = "with_cfg.bzl", version = "0.9.2")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")    
+
+LLVM_VERSION = "20.1.5"
+
+http_archive(
+    name = "llvm-toolchain-minimal-{llvm_version}-darwin-arm64".format(llvm_version = LLVM_VERSION),
+    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/llvm-{llvm_version}/llvm-toolchain-minimal-{llvm_version}-darwin-arm64.tar.zst".format(llvm_version = LLVM_VERSION)],
+    sha256 = "c2e10898943b5d56e1a3552e3fa806382299d2242e312a7dd2ef6af7395c6143",
+    build_file = "//toolchain/llvm:BUILD.llvm_release.tpl",
+)
+http_archive(
+    name = "static-extras-toolchain-artifacts-darwin-arm64",
+    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/bootstrap%2Fextras%2F20250505/toolchain-extra-prebuilts-20250505-darwin-arm64.tar.zst"],
+    sha256 = "5f21cff510da9a5fd6444f4239383c220246193bbc17d48ffe7d2583476d6a25",
+    build_file = "//bootstrap/extras:BUILD.extras.tpl",
+)
+
+http_archive(
+    name = "llvm-toolchain-minimal-{llvm_version}-linux-amd64".format(llvm_version = LLVM_VERSION),
+    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/llvm-{llvm_version}/llvm-toolchain-minimal-{llvm_version}-linux-amd64-musl.tar.zst".format(llvm_version = LLVM_VERSION)],
+    sha256 = "bbba8aad0a92812978b4f57469d4a778c6887a3d2ab9bd70064da5b2d4ee98fd",
+    build_file = "//toolchain/llvm:BUILD.llvm_release.tpl",
+)
+http_archive(
+    name = "static-extras-toolchain-artifacts-linux-amd64",
+    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/bootstrap%2Fextras%2F20250505/toolchain-extra-prebuilts-20250505-linux-amd64-musl.tar.zst"],
+    sha256 = "7296ab64eaea3276260d4db934d9986e6b8ec01effb89fb35cf87c02f93ea027",
+    build_file = "//bootstrap/extras:BUILD.extras.tpl",
+)
+
+http_archive(
+    name = "llvm-toolchain-minimal-{llvm_version}-linux-arm64".format(llvm_version = LLVM_VERSION),
+    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/llvm-{llvm_version}/llvm-toolchain-minimal-{llvm_version}-linux-arm64-musl.tar.zst".format(llvm_version = LLVM_VERSION)],
+    sha256 = "6b365b9bcbe780241ddd9aae5dbb00d82ee0b65fa25a5361e126b0df5eb91dd1",
+    build_file = "//toolchain/llvm:BUILD.llvm_release.tpl",
+)
+http_archive(
+    name = "static-extras-toolchain-artifacts-linux-arm64",
+    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/bootstrap%2Fextras%2F20250505/toolchain-extra-prebuilts-20250505-linux-arm64-musl.tar.zst"],
+    sha256 = "b886c1bc2c48a214b2a1076f14968f2e36fd9bfc926975f09515f287bbd9b734",
+    build_file = "//bootstrap/extras:BUILD.extras.tpl",
+)
+
+http_archive(
+    name = "musl_libc",
+    urls = ["https://musl.libc.org/releases/musl-1.2.5.tar.gz"],
+    strip_prefix = "musl-1.2.5",
+    integrity = "sha256-qaEYu+hNh2TaDqDSizqz+uhHf8fkCF2QECuFlvx8deQ=",
+    build_file = "//third_party/libc/musl:BUILD.tpl",
+)
+
+http_archive(
+    name = "compiler-rt",
+    urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.5/compiler-rt-20.1.5.src.tar.xz"],
+    strip_prefix = "compiler-rt-20.1.5.src",
+    sha256 = "bdcebca627f377ffcff5405cd5694efbddb14c89ad7d0ea481b1646a42bfeca3",
+    build_file = "//third_party/llvm-project/20.1.5/compiler-rt:BUILD.tpl",
+)
+
+http_archive(
+    name = "libcxx",
+    urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.5/libcxx-20.1.5.src.tar.xz"],
+    strip_prefix = "libcxx-20.1.5.src",
+    sha256 = "39ceddb7ee02103809e59b8a87904fc40a8e4f33ff5cce95e6da1fc22406349f",
+    build_file = "//third_party/llvm-project/20.1.5/libcxx:BUILD.tpl",
+)
+
+http_archive(
+    name = "libcxxabi",
+    urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.5/libcxxabi-20.1.5.src.tar.xz"],
+    strip_prefix = "libcxxabi-20.1.5.src",
+    sha256 = "cb9f20e6779a5ab7881b049469504a7da44aada6e9dc72c85dd68fc9c6430b57",
+    build_file = "//third_party/llvm-project/20.1.5/libcxxabi:BUILD.tpl",
+)
+
+http_archive(
+    name = "libunwind",
+    urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.5/libunwind-20.1.5.src.tar.xz"],
+    strip_prefix = "libunwind-20.1.5.src",
+    sha256 = "f0555603222189d8d2ff2d02747c63a3bbeb291fa72ce042c1a6d26399150baf",
+    build_file = "//third_party/llvm-project/20.1.5/libunwind:BUILD.tpl",
+)
+
+http_pkg_archive = use_repo_rule("//:http_pkg_archive.bzl", "http_pkg_archive")
+http_pkg_archive(
+    name = "macosx15.4.sdk",
+    urls = ["https://swcdn.apple.com/content/downloads/10/32/082-12052-A_AHPGDY76PT/1a419zaf3vh8o9t3c0usblyr8eystpnsh5/CLTools_macOSNMOS_SDK.pkg"],
+    strip_files = [
+        "Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/System/Library/Frameworks/Ruby.framework/Versions/Current/Headers/ruby",
+    ],
+    sha256 = "f8b0600aa4ad9b0b0b150fb62691dc561f47bc33ebc40546439f1460a0680913",
+    build_file = "//third_party/macosx.sdk:BUILD.MacOSX15.4.sdk.tpl",
+    strip_prefix = "Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk",
+)
+
+glibc = use_extension("//libc/glibc/extension:glibc.bzl", "glibc")
+# https://cerisier.github.io/glibc-headers/index.json
+glibc.index(file = "//libc/glibc/extension:glibc_headers_index.json")
+use_repo(glibc, "glibc")
+
+kernel_headers = use_extension("//kernel/extension:kernel_headers.bzl", "kernel_headers")
+# https://cerisier.github.io/kernel-headers/index.json
+kernel_headers.index(file = "//kernel/extension:kernel_headers_index.json")
+use_repo(kernel_headers, "kernel_headers")
+
+## DEV DEPENDENCIES
+
+GLIBC_STUBS_GENERATOR_COMMIT = "b8ef1c5f070b8297505a61d32ee9d6ca773d02b3"
+
+bazel_dep(name = "glibc-stubs-generator", version = "2.0.1", dev_dependency = True)
+archive_override(
+    module_name = "glibc-stubs-generator",
+    urls = ["https://github.com/cerisier/glibc-stubs-generator/archive/{}.tar.gz".format(GLIBC_STUBS_GENERATOR_COMMIT)],
+    integrity = "sha256-ZctTSdI8zXZrC0f78a7g9WNt8Xi+sIAnBZBNrIf5avk=",
+    strip_prefix = "glibc-stubs-generator-{}".format(GLIBC_STUBS_GENERATOR_COMMIT),
+)
+
+LIBSTDCXX_STUBS_GENERATOR_COMMIT = "0b271e429a4ab412de16946782257dbede9ca091"
+
+bazel_dep(name = "libstdcxx-stubs-generator", version = "0.0.1", dev_dependency = True)
+archive_override(
+    module_name = "libstdcxx-stubs-generator",
+    urls = ["https://github.com/cerisier/libstdcxx-stubs-generator/archive/{}.tar.gz".format(LIBSTDCXX_STUBS_GENERATOR_COMMIT)],
+    integrity = "sha256-LRoUyHeuA0qGZ7eFJ7iIGz15KiEYPx4Z+l+uY0GUDHw=",
+    strip_prefix = "libstdcxx-stubs-generator-{}".format(LIBSTDCXX_STUBS_GENERATOR_COMMIT),
+)
+
+bazel_dep(name = "rules_python", version = "0.40.0", dev_dependency = True)
+
+llvm_raw = use_extension("//:llvm_raw.bzl", "llvm_raw", dev_dependency = True)
+use_repo(llvm_raw, "llvm-raw", "llvm_zlib", "llvm_zstd")
+
+llvm = use_extension("//:llvm.bzl", "llvm", dev_dependency = True)
+llvm.configure(
+    targets = ["AArch64", "X86"],
+)
+use_repo(llvm, "llvm-project")
+
+# llvm_configure = use_repo_rule("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
+# llvm_configure(name = "llvm-project")
+
+## OVERRIDES PORTS FROM DEPENDENCIES 
+
+RULES_ZIG_COMMIT = "b9739c615ce62b64ee595ac4bcd9ee7cc06b0422" # branch=zml
+
+bazel_dep(name = "rules_zig", version = "20250314.0-b9739c6", dev_dependency = True)
+archive_override(
+    module_name = "rules_zig",
+    urls = ["https://github.com/zml/rules_zig/archive/{}.tar.gz".format(RULES_ZIG_COMMIT)],
+    integrity = "sha256-p1rYD9gvYS3DgBjN6jo1pB86Kr4k2wojKjVpYRTZ3Us=",
+    strip_prefix = "rules_zig-{}".format(RULES_ZIG_COMMIT),
+)
+
+zig = use_extension("@rules_zig//zig:extensions.bzl", "zig", dev_dependency = True)
+zig.index(file = "//:zig_index.json")
+zig.toolchain(zig_version = "0.14.0")
+zig.mirrors(urls = [
+    "https://mirror.zml.ai/zig",
+])
+use_repo(zig, "zig_toolchains")
+
+register_toolchains("@rules_zig//zig/target:all", dev_dependency = True)
+register_toolchains("@zig_toolchains//:all", dev_dependency = True)
+
+# Register the bootstrap toolchain since it is a prerequisite to all other toolchains.
+register_toolchains(
+    "@toolchains_llvm_bootstrapped//toolchain/stage2:stage2_toolchain",
+)

--- a/modules/toolchains_llvm_bootstrapped/0.1.9/attestations.json
+++ b/modules/toolchains_llvm_bootstrapped/0.1.9/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.1.9/source.json.intoto.jsonl",
+            "integrity": "sha256-7W5z37MYmaf6sNjYCkLTWhNpNjmObEqRVKMWgptVmwU="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.1.9/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-xfFbcErN99JT/EPrGfeZ4DPQg5VhPz3t0Q8FxiPjzJY="
+        },
+        "toolchains_llvm_bootstrapped-0.1.9.tar.gz": {
+            "url": "https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.1.9/toolchains_llvm_bootstrapped-0.1.9.tar.gz.intoto.jsonl",
+            "integrity": "sha256-qp5x2UGoaIdaeqfjtqqkanDeOv+ONNtNqAVqSlptiXU="
+        }
+    }
+}

--- a/modules/toolchains_llvm_bootstrapped/0.1.9/presubmit.yml
+++ b/modules/toolchains_llvm_bootstrapped/0.1.9/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: examples/rules_cc
+  matrix:
+    bazel: [7.x, 8.x]
+    platform: [debian11, ubuntu2004, macos_arm64]
+  tasks:
+    run_test_module:
+      name: Run test module
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      build_targets:
+        - //:all

--- a/modules/toolchains_llvm_bootstrapped/0.1.9/source.json
+++ b/modules/toolchains_llvm_bootstrapped/0.1.9/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-Zzi51LMK06E/HYGvG+gWxDWpHdw15R3k8nDDdoT7vRY=",
+    "strip_prefix": "toolchains_llvm_bootstrapped-0.1.9",
+    "url": "https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.1.9/toolchains_llvm_bootstrapped-0.1.9.tar.gz"
+}

--- a/modules/toolchains_llvm_bootstrapped/metadata.json
+++ b/modules/toolchains_llvm_bootstrapped/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/cerisier/toolchains_llvm_bootstrapped",
+    "maintainers": [
+        {
+            "name": "Corentin Kerisit",
+            "email": "corentin.kerisit@gmail.com",
+            "github": "cerisier",
+            "github_user_id": 1126594
+        }
+    ],
+    "repository": [
+        "github:cerisier/toolchains_llvm_bootstrapped"
+    ],
+    "versions": [
+        "0.1.9"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/tag/0.1.9

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_