### PR TITLE
Add Boost 1.88.0 Level 1 dependencies

### DIFF
--- a/modules/boost.endian/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.endian/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.endian",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = "108800",
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.endian/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.endian/1.88.0.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "boost.endian",
+    version = "1.88.0.bcr.1",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = "108800",
+)
+
+bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.1.3")

--- a/modules/boost.endian/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.endian/1.88.0.bcr.1/MODULE.bazel
@@ -6,4 +6,5 @@ module(
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")
+bazel_dep(name = "boost.pin_version", version = "1.88.0.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.1.3")

--- a/modules/boost.endian/1.88.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.endian/1.88.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "boost.endian",
+    hdrs = glob(
+        [
+            "include/**/*.hpp",
+        ],
+        exclude = [
+            "include/boost/endian/endian.hpp",
+        ],
+    ),
+    features = [
+        "parse_headers",
+    ],
+    includes = ["include"],
+    textual_hdrs = [
+        "include/boost/endian/endian.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boost.config",
+    ],
+)

--- a/modules/boost.endian/1.88.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/boost.endian/1.88.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/boost.endian/1.88.0.bcr.1/presubmit.yml
+++ b/modules/boost.endian/1.88.0.bcr.1/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.endian//:boost.endian'

--- a/modules/boost.endian/1.88.0.bcr.1/source.json
+++ b/modules/boost.endian/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-h3l3CKAjLWoALUGf4lt1X0ba/CyxbwSeT/JYGGNvs+c=",
-        "MODULE.bazel": "sha256-8Yqu84l3BX6xwQWAJ9zaHs59dCZeU13qtfo6Dp/zn8A="
+        "MODULE.bazel": "sha256-Ep1BUZ8Jbuu2ozujLbIf96pBYp4ywh20Kg2+koENkHQ="
     }
 }

--- a/modules/boost.endian/1.88.0.bcr.1/source.json
+++ b/modules/boost.endian/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-h3l3CKAjLWoALUGf4lt1X0ba/CyxbwSeT/JYGGNvs+c=",
-        "MODULE.bazel": "sha256-KuqIk45NmrI4BpXStkKmoSPKqu2wlvIjuKewmjyPAwc="
+        "MODULE.bazel": "sha256-8Yqu84l3BX6xwQWAJ9zaHs59dCZeU13qtfo6Dp/zn8A="
     }
 }

--- a/modules/boost.endian/1.88.0.bcr.1/source.json
+++ b/modules/boost.endian/1.88.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-Il5xzbnsyinHNe23ETGvE8SAp5hApCKm+Niwi3w2IN8=",
+    "strip_prefix": "endian-boost-1.88.0",
+    "url": "https://github.com/boostorg/endian/archive/refs/tags/boost-1.88.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-h3l3CKAjLWoALUGf4lt1X0ba/CyxbwSeT/JYGGNvs+c=",
+        "MODULE.bazel": "sha256-KuqIk45NmrI4BpXStkKmoSPKqu2wlvIjuKewmjyPAwc="
+    }
+}

--- a/modules/boost.endian/metadata.json
+++ b/modules/boost.endian/metadata.json
@@ -4,14 +4,14 @@
         {
             "email": "daisuke.nishimatsu1021@gmail.com",
             "github": "wep21",
-            "name": "Daisuke Nishimatsu",
-            "github_user_id": 42202095
+            "github_user_id": 42202095,
+            "name": "Daisuke Nishimatsu"
         },
         {
             "email": "julian.amann@tum.de",
             "github": "Vertexwahn",
-            "name": "Julian Amann",
-            "github_user_id": 3775001
+            "github_user_id": 3775001,
+            "name": "Julian Amann"
         }
     ],
     "repository": [
@@ -21,7 +21,8 @@
         "1.83.0",
         "1.83.0.bcr.1",
         "1.83.0.bcr.2",
-        "1.87.0"
+        "1.87.0",
+        "1.88.0.bcr.1"
     ],
     "yanked_versions": {}
 }

