### PR TITLE
Improve setup of the BCR MCP server

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -5,10 +5,10 @@ It is implemented using [FastMCP](https://gofastmcp.com/getting-started/quicksta
 
 ## Running the server
 
-Use Bazel to start the server (dependencies are declared in `tools/requirements.in`):
+Use Bazel to start the server, no Python virtual environment setup needed:
 
 ```bash
-python3 tools/mcp_server.py
+bazel run //tools:mcp_server
 ```
 
 ## Available tools
@@ -32,8 +32,8 @@ Add the server to Gemini CLI's [settings](https://github.com/google-gemini/gemin
 ```json
   "mcpServers": {
     "BCR": {
-      "command": "python3",
-      "args": ["./tools/mcp_server.py"],
+      "command": "bazel",
+      "args": ["run", "//tools:mcp_server"],
       "cwd": "<Your local path to this repository>",
       "timeout": 5000,
       "trusted": true

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -41,6 +41,8 @@ Add the server to Gemini CLI's [settings](https://github.com/google-gemini/gemin
   }
 ```
 
+Make sure to build the target first to reduce startup time.
+
 ## Example prompts
 
 - Update all Bazel modules in my MODULE.bazel file.

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -119,6 +119,15 @@ py_binary(
     ],
 )
 
+py_binary(
+    name = "mcp_server",
+    srcs = ["mcp_server.py"],
+    deps = [
+        ":registry",
+        requirement("fastmcp"),
+    ],
+)
+
 genrule(
     name = "bazelci_py",
     srcs = ["@bazelci_py_file//file"],

--- a/tools/README.md
+++ b/tools/README.md
@@ -143,3 +143,7 @@ options:
   -h, --help       show this help message and exit
   --module MODULE  Module name and version, e.g. foo@1.2.0
 ```
+
+## mcp_server.py
+
+Check how to setup the [BCR MCP server](../docs/mcp.md) for coding agents.


### PR DESCRIPTION
Use `bazel run` to start the server, which is more convenient than requiring users to set up the python environment.