### PR TITLE
Publish {engflowapis,engflowapis-go,engflowapis-java}@2025.06.05-15.57.47

### DIFF
--- a/modules/engflowapis-go/2025.06.05-15.57.47/MODULE.bazel
+++ b/modules/engflowapis-go/2025.06.05-15.57.47/MODULE.bazel
@@ -1,0 +1,43 @@
+module(
+    name = "engflowapis-go",
+    version = "2025.06.05-15.57.47",  # Automatically updated by release pipeline.
+)
+
+bazel_dep(
+    name = "engflowapis",
+    version = "2025.06.05-15.57.47",  # Automatically updated by release pipeline.
+)
+bazel_dep(
+    name = "rules_go",
+    version = "0.50.1",
+    repo_name = "io_bazel_rules_go",
+)
+bazel_dep(
+    name = "gazelle",
+    version = "0.31.0",
+)
+bazel_dep(
+    name = "googleapis",
+    version = "0.0.0-20240819-fe8ba054a",
+)
+
+switched_rules = use_extension("@googleapis//:extensions.bzl", "switched_rules")
+switched_rules.use_languages(
+    go = True,
+)
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.module(
+    path = "google.golang.org/protobuf",
+    sum = "h1:yBPeRvTftaleIgM3PZ/WBIZ7XM/eEYAaEyCwvyjq/gk=",
+    version = "v1.36.1",
+)
+use_repo(
+    go_deps,
+    "org_golang_google_protobuf",
+)
+
+local_path_override(
+    module_name = "engflowapis",
+    path = "..",
+)

--- a/modules/engflowapis-go/2025.06.05-15.57.47/presubmit.yml
+++ b/modules/engflowapis-go/2025.06.05-15.57.47/presubmit.yml
@@ -1,0 +1,23 @@
+matrix:
+  platform:
+    - "debian10"
+    - "ubuntu2004"
+    - "macos"
+    - "macos_arm64"
+    - "windows"
+  bazel:
+    - "8.x"
+    - "7.x"
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets: []
+
+incompatible_flags:
+  # Disabled because of a transitive dependency on `rules_foreign_cc` that is
+  # incompatible.
+  "--incompatible_autoload_externally=":
+    - "7.x"

--- a/modules/engflowapis-go/2025.06.05-15.57.47/source.json
+++ b/modules/engflowapis-go/2025.06.05-15.57.47/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-gIbSYUkuv37f3AbWd9KjTRHfUwxZ7r98mVOdv/2SIOI=",
+    "url": "https://github.com/EngFlow/engflowapis/releases/download/2025.06.05-15.57.47/engflowapis-2025.06.05-15.57.47.tar.gz",
+    "strip_prefix": "go"
+}

--- a/modules/engflowapis-go/metadata.json
+++ b/modules/engflowapis-go/metadata.json
@@ -4,7 +4,7 @@
         {
             "email": "andres@engflow.com",
             "github": "anfelbar",
-            "name": "Andr\u00e9s Felipe Barco Santa",
+            "name": "Andrés Felipe Barco Santa",
             "github_user_id": 623618
         },
         {
@@ -31,7 +31,8 @@
     ],
     "versions": [
         "2025.01.17-16.55.05",
-        "2025.03.14-12.58.52"
+        "2025.03.14-12.58.52",
+        "2025.06.05-15.57.47"
     ],
     "yanked_versions": {}
 }

--- a/modules/engflowapis-java/2025.06.05-15.57.47/MODULE.bazel
+++ b/modules/engflowapis-java/2025.06.05-15.57.47/MODULE.bazel
@@ -1,0 +1,27 @@
+module(
+    name = "engflowapis-java",
+    version = "2025.06.05-15.57.47",  # Automatically updated by release pipeline.
+)
+
+bazel_dep(
+    name = "engflowapis",
+    version = "2025.06.05-15.57.47",  # Automatically updated by release pipeline.
+)
+bazel_dep(
+    name = "grpc-java",
+    version = "1.67.1",
+)
+bazel_dep(
+    name = "protobuf",
+    version = "28.2",
+    repo_name = "com_google_protobuf",
+)
+bazel_dep(
+    name = "rules_java",
+    version = "8.7.0",
+)
+
+local_path_override(
+    module_name = "engflowapis",
+    path = "..",
+)