--- a/modules/boost.static_assert/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.static_assert/1.88.0.bcr.1/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "boost.static_assert",
+    version = "1.88.0.bcr.1",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = "108800",
+)
+
+bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")
+bazel_dep(name = "boost.pin_version", version = "1.88.0.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.1.3")

--- a/modules/boost.static_assert/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.static_assert/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.static_assert",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = "108800",
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.static_assert/1.88.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.static_assert/1.88.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "boost.static_assert",
+    hdrs = glob([
+        "include/**/*.hpp",
+    ]),
+    features = ["parse_headers"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = ["@boost.config"],
+)

--- a/modules/boost.static_assert/1.88.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/boost.static_assert/1.88.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/boost.static_assert/1.88.0.bcr.1/presubmit.yml
+++ b/modules/boost.static_assert/1.88.0.bcr.1/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+  - debian10
+  - debian11
+  - ubuntu2004
+  - ubuntu2204
+  - ubuntu2404
+  - macos
+  - macos_arm64
+  - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+    - '@boost.static_assert//:boost.static_assert'

--- a/modules/boost.static_assert/1.88.0.bcr.1/source.json
+++ b/modules/boost.static_assert/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-8NmQrrada0n4bRl/+j7npF32uqBFWltu7EDD0amPB1U=",
-        "MODULE.bazel": "sha256-bYFedT0ZYAyJGVii6hO+V8wpK5hRXBbUT2SC9PzGJhM="
+        "MODULE.bazel": "sha256-3Se38R7Qsg8Mmfr5UIwQlRro2eSaoBX07e9c9ayImT4="
     }
 }

--- a/modules/boost.static_assert/1.88.0.bcr.1/source.json
+++ b/modules/boost.static_assert/1.88.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-wKRgEr94e8FGnNE/gRaCPakErrhxcG4WaKR67Vj0udg=",
+    "strip_prefix": "static_assert-boost-1.88.0",
+    "url": "https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.88.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-8NmQrrada0n4bRl/+j7npF32uqBFWltu7EDD0amPB1U=",
+        "MODULE.bazel": "sha256-bYFedT0ZYAyJGVii6hO+V8wpK5hRXBbUT2SC9PzGJhM="
+    }
+}

--- a/modules/boost.static_assert/metadata.json
+++ b/modules/boost.static_assert/metadata.json
@@ -4,14 +4,14 @@
         {
             "email": "daisuke.nishimatsu1021@gmail.com",
             "github": "wep21",
-            "name": "Daisuke Nishimatsu",
-            "github_user_id": 42202095
+            "github_user_id": 42202095,
+            "name": "Daisuke Nishimatsu"
         },
         {
             "email": "julian.amann@tum.de",
             "github": "Vertexwahn",
-            "name": "Julian Amann",
-            "github_user_id": 3775001
+            "github_user_id": 3775001,
+            "name": "Julian Amann"
         }
     ],
     "repository": [
@@ -20,7 +20,8 @@
     "versions": [
         "1.83.0",
         "1.83.0.bcr.1",
-        "1.87.0"
+        "1.87.0",
+        "1.88.0.bcr.1"
     ],
     "yanked_versions": {}
 }

--- a/modules/boost.typeof/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.typeof/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.typeof",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = "108800",
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.typeof/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.typeof/1.88.0.bcr.1/MODULE.bazel
@@ -6,6 +6,4 @@ module(
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")
-bazel_dep(name = "boost.preprocessor", version = "1.88.0.bcr.1")
-bazel_dep(name = "boost.type_traits", version = "1.88.0.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.1.3")

--- a/modules/boost.typeof/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.typeof/1.88.0.bcr.1/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "boost.typeof",
+    version = "1.88.0.bcr.1",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = "108800",
+)
+
+bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")
+bazel_dep(name = "boost.preprocessor", version = "1.88.0.bcr.1")
+bazel_dep(name = "boost.type_traits", version = "1.88.0.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.1.3")

