### PR TITLE
freeimage@3.19.10.bcr.1

### DIFF
--- a/modules/freeimage/3.19.10.bcr.1/MODULE.bazel
+++ b/modules/freeimage/3.19.10.bcr.1/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "freeimage",
+    version = "3.19.10.bcr.1",
+    compatibility_level = 0,
+)
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "libwebp", version = "1.5.0")
+bazel_dep(name = "openexr", version = "3.3.3.bcr.1")
+bazel_dep(name = "libpng", version = "1.6.41")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")

--- a/modules/freeimage/3.19.10.bcr.1/patches/add_build_file.patch
+++ b/modules/freeimage/3.19.10.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,236 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,232 @@
++load("@rules_license//rules:license.bzl", "license")
++
++package(
++    default_applicable_licenses = [":license"],
++)
++
++license(
++    name = "license",
++    package_name = "freeimage",
++)
++
++# Dual licensed FreeImage and GPL
++# https://freeimage.sourceforge.io/license.html
++licenses(["reciprocal"])
++
++exports_files(glob(["license-*.txt"]))
++
++
++internal_zlib_private_headers = glob(
++    include = [
++        "Source/ZLib/*.h",
++    ],
++)
++
++internal_libpng_private_headers = ["Source/LibPNG/png.h"]
++
++internal_openexr_public_headers = glob(
++    include = [
++        "Source/OpenEXR/*.h",
++    ],
++)
++
++internal_openexr_half_private_headers = glob(
++    include = [
++        "Source/OpenEXR/Half/*.h",
++    ],
++)
++
++internal_openexr_half_sources = glob(
++    include = [
++        "Source/OpenEXR/Half/*.cpp",
++    ],
++    exclude = [
++        "Source/OpenEXR/Half/toFloat.cpp",
++        "Source/OpenEXR/Half/eLut.cpp",
++    ],
++)
++
++cc_library(
++    name = "openexr_half",
++    srcs = internal_openexr_half_sources +
++           internal_openexr_half_private_headers,
++    hdrs = internal_openexr_public_headers,
++    copts = [
++        "-w",
++    ],
++    includes = ["Source/OpenEXR/Half"],
++)
++
++internal_libjpeg_private_headers = glob(
++    include = [
++        "Source/LibJPEG/*.h",
++    ],
++)
++
++internal_libjpeg_sources = glob(
++    include = [
++        "Source/LibJPEG/*.c",
++    ],
++    exclude = [
++        "Source/LibJPEG/cjpeg.c",
++        "Source/LibJPEG/ckconfig.c",
++        "Source/LibJPEG/djpeg.c",
++        "Source/LibJPEG/example.c",
++        "Source/LibJPEG/jpegtran.c",
++        "Source/LibJPEG/jmemansi.c",
++        "Source/LibJPEG/jmemdos.c",
++        "Source/LibJPEG/jmemmac.c",
++        "Source/LibJPEG/jmemnobs.c",
++        "Source/LibJPEG/rdjpgcom.c",
++        "Source/LibJPEG/wrjpgcom.c",
++    ],
++)
++
++cc_library(
++    name = "libjpeg",
++    srcs = internal_libjpeg_sources +
++           internal_libjpeg_private_headers,
++    copts = [
++        "-w",
++        "-Wno-error=implicit-function-declaration",
++    ],
++    includes = ["Source/LibJPEG"],
++)
++
++internal_openjpeg_private_headers = glob(
++    include = [
++        "Source/LibOpenJPEG/*.h",
++    ],
++    exclude = [
++        "Source/LibOpenJPEG/*manager.h",
++    ],
++)
++
++internal_openjpeg_sources = glob(
++    include = [
++        "Source/LibOpenJPEG/*.c",
++    ],
++    exclude = [
++        "Source/LibOpenJPEG/*manager.c",
++        "Source/LibOpenJPEG/t1_generate_luts.c",
++    ],
++)
++
++cc_library(
++    name = "openjpeg",
++    srcs = internal_openjpeg_sources +
++           internal_openjpeg_private_headers,
++    copts = [
++        "-w",
++    ],
++    includes = ["Source/LibOpenJPEG"],
++)
++
++internal_tiff_private_headers = glob(
++    include = [
++        "Source/LibTIFF4/*.h",
++    ],
++    exclude = [
++        "Source/LibTIFF4/tif_win32.h",
++        "Source/LibTIFF4/tif_wince.h",
++        "Source/LibTIFF4/tif_config.vc.h",
++    ],
++)
++
++internal_tiff_sources = glob(
++    include = [
++        "Source/LibTIFF4/*.c",
++    ],
++    exclude = [
++        "Source/LibTIFF4/tif_win32.c",
++        "Source/LibTIFF4/tif_wince.c",
++        "Source/LibTIFF4/tif_vms.c",
++        "Source/LibTIFF4/mkg3states.c",
++        "Source/LibTIFF4/mkspans.c",
++    ],
++)
++
++cc_library(
++    name = "tiff",
++    srcs = internal_tiff_sources +
++           internal_tiff_private_headers +
++           internal_libjpeg_private_headers,
++    copts = [
++        "-w",
++        "-Wno-error=implicit-function-declaration",
++    ],
++    includes = [
++        "Source/LibJPEG",
++        "Source/LibTIFF4",
++    ],
++)
++
++freeimage_public_headers = ["Source/FreeImage.h"]
++
++freeimage_sources = glob(
++    include = [
++        "Source/FreeImage/*.cpp",
++        "Source/FreeImageToolkit/*.cpp",
++        "Source/Metadata/*.cpp",
++    ],
++)
++
++freeimage_private_headers = glob(
++    include = [
++        "Source/*.h",
++        "Source/FreeImage/*.h",
++        "Source/FreeImageToolkit/*.h",
++        "Source/Metadata/*.h",
++    ],
++    exclude = freeimage_public_headers,
++)
++
++cc_library(
++    name = "freeimage",
++    srcs = freeimage_sources + freeimage_private_headers +
++           internal_zlib_private_headers +
++           internal_libpng_private_headers,
++    hdrs = freeimage_public_headers,
++    copts = [
++        "-w",
++        "-Wno-error=implicit-function-declaration",
++    ],
++    includes = [
++        "Source",
++    ],
++    visibility = ["//visibility:public"],
++    deps = [
++        ":libjpeg",
++        ":openexr_half",
++        ":openjpeg",
++        ":tiff",
++        "@libpng",
++        "@libwebp",
++        "@openexr//:OpenEXR",
++        "@zlib",
++    ],
++)
++
++freeimageplus_sources = glob(
++    include = [
++        "Wrapper/FreeImagePlus/src/*.cpp",
++    ],
++)
++
++freeimageplus_public_headers = ["Wrapper/FreeImagePlus/FreeImagePlus.h"]
++
++cc_library(
++    name = "freeimageplus",
++    srcs = freeimageplus_sources,
++    hdrs = freeimageplus_public_headers,
++    copts = [
++        "-w",
++    ],
++    includes = [
++        "Wrapper/FreeImagePlus",
++    ],
++    visibility = ["//visibility:public"],
++    deps = [
++        ":freeimage",
++    ],
++)
+

