### PR TITLE
fix(civetweb): fix undefined reference to 'mg_websocket_write'

### DIFF
--- a/modules/civetweb/1.16.bcr.2/MODULE.bazel
+++ b/modules/civetweb/1.16.bcr.2/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "civetweb",
+    version = "1.16.bcr.2",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "boringssl",
+    version = "0.0.0-20230215-5c22014",
+)
+bazel_dep(
+    name = "platforms",
+    version = "0.0.8",
+)

--- a/modules/civetweb/1.16.bcr.2/patches/add_build_file.patch
+++ b/modules/civetweb/1.16.bcr.2/patches/add_build_file.patch
@@ -1,0 +1,119 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,116 @@
++licenses(["notice"])  # MIT license
++
++config_setting(
++    name = "osx",
++    constraint_values = [
++        "@platforms//os:osx",
++    ],
++)
++
++config_setting(
++    name = "windows",
++    constraint_values = [
++        "@platforms//os:windows",
++    ],
++)
++
++config_setting(
++    name = "with_ssl",
++    define_values = {
++        "with_civetweb_ssl": "true",
++    },
++    visibility = ["//visibility:public"],
++)
++
++COPTS = [
++    "-DUSE_IPV6",
++    "-DNDEBUG",
++    "-DNO_CGI",
++    "-DNO_CACHING",
++    "-DNO_FILES",
++    "-UDEBUG",
++    "-DUSE_WEBSOCKET",
++] + select({
++    ":with_ssl": [
++        "-DOPENSSL_API_3_0",
++        "-DNO_SSL_DL",
++    ],
++    "//conditions:default": [
++        "-DNO_SSL",
++    ],
++})
++
++DEPS = select({
++    ":with_ssl": [
++        "@boringssl//:crypto",
++        "@boringssl//:ssl",
++    ],
++    "//conditions:default": [],
++})
++
++cc_library(
++    name = "inl_headers",
++    hdrs = glob([
++        "src/*.inl",
++    ]),
++    strip_include_prefix = "src",
++)
++
++cc_library(
++    name = "civetweb",
++    srcs = [
++        "src/civetweb.c",
++    ],
++    hdrs = [
++        "include/civetweb.h",
++    ],
++    copts = COPTS,
++    includes = [
++        "include",
++    ],
++    linkopts = select({
++        ":windows": [],
++        "//conditions:default": ["-lpthread"],
++    }) + select({
++        ":osx": [],
++        ":windows": [],
++        "//conditions:default": ["-lrt"],
++    }),
++    textual_hdrs = [
++        "src/handle_form.inl",
++        "src/match.inl",
++        "src/md5.inl",
++        "src/response.inl",
++        "src/sort.inl",
++    ],
++    visibility = ["//visibility:public"],
++    deps = [
++        "inl_headers",
++    ] + DEPS,
++)
++
++cc_library(
++    name = "civetserver",
++    srcs = [
++        "src/CivetServer.cpp",
++    ],
++    hdrs = [
++        "include/CivetServer.h",
++    ],
++    copts = COPTS,
++    includes = [
++        "include",
++    ],
++    linkopts = select({
++        ":windows": [],
++        "//conditions:default": ["-lpthread"],
++    }) + select({
++        ":osx": [],
++        ":windows": [],
++        "//conditions:default": ["-lrt"],
++    }),
++    visibility = ["//visibility:public"],
++    deps = [
++        ":civetweb",
++    ],
++)

--- a/modules/civetweb/1.16.bcr.2/patches/module_dot_bazel.patch
+++ b/modules/civetweb/1.16.bcr.2/patches/module_dot_bazel.patch
@@ -1,0 +1,17 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,14 @@
++module(
++    name = "civetweb",
++    version = "1.16.bcr.2",
++    compatibility_level = 1,
++)
++
++bazel_dep(
++    name = "boringssl",
++    version = "0.0.0-20230215-5c22014",
++)
++bazel_dep(
++    name = "platforms",
++    version = "0.0.8",
++)

--- a/modules/civetweb/1.16.bcr.2/presubmit.yml
+++ b/modules/civetweb/1.16.bcr.2/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@civetweb//...'

--- a/modules/civetweb/1.16.bcr.2/source.json
+++ b/modules/civetweb/1.16.bcr.2/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/civetweb/civetweb/archive/v1.16.tar.gz",
+    "integrity": "sha256-8ORxwb9OeASmz7QeqdE+fWI7K8x7weKk3VSVGiTWAoU=",
+    "strip_prefix": "civetweb-1.16",
+    "patches": {
+        "add_build_file.patch": "sha256-I67jPk+ISMIaFesTKRDWxS8go2huwQKg+5V7GgQiOpg=",
+        "module_dot_bazel.patch": "sha256-IbnB7mNe4i/gyeU9PPkszATs+JSuBx4yJFigOclDb70="
+    },
+    "patch_strip": 0
+}

--- a/modules/civetweb/metadata.json
+++ b/modules/civetweb/metadata.json
@@ -2,8 +2,8 @@
     "homepage": "https://github.com/civetweb/civetweb",
     "maintainers": [
         {
-            "email": "bcr-maintainers@bazel.build",
-            "name": "No Maintainer Specified"
+            "email": "daohu527@gmail.com",
+            "name": "daohu527"
         }
     ],
     "repository": [
@@ -11,7 +11,8 @@
     ],
     "versions": [
         "1.16",
-        "1.16.bcr.1"
+        "1.16.bcr.1",
+        "1.16.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
When websocket is needed, the original library lacks "-DUSE_WEBSOCKET", so a link error will occur
```
bazel-out/k8-fastbuild/bin/modules/dreamview/backend/handlers/_objs/websocket_handler/websocket_handler.pic.o:websocket_handler.cc:function apollo::dreamview::WebSocketHandler::SendData(mg_connection*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, int): error: undefined reference to 'mg_websocket_write'
```
Add -DUSE_WEBSOCKET and add header files