--- a/modules/boost.typeof/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.typeof/1.88.0.bcr.1/MODULE.bazel
@@ -6,4 +6,5 @@ module(
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")
+bazel_dep(name = "boost.pin_version", version = "1.88.0.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.1.3")

--- a/modules/boost.typeof/1.88.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.typeof/1.88.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "boost.typeof",
+    hdrs = glob(
+        [
+            "include/**/*.hpp",
+        ],
+        exclude = ["include/boost/typeof/msvc/typeof_impl.hpp"],
+    ),
+    features = [
+        "parse_headers",
+    ],
+    includes = ["include"],
+    textual_hdrs = [
+        "include/boost/typeof/msvc/typeof_impl.hpp",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boost.config",
+        "@boost.preprocessor",
+        "@boost.type_traits",
+    ],
+)

--- a/modules/boost.typeof/1.88.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.typeof/1.88.0.bcr.1/overlay/BUILD.bazel
@@ -19,6 +19,5 @@ cc_library(
     deps = [
         "@boost.config",
         "@boost.preprocessor",
-        "@boost.type_traits",
     ],
 )

--- a/modules/boost.typeof/1.88.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.typeof/1.88.0.bcr.1/overlay/BUILD.bazel
@@ -18,6 +18,5 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@boost.config",
-        "@boost.preprocessor",
     ],
 )

--- a/modules/boost.typeof/1.88.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/boost.typeof/1.88.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/boost.typeof/1.88.0.bcr.1/presubmit.yml
+++ b/modules/boost.typeof/1.88.0.bcr.1/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.typeof//:boost.typeof'

--- a/modules/boost.typeof/1.88.0.bcr.1/source.json
+++ b/modules/boost.typeof/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-Ga2HTORnBJ0QTbwfZKUNvHEf8B6lEVagc66YjBxHJ54=",
-        "MODULE.bazel": "sha256-dboYAGY+XVhJdT7GQJZ+CAhFWvDEZCkLNALHZTBLwFE="
+        "MODULE.bazel": "sha256-7DQV9bBtuLyciI/PSYnGZzTap87SBlezr8RBzjuP1x0="
     }
 }

--- a/modules/boost.typeof/1.88.0.bcr.1/source.json
+++ b/modules/boost.typeof/1.88.0.bcr.1/source.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/boostorg/typeof/archive/refs/tags/boost-1.88.0.tar.gz",
     "patch_strip": 0,
     "overlay": {
-        "BUILD.bazel": "sha256-Ga2HTORnBJ0QTbwfZKUNvHEf8B6lEVagc66YjBxHJ54=",
+        "BUILD.bazel": "sha256-VoL919EYRqiQDRv6EgeSLdk24eMa8WdX8qkrQyXPdJM=",
         "MODULE.bazel": "sha256-Nwx7Wk/27T2fGic976s1efbhkKsdY4cX3PvfB+7ZQV0="
     }
 }

--- a/modules/boost.typeof/1.88.0.bcr.1/source.json
+++ b/modules/boost.typeof/1.88.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-U7LWShrwdgywIUFZ99wGRRs0QJ16/QVCZD+AmMQm4Mw=",
+    "strip_prefix": "typeof-boost-1.88.0",
+    "url": "https://github.com/boostorg/typeof/archive/refs/tags/boost-1.88.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-Ga2HTORnBJ0QTbwfZKUNvHEf8B6lEVagc66YjBxHJ54=",
+        "MODULE.bazel": "sha256-dboYAGY+XVhJdT7GQJZ+CAhFWvDEZCkLNALHZTBLwFE="
+    }
+}

--- a/modules/boost.typeof/1.88.0.bcr.1/source.json
+++ b/modules/boost.typeof/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-Ga2HTORnBJ0QTbwfZKUNvHEf8B6lEVagc66YjBxHJ54=",
-        "MODULE.bazel": "sha256-7DQV9bBtuLyciI/PSYnGZzTap87SBlezr8RBzjuP1x0="
+        "MODULE.bazel": "sha256-Nwx7Wk/27T2fGic976s1efbhkKsdY4cX3PvfB+7ZQV0="
     }
 }

