### PR TITLE
Add gz-sim (core)

### DIFF
--- a/modules/gz-sim/9.2.0/MODULE.bazel
+++ b/modules/gz-sim/9.2.0/MODULE.bazel
@@ -1,0 +1,23 @@
+module(
+    name = "gz-sim",
+    version = "9.2.0",
+    compatibility_level = 9,
+)
+
+bazel_dep(name = "googletest", version = "1.15.2")
+bazel_dep(name = "protobuf", version = "29.4", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "tinyxml2", version = "10.0.0")
+
+# Gazebo Dependencies
+bazel_dep(name = "rules_gazebo", version = "0.0.6")
+bazel_dep(name = "gz-common", version = "6.1.0")
+bazel_dep(name = "gz-fuel-tools", version = "10.1.0")
+bazel_dep(name = "gz-math", version = "8.1.1")
+bazel_dep(name = "gz-msgs", version = "11.1.0.bcr.1")
+bazel_dep(name = "gz-plugin", version = "3.1.0")
+bazel_dep(name = "gz-rendering", version = "9.2.0")
+bazel_dep(name = "gz-transport", version = "14.1.0.bcr.1")
+bazel_dep(name = "gz-utils", version = "3.1.0")
+bazel_dep(name = "sdformat", version = "15.3.0.bcr.2")

--- a/modules/gz-sim/9.2.0/patches/module_dot_bazel.patch
+++ b/modules/gz-sim/9.2.0/patches/module_dot_bazel.patch
@@ -1,0 +1,88 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,7 +1,7 @@
+-## MODULE.bazel
+ module(
+     name = "gz-sim",
+-    repo_name = "org_gazebosim_gz-sim",
++    version = "9.2.0",
++    compatibility_level = 9,
+ )
+ 
+ bazel_dep(name = "googletest", version = "1.15.2")
+@@ -12,66 +12,12 @@
+ 
+ # Gazebo Dependencies
+ bazel_dep(name = "rules_gazebo", version = "0.0.6")
+-bazel_dep(name = "gz-common")
+-bazel_dep(name = "gz-fuel-tools")
+-bazel_dep(name = "gz-math")
+-bazel_dep(name = "gz-msgs")
+-bazel_dep(name = "gz-plugin")
+-bazel_dep(name = "gz-rendering")
+-bazel_dep(name = "gz-transport")
+-bazel_dep(name = "gz-utils")
+-bazel_dep(name = "sdformat")
+-
+-archive_override(
+-    module_name = "gz-common",
+-    strip_prefix = "gz-common-gz-common6",
+-    urls = ["https://github.com/gazebosim/gz-common/archive/refs/heads/gz-common6.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-fuel-tools",
+-    strip_prefix = "gz-fuel-tools-gz-fuel-tools10",
+-    urls = ["https://github.com/gazebosim/gz-fuel-tools/archive/refs/heads/gz-fuel-tools10.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-math",
+-    strip_prefix = "gz-math-gz-math8",
+-    urls = ["https://github.com/gazebosim/gz-math/archive/refs/heads/gz-math8.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-msgs",
+-    strip_prefix = "gz-msgs-gz-msgs11",
+-    urls = ["https://github.com/gazebosim/gz-msgs/archive/refs/heads/gz-msgs11.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-plugin",
+-    strip_prefix = "gz-plugin-gz-plugin3",
+-    urls = ["https://github.com/gazebosim/gz-plugin/archive/refs/heads/gz-plugin3.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-rendering",
+-    strip_prefix = "gz-rendering-gz-rendering9",
+-    urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/heads/gz-rendering9.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-transport",
+-    strip_prefix = "gz-transport-gz-transport14",
+-    urls = ["https://github.com/gazebosim/gz-transport/archive/refs/heads/gz-transport14.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-utils",
+-    strip_prefix = "gz-utils-gz-utils3",
+-    urls = ["https://github.com/gazebosim/gz-utils/archive/refs/heads/gz-utils3.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "sdformat",
+-    strip_prefix = "sdformat-sdf15",
+-    urls = ["https://github.com/gazebosim/sdformat/archive/refs/heads/sdf15.tar.gz"],
+-)
++bazel_dep(name = "gz-common", version = "6.1.0")
++bazel_dep(name = "gz-fuel-tools", version = "10.1.0")
++bazel_dep(name = "gz-math", version = "8.1.1")
++bazel_dep(name = "gz-msgs", version = "11.1.0.bcr.1")
++bazel_dep(name = "gz-plugin", version = "3.1.0")
++bazel_dep(name = "gz-rendering", version = "9.2.0")
++bazel_dep(name = "gz-transport", version = "14.1.0.bcr.1")
++bazel_dep(name = "gz-utils", version = "3.1.0")
++bazel_dep(name = "sdformat", version = "15.3.0.bcr.2")

--- a/modules/gz-sim/9.2.0/presubmit.yml
+++ b/modules/gz-sim/9.2.0/presubmit.yml
@@ -2,7 +2,9 @@ matrix:
   platform:
   - ubuntu2004
   - macos
-  - macos_arm64
+  # Disabled due to https://github.com/bazel-contrib/rules_foreign_cc/issues/1305.
+  # rules_foreign_cc is transitively pulled in through libzmq.
+  # - macos_arm64
   bazel:
   - 8.x
   - 7.x

--- a/modules/gz-sim/9.2.0/presubmit.yml
+++ b/modules/gz-sim/9.2.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@gz-sim'

--- a/modules/gz-sim/9.2.0/source.json
+++ b/modules/gz-sim/9.2.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/gazebosim/gz-sim/archive/refs/tags/gz-sim9_9.2.0.tar.gz",
+    "integrity": "sha256-i2K74SmwYrGx/fuc3IcKjf/hQSDMTSmzO2MaMSuHUbY=",
+    "strip_prefix": "gz-sim-gz-sim9_9.2.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-vp2YYoIY07h0Ju/LWj5MfogvRRGfDqoZldT3XdLJWTQ="
+    }
+}

--- a/modules/gz-sim/metadata.json
+++ b/modules/gz-sim/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/gazebosim/gz-sim",
+    "maintainers": [
+        {
+            "email": "shameek@intrinsic.ai",
+            "github": "shameekganguly",
+            "github_user_id": 2412842,
+            "name": "Shameek Ganguly"
+        }
+    ],
+    "repository": [
+        "github:gazebosim/gz-sim"
+    ],
+    "versions": [
+        "9.2.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This PR adds the Gz Sim package to BCR, which is part of the Gazebo simulation framework. Only the core library is currently supported in bazel.