### PR TITLE
feat: Add package libxslt 1.1.43

### DIFF
--- a/modules/libxslt/1.1.43/MODULE.bazel
+++ b/modules/libxslt/1.1.43/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "libxslt",
+    version = "1.1.43",
+    compatibility_level = 0,
+)
+bazel_dep(name = "libxml2", version = "2.13.5")
+bazel_dep(name = "rules_foreign_cc", version = "0.13.0")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/libxslt/1.1.43/patches/build_dot_bazel.patch
+++ b/modules/libxslt/1.1.43/patches/build_dot_bazel.patch
@@ -1,0 +1,56 @@
+commit a2a01082f45cbb83deaf04f71680aeb6893b3529 (HEAD -> master)
+Author: hmelder <service@hugomelder.com>
+Date:   Tue Jul 1 16:07:55 2025 +0200
+
+    feat: Add BUILD.bazel
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 00000000..0ee4b99f
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,44 @@
++""" Builds libxslt.
++"""
++
++load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
++
++filegroup(
++    name = "srcs",
++    srcs = glob(["**"]),
++)
++
++cache_entries = {
++    "CMAKE_INSTALL_LIBDIR": "lib",
++    "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
++    "BUILD_SHARED_LIBS": "OFF",
++    #libxslt specific options.
++    "LIBXSLT_WITH_DEBUGGER": "OFF",
++    "LIBXSLT_WITH_CRYPTO": "OFF",
++    "LIBXSLT_WITH_MODULES": "OFF",
++    "LIBXSLT_WITH_PROFILER": "OFF",
++    "LIBXSLT_WITH_PROGRAMS": "OFF",
++    "LIBXSLT_WITH_PYTHON": "OFF",
++    "LIBXSLT_WITH_TESTS": "OFF",
++}
++
++cmake(
++    name = "libxslt",
++    env = {"CMAKE_BUILD_TYPE": "Release"},
++    lib_source = ":srcs",
++    cache_entries = cache_entries,
++    out_static_libs = select({
++        "@platforms//os:windows": [
++            "libxslts.lib",
++            "libexslts.lib",
++        ],
++        "//conditions:default": [
++            "libxslt.a",
++            "libexslt.a",
++        ],
++    }),
++    visibility = ["//visibility:public"],
++    deps = [
++      "@libxml2//:libxml2",
++    ],
++)

--- a/modules/libxslt/1.1.43/patches/module_dot_bazel.patch
+++ b/modules/libxslt/1.1.43/patches/module_dot_bazel.patch
@@ -1,0 +1,14 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 00000000..d41a1ed8
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,8 @@
++module(
++    name = "libxslt",
++    version = "1.1.43",
++    compatibility_level = 0,
++)
++bazel_dep(name = "libxml2", version = "2.13.5")
++bazel_dep(name = "rules_foreign_cc", version = "0.13.0")
++bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/libxslt/1.1.43/presubmit.yml
+++ b/modules/libxslt/1.1.43/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@libxslt//:libxslt'

--- a/modules/libxslt/1.1.43/source.json
+++ b/modules/libxslt/1.1.43/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.43.tar.xz",
+    "integrity": "sha256-Wj1rODylr8I1sXERjpD1/2qifp/qMwMGUjGm1APwGDo=",
+    "strip_prefix": "libxslt-1.1.43",
+    "patches": {
+        "build_dot_bazel.patch": "sha256-BBPCknwtkCetWCro4EbPhOln2ztmcm/LZ0ijGBf97z8=",
+        "module_dot_bazel.patch": "sha256-WSjQ5Egwd/xFvO273k8BOLyqw7CxNyX2KqKHsbedpPU="
+    },
+    "patch_strip": 1
+}

--- a/modules/libxslt/metadata.json
+++ b/modules/libxslt/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://gitlab.gnome.org/GNOME/libxslt/-/wikis/home",
+    "maintainers": [
+        {
+            "email": "contact@hugomelder.com",
+            "github": "hmelder",
+            "name": "Hugo Melder",
+            "github_user_id": 45601940
+        }
+    ],
+    "repository": [
+        "https://download.gnome.org/sources/libxslt"
+    ],
+    "versions": [
+        "1.1.43"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This pull request packages [libxslt](https://gitlab.gnome.org/GNOME/libxslt) using `rules_foreign_cc`'s `cmake` module.

The package was tested with a small test program depending on libxslt and libxml2 on Ubuntu 25.04 aarch64.
The validation test `bazel run -- //tools:bcr_validation --check=libxlt` passed.

This is my first contribution to the bazel-central-registry, so please review this PR carefully :)
Also, is there a way to split libxslt and libexslt into separate entities, i.e. `@libxslt//:libxslt` and `@libxslt//:libexslt`?