--- a/modules/boost.typeof/1.88.0.bcr.1/source.json
+++ b/modules/boost.typeof/1.88.0.bcr.1/source.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/boostorg/typeof/archive/refs/tags/boost-1.88.0.tar.gz",
     "patch_strip": 0,
     "overlay": {
-        "BUILD.bazel": "sha256-VoL919EYRqiQDRv6EgeSLdk24eMa8WdX8qkrQyXPdJM=",
+        "BUILD.bazel": "sha256-DbUB+pbhdgOgdDLr8fxvC3aDGd1rJv19LDE+3luT4XM=",
         "MODULE.bazel": "sha256-Nwx7Wk/27T2fGic976s1efbhkKsdY4cX3PvfB+7ZQV0="
     }
 }

--- a/modules/boost.typeof/1.88.0.bcr.1/source.json
+++ b/modules/boost.typeof/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-DbUB+pbhdgOgdDLr8fxvC3aDGd1rJv19LDE+3luT4XM=",
-        "MODULE.bazel": "sha256-Nwx7Wk/27T2fGic976s1efbhkKsdY4cX3PvfB+7ZQV0="
+        "MODULE.bazel": "sha256-vfZdVJw6JPmw3jFJpyqUOeLQaWUndXyZF/qSdPDeWNQ="
     }
 }

--- a/modules/boost.vmd/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.vmd/1.88.0.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "boost.vmd",
+    version = "1.88.0.bcr.1",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = 108800,
+)
+
+bazel_dep(name = "boost.preprocessor", version = "1.88.0.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.1.3")

--- a/modules/boost.vmd/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.vmd/1.88.0.bcr.1/MODULE.bazel
@@ -5,5 +5,6 @@ module(
     compatibility_level = 108800,
 )
 
+bazel_dep(name = "boost.pin_version", version = "1.88.0.bcr.1")
 bazel_dep(name = "boost.preprocessor", version = "1.88.0.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.1.3")

--- a/modules/boost.vmd/1.88.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.vmd/1.88.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "boost.vmd",
+    hdrs = glob([
+        "include/**/*.hpp",
+    ]),
+    includes = ["include"],
+    visibility = ["//visibility:public"]),
+    features = [
+        "parse_headers",
+    ],    deps = [
+        "@boost.preprocessor",
+    ],
+)

--- a/modules/boost.vmd/1.88.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.vmd/1.88.0.bcr.1/overlay/BUILD.bazel
@@ -5,11 +5,12 @@ cc_library(
     hdrs = glob([
         "include/**/*.hpp",
     ]),
-    includes = ["include"],
-    visibility = ["//visibility:public"]),
     features = [
         "parse_headers",
-    ],    deps = [
+    ],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [
         "@boost.preprocessor",
     ],
 )

--- a/modules/boost.vmd/1.88.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/boost.vmd/1.88.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/boost.vmd/1.88.0.bcr.1/presubmit.yml
+++ b/modules/boost.vmd/1.88.0.bcr.1/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.vmd//:boost.vmd'

--- a/modules/boost.vmd/1.88.0.bcr.1/source.json
+++ b/modules/boost.vmd/1.88.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-mQobXdcLxELx+vvyDT2vxDkN2XaXC2KgPOaHseXlkvA=",
+    "strip_prefix": "vmd-boost-1.88.0",
+    "url": "https://github.com/boostorg/vmd/archive/refs/tags/boost-1.88.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-Yf7vgRWWVIrYFPM3CMBuFwSTu3vnB7KJFmj4vkrVkW4=",
+        "MODULE.bazel": "sha256-0TwmfnpF5xIEa7QUKgaK29o9mKuNNr06Nx9VxNdQlVY="
+    }
+}

