### PR TITLE
Add aom

### DIFF
--- a/modules/aom/3.12.1/MODULE.bazel
+++ b/modules/aom/3.12.1/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "aom",
+    version = "3.12.1",
+)
+bazel_dep(name = "rules_foreign_cc", version = "0.15.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "nasm", version = "2.16.03.bcr.1")

--- a/modules/aom/3.12.1/patches/add_build_file.patch
+++ b/modules/aom/3.12.1/patches/add_build_file.patch
@@ -1,0 +1,48 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,45 @@
++load("@rules_license//rules:license.bzl", "license")
++load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
++
++package(
++    default_applicable_licenses = [":license"],
++    default_visibility = ["//visibility:public"],
++)
++
++exports_files(["LICENSE"])
++
++license(
++    name = "license",
++    package_name = "aom",
++    license_kinds = [
++        "@rules_license//licenses/spdx:BSD-3-Clause",
++    ],
++    license_text = "LICENSE",
++    package_url = "https://aomedia.googlesource.com/aom",
++)
++
++filegroup(
++    name = "all_srcs",
++    srcs = glob(["**"]),
++)
++
++cmake(
++    name = "aom",
++    build_data = [
++        "@nasm",
++    ],
++    cache_entries = {
++        "BUILD_SHARED_LIBS": "OFF",
++        "ENABLE_DOCS": "OFF",
++        "ENABLE_EXAMPLES": "OFF",
++        "ENABLE_TESTS": "OFF",
++        "ENABLE_TOOLS": "OFF",
++    },
++    env = {
++        "CMAKE_BUILD_TYPE": "Release",
++        "CMAKE_BUILD_PARALLEL_LEVEL": "4",
++        "PATH": "$$PATH:$$(dirname $(execpath @nasm))",
++    },
++    lib_source = ":all_srcs",
++    out_static_libs = ["libaom.a"],
++)

--- a/modules/aom/3.12.1/patches/module_dot_bazel.patch
+++ b/modules/aom/3.12.1/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "aom",
++    version = "3.12.1",
++)
++bazel_dep(name = "rules_foreign_cc", version = "0.15.0")
++bazel_dep(name = "rules_license", version = "1.0.0")
++bazel_dep(name = "nasm", version = "2.16.03.bcr.1")

--- a/modules/aom/3.12.1/presubmit.yml
+++ b/modules/aom/3.12.1/presubmit.yml
@@ -4,11 +4,9 @@ matrix:
   - ubuntu2204
   - macos
   - macos_arm64
-  - windows
   bazel:
   - 8.x
   - 7.x
-  - 6.x
 tasks:
   verify_targets:
     name: Verify build targets

--- a/modules/aom/3.12.1/presubmit.yml
+++ b/modules/aom/3.12.1/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@aom'

--- a/modules/aom/3.12.1/source.json
+++ b/modules/aom/3.12.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://storage.googleapis.com/aom-releases/libaom-3.12.1.tar.gz",
+    "integrity": "sha256-npd1GA3sff1hp54AvaOAnUOJGu5rLjMf9/JphiB+oi4=",
+    "strip_prefix": "libaom-3.12.1",
+    "patches": {
+        "add_build_file.patch": "sha256-pxSfSEiiQewjxuhgsejPNj8tvroprTMMC36V5Iv8sNI=",
+        "module_dot_bazel.patch": "sha256-QST+Sn3Hezpr6mtSc/l0KkwNA9cGUrFa4hHn9fckGuQ="
+    },
+    "patch_strip": 0
+}

--- a/modules/aom/metadata.json
+++ b/modules/aom/metadata.json
@@ -1,6 +1,13 @@
 {
     "homepage": "https://aomedia.googlesource.com/aom/",
-    "maintainers": [],
+    "maintainers": [
+        {
+            "email": "alexanderfaxa@intrinsic.ai",
+            "github": "faximan",
+            "github_user_id": 207300,
+            "name": "Alex Faxa"
+        }
+    ],
     "repository": [],
     "versions": [
         "3.12.1"

--- a/modules/aom/metadata.json
+++ b/modules/aom/metadata.json
@@ -8,7 +8,9 @@
             "name": "Alex Faxa"
         }
     ],
-    "repository": [],
+    "repository": [
+        "https://aomedia.googlesource.com/aom/"
+    ],
     "versions": [
         "3.12.1"
     ],

--- a/modules/aom/metadata.json
+++ b/modules/aom/metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "repository": [
-        "https://aomedia.googlesource.com/aom/"
+        "https://storage.googleapis.com/aom-releases"
     ],
     "versions": [
         "3.12.1"

--- a/modules/aom/metadata.json
+++ b/modules/aom/metadata.json
@@ -9,6 +9,7 @@
         }
     ],
     "repository": [
+        "https://aomedia.googlesource.com/aom/",
         "https://storage.googleapis.com/aom-releases"
     ],
     "versions": [

--- a/modules/aom/metadata.json
+++ b/modules/aom/metadata.json
@@ -1,0 +1,9 @@
+{
+    "homepage": "https://aomedia.googlesource.com/aom/",
+    "maintainers": [],
+    "repository": [],
+    "versions": [
+        "3.12.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Note: this is my first BCR contribution.

I am not quite sure whether the module as well as the top-level build target should be called `aom` or `libaom`. It seems to be referenced as only aom at https://aomedia.googlesource.com/aom/, but it builds `libaom.so` and I've seen that used in other places.