### PR TITLE
Z3: Replace unstable URL with stable one.

### DIFF
--- a/modules/z3/4.15.2/source.json
+++ b/modules/z3/4.15.2/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.15.2.zip",
+    "url": "https://github.com/Z3Prover/z3/releases/download/z3-4.15.2/z3-z3-4.15.2.zip",
     "strip_prefix": "z3-z3-4.15.2",
     "integrity": "sha256-YGAaZ0II/2EDgM8NVhIayGeMRcXE6sOtFNv+kZmOzIo="
 }


### PR DESCRIPTION
Follow up to https://github.com/bazelbuild/bazel-central-registry/pull/5073, which first added Z3 to the BCR, but with an unstable URL.

cc @fmeum @NikolajBjorner 