--- a/modules/boost.vmd/1.88.0.bcr.1/source.json
+++ b/modules/boost.vmd/1.88.0.bcr.1/source.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/boostorg/vmd/archive/refs/tags/boost-1.88.0.tar.gz",
     "patch_strip": 0,
     "overlay": {
-        "BUILD.bazel": "sha256-Yf7vgRWWVIrYFPM3CMBuFwSTu3vnB7KJFmj4vkrVkW4=",
+        "BUILD.bazel": "sha256-LrdfUibuCf2W7frwn10w2iYj1+b/OkPZZUrp4qAlseE=",
         "MODULE.bazel": "sha256-0TwmfnpF5xIEa7QUKgaK29o9mKuNNr06Nx9VxNdQlVY="
     }
 }

--- a/modules/boost.vmd/1.88.0.bcr.1/source.json
+++ b/modules/boost.vmd/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-LrdfUibuCf2W7frwn10w2iYj1+b/OkPZZUrp4qAlseE=",
-        "MODULE.bazel": "sha256-0TwmfnpF5xIEa7QUKgaK29o9mKuNNr06Nx9VxNdQlVY="
+        "MODULE.bazel": "sha256-EJP8GL2VR0ybB1zrD5qbuu+6rmy5oTWgfDPBlwyCV7s="
     }
 }

--- a/modules/boost.vmd/metadata.json
+++ b/modules/boost.vmd/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "http://boost.org/libs/vdm",
+    "homepage": "http://boost.org/libs/vmd",
     "maintainers": [
         {
             "email": "daisuke.nishimatsu1021@gmail.com",
@@ -15,7 +15,7 @@
         }
     ],
     "repository": [
-        "github:boostorg/vdm"
+        "github:boostorg/vmd"
     ],
     "versions": [
         "1.88.0.bcr.1"

--- a/modules/boost.vmd/metadata.json
+++ b/modules/boost.vmd/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "http://boost.org/libs/typeof",
+    "homepage": "http://boost.org/libs/winapi",
     "maintainers": [
         {
             "email": "daisuke.nishimatsu1021@gmail.com",
@@ -15,12 +15,9 @@
         }
     ],
     "repository": [
-        "github:boostorg/typeof"
+        "github:boostorg/winapi"
     ],
     "versions": [
-        "1.83.0",
-        "1.83.0.bcr.1",
-        "1.87.0",
         "1.88.0.bcr.1"
     ],
     "yanked_versions": {}

--- a/modules/boost.vmd/metadata.json
+++ b/modules/boost.vmd/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "http://boost.org/libs/winapi",
+    "homepage": "http://boost.org/libs/vdm",
     "maintainers": [
         {
             "email": "daisuke.nishimatsu1021@gmail.com",
@@ -15,7 +15,7 @@
         }
     ],
     "repository": [
-        "github:boostorg/winapi"
+        "github:boostorg/vdm"
     ],
     "versions": [
         "1.88.0.bcr.1"

--- a/modules/boost.winapi/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.winapi/1.88.0.bcr.1/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "boost.winapi",
+    version = "1.88.0.bcr.1",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = "108800",
+)
+
+bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")
+bazel_dep(name = "boost.preprocessor", version = "1.88.0.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.1.3")

--- a/modules/boost.winapi/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.winapi/1.88.0.bcr.1/MODULE.bazel
@@ -6,5 +6,5 @@ module(
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")
-bazel_dep(name = "boost.preprocessor", version = "1.88.0.bcr.1")
+bazel_dep(name = "boost.predef", version = "1.88.0.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.1.3")

--- a/modules/boost.winapi/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.winapi/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.winapi",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = "108800",
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.winapi/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.winapi/1.88.0.bcr.1/MODULE.bazel
@@ -6,5 +6,6 @@ module(
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")
+bazel_dep(name = "boost.pin_version", version = "1.88.0.bcr.1")
 bazel_dep(name = "boost.predef", version = "1.88.0.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.1.3")

--- a/modules/boost.winapi/1.88.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.winapi/1.88.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "boost.winapi",
+    hdrs = glob(
+        [
+            "include/**/*.hpp",
+        ],
+        exclude = glob([
+            "include/boost/detail/**/*.hpp",
+            "include/boost/winapi/*.hpp",
+        ]),
+    ),
+    features = [
+        "parse_headers",
+    ],
+    includes = ["include"],
+    textual_hdrs = glob([
+        "include/boost/detail/**/*.hpp",
+        "include/boost/winapi/*.hpp",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boost.config",
+        "@boost.predef",
+    ],
+)

--- a/modules/boost.winapi/1.88.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/boost.winapi/1.88.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/boost.winapi/1.88.0.bcr.1/presubmit.yml
+++ b/modules/boost.winapi/1.88.0.bcr.1/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.winapi//:boost.winapi'

--- a/modules/boost.winapi/1.88.0.bcr.1/source.json
+++ b/modules/boost.winapi/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-IHwBZiY5qaaTrjSzKoMkIZaA4p0mrggYrO0L5aYdnS8=",
-        "MODULE.bazel": "sha256-SXGSIykW/JYKniEZ5OayJjVuQWR4SX5pJfdIkPo5uLo="
+        "MODULE.bazel": "sha256-QLvQqMEaqfWTFWijKczllhMjXbJPpeIBrRJ12JZrgKY="
     }
 }

--- a/modules/boost.winapi/1.88.0.bcr.1/source.json
+++ b/modules/boost.winapi/1.88.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-/qNS/Fjm5z7cweFKttjf7U7InJ+hrZHSdkEr9HobJ6c=",
+    "strip_prefix": "winapi-boost-1.88.0",
+    "url": "https://github.com/boostorg/winapi/archive/refs/tags/boost-1.88.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-IHwBZiY5qaaTrjSzKoMkIZaA4p0mrggYrO0L5aYdnS8=",
+        "MODULE.bazel": "sha256-iQBx1AfBjK9FWZOzgzmUIjxPz5CvNwFGX+UDYbG4pa0="
+    }
+}

