### PR TITLE
Adding support for Pinocchio@2.6.1

### DIFF
--- a/modules/pinocchio/2.6.21/MODULE.bazel
+++ b/modules/pinocchio/2.6.21/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "pinocchio",
+    version = "2.6.21",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "eigen", version = "4.0.0-20241125.bcr.2", repo_name = "com_gitlab_libeigen_eigen")
+bazel_dep(name = "sdformat", version = "15.3.0.bcr.1")
+bazel_dep(name = "boost.filesystem", version = "1.83.0")
+bazel_dep(name = "boost.test", version = "1.83.0")

--- a/modules/pinocchio/2.6.21/patches/boost_tests_dot_bzl.patch
+++ b/modules/pinocchio/2.6.21/patches/boost_tests_dot_bzl.patch
@@ -1,0 +1,899 @@
+diff --git a/unittest/aba-derivatives.cpp b/unittest/aba-derivatives.cpp
+index 0cb3ad9..e03bf3f 100644
+--- unittest/aba-derivatives.cpp
++++ unittest/aba-derivatives.cpp
+@@ -16,8 +16,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE ABADerivativesTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/aba.cpp b/unittest/aba.cpp
+index a37589c..df4b8fb 100644
+--- unittest/aba.cpp
++++ unittest/aba.cpp
+@@ -18,8 +18,8 @@
+ #include "pinocchio/utils/timer.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE ABATest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
+diff --git a/unittest/algo-check.cpp b/unittest/algo-check.cpp
+index 69cbdbc..f8081af 100644
+--- unittest/algo-check.cpp
++++ unittest/algo-check.cpp
+@@ -13,8 +13,8 @@
+ #include <iostream>
+ 
+ using namespace pinocchio;
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE AlgoCheckTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ // Dummy checker.
+diff --git a/unittest/all-joints.cpp b/unittest/all-joints.cpp
+index b8aac2e..5de302e 100644
+--- unittest/all-joints.cpp
++++ unittest/all-joints.cpp
+@@ -2,8 +2,8 @@
+ // Copyright(c) 2015-2021 CNRS INRIA
+ // Copyright(c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+ //
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE AllJointsTest
++#include <boost/test/included/unit_test.hpp>
+ #include <iostream>
+ 
+ #include "pinocchio/math/fwd.hpp"
+diff --git a/unittest/cartesian-product-liegroups.cpp b/unittest/cartesian-product-liegroups.cpp
+index 30b53bd..b698427 100644
+--- unittest/cartesian-product-liegroups.cpp
++++ unittest/cartesian-product-liegroups.cpp
+@@ -9,8 +9,8 @@
+ #include "pinocchio/multibody/liegroup/cartesian-product.hpp"
+ 
+ #include "pinocchio/multibody/joint/joint-generic.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE CartesianProductLieGroupsTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ #include <boost/algorithm/string.hpp>
+ 
+diff --git a/unittest/center-of-mass-derivatives.cpp b/unittest/center-of-mass-derivatives.cpp
+index d1f54d6..acff159 100644
+--- unittest/center-of-mass-derivatives.cpp
++++ unittest/center-of-mass-derivatives.cpp
+@@ -7,8 +7,8 @@
+ #include "pinocchio/algorithm/compute-all-terms.hpp"
+ #include "pinocchio/algorithm/center-of-mass-derivatives.hpp"
+ #include "pinocchio/parsers/sample-models.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE CenterOfMassDerivativesTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/centroidal-derivatives.cpp b/unittest/centroidal-derivatives.cpp
+index 4ad9d4a..1d03f7b 100644
+--- unittest/centroidal-derivatives.cpp
++++ unittest/centroidal-derivatives.cpp
+@@ -16,8 +16,8 @@
+ #include "pinocchio/utils/timer.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE CentroidalDerivativesTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ template<typename JointModel>
+diff --git a/unittest/centroidal.cpp b/unittest/centroidal.cpp
+index 227a578..ffb5ada 100644
+--- unittest/centroidal.cpp
++++ unittest/centroidal.cpp
+@@ -14,8 +14,8 @@
+ #include "pinocchio/utils/timer.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE CentroidalTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ template<typename JointModel>
+diff --git a/unittest/cholesky.cpp b/unittest/cholesky.cpp
+index dd3a6c4..23af038 100644
+--- unittest/cholesky.cpp
++++ unittest/cholesky.cpp
+@@ -22,8 +22,8 @@
+ #ifdef NDEBUG
+ #  include <Eigen/Cholesky>
+ #endif
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE CholeskyTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ 
+diff --git a/unittest/com.cpp b/unittest/com.cpp
+index 4254833..ea92868 100644
+--- unittest/com.cpp
++++ unittest/com.cpp
+@@ -14,8 +14,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE CoMTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
+diff --git a/unittest/compute-all-terms.cpp b/unittest/compute-all-terms.cpp
+index 1e112ff..cb116d6 100644
+--- unittest/compute-all-terms.cpp
++++ unittest/compute-all-terms.cpp
+@@ -14,8 +14,8 @@
+ #include "pinocchio/algorithm/compute-all-terms.hpp"
+ #include "pinocchio/parsers/sample-models.hpp"
+ #include "pinocchio/utils/timer.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE ComputeAllTermsTest
++#include <boost/test/included/unit_test.hpp>
+ 
+ using namespace pinocchio;
+ 
+diff --git a/unittest/constraint.cpp b/unittest/constraint.cpp
+index 4a9189e..54c324c 100644
+--- unittest/constraint.cpp
++++ unittest/constraint.cpp
+@@ -11,8 +11,8 @@
+ #include "utils/macros.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE ConstraintTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/contact-dynamics-derivatives.cpp b/unittest/contact-dynamics-derivatives.cpp
+index 03853b0..1cb21e0 100644
+--- unittest/contact-dynamics-derivatives.cpp
++++ unittest/contact-dynamics-derivatives.cpp
+@@ -11,8 +11,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE ContactDynamicsDerivativesTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
+diff --git a/unittest/contact-dynamics.cpp b/unittest/contact-dynamics.cpp
+index 0de653d..104214c 100644
+--- unittest/contact-dynamics.cpp
++++ unittest/contact-dynamics.cpp
+@@ -12,8 +12,8 @@
+ #include "pinocchio/utils/timer.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE ContactDynamicsTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
+diff --git a/unittest/copy.cpp b/unittest/copy.cpp
+index 829daaf..06dc911 100644
+--- unittest/copy.cpp
++++ unittest/copy.cpp
+@@ -7,8 +7,8 @@
+ #include "pinocchio/algorithm/rnea.hpp"
+ #include "pinocchio/algorithm/joint-configuration.hpp"
+ #include "pinocchio/parsers/sample-models.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE CopyTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/crba.cpp b/unittest/crba.cpp
+index 8073ef4..5ea533a 100644
+--- unittest/crba.cpp
++++ unittest/crba.cpp
+@@ -22,8 +22,8 @@
+ #include "pinocchio/utils/timer.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE CRBATest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ template<typename JointModel>
+diff --git a/unittest/data.cpp b/unittest/data.cpp
+index 122156f..088fb9d 100644
+--- unittest/data.cpp
++++ unittest/data.cpp
+@@ -7,8 +7,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ 
+ #include "pinocchio/algorithm/check.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE DataTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/eigen-basic-op.cpp b/unittest/eigen-basic-op.cpp
+index 3d7fed0..64656b7 100644
+--- unittest/eigen-basic-op.cpp
++++ unittest/eigen-basic-op.cpp
+@@ -6,8 +6,8 @@
+ 
+ #include <Eigen/Core>
+ #include "pinocchio/math/matrix.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE EigenBasicOpTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/eigen-tensor.cpp b/unittest/eigen-tensor.cpp
+index f41e28f..fdbe50b 100644
+--- unittest/eigen-tensor.cpp
++++ unittest/eigen-tensor.cpp
+@@ -4,8 +4,8 @@
+ 
+ #include "pinocchio/math/tensor.hpp"
+ #include "pinocchio/multibody/model.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE EigenTensorTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ #include <iostream>
+diff --git a/unittest/energy.cpp b/unittest/energy.cpp
+index c3a8064..6027725 100644
+--- unittest/energy.cpp
++++ unittest/energy.cpp
+@@ -8,8 +8,8 @@
+ #include "pinocchio/algorithm/center-of-mass.hpp"
+ 
+ #include "pinocchio/parsers/sample-models.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE EnergyTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ #include <boost/test/tools/floating_point_comparison.hpp>
+ 
+diff --git a/unittest/explog.cpp b/unittest/explog.cpp
+index 208637f..ff3bad1 100644
+--- unittest/explog.cpp
++++ unittest/explog.cpp
+@@ -4,8 +4,8 @@
+ //
+ 
+ #include "pinocchio/spatial/explog.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE ExpLogTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ #include "utils/macros.hpp"
+diff --git a/unittest/finite-differences.cpp b/unittest/finite-differences.cpp
+index d6aeb00..42511d7 100644
+--- unittest/finite-differences.cpp
++++ unittest/finite-differences.cpp
+@@ -8,8 +8,8 @@
+ #include "pinocchio/algorithm/joint-configuration.hpp"
+ #include "pinocchio/algorithm/kinematics.hpp"
+ #include "pinocchio/algorithm/jacobian.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE FiniteDifferencesTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/frames-derivatives.cpp b/unittest/frames-derivatives.cpp
+index 6c99202..7c97fd5 100644
+--- unittest/frames-derivatives.cpp
++++ unittest/frames-derivatives.cpp
+@@ -11,8 +11,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE FrameDerivativesTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/frames.cpp b/unittest/frames.cpp
+index eded34d..72bddb7 100644
+--- unittest/frames.cpp
++++ unittest/frames.cpp
+@@ -15,8 +15,8 @@
+ #include "pinocchio/algorithm/joint-configuration.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE FramesTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ template<typename Derived>
+diff --git a/unittest/fusion.cpp b/unittest/fusion.cpp
+index 8827925..b6125c4 100644
+--- unittest/fusion.cpp
++++ unittest/fusion.cpp
+@@ -15,8 +15,8 @@
+ 
+ #include "pinocchio/tools/timer.hpp"
+ #include <Eigen/Core>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE FusionTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ struct TestObj
+diff --git a/unittest/geom.cpp b/unittest/geom.cpp
+index a9139d7..90daa06 100644
+--- unittest/geom.cpp
++++ unittest/geom.cpp
+@@ -14,7 +14,8 @@
+ #include "pinocchio/parsers/srdf.hpp"
+ 
+ #include <vector>
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE GeomTest
++#include <boost/test/included/unit_test.hpp>
+ 
+ using namespace pinocchio;
+ 
+diff --git a/unittest/joint-composite.cpp b/unittest/joint-composite.cpp
+index 6f04dab..c7fe858 100644
+--- unittest/joint-composite.cpp
++++ unittest/joint-composite.cpp
+@@ -5,8 +5,8 @@
+ #include "pinocchio/multibody/joint/joint-composite.hpp"
+ #include "pinocchio/algorithm/joint-configuration.hpp"
+ #include "pinocchio/algorithm/kinematics.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE JointCompositeTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/joint-configurations.cpp b/unittest/joint-configurations.cpp
+index fa38e6d..9f85ca1 100644
+--- unittest/joint-configurations.cpp
++++ unittest/joint-configurations.cpp
+@@ -6,8 +6,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ #include "pinocchio/algorithm/joint-configuration.hpp"
+ #include "pinocchio/math/quaternion.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE JointConfigurationTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/joint-free-flyer.cpp b/unittest/joint-free-flyer.cpp
+index 99177a1..101e219 100644
+--- unittest/joint-free-flyer.cpp
++++ unittest/joint-free-flyer.cpp
+@@ -10,8 +10,8 @@
+ #include "pinocchio/algorithm/crba.hpp"
+ #include "pinocchio/algorithm/jacobian.hpp"
+ #include "pinocchio/algorithm/compute-all-terms.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE JointFreeFlyerTest
++#include <boost/test/included/unit_test.hpp>
+ #include <iostream>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/joint-generic.cpp b/unittest/joint-generic.cpp
+index c3300c4..77d3b48 100644
+--- unittest/joint-generic.cpp
++++ unittest/joint-generic.cpp
+@@ -9,8 +9,8 @@
+ #include "pinocchio/multibody/model.hpp"
+ 
+ #include "pinocchio/algorithm/joint-configuration.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE JointGenericTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/joint-jacobian.cpp b/unittest/joint-jacobian.cpp
+index 215ade1..d421946 100644
+--- unittest/joint-jacobian.cpp
++++ unittest/joint-jacobian.cpp
+@@ -13,8 +13,8 @@
+ #include "pinocchio/algorithm/joint-configuration.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE JointJacobianTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ template<typename Derived>
+diff --git a/unittest/joint-mimic.cpp b/unittest/joint-mimic.cpp
+index 3bc1db8..4376040 100644
+--- unittest/joint-mimic.cpp
++++ unittest/joint-mimic.cpp
+@@ -4,8 +4,8 @@
+ 
+ #include "pinocchio/multibody/joint/joint-generic.hpp"
+ #include "pinocchio/multibody/liegroup/liegroup.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE JointMimicTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/joint-planar.cpp b/unittest/joint-planar.cpp
+index 25c40e4..6f61d94 100644
+--- unittest/joint-planar.cpp
++++ unittest/joint-planar.cpp
+@@ -10,8 +10,8 @@
+ #include "pinocchio/algorithm/crba.hpp"
+ #include "pinocchio/algorithm/jacobian.hpp"
+ #include "pinocchio/algorithm/compute-all-terms.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE JointPlanarTest
++#include <boost/test/included/unit_test.hpp>
+ #include <iostream>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/joint-prismatic.cpp b/unittest/joint-prismatic.cpp
+index fab0e0f..a59473c 100644
+--- unittest/joint-prismatic.cpp
++++ unittest/joint-prismatic.cpp
+@@ -10,8 +10,8 @@
+ #include "pinocchio/algorithm/crba.hpp"
+ #include "pinocchio/algorithm/jacobian.hpp"
+ #include "pinocchio/algorithm/compute-all-terms.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE JointPrismaticTest
++#include <boost/test/included/unit_test.hpp>
+ #include <iostream>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/joint-revolute.cpp b/unittest/joint-revolute.cpp
+index 7d8a39d..d7c7010 100644
+--- unittest/joint-revolute.cpp
++++ unittest/joint-revolute.cpp
+@@ -10,8 +10,8 @@
+ #include "pinocchio/algorithm/crba.hpp"
+ #include "pinocchio/algorithm/jacobian.hpp"
+ #include "pinocchio/algorithm/compute-all-terms.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE JointRevoluteTest
++#include <boost/test/included/unit_test.hpp>
+ #include <iostream>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/joint-spherical.cpp b/unittest/joint-spherical.cpp
+index 4a50682..2043b6a 100644
+--- unittest/joint-spherical.cpp
++++ unittest/joint-spherical.cpp
+@@ -10,8 +10,8 @@
+ #include "pinocchio/algorithm/crba.hpp"
+ #include "pinocchio/algorithm/jacobian.hpp"
+ #include "pinocchio/algorithm/compute-all-terms.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE JointSphericalTest
++#include <boost/test/included/unit_test.hpp>
+ #include <iostream>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/joint-translation.cpp b/unittest/joint-translation.cpp
+index c5492b0..e7fb754 100644
+--- unittest/joint-translation.cpp
++++ unittest/joint-translation.cpp
+@@ -10,8 +10,8 @@
+ #include "pinocchio/algorithm/crba.hpp"
+ #include "pinocchio/algorithm/jacobian.hpp"
+ #include "pinocchio/algorithm/compute-all-terms.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE JointTranslationTest
++#include <boost/test/included/unit_test.hpp>
+ #include <iostream>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/kinematics-derivatives.cpp b/unittest/kinematics-derivatives.cpp
+index 0b1f6e4..a26cbe8 100644
+--- unittest/kinematics-derivatives.cpp
++++ unittest/kinematics-derivatives.cpp
+@@ -11,8 +11,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE KinematicsDerivativesTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/kinematics.cpp b/unittest/kinematics.cpp
+index 4a04c4b..9dddfb1 100644
+--- unittest/kinematics.cpp
++++ unittest/kinematics.cpp
+@@ -10,8 +10,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE KinematicsTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/liegroups.cpp b/unittest/liegroups.cpp
+index 065a656..746cc70 100644
+--- unittest/liegroups.cpp
++++ unittest/liegroups.cpp
+@@ -8,8 +8,8 @@
+ #include "pinocchio/multibody/liegroup/cartesian-product-variant.hpp"
+ 
+ #include "pinocchio/multibody/joint/joint-generic.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE LieGroupsTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ #include <boost/algorithm/string.hpp>
+ #include <boost/mpl/vector.hpp>
+diff --git a/unittest/macros.cpp b/unittest/macros.cpp
+index 56a8cc9..107cff2 100644
+--- unittest/macros.cpp
++++ unittest/macros.cpp
+@@ -3,8 +3,8 @@
+ //
+ 
+ #include "pinocchio/macros.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE MacrosTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/model.cpp b/unittest/model.cpp
+index 5209777..88196b0 100644
+--- unittest/model.cpp
++++ unittest/model.cpp
+@@ -13,8 +13,8 @@
+ #include "pinocchio/algorithm/geometry.hpp"
+ 
+ #include "pinocchio/parsers/sample-models.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE ModelTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ using namespace pinocchio;
+diff --git a/unittest/quaternion.cpp b/unittest/quaternion.cpp
+index 6730dff..b9317ec 100644
+--- unittest/quaternion.cpp
++++ unittest/quaternion.cpp
+@@ -6,8 +6,8 @@
+ #include <pinocchio/spatial/se3.hpp>
+ 
+ #include <boost/variant.hpp> // to avoid C99 warnings
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE QuaternionTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/regressor.cpp b/unittest/regressor.cpp
+index c8fcfb1..b58a2dc 100644
+--- unittest/regressor.cpp
++++ unittest/regressor.cpp
+@@ -12,8 +12,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE RegressorTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/rnea-derivatives.cpp b/unittest/rnea-derivatives.cpp
+index 0f1c2a8..0d810a4 100644
+--- unittest/rnea-derivatives.cpp
++++ unittest/rnea-derivatives.cpp
+@@ -14,8 +14,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE RNEADerivativesTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/rnea-second-order-derivatives.cpp b/unittest/rnea-second-order-derivatives.cpp
+index f8b582f..4f91a17 100644
+--- unittest/rnea-second-order-derivatives.cpp
++++ unittest/rnea-second-order-derivatives.cpp
+@@ -11,8 +11,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE RNEASecondOrderDerivativesTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/rnea.cpp b/unittest/rnea.cpp
+index 1d9c894..b3da853 100644
+--- unittest/rnea.cpp
++++ unittest/rnea.cpp
+@@ -29,8 +29,8 @@
+ #ifdef __SSE3__
+ #include <pmmintrin.h>
+ #endif
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE RNEATest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
+diff --git a/unittest/rotation.cpp b/unittest/rotation.cpp
+index 10ae784..7b41338 100644
+--- unittest/rotation.cpp
++++ unittest/rotation.cpp
+@@ -9,8 +9,8 @@
+ #include <Eigen/Geometry>
+ 
+ #include <boost/variant.hpp> // to avoid C99 warnings
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE RotationTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/rpy.cpp b/unittest/rpy.cpp
+index 0198b28..9deb8c4 100644
+--- unittest/rpy.cpp
++++ unittest/rpy.cpp
+@@ -7,8 +7,8 @@
+ #include <pinocchio/spatial/skew.hpp>
+ 
+ #include <boost/variant.hpp> // to avoid C99 warnings
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE RPYTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/sample-models.cpp b/unittest/sample-models.cpp
+index fd1660c..727ae94 100644
+--- unittest/sample-models.cpp
++++ unittest/sample-models.cpp
+@@ -9,8 +9,8 @@
+ #include "pinocchio/algorithm/kinematics.hpp"
+ #include "pinocchio/algorithm/geometry.hpp"
+ #include "pinocchio/parsers/sample-models.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE SampleModelsTest
++#include <boost/test/included/unit_test.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
+ 
+diff --git a/unittest/serialization.cpp b/unittest/serialization.cpp
+index 682cc13..c98b01c 100644
+--- unittest/serialization.cpp
++++ unittest/serialization.cpp
+@@ -23,8 +23,8 @@
+ #include "pinocchio/parsers/sample-models.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE SerializationTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/sincos.cpp b/unittest/sincos.cpp
+index 5b9b191..da2b0b8 100644
+--- unittest/sincos.cpp
++++ unittest/sincos.cpp
+@@ -7,8 +7,8 @@
+ #include <cstdlib>
+ 
+ #include "utils/macros.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE SinCosTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ namespace 
+diff --git a/unittest/spatial.cpp b/unittest/spatial.cpp
+index 0da7ce1..480e1f1 100644
+--- unittest/spatial.cpp
++++ unittest/spatial.cpp
+@@ -13,8 +13,8 @@
+ #include "pinocchio/spatial/skew.hpp"
+ #include "pinocchio/spatial/cartesian-axis.hpp"
+ #include "pinocchio/spatial/spatial-axis.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE SpatialTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
+diff --git a/unittest/srdf.cpp b/unittest/srdf.cpp
+index f10cda0..7b9060c 100644
+--- unittest/srdf.cpp
++++ unittest/srdf.cpp
+@@ -7,8 +7,8 @@
+ #include "pinocchio/multibody/model.hpp"
+ #include "pinocchio/parsers/urdf.hpp"
+ #include "pinocchio/parsers/srdf.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE SRDFTest
++#include <boost/test/included/unit_test.hpp>
+ 
+ using namespace pinocchio;
+ using namespace std;
+diff --git a/unittest/symmetric.cpp b/unittest/symmetric.cpp
+index b0e4b36..84d53a3 100644
+--- unittest/symmetric.cpp
++++ unittest/symmetric.cpp
+@@ -25,8 +25,8 @@
+ #include <Eigen/Geometry>
+ 
+ #include "pinocchio/spatial/symmetric3.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE SymmetricTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ 
+diff --git a/unittest/urdf.cpp b/unittest/urdf.cpp
+index b0cdf2f..0a9f7ea 100644
+--- unittest/urdf.cpp
++++ unittest/urdf.cpp
+@@ -12,8 +12,8 @@
+ #ifdef PINOCCHIO_WITH_HPP_FCL
+ #include <hpp/fcl/collision_object.h>
+ #endif // PINOCCHIO_WITH_HPP_FCL
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE URDFTest
++#include <boost/test/included/unit_test.hpp>
+ 
+ #include <urdf_parser/urdf_parser.h>
+ 
+diff --git a/unittest/value.cpp b/unittest/value.cpp
+index 0e5dbd9..59294b8 100644
+--- unittest/value.cpp
++++ unittest/value.cpp
+@@ -23,8 +23,8 @@
+ #include "pinocchio/parsers/urdf.hpp"
+ #include "pinocchio/algorithm/rnea.hpp"
+ #include "pinocchio/algorithm/kinematics.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE ValueTest
++#include <boost/test/included/unit_test.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
+ 
+diff --git a/unittest/vector.cpp b/unittest/vector.cpp
+index 1c9fd8e..bb3bc72 100644
+--- unittest/vector.cpp
++++ unittest/vector.cpp
+@@ -5,8 +5,8 @@
+ #include <pinocchio/math/matrix.hpp>
+ 
+ #include <boost/variant.hpp> // to avoid C99 warnings
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE VectorTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/version.cpp b/unittest/version.cpp
+index bc51a7a..6a5e922 100644
+--- unittest/version.cpp
++++ unittest/version.cpp
+@@ -6,8 +6,8 @@
+ #include <pinocchio/utils/version.hpp>
+ 
+ #include "utils/macros.hpp"
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE VersionTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+diff --git a/unittest/visitor.cpp b/unittest/visitor.cpp
+index 245b801..8a1ffc6 100644
+--- unittest/visitor.cpp
++++ unittest/visitor.cpp
+@@ -7,8 +7,8 @@
+ #include "pinocchio/multibody/visitor.hpp"
+ 
+ #include <iostream>
+-
+-#include <boost/test/unit_test.hpp>
++#define BOOST_TEST_MODULE VisitorTest
++#include <boost/test/included/unit_test.hpp>
+ #include <boost/utility/binary.hpp>
+ 
+ namespace bf = boost::fusion;

