### PR TITLE
feat: add `rules_patchelf`

### DIFF
--- a/modules/rules_patchelf/1.0.0/MODULE.bazel
+++ b/modules/rules_patchelf/1.0.0/MODULE.bazel
@@ -1,0 +1,26 @@
+module(
+    name = "rules_patchelf",
+    version = "1.0.0",
+    bazel_compatibility = [
+        ">=7.1.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "patchelf", version = "0.18.0")
+bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0", dev_dependency = True)
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.18", dev_dependency = True)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    configure_coverage_tool = True,
+    # TODO: need hermetic `chmod`/`id`: https://github.com/bazelbuild/rules_python/pull/2024
+    ignore_root_user_error = True,
+    python_version = "3.13",
+)
+use_repo(python, python = "python_versions")

--- a/modules/rules_patchelf/1.0.0/presubmit.yml
+++ b/modules/rules_patchelf/1.0.0/presubmit.yml
@@ -1,0 +1,20 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+      - 8.x
+    platform:
+      - centos7_java11_devtoolset10
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - fedora39
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_patchelf/1.0.0/source.json
+++ b/modules/rules_patchelf/1.0.0/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_patchelf/-/releases/v1.0.0/downloads/src.tar.gz",
+  "integrity": "sha512-MKfLwgVMTy8Yvu/MMQbovtNpAGdd/ef/z6NeI6Yif+hHiLsXaQmS3GiZkmwSCQdoM4uFOg6VGqxjs84B99uLgg==",
+  "strip_prefix": "rules_patchelf-v1.0.0"
+}

--- a/modules/rules_patchelf/metadata.json
+++ b/modules/rules_patchelf/metadata.json
@@ -1,0 +1,16 @@
+{
+  "homepage": "https://gitlab.arm.com/bazel/rules_patchelf",
+  "repository": [
+    "https://gitlab.arm.com/bazel/rules_patchelf"
+  ],
+  "versions": [
+    "1.0.0"
+  ],
+  "maintainers": [
+    {
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson",
+      "github_user_id": "1081113"
+    }
+  ]
+}


### PR DESCRIPTION
Use `patchelf_unpack` to unpack the downloaded packages and patch the ELF interpreter path:

```py
patchelf_unpack(
    name = "patched",
    # `rules_distroless#apt` extension is *highly* recommended
    srcs = ["@debian-bookworm-qemu//:packages"],
    filters = [
        "usr/share/doc/**",       # No need to unpack documentation
        "lib64/ld-linux-*.so.?",  # Remove dangling symlink
    ],
)
```

Use `patchelf_launcher` to launch a binary from the unpacked directory:

```py
patchelf_launcher(
    name = "qemu-system-x86_64",
    srcs = [
        ":patched",
        "@rules_patchelf//patchelf/launcher/elf/interpreter/debian",
        "@rules_patchelf//patchelf/launcher/library/path/debian",
    ],
    env = {
        "TMPDIR": "./tmp",
    },
)
```

Run the binary:

```console
$ bazelisk run -- :qemu-system-x86_64 --version
QEMU emulator version 7.2.13 (Debian 1:7.2+dfsg-7+deb12u7)
Copyright (c) 2003-2022 Fabrice Bellard and the QEMU Project developers
```