--- a/modules/boost.winapi/1.88.0.bcr.1/source.json
+++ b/modules/boost.winapi/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-IHwBZiY5qaaTrjSzKoMkIZaA4p0mrggYrO0L5aYdnS8=",
-        "MODULE.bazel": "sha256-FZs2b4S+YUs+Q8ffVpondeH7KYFysWTxj2yYmle/nPE="
+        "MODULE.bazel": "sha256-SXGSIykW/JYKniEZ5OayJjVuQWR4SX5pJfdIkPo5uLo="
     }
 }

--- a/modules/boost.winapi/1.88.0.bcr.1/source.json
+++ b/modules/boost.winapi/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-IHwBZiY5qaaTrjSzKoMkIZaA4p0mrggYrO0L5aYdnS8=",
-        "MODULE.bazel": "sha256-iQBx1AfBjK9FWZOzgzmUIjxPz5CvNwFGX+UDYbG4pa0="
+        "MODULE.bazel": "sha256-FZs2b4S+YUs+Q8ffVpondeH7KYFysWTxj2yYmle/nPE="
     }
 }

--- a/modules/boost.winapi/metadata.json
+++ b/modules/boost.winapi/metadata.json
@@ -4,14 +4,14 @@
         {
             "email": "daisuke.nishimatsu1021@gmail.com",
             "github": "wep21",
-            "name": "Daisuke Nishimatsu",
-            "github_user_id": 42202095
+            "github_user_id": 42202095,
+            "name": "Daisuke Nishimatsu"
         },
         {
             "email": "julian.amann@tum.de",
             "github": "Vertexwahn",
-            "name": "Julian Amann",
-            "github_user_id": 3775001
+            "github_user_id": 3775001,
+            "name": "Julian Amann"
         }
     ],
     "repository": [
@@ -20,7 +20,8 @@
     "versions": [
         "1.83.0",
         "1.83.0.bcr.1",
-        "1.87.0"
+        "1.87.0",
+        "1.88.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Add Boost 1.88.0 Level 1 dependencies, in particular:

- endian
- static_assert
- typeof
- vmd
- winapi