--- a/modules/pinocchio/2.6.21/patches/build_dot_bazel.patch
+++ b/modules/pinocchio/2.6.21/patches/build_dot_bazel.patch
@@ -1,0 +1,463 @@
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -0,0 +1,460 @@
++load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
++load(":generate_file.bzl", "generate_file")
++
++package(default_visibility = ["//visibility:public"])
++
++# Retrieve the module name and version.
++_MODULE_NAME = "pinocchio"
++_MODULE_VERSION = "2.6.1"
++
++# Define the required headers to be generated.
++generate_file(
++    name = "config_header",
++    out = "include/pinocchio/config.hpp",
++    library_name = _MODULE_NAME,
++    library_version = _MODULE_VERSION,
++    template = "cmake/config.hh.cmake",
++)
++
++generate_file(
++    name = "deprecated_header",
++    out = "include/pinocchio/deprecated.hpp",
++    library_name = _MODULE_NAME,
++    library_version = _MODULE_VERSION,
++    template = "cmake/deprecated.hh.cmake",
++)
++
++generate_file(
++    name = "warning_header",
++    out = "include/pinocchio/warning.hpp",
++    library_name = _MODULE_NAME,
++    library_version = _MODULE_VERSION,
++    template = "cmake/warning.hh.cmake",
++)
++
++filegroup(
++    name = "pinocchio_models",
++    srcs = glob(["models/**/*"]),
++)
++
++cc_library(
++    name = "pinocchio_includes",
++    srcs = glob(["src/**/*.cpp"]),
++    hdrs = glob([
++        "include/**/*.hpp",
++        "include/**/*.hxx",
++    ]) + [
++        ":config_header",
++        ":deprecated_header",
++        ":warning_header",
++    ],
++    copts = ["-DPINOCCHIO_URDFDOM_USE_STD_SHARED_PTR"],
++    includes = ["include/"],
++    deps = [
++        "@boost.filesystem//:boost.filesystem",
++        "@com_gitlab_libeigen_eigen//:eigen",
++        "@sdformat//:urdf_parser",
++    ],
++)
++
++BINARY_DEPS = [
++    ":pinocchio_includes",
++    "@com_gitlab_libeigen_eigen//:eigen",
++]
++
++# Core examples
++cc_binary(
++    name = "inverse-kinematics",
++    srcs = ["examples/inverse-kinematics.cpp"],
++    deps = BINARY_DEPS,
++)
++
++cc_binary(
++    name = "overview-simple",
++    srcs = ["examples/overview-simple.cpp"],
++    deps = BINARY_DEPS,
++)
++
++cc_binary(
++    name = "overview-lie",
++    srcs = ["examples/overview-lie.cpp"],
++    deps = BINARY_DEPS,
++)
++
++cc_binary(
++    name = "overview-SE3",
++    srcs = ["examples/overview-SE3.cpp"],
++    deps = BINARY_DEPS,
++)
++
++cc_binary(
++    name = "interpolation-SE3",
++    srcs = ["examples/interpolation-SE3.cpp"],
++    deps = BINARY_DEPS,
++)
++
++# Urdf-based examples
++cc_binary(
++    name = "overview-urdf",
++    srcs = ["examples/overview-urdf.cpp"],
++    deps = BINARY_DEPS,
++)
++
++cc_binary(
++    name = "build-reduced-model",
++    srcs = ["examples/build-reduced-model.cpp"],
++    deps = BINARY_DEPS,
++)
++
++cc_binary(
++    name = "geometry-models",
++    srcs = ["examples/geometry-models.cpp"],
++    deps = BINARY_DEPS,
++)
++
++cc_binary(
++    name = "kinematics-derivatives",
++    srcs = ["examples/kinematics-derivatives.cpp"],
++    deps = BINARY_DEPS,
++)
++
++cc_binary(
++    name = "forward-dynamics-derivatives",
++    srcs = ["examples/forward-dynamics-derivatives.cpp"],
++    deps = BINARY_DEPS,
++)
++
++cc_binary(
++    name = "inverse-dynamics-derivatives",
++    srcs = ["examples/inverse-dynamics-derivatives.cpp"],
++    deps = BINARY_DEPS,
++)
++
++TEST_DEPS = [
++    ":pinocchio_includes",
++    "@boost.test//:boost.test",
++    "@com_gitlab_libeigen_eigen//:eigen",
++]
++
++COMMON_TEST_HEADERS = [
++    "unittest/utils/macros.hpp",
++    "unittest/utils/model-generator.hpp",
++]
++
++cc_test(
++    name = "aba-derivatives_test",
++    srcs = ["unittest/aba-derivatives.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "aba_test",
++    srcs = ["unittest/aba.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "algo-check_test",
++    srcs = ["unittest/algo-check.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "all-joints_test",
++    srcs = ["unittest/all-joints.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "cartesian-product-liegroups_test",
++    srcs = ["unittest/cartesian-product-liegroups.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "center-of-mass-derivatives_test",
++    srcs = ["unittest/center-of-mass-derivatives.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "centroidal-derivatives_test",
++    srcs = ["unittest/centroidal-derivatives.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "centroidal_test",
++    srcs = ["unittest/centroidal.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "cholesky_test",
++    srcs = ["unittest/cholesky.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "com_test",
++    srcs = ["unittest/com.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "compute-all-terms_test",
++    srcs = ["unittest/compute-all-terms.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "constraint_test",
++    srcs = ["unittest/constraint.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "contact-dynamics-derivatives_test",
++    srcs = ["unittest/contact-dynamics-derivatives.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "contact-dynamics_test",
++    srcs = ["unittest/contact-dynamics.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "copy_test",
++    srcs = ["unittest/copy.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "crba_test",
++    srcs = ["unittest/crba.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "data_test",
++    srcs = ["unittest/data.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "eigen-basic-op_test",
++    srcs = ["unittest/eigen-basic-op.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "eigen-tensor_test",
++    srcs = ["unittest/eigen-tensor.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "energy_test",
++    srcs = ["unittest/energy.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "explog_test",
++    srcs = ["unittest/explog.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "finite-differences_test",
++    srcs = ["unittest/finite-differences.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "frames-derivatives_test",
++    srcs = ["unittest/frames-derivatives.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "frames_test",
++    srcs = ["unittest/frames.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "joint-composite_test",
++    srcs = ["unittest/joint-composite.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "joint-configurations_test",
++    srcs = ["unittest/joint-configurations.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "joint-free-flyer_test",
++    srcs = ["unittest/joint-free-flyer.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "joint-generic_test",
++    srcs = ["unittest/joint-generic.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "joint-jacobian_test",
++    srcs = ["unittest/joint-jacobian.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "joint-mimic_test",
++    srcs = ["unittest/joint-mimic.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "joint-planar_test",
++    srcs = ["unittest/joint-planar.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "joint-prismatic_test",
++    srcs = ["unittest/joint-prismatic.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "joint-revolute_test",
++    srcs = ["unittest/joint-revolute.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "joint-spherical_test",
++    srcs = ["unittest/joint-spherical.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "joint-translation_test",
++    srcs = ["unittest/joint-translation.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "kinematics-derivatives_test",
++    srcs = ["unittest/kinematics-derivatives.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "kinematics_test",
++    srcs = ["unittest/kinematics.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "liegroups_test",
++    srcs = ["unittest/liegroups.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "macros_test",
++    srcs = ["unittest/macros.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "model_test",
++    srcs = ["unittest/model.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "quaternion_test",
++    srcs = ["unittest/quaternion.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "regressor_test",
++    srcs = ["unittest/regressor.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "rnea-derivatives_test",
++    srcs = ["unittest/rnea-derivatives.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "rnea-second-order-derivatives_test",
++    srcs = ["unittest/rnea-second-order-derivatives.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "rnea_test",
++    srcs = ["unittest/rnea.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "rotation_test",
++    srcs = ["unittest/rotation.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "rpy_test",
++    srcs = ["unittest/rpy.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "sample-models_test",
++    srcs = ["unittest/sample-models.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "sincos_test",
++    srcs = ["unittest/sincos.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "symmetric_test",
++    srcs = ["unittest/symmetric.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "vector_test",
++    srcs = ["unittest/vector.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "version_test",
++    srcs = ["unittest/version.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)
++
++cc_test(
++    name = "visitor_test",
++    srcs = ["unittest/visitor.cpp"] + COMMON_TEST_HEADERS,
++    deps = TEST_DEPS,
++)

--- a/modules/pinocchio/2.6.21/patches/generate_file_dot_bzl.patch
+++ b/modules/pinocchio/2.6.21/patches/generate_file_dot_bzl.patch
@@ -1,0 +1,55 @@
+--- generate_file.bzl
++++ generate_file.bzl
+@@ -0,0 +1,52 @@
++load("@bazel_skylib//lib:shell.bzl", "shell")
++
++def _generate_file_impl(ctx):
++    """Rule for generating custom files from templates."""
++
++    output = ctx.actions.declare_file(ctx.attr.out)
++
++    sanitized_library_name = shell.quote(ctx.attr.library_name).replace("'", "").upper()
++    derived_export_symbol = sanitized_library_name + "_EXPORTS"
++    version_parts = ctx.attr.library_version.split(".")
++    if len(version_parts) < 3:
++        fail("Version string '{}' is not in the expected 'major.minor.patch' format.".format(ctx.attr.library_version))
++
++    substitutions = {
++        "@LIBRARY_NAME@": sanitized_library_name,
++        "@PACKAGE_CPPNAME@": sanitized_library_name,
++        "@PROJECT_VERSION@": ctx.attr.library_version,
++        "@PROJECT_VERSION_MAJOR_CONFIG@": version_parts[0],
++        "@PROJECT_VERSION_MINOR_CONFIG@": version_parts[1],
++        "@PROJECT_VERSION_PATCH_CONFIG@": version_parts[2],
++        "@EXPORT_SYMBOL@": derived_export_symbol,
++    }
++
++    ctx.actions.expand_template(
++        output = output,
++        template = ctx.file.template,
++        substitutions = substitutions,
++    )
++    return [DefaultInfo(files = depset([output]))]
++
++generate_file = rule(
++    implementation = _generate_file_impl,
++    attrs = {
++        "template": attr.label(
++            doc = "The template base file used for generation.",
++            allow_single_file = True,
++            mandatory = True,
++        ),
++        "out": attr.string(
++            doc = "The path and name of the output file.",
++            mandatory = True,
++        ),
++        "library_name": attr.string(
++            doc = "The base name of the library, used for macro prefixes.",
++            mandatory = True,
++        ),
++        "library_version": attr.string(
++            doc = "The full project version string (e.g., '1.2.3').",
++            mandatory = True,
++        ),
++    },
++)

--- a/modules/pinocchio/2.6.21/patches/module_dot_bazel.patch
+++ b/modules/pinocchio/2.6.21/patches/module_dot_bazel.patch
@@ -1,0 +1,15 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,12 @@
++module(
++    name = "pinocchio",
++    version = "2.6.21",
++    compatibility_level = 0,
++)
++
++bazel_dep(name = "rules_cc", version = "0.1.1")
++bazel_dep(name = "bazel_skylib", version = "1.7.1")
++bazel_dep(name = "eigen", version = "4.0.0-20241125.bcr.2", repo_name = "com_gitlab_libeigen_eigen")
++bazel_dep(name = "sdformat", version = "15.3.0.bcr.1")
++bazel_dep(name = "boost.filesystem", version = "1.83.0")
++bazel_dep(name = "boost.test", version = "1.83.0")

--- a/modules/pinocchio/2.6.21/patches/undefine_ptr_casts_dot_bzl.patch
+++ b/modules/pinocchio/2.6.21/patches/undefine_ptr_casts_dot_bzl.patch
@@ -1,0 +1,18 @@
+--- include/pinocchio/parsers/urdf/types.hpp
++++ include/pinocchio/parsers/urdf/types.hpp
+@@ -41,6 +41,7 @@ namespace urdf
+   PINOCCHIO_URDF_TYPEDEF_CLASS_POINTER(Sphere);
+   PINOCCHIO_URDF_TYPEDEF_CLASS_POINTER(Visual);
+   
++/*
+   template<class T, class U>
+   PINOCCHIO_URDF_SHARED_PTR(T) const_pointer_cast(PINOCCHIO_URDF_SHARED_PTR(U) const & r)
+   {
+@@ -70,6 +71,7 @@ namespace urdf
+     return boost::static_pointer_cast<T>(r);
+ #endif
+   }
++*/
+ }
+ 
+ #undef PINOCCHIO_URDF_TYPEDEF_CLASS_POINTER

--- a/modules/pinocchio/2.6.21/presubmit.yml
+++ b/modules/pinocchio/2.6.21/presubmit.yml
@@ -1,0 +1,36 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - "@pinocchio//:*"
+bcr_test_module:
+  module_path: .
+  matrix:
+    platform:
+    - debian11
+    - ubuntu2204
+    - macos
+    - macos_arm64
+    bazel:
+    - 8.x
+    - 7.x
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - "@pinocchio//:*"
+      test_targets:
+      - "@pinocchio//:*"

--- a/modules/pinocchio/2.6.21/source.json
+++ b/modules/pinocchio/2.6.21/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://github.com/stack-of-tasks/pinocchio/releases/download/v2.6.21/pinocchio-2.6.21.tar.gz",
+    "integrity": "sha256-ERMeKmlDiPc2T52NkWFVB60uE/r1iieomLkw829ePbM=",
+    "strip_prefix": "pinocchio-2.6.21",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-+SE9H2DetFA4XM5ojBpARJzO2oAzOGfMiaNr9qQL2FY=",
+        "build_dot_bazel.patch": "sha256-X4EjE97Y4C/nOURl85cf8UmmrlQ95sfP1m3pVmRSDww=",
+        "generate_file_dot_bzl.patch": "sha256-0Y4oQlz9BbNcVqiOl9P7wYa9neZomujXgaGSJ2KDPbM=",
+        "undefine_ptr_casts_dot_bzl.patch": "sha256-pfB/894MupNgGUYGxAncfzqqmZZgAJq2bFEM34dSJL4=",
+        "boost_tests_dot_bzl.patch": "sha256-92lqzP4B9aD6WPg4eC9ec/QE1d2TmA4E4UXEGLfaVNg="
+    }
+}

--- a/modules/pinocchio/metadata.json
+++ b/modules/pinocchio/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/stack-of-tasks/pinocchio",
+    "maintainers": [
+        {
+            "email": "bponton@intrinsic.ai",
+            "name": "bponton-intrinsic"
+        }
+    ],
+    "repository": [
+        "github:stack-of-tasks/pinocchio.git",
+        "https://github.com/stack-of-tasks/pinocchio"
+    ],
+    "versions": [
+        "2.6.21"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Publish Pinocchio@2.6.1

Release: https://github.com/stack-of-tasks/pinocchio/releases/tag/v2.6.21

It also updates the tests to make them compatible with a newer available boost version than it was originally built for.