### PR TITLE
contrib_rules_jvm@0.29.0

### DIFF
--- a/modules/contrib_rules_jvm/0.29.0/MODULE.bazel
+++ b/modules/contrib_rules_jvm/0.29.0/MODULE.bazel
@@ -1,0 +1,222 @@
+module(
+    name = "contrib_rules_jvm",
+    version = "0.29.0",
+    repo_name = "contrib_rules_jvm",
+)
+
+# TODO: This should be read from repositories.bzl, but we can't until this issue is solved:
+# - https://github.com/bazelbuild/bazel/issues/17880
+PROTOBUF_VERSION = "21.7"
+
+# The java packages are published to maven under a different versioning scheme.
+PROTOBUF_JAVA_VERSION = "3.{}".format(PROTOBUF_VERSION)
+
+bazel_dep(name = "apple_rules_lint", version = "0.4.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "grpc-java", version = "1.69.0")
+bazel_dep(name = "gazelle", version = "0.42.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "protobuf", version = "29.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_cc", version = "0.0.16")
+bazel_dep(name = "rules_go", version = "0.52.0")
+bazel_dep(name = "rules_java", version = "7.12.2")
+bazel_dep(name = "rules_jvm_external", version = "6.7")
+bazel_dep(name = "rules_proto", version = "7.0.2")
+
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.7.1", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.7.1", dev_dependency = True, repo_name = "io_bazel_stardoc")
+
+linter = use_extension("@apple_rules_lint//lint:extensions.bzl", "linter")
+linter.register(name = "java-checkstyle")
+linter.configure(
+    name = "java-checkstyle",
+    config = "//java:checkstyle-default-config",
+)
+linter.register(name = "java-pmd")
+linter.configure(
+    name = "java-pmd",
+    config = "//java:pmd-config",
+)
+linter.register(name = "java-spotbugs")
+linter.configure(
+    name = "java-spotbugs",
+    config = "//java:spotbugs-default-config",
+)
+use_repo(
+    linter,
+    "apple_linters",
+)
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+
+IO_GRPC_GRPC_JAVA_ARTIFACTS = [
+    "com.google.android:annotations:4.1.1.4",
+    "com.google.api.grpc:proto-google-common-protos:2.9.0",
+    "com.google.auth:google-auth-library-credentials:0.22.0",
+    "com.google.auth:google-auth-library-oauth2-http:0.22.0",
+    "com.google.auto.value:auto-value-annotations:1.9",
+    "com.google.auto.value:auto-value:1.9",
+    "com.google.code.findbugs:jsr305:3.0.2",
+    "com.google.code.gson:gson:2.9.0",
+    "com.google.guava:failureaccess:1.0.1",
+    "com.google.j2objc:j2objc-annotations:1.3",
+    "com.google.re2j:re2j:1.6",
+    "com.google.truth:truth:1.0.1",
+    "com.squareup.okhttp:okhttp:2.7.5",
+    "com.squareup.okio:okio:1.17.5",
+    "io.netty:netty-buffer",
+    "io.netty:netty-codec-http2",
+    "io.netty:netty-codec-http",
+    "io.netty:netty-codec-socks",
+    "io.netty:netty-codec",
+    "io.netty:netty-common",
+    "io.netty:netty-handler-proxy",
+    "io.netty:netty-handler",
+    "io.netty:netty-resolver",
+    "io.netty:netty-tcnative-boringssl-static:2.0.56.Final",
+    "io.netty:netty-tcnative-classes:2.0.56.Final",
+    "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.87.Final",
+    "io.netty:netty-transport-native-unix-common",
+    "io.netty:netty-transport",
+    "io.opencensus:opencensus-api:0.24.0",
+    "io.opencensus:opencensus-contrib-grpc-metrics:0.24.0",
+    "io.perfmark:perfmark-api:0.25.0",
+    "junit:junit:4.12",
+    "org.apache.tomcat:annotations-api:6.0.53",
+    "org.codehaus.mojo:animal-sniffer-annotations:1.21",
+]
+
+slf4j_version = "1.7.32"
+
+spotbugs_version = "4.8.6"
+
+maven.install(
+    name = "contrib_rules_jvm_deps",
+    artifacts = [
+        "com.github.spotbugs:spotbugs-annotations:%s" % spotbugs_version,
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.errorprone:error_prone_annotations:2.35.1",
+        "com.google.googlejavaformat:google-java-format:1.24.0",
+        "com.google.guava:guava:33.3.1-jre",
+        "commons-cli:commons-cli:1.9.0",
+        "io.grpc:grpc-api",
+        "io.grpc:grpc-core",
+        "io.grpc:grpc-netty",
+        "io.grpc:grpc-services",
+        "io.grpc:grpc-stub",
+
+        # These can be versioned independently of the versions in `repositories.bzl`
+        # so long as the version numbers are higher.
+        "org.junit.jupiter:junit-jupiter-engine",
+        "org.junit.jupiter:junit-jupiter-api",
+        "org.junit.platform:junit-platform-launcher",
+        "org.junit.platform:junit-platform-reporting",
+        "org.junit.vintage:junit-vintage-engine",
+
+        # Open Test Alliance for the JVM dep
+        "org.opentest4j:opentest4j:1.3.0",
+
+        # Checkstyle deps
+        "com.puppycrawl.tools:checkstyle:10.20.2",
+
+        # PMD deps
+        "net.sourceforge.pmd:pmd-dist:7.8.0",
+
+        # Spotbugs deps
+        "org.slf4j:slf4j-api:%s" % slf4j_version,
+        "org.slf4j:slf4j-jdk14:%s" % slf4j_version,
+
+        # Used by us at runtime
+        "org.slf4j:slf4j-simple:%s" % slf4j_version,
+
+        # We explicitly declare a protobuf runtime version
+        # so that it coincides with the one we use to generate the code.
+        "com.google.protobuf:protobuf-java:{}".format(PROTOBUF_JAVA_VERSION),
+    ] + IO_GRPC_GRPC_JAVA_ARTIFACTS,
+    boms = [
+        "io.grpc:grpc-bom:1.68.2",
+        "io.netty:netty-bom:4.1.87.Final",
+        "org.junit:junit-bom:5.11.3",
+    ],
+    fail_if_repin_required = True,
+    generate_compat_repositories = True,
+    lock_file = "//:contrib_rules_jvm_deps_install.json",
+    resolver = "maven",
+    strict_visibility = False,
+)
+
+# Spotbugs deps
+# We don't want to force people to use 1.8-beta
+# but we can't use the `maven` macros because
+# we've not loaded rules yet. Fortunately, the
+# expansion is easy :)
+maven.artifact(
+    name = "contrib_rules_jvm_deps",
+    artifact = "spotbugs",
+    exclusions = ["org.slf4j:slf4j-api"],
+    group = "com.github.spotbugs",
+    version = spotbugs_version,
+)
+use_repo(
+    maven,
+    "com_google_api_grpc_proto_google_common_protos",
+    "com_google_code_findbugs_jsr305",
+    "com_google_errorprone_error_prone_annotations",
+    "com_google_guava_failureaccess",
+    "com_google_guava_guava",
+    "com_google_j2objc_j2objc_annotations",
+    "contrib_rules_jvm_deps",
+    "org_apache_tomcat_annotations_api",
+)
+
+dev_maven = use_extension(
+    "@rules_jvm_external//:extensions.bzl",
+    "maven",
+    dev_dependency = True,
+)
+dev_maven.install(
+    name = "contrib_rules_jvm_tests",
+    artifacts = [
+        # These can be versioned independently of the versions in `repositories.bzl`
+        # so long as the version numbers are higher.
+        "org.junit.jupiter:junit-jupiter-engine:5.8.2",
+        "org.junit.jupiter:junit-jupiter-api:5.8.2",
+        "org.junit.jupiter:junit-jupiter-params:5.8.2",
+        "org.junit.platform:junit-platform-launcher:1.8.2",
+        "org.junit.platform:junit-platform-reporting:1.8.2",
+        "org.junit.platform:junit-platform-suite:1.8.2",
+        "org.junit.platform:junit-platform-suite-api:1.8.2",
+        "org.junit.platform:junit-platform-suite-engine:1.8.2",
+        "org.junit.platform:junit-platform-testkit:1.8.2",
+        "org.junit.vintage:junit-vintage-engine:5.8.2",
+        "org.mockito:mockito-core:4.8.1",
+    ],
+    fail_if_repin_required = True,
+    fetch_sources = True,
+    lock_file = "//:contrib_rules_jvm_tests_install.json",
+)
+use_repo(
+    dev_maven,
+    "contrib_rules_jvm_tests",
+)
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.23.6")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_aristanetworks_goarista",
+    "com_github_bazelbuild_buildtools",
+    "com_github_google_btree",
+    "com_github_google_go_cmp",
+    "com_github_google_uuid",
+    "com_github_hashicorp_golang_lru",
+    "com_github_rs_zerolog",
+    "com_github_sergi_go_diff",
+    "com_github_stretchr_testify",
+    "net_starlark_go",
+    "org_golang_google_grpc",
+    "org_golang_x_tools",
+    "org_golang_x_tools_go_vcs",
+)

