### PR TITLE
Add gz-rendering (core only, no plugins yet)

### DIFF
--- a/modules/gz-rendering/9.2.0/MODULE.bazel
+++ b/modules/gz-rendering/9.2.0/MODULE.bazel
@@ -1,0 +1,13 @@
+module(
+    name = "gz-rendering",
+    version = "9.2.0",
+    compatibility_level = 9,
+)
+
+bazel_dep(name = "googletest", version = "1.15.2")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_gazebo", version = "0.0.3")
+bazel_dep(name = "gz-common", version = "6.1.0")
+bazel_dep(name = "gz-math", version = "8.1.1")
+bazel_dep(name = "gz-plugin", version = "3.1.0")
+bazel_dep(name = "gz-utils", version = "3.1.0")

--- a/modules/gz-rendering/9.2.0/patches/module_dot_bazel.patch
+++ b/modules/gz-rendering/9.2.0/patches/module_dot_bazel.patch
@@ -1,0 +1,48 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,39 +1,13 @@
+-## MODULE.bazel
+ module(
+     name = "gz-rendering",
+-    repo_name = "org_gazebosim_gz-rendering",
++    version = "9.2.0",
++    compatibility_level = 9,
+ )
+ 
+ bazel_dep(name = "googletest", version = "1.15.2")
+ bazel_dep(name = "rules_license", version = "1.0.0")
+-
+-# Gazebo Dependencies
+ bazel_dep(name = "rules_gazebo", version = "0.0.3")
+-bazel_dep(name = "gz-common")
+-bazel_dep(name = "gz-math")
+-bazel_dep(name = "gz-plugin")
+-bazel_dep(name = "gz-utils")
+-
+-archive_override(
+-    module_name = "gz-common",
+-    strip_prefix = "gz-common-gz-common6",
+-    urls = ["https://github.com/gazebosim/gz-common/archive/refs/heads/gz-common6.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-math",
+-    strip_prefix = "gz-math-gz-math8",
+-    urls = ["https://github.com/gazebosim/gz-math/archive/refs/heads/gz-math8.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-plugin",
+-    strip_prefix = "gz-plugin-gz-plugin3",
+-    urls = ["https://github.com/gazebosim/gz-plugin/archive/refs/heads/gz-plugin3.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-utils",
+-    strip_prefix = "gz-utils-gz-utils3",
+-    urls = ["https://github.com/gazebosim/gz-utils/archive/refs/heads/gz-utils3.tar.gz"],
+-)
++bazel_dep(name = "gz-common", version = "6.1.0")
++bazel_dep(name = "gz-math", version = "8.1.1")
++bazel_dep(name = "gz-plugin", version = "3.1.0")
++bazel_dep(name = "gz-utils", version = "3.1.0")

--- a/modules/gz-rendering/9.2.0/presubmit.yml
+++ b/modules/gz-rendering/9.2.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@gz-rendering'

--- a/modules/gz-rendering/9.2.0/source.json
+++ b/modules/gz-rendering/9.2.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/gazebosim/gz-rendering/archive/refs/tags/gz-rendering9_9.2.0.tar.gz",
+    "integrity": "sha256-vmfxIvM/U85vyRdOOh/s5XkEF7o9+bQeL0l4/UDOCN0=",
+    "strip_prefix": "gz-rendering-gz-rendering9_9.2.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-ibIapjOHvPU6frKYVMEQJopcLA0+J8rA0EjVN0yoc+U="
+    }
+}

--- a/modules/gz-rendering/metadata.json
+++ b/modules/gz-rendering/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/gazebosim/gz-rendering",
+    "maintainers": [
+        {
+            "email": "shameek@intrinsic.ai",
+            "github": "shameekganguly",
+            "github_user_id": 2412842,
+            "name": "Shameek Ganguly"
+        }
+    ],
+    "repository": [
+        "github:gazebosim/gz-rendering"
+    ],
+    "versions": [
+        "9.2.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This PR adds gz-rendering to the listed modules in BCR. Note that gz-rendering currently only provides the core library target in bazel, not the render engine plugins.