### PR TITLE
Upgrade slsa-verifier to v2.7.1

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -79,8 +79,7 @@ COLOR = {
 
 UPSTREAM_MODULES_DIR_URL = "https://bcr.bazel.build/modules"
 
-# TODO(fweikert): switch to a stable release that contains https://github.com/slsa-framework/slsa-verifier/pull/840
-DEFAULT_SLSA_VERIFIER_VERSION = "v2.7.1-rc.1"
+DEFAULT_SLSA_VERIFIER_VERSION = "v2.7.1"
 
 ATTESTATIONS_DOCS_URL = "https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/attestations.md"
 

--- a/tools/slsa.py
+++ b/tools/slsa.py
@@ -116,8 +116,6 @@ class Verifier:
             [self._executable, cmd] + args,
             capture_output=True,
             encoding="utf-8",
-            # TODO(fweikert): remove once GH attestation support is stable.
-            env={"SLSA_VERIFIER_EXPERIMENTAL": "1", **os.environ},
         )
 
         if result.returncode:
@@ -139,8 +137,7 @@ class Verifier:
         url = self._get_url()
         raw_content = download(url)
 
-        # TODO(fweikert): Re-enable once we use a stable release.
-        # self._check_sha256sum(raw_content, os.path.basename(url))
+        self._check_sha256sum(raw_content, os.path.basename(url))
 
         with open(self._executable, "wb") as f:
             f.write(raw_content)

--- a/tools/slsa.py
+++ b/tools/slsa.py
@@ -128,7 +128,8 @@ class Verifier:
                 )
             )
 
-        eprint(f"Result:\n\t{result.stdout}")
+        # slsa-verifier prints to stderr.
+        eprint(f"\n\nResult:\n\n{result.stderr}")
 
     def _download_binary_if_necessary(self):
         if self._executable.exists():


### PR DESCRIPTION
We no longer need to depend on an experimental feature.

This change also fixes slsa-verifier output - for some reason it doesn't print to stdout, only stderr.