### PR TITLE
Publish protovalidate-cc@1.0.0-rc.3

### DIFF
--- a/modules/protovalidate-cc/1.0.0-rc.3/MODULE.bazel
+++ b/modules/protovalidate-cc/1.0.0-rc.3/MODULE.bazel
@@ -1,0 +1,36 @@
+# Copyright 2023-2025 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DO NOT EDIT MODULE.bazel - Edit MODULE.bazel.tmpl instead, then run make generate.
+
+module(
+    name = "protovalidate-cc",
+    version = "1.0.0-rc.3",
+)
+
+bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")
+
+bazel_dep(name = "protobuf", version = "29.2", repo_name = "com_google_protobuf")
+
+bazel_dep(name = "rules_proto", version = "7.1.0")
+
+bazel_dep(name = "rules_buf", version = "0.3.0")
+
+bazel_dep(name = "googletest", version = "1.16.0.bcr.1", repo_name = "com_google_googletest")
+
+bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
+
+bazel_dep(name = "cel-cpp", version = "0.11.0", repo_name = "com_google_cel_cpp")
+
+bazel_dep(name = "protovalidate", version = "1.0.0-rc.2", repo_name = "com_github_bufbuild_protovalidate")

--- a/modules/protovalidate-cc/1.0.0-rc.3/attestations.json
+++ b/modules/protovalidate-cc/1.0.0-rc.3/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/bufbuild/protovalidate-cc/releases/download/v1.0.0-rc.3/source.json.intoto.jsonl",
+            "integrity": "sha256-qoV1Isd203g5vhmA1LHcoRDDZL15hRZ2TLV7hal4/b8="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/bufbuild/protovalidate-cc/releases/download/v1.0.0-rc.3/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-MlKZiHZfIUJ7igSMz2tQAYZ4wkExoCUG0qnhFhygfI4="
+        },
+        "protovalidate-cc-1.0.0-rc.3.tar.gz": {
+            "url": "https://github.com/bufbuild/protovalidate-cc/releases/download/v1.0.0-rc.3/protovalidate-cc-1.0.0-rc.3.tar.gz.intoto.jsonl",
+            "integrity": "sha256-OPDJt/yQPhEylRhYtqsTT0eXvmcyH/Bi5LR6XP1bWxA="
+        }
+    }
+}

--- a/modules/protovalidate-cc/1.0.0-rc.3/presubmit.yml
+++ b/modules/protovalidate-cc/1.0.0-rc.3/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["debian10", "macos"]
+    bazel: [7.x, 8.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/protovalidate-cc/1.0.0-rc.3/source.json
+++ b/modules/protovalidate-cc/1.0.0-rc.3/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-UpF0HOwfm+9o2wVxqpaWvOoR0ZnIcFMaCdwBA4W2tGM=",
+    "strip_prefix": "protovalidate-cc-1.0.0-rc.3",
+    "url": "https://github.com/bufbuild/protovalidate-cc/releases/download/v1.0.0-rc.3/protovalidate-cc-1.0.0-rc.3.tar.gz"
+}

--- a/modules/protovalidate-cc/metadata.json
+++ b/modules/protovalidate-cc/metadata.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://github.com/bufbuild/protovalidate-cc",
+    "maintainers": [
+        {
+            "name": "Protovalidate Team",
+            "email": "bcr-github@buf.build",
+            "github": "bcr-buf",
+            "github_user_id": 196968995
+        },
+        {
+            "name": "John Chadwick",
+            "email": "jchadwick@buf.build",
+            "github": "jchadwick-buf",
+            "github_user_id": 116005195
+        }
+    ],
+    "repository": [
+        "github:bufbuild/protovalidate-cc"
+    ],
+    "versions": [
+        "1.0.0-rc.3"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/bufbuild/protovalidate-cc/releases/tag/v1.0.0-rc.3

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_