### PR TITLE
Add the new `apilark` package (@v0.1) to the Bazel Central Registry

### DIFF
--- a/modules/apilark/0.1/MODULE.bazel
+++ b/modules/apilark/0.1/MODULE.bazel
@@ -1,0 +1,20 @@
+# Copyright 2024 The APIlark Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Top-level Bazel module configuration for ApiLark."""
+
+module(name = "apilark", version = "0.1")
+
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "rules_testing", version = "0.6.0")

--- a/modules/apilark/0.1/presubmit.yml
+++ b/modules/apilark/0.1/presubmit.yml
@@ -1,0 +1,42 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@apilark//apilark:access_token'
+    - '@apilark//apilark:api'
+    - '@apilark//apilark:aspect_definition'
+    - '@apilark//apilark:aspect_interface'
+    - '@apilark//apilark:rule_definition'
+    - '@apilark//apilark:rule_interface'
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform:
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    - windows
+    bazel:
+    - 8.x
+    - 7.x
+    - 6.x
+  tasks:
+    run_tests:
+      name: Run test
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+      - '//tests/...'

--- a/modules/apilark/0.1/source.json
+++ b/modules/apilark/0.1/source.json
@@ -1,0 +1,7 @@
+{
+    "url": "https://github.com/google/apilark/releases/download/v0.1/apilark-0.1.tar.gz",
+    "strip_prefix": "apilark-0.1",
+    "integrity": "sha256-9RzSB0hAT7hrtx4I/fqkGbQvldr85a7fEXw95a18aww=",
+    "patch_strip": 1,
+    "patches": {}
+}

--- a/modules/apilark/metadata.json
+++ b/modules/apilark/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/google/apilark/",
+    "maintainers": [
+        {
+            "email": "kmoffett@google.com",
+            "github": "kmoffett",
+            "github_user_id": 713142,
+            "name": "Kyle Moffett"
+        }
+    ],
+    "repository": [
+        "github:google/apilark"
+    ],
+    "versions": [
+        "0.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This package is just a set of Starlark wrapper libraries; it passes tests under all platforms and environments.