### PR TITLE
Update gz-physics

### DIFF
--- a/modules/gz-physics/8.2.0.bcr.1/MODULE.bazel
+++ b/modules/gz-physics/8.2.0.bcr.1/MODULE.bazel
@@ -1,0 +1,20 @@
+module(
+    name = "gz-physics",
+    version = "8.2.0.bcr.1",
+    compatibility_level = 8,
+)
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
+bazel_dep(name = "bullet", version = "3.26.0-rc0")
+bazel_dep(name = "dartsim", version = "6.13.2")
+bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
+bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+
+# Gazebo Dependencies
+bazel_dep(name = "rules_gazebo", version = "0.0.6")
+bazel_dep(name = "gz-common", version = "6.1.0")
+bazel_dep(name = "gz-math", version = "8.1.1.bcr.1")
+bazel_dep(name = "gz-plugin", version = "3.1.0")
+bazel_dep(name = "gz-utils", version = "3.1.0")
+bazel_dep(name = "sdformat", version = "15.3.0.bcr.2")

--- a/modules/gz-physics/8.2.0.bcr.1/patches/fix_build_bazel.patch
+++ b/modules/gz-physics/8.2.0.bcr.1/patches/fix_build_bazel.patch
@@ -1,0 +1,18 @@
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -58,7 +58,6 @@ sources = glob(
+     ],
+     exclude = [
+         "src/*_TEST.cc",
+-        "src/InstallationDirectories.cc",
+     ],
+ )
+
+@@ -72,6 +71,7 @@ cc_library(
+     name = "gz-physics",
+     srcs = sources,
+     hdrs = public_headers,
++    defines = ["GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR='\"\"'"],
+     includes = ["include"],
+     visibility = ["//visibility:public"],
+     deps = [

--- a/modules/gz-physics/8.2.0.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/gz-physics/8.2.0.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,59 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,9 +1,10 @@
+-## MODULE.bazel
+ module(
+     name = "gz-physics",
+-    repo_name = "org_gazebosim_gz-physics",
++    version = "8.2.0.bcr.1",
++    compatibility_level = 8,
+ )
+ 
++bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
+ bazel_dep(name = "bullet", version = "3.26.0-rc0")
+ bazel_dep(name = "dartsim", version = "6.13.2")
+ bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
+@@ -12,38 +13,8 @@
+ 
+ # Gazebo Dependencies
+ bazel_dep(name = "rules_gazebo", version = "0.0.6")
+-bazel_dep(name = "gz-common")
+-bazel_dep(name = "gz-math")
+-bazel_dep(name = "gz-plugin")
+-bazel_dep(name = "gz-utils")
+-bazel_dep(name = "sdformat")
+-
+-archive_override(
+-    module_name = "gz-common",
+-    strip_prefix = "gz-common-gz-common6",
+-    urls = ["https://github.com/gazebosim/gz-common/archive/refs/heads/gz-common6.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-math",
+-    strip_prefix = "gz-math-gz-math8",
+-    urls = ["https://github.com/gazebosim/gz-math/archive/refs/heads/gz-math8.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-plugin",
+-    strip_prefix = "gz-plugin-gz-plugin3",
+-    urls = ["https://github.com/gazebosim/gz-plugin/archive/refs/heads/gz-plugin3.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "gz-utils",
+-    strip_prefix = "gz-utils-gz-utils3",
+-    urls = ["https://github.com/gazebosim/gz-utils/archive/refs/heads/gz-utils3.tar.gz"],
+-)
+-
+-archive_override(
+-    module_name = "sdformat",
+-    strip_prefix = "sdformat-sdf15",
+-    urls = ["https://github.com/gazebosim/sdformat/archive/refs/heads/sdf15.tar.gz"],
+-)
++bazel_dep(name = "gz-common", version = "6.1.0")
++bazel_dep(name = "gz-math", version = "8.1.1.bcr.1")
++bazel_dep(name = "gz-plugin", version = "3.1.0")
++bazel_dep(name = "gz-utils", version = "3.1.0")
++bazel_dep(name = "sdformat", version = "15.3.0.bcr.2")

--- a/modules/gz-physics/8.2.0.bcr.1/presubmit.yml
+++ b/modules/gz-physics/8.2.0.bcr.1/presubmit.yml
@@ -1,0 +1,31 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@gz-physics'
+    - '@gz-physics//:heightmap'
+    - '@gz-physics//:mesh'
+    - '@gz-physics//:sdf'
+    - '@gz-physics//dartsim'
+    - '@gz-physics//dartsim:libgz-physics-dartsim-plugin.so'
+    - '@gz-physics//bullet'
+    - '@gz-physics//bullet:libgz-physics-bullet-plugin.so'
+    - '@gz-physics//bullet-featherstone'
+    - '@gz-physics//bullet-featherstone:libgz-physics-bullet-featherstone-plugin.so'
+    - '@gz-physics//tpe'
+    - '@gz-physics//tpe:libgz-physics-tpe-plugin.so'
+    - '@gz-physics//tpe:tpelib'

--- a/modules/gz-physics/8.2.0.bcr.1/source.json
+++ b/modules/gz-physics/8.2.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/gazebosim/gz-physics/archive/refs/tags/gz-physics8_8.2.0.tar.gz",
+    "integrity": "sha256-fXcjG494f2xaY+H+dosWJ1yORL3NG77Mu/wjAMf4bVc=",
+    "strip_prefix": "gz-physics-gz-physics8_8.2.0",
+    "patch_strip": 0,
+    "patches": {
+        "fix_build_bazel.patch": "sha256-E8fSECXCwUkuBTJ/6m/MZmv62jXFWE8wJx9LkXeH7hg=",
+        "module_dot_bazel.patch": "sha256-qWdeJ3J/h3KHB34yqH94QtBcDSZRb/rngxawsAqaEOA="
+    }
+}

--- a/modules/gz-physics/metadata.json
+++ b/modules/gz-physics/metadata.json
@@ -18,7 +18,8 @@
         "github:gazebosim/gz-physics"
     ],
     "versions": [
-        "8.2.0"
+        "8.2.0",
+        "8.2.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Pulls in https://github.com/gazebosim/gz-physics/pull/755 as a patch and bumps version to gz-physics@8.2.0.bcr.1