--- a/modules/contrib_rules_jvm/0.29.0/patches/module_dot_bazel_version.patch
+++ b/modules/contrib_rules_jvm/0.29.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "contrib_rules_jvm",
+-    version = "0.18.0",
++    version = "0.29.0",
+     repo_name = "contrib_rules_jvm",
+ )
+ 
+ # TODO: This should be read from repositories.bzl, but we can't until this issue is solved:

--- a/modules/contrib_rules_jvm/0.29.0/presubmit.yml
+++ b/modules/contrib_rules_jvm/0.29.0/presubmit.yml
@@ -1,0 +1,21 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004"]
+  tasks:
+    gazelle:
+      working_directory: "examples/gazelle"
+      name: "Gazelle"
+      platform: ${{ platform }}
+      bazel: "7.x"
+      run_targets:
+        - "//:gazelle"
+      test_targets:
+        - "//..."
+    tests_and_lints:
+      working_directory: "examples/tests_and_lints"
+      name: "Tests and lints"
+      platform: ${{ platform }}
+      bazel: "7.x"
+      test_targets:
+        - "//..."

--- a/modules/contrib_rules_jvm/0.29.0/source.json
+++ b/modules/contrib_rules_jvm/0.29.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/bazel-contrib/rules_jvm/releases/download/v0.29.0/rules_jvm-v0.29.0.tar.gz",
+    "integrity": "sha256-RMSUZWetufchix7qetUS4K9xifZmc8Pr6UtISsXCRqc=",
+    "strip_prefix": "rules_jvm-0.29.0",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-lWE/SbSBHvimUYlhzB8XhFckjcOWClaHgMz+LC3CHr0="
+    },
+    "patch_strip": 1
+}