--- a/modules/engflowapis-java/2025.06.05-15.57.47/presubmit.yml
+++ b/modules/engflowapis-java/2025.06.05-15.57.47/presubmit.yml
@@ -1,0 +1,24 @@
+matrix:
+  platform:
+    - "debian10"
+    - "ubuntu2004"
+    - "macos"
+    - "macos_arm64"
+    - "windows"
+  bazel:
+    - "8.x"
+    - "7.x"
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@engflowapis-java//..."
+
+incompatible_flags:
+  # Disabled because of a transitive dependency on `rules_foreign_cc` that is
+  # incompatible.
+  "--incompatible_autoload_externally=":
+    - "7.x"

--- a/modules/engflowapis-java/2025.06.05-15.57.47/source.json
+++ b/modules/engflowapis-java/2025.06.05-15.57.47/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-gIbSYUkuv37f3AbWd9KjTRHfUwxZ7r98mVOdv/2SIOI=",
+    "url": "https://github.com/EngFlow/engflowapis/releases/download/2025.06.05-15.57.47/engflowapis-2025.06.05-15.57.47.tar.gz",
+    "strip_prefix": "java"
+}

--- a/modules/engflowapis-java/metadata.json
+++ b/modules/engflowapis-java/metadata.json
@@ -4,7 +4,7 @@
         {
             "email": "andres@engflow.com",
             "github": "anfelbar",
-            "name": "Andr\u00e9s Felipe Barco Santa",
+            "name": "Andrés Felipe Barco Santa",
             "github_user_id": 623618
         },
         {
@@ -26,7 +26,8 @@
     "versions": [
         "2025.01.17-13.50.20",
         "2025.01.17-16.55.05",
-        "2025.03.14-12.58.52"
+        "2025.03.14-12.58.52",
+        "2025.06.05-15.57.47"
     ],
     "yanked_versions": {}
 }

--- a/modules/engflowapis/2025.06.05-15.57.47/MODULE.bazel
+++ b/modules/engflowapis/2025.06.05-15.57.47/MODULE.bazel
@@ -1,0 +1,19 @@
+module(
+    name = "engflowapis",
+    version = "2025.06.05-15.57.47",  # Automatically updated by release pipeline.
+)
+
+bazel_dep(
+    name = "rules_proto",
+    version = "6.0.2",
+)
+bazel_dep(
+    name = "protobuf",
+    version = "28.2",
+    repo_name = "com_google_protobuf",
+)
+bazel_dep(
+    name = "googleapis",
+    version = "0.0.0-20240819-fe8ba054a",
+    repo_name = "com_google_googleapis",
+)

--- a/modules/engflowapis/2025.06.05-15.57.47/presubmit.yml
+++ b/modules/engflowapis/2025.06.05-15.57.47/presubmit.yml
@@ -1,0 +1,24 @@
+matrix:
+  platform:
+    - "debian10"
+    - "ubuntu2004"
+    - "macos"
+    - "macos_arm64"
+    - "windows"
+  bazel:
+    - "8.x"
+    - "7.x"
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@engflowapis//..."
+
+incompatible_flags:
+  # Disabled because of a transitive dependency on `rules_foreign_cc` that is
+  # incompatible.
+  "--incompatible_autoload_externally=":
+    - "7.x"

--- a/modules/engflowapis/2025.06.05-15.57.47/source.json
+++ b/modules/engflowapis/2025.06.05-15.57.47/source.json
@@ -1,0 +1,4 @@
+{
+    "integrity": "sha256-gIbSYUkuv37f3AbWd9KjTRHfUwxZ7r98mVOdv/2SIOI=",
+    "url": "https://github.com/EngFlow/engflowapis/releases/download/2025.06.05-15.57.47/engflowapis-2025.06.05-15.57.47.tar.gz"
+}

--- a/modules/engflowapis/metadata.json
+++ b/modules/engflowapis/metadata.json
@@ -4,7 +4,7 @@
         {
             "email": "andres@engflow.com",
             "github": "anfelbar",
-            "name": "Andr\u00e9s Felipe Barco Santa",
+            "name": "Andrés Felipe Barco Santa",
             "github_user_id": 623618
         },
         {
@@ -34,7 +34,8 @@
         "2025.01.15-16.16.07",
         "2025.01.17-13.50.20",
         "2025.01.17-16.55.05",
-        "2025.03.14-12.58.52"
+        "2025.03.14-12.58.52",
+        "2025.06.05-15.57.47"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/EngFlow/engflowapis/releases/tag/2025.06.05-15.57.47

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_