--- a/modules/freeimage/3.19.10.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/freeimage/3.19.10.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,13 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,10 @@
++module(
++    name = "freeimage",
++    version = "3.19.10.bcr.1",
++    compatibility_level = 0,
++)
++bazel_dep(name = "rules_license", version = "1.0.0")
++bazel_dep(name = "libwebp", version = "1.5.0")
++bazel_dep(name = "openexr", version = "3.3.3.bcr.1")
++bazel_dep(name = "libpng", version = "1.6.41")
++bazel_dep(name = "zlib", version = "1.3.1.bcr.5")

--- a/modules/freeimage/3.19.10.bcr.1/patches/tif_unix.patch
+++ b/modules/freeimage/3.19.10.bcr.1/patches/tif_unix.patch
@@ -1,0 +1,19 @@
+--- Source/FreeImage/PluginTIFF.cpp
++++ Source/FreeImage/PluginTIFF.cpp
+@@ -197,6 +197,8 @@ TIFFFdOpen(thandle_t handle, const char *name, const char *mode) {
+ 	return tif;
+ }
+ 
++#ifndef USE_INTERNAL_TIFF_UNIX_ROUTINES
++
+ // ----------------------------------------------------------
+ //   TIFF library FreeImage-specific routines.
+ // ----------------------------------------------------------
+@@ -267,6 +269,7 @@ msdosErrorHandler(const char* module, const char* fmt, va_list ap) {
+ 
+ TIFFErrorHandler _TIFFerrorHandler = msdosErrorHandler;
+ #endif // ndef _WIN32
++#endif // ndef USE_INTERNAL_TIFF_UNIX_ROUTINES
+ // ----------------------------------------------------------
+ 
+ #define CVT(x)      (((x) * 255L) / ((1L<<16)-1))

--- a/modules/freeimage/3.19.10.bcr.1/presubmit.yml
+++ b/modules/freeimage/3.19.10.bcr.1/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@freeimage'
+    - '@freeimage//:freeimage'
+    - '@freeimage//:freeimageplus'

--- a/modules/freeimage/3.19.10.bcr.1/source.json
+++ b/modules/freeimage/3.19.10.bcr.1/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/danoli3/FreeImage/archive/refs/tags/3.19.10.tar.gz",
+    "integrity": "sha256-fdIu65XpZ+VB2GTaizvAPjBQmD8t4sscCaYNKOZ5xvI=",
+    "strip_prefix": "FreeImage-3.19.10",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-zyjS2dM7ephO7wVy5Dzmea/9cm72C2GH279qed/jNqE=",
+        "module_dot_bazel.patch": "sha256-FblDwe8IeDAj10qOUjRmi6ktBamAb4OIXyKFcPG5GFI=",
+        "tif_unix.patch": "sha256-C8hD7bdX40gNHdDuF018qfj8ASmd1pgNcWaEB8IUVS8="
+    }
+}

--- a/modules/freeimage/metadata.json
+++ b/modules/freeimage/metadata.json
@@ -12,7 +12,8 @@
         "github:danoli3/FreeImage"
     ],
     "versions": [
-        "3.19.10"
+        "3.19.10",
+        "3.19.10.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds a patch to avoid duplicate tif unix function definitions.