--- a/modules/contrib_rules_jvm/metadata.json
+++ b/modules/contrib_rules_jvm/metadata.json
@@ -2,22 +2,22 @@
     "homepage": "https://github.com/bazel-contrib/rules_jvm",
     "maintainers": [
         {
-            "name": "Daniel Wagner-Hall",
             "email": "dawagner@gmail.com",
             "github": "illicitonion",
-            "github_user_id": 1131704
+            "github_user_id": 1131704,
+            "name": "Daniel Wagner-Hall"
         },
         {
-            "name": "Gibson Fahnestock",
             "email": "gibfahn@gmail.com",
             "github": "gibfahn",
-            "github_user_id": 15943089
+            "github_user_id": 15943089,
+            "name": "Gibson Fahnestock"
         },
         {
-            "name": "Simon Stewart",
             "email": "simon.m.stewart@gmail.com",
             "github": "shs96c",
-            "github_user_id": 28229
+            "github_user_id": 28229,
+            "name": "Simon Stewart"
         }
     ],
     "repository": [
@@ -34,7 +34,8 @@
         "0.26.0",
         "0.26.1",
         "0.27.0",
-        "0.28.0"
+        "0.28.0",
+        "0.29.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Tried to make this look exactly like 0.28.0 looked.

I would have used the publish-to-bcr-bot, but that only works if you
already registered for the bot before pushing the rules_jvm tag.