### PR TITLE
Add gifsicle@1.96 to BCR

### DIFF
--- a/modules/gifsicle/1.96/MODULE.bazel
+++ b/modules/gifsicle/1.96/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "gifsicle",
+    version = "1.96",
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_foreign_cc", version = "0.14.0")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/gifsicle/1.96/patches/add_build_file.patch
+++ b/modules/gifsicle/1.96/patches/add_build_file.patch
@@ -1,0 +1,39 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,36 @@
++load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make", "runnable_binary")
++load("@rules_license//rules:license.bzl", "license")
++
++package(
++    default_applicable_licenses = [":license"],
++    default_visibility = ["//visibility:public"],
++)
++
++exports_files(["COPYING"])
++
++license(
++    name = "license",
++    package_name = "gifsicle",
++    license_kinds = [
++        "@rules_license//licenses/spdx:GPL-2.0-or-later",
++    ],
++    license_text = "COPYING",
++    package_url = "http://www.lcdf.org/gifsicle/",
++)
++
++filegroup(
++    name = "all_srcs",
++    srcs = glob(["**"]),
++)
++
++configure_make(
++    name = "gifsicle_make",
++    lib_source = ":all_srcs",
++    out_binaries = ["gifsicle"],
++)
++
++runnable_binary(
++    name = "gifsicle",
++    binary = "gifsicle",
++    foreign_cc_target = ":gifsicle_make",
++)

--- a/modules/gifsicle/1.96/patches/module_dot_bazel.patch
+++ b/modules/gifsicle/1.96/patches/module_dot_bazel.patch
@@ -1,0 +1,11 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,8 @@
++module(
++    name = "gifsicle",
++    version = "1.96",
++)
++
++bazel_dep(name = "platforms", version = "1.0.0")
++bazel_dep(name = "rules_foreign_cc", version = "0.14.0")
++bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/gifsicle/1.96/presubmit.yml
+++ b/modules/gifsicle/1.96/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2204
+    - macos
+  bazel:
+    - 8.x
+    - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@gifsicle//:gifsicle"

--- a/modules/gifsicle/1.96/source.json
+++ b/modules/gifsicle/1.96/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://www.lcdf.org/gifsicle/gifsicle-1.96.tar.gz",
+    "integrity": "sha256-/SPSeWgabf48FSZOM/NEBFs7pHPaTRn0nmelCZSwd/s=",
+    "strip_prefix": "gifsicle-1.96",
+    "patches": {
+        "add_build_file.patch": "sha256-ApVpFpphtkleSINKWTRHd6+GPBZjZc9cMpQDJ6Ojbw0=",
+        "module_dot_bazel.patch": "sha256-HQpdczJK6KztvOfOYzEyMC8rbV97imL9EokBSPCwgtQ="
+    },
+    "patch_strip": 0
+}

--- a/modules/gifsicle/metadata.json
+++ b/modules/gifsicle/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://www.lcdf.org/gifsicle/",
+    "maintainers": [
+        {
+            "email": "sbarfurth@intrinsic.ai",
+            "github": "sbarfurth",
+            "github_user_id": 6641565,
+            "name": "Sebastian Barfurth"
+        }
+    ],
+    "repository": [
+        "https://www.lcdf.org/gifsicle/"
+    ],
+    "versions": [
+        "1.96"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
The following changes to the default setup were required:

* removed platform `windows` because the binary is not windows-compatible
* removed platform `macos_arm64` because of `ModuleNotFoundError` in Bazel 8 presubmit that seems unrelated to the module
* disable presubmit running on `6.x` since the dependency chain is incompatible