### PR TITLE
Yank rules_swift 3.0.0

### DIFF
--- a/modules/rules_swift/metadata.json
+++ b/modules/rules_swift/metadata.json
@@ -77,5 +77,7 @@
         "3.0.0",
         "3.0.2"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "3.0.0": "Using wrong compatibility_level of 2 when should be 3. Fixed in 3.0.2."
+    }
 }


### PR DESCRIPTION
This had the wrong `compatibility_level` when we published it. Fixed in 3.0.2