### PR TITLE
Add liburing 2.10

### DIFF
--- a/modules/liburing/2.10/MODULE.bazel
+++ b/modules/liburing/2.10/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "liburing",
+    version = "2.10",
+    bazel_compatibility = [">=7.2.1"],  # need support for "overlay" directory
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/liburing/2.10/overlay/BUILD.bazel
+++ b/modules/liburing/2.10/overlay/BUILD.bazel
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This genrule facilitates the installed kernel headers to configure a
+# compatibility header file. While that effectively breaks hermeticity, there
+# is not much we can do about that. We can't really bring the kernel headers
+# into BCR as they correspond to the host kernel. The good news is that the
+# resulting library is portable due to the compatibility layer at compile
+# time.
+genrule(
+    name = "generate_headers",
+    srcs = [
+        "Makefile.common",
+        "liburing.spec",
+    ],
+    outs = [
+        "config-host.h",
+        "src/include/liburing/compat.h",
+        "src/include/liburing/io_uring_version.h",
+    ],
+    cmd = """
+            export CC=$(CC) CXX=$(CC)++
+
+            # switch to the package dir to execute "configure" right there
+            pushd $$(dirname $(location configure))
+              mkdir -p src/include/liburing
+              ./configure --use-libc
+            popd
+
+            # collect the outputs
+            for out in $(OUTS); do
+              cp $$(realpath --relative-to=$(BINDIR) $$out) $$out
+            done
+          """,
+    toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
+    tools = ["configure"],
+)
+
+cc_library(
+    name = "uring",
+    srcs = [
+        "config-host.h",
+        "src/include/liburing/compat.h",
+        "src/include/liburing/io_uring_version.h",
+        "src/queue.c",
+        "src/register.c",
+        "src/setup.c",
+        "src/syscall.c",
+        "src/version.c",
+    ] + glob([
+        "src/arch/**/*.h",
+        "src/*.h",
+    ]),
+    hdrs = glob(["src/include/**/*.h"]),
+
+    # cflags aligned with upstream:
+    # https://github.com/axboe/liburing/blob/master/src/Makefile#L13
+    copts = [
+        "-D_GNU_SOURCE",
+        "-D_LARGEFILE_SOURCE",
+        "-D_FILE_OFFSET_BITS=64",
+        "-DLIBURING_INTERNAL",
+        "-O3",
+        "-Wall",
+        "-Wextra",
+        "-fno-stack-protector",
+        "-include config-host.h",
+    ],
+    includes = ["src/include"],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "liburing",
+    actual = ":uring",
+    visibility = ["//visibility:public"],
+)

--- a/modules/liburing/2.10/overlay/MODULE.bazel
+++ b/modules/liburing/2.10/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/liburing/2.10/presubmit.yml
+++ b/modules/liburing/2.10/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - debian10
+  - fedora39
+  - ubuntu2004
+  - ubuntu2204
+  - ubuntu2404
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@liburing'

--- a/modules/liburing/2.10/source.json
+++ b/modules/liburing/2.10/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/axboe/liburing/archive/refs/tags/liburing-2.10.tar.gz",
+    "integrity": "sha256-Cmh2FqaIbNgrdGt5xOM9xAuNfAxuJND28/189BiGv1M=",
+    "strip_prefix": "liburing-liburing-2.10",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-I2zFirR92K5vnCt7/7d4c483py9Ib+sZH5gtLaZH84c=",
+        "MODULE.bazel": "sha256-/TmFks2zREKHCWXABOboLg7YX23CkNW3H9yK+DML5gw="
+    }
+}

--- a/modules/liburing/metadata.json
+++ b/modules/liburing/metadata.json
@@ -12,7 +12,8 @@
         "github:axboe/liburing"
     ],
     "versions": [
-        "2.5"
+        "2.5",
+        "2.10"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
BUILD.bazel is identical to liburing 2.5. Migrated to using overlay dir.