### PR TITLE
Fix libxcb build in linux

### DIFF
--- a/modules/libxcb/1.17.0.bcr.1/MODULE.bazel
+++ b/modules/libxcb/1.17.0.bcr.1/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "libxcb",
+    version = "1.17.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "libxau", version = "1.0.12")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_python", version = "1.3.0")
+bazel_dep(name = "xcb-proto", version = "1.17.0")

--- a/modules/libxcb/1.17.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/libxcb/1.17.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,145 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+
+EXTENSIONS = [
+    "bigreq",
+    "composite",
+    "damage",
+    "dbe",
+    "dpms",
+    "dri2",
+    "dri3",
+    "ge",
+    "glx",
+    "present",
+    "randr",
+    "record",
+    "render",
+    "res",
+    "screensaver",
+    "shape",
+    "shm",
+    "sync",
+    "xc_misc",
+    "xevie",
+    "xf86dri",
+    "xfixes",
+    "xinerama",
+    "xinput",
+    "xkb",
+    "xprint",
+    "xproto",
+    "xselinux",
+    "xtest",
+    "xv",
+    "xvmc",
+]
+
+py_binary(
+    name = "c_client",
+    srcs = ["src/c_client.py"],
+    data = [
+        "@xcb-proto//:xml",
+    ],
+    deps = [
+        "@xcb-proto//:py_xcbgen",
+    ],
+)
+
+[genrule(
+    name = "c_client_{}".format(extension),
+    srcs = [
+        "@xcb-proto//:src/{}.xml".format(extension),
+        "@xcb-proto//:xml",
+    ],
+    outs = [
+        "{}.c".format(extension),
+        "{}.h".format(extension),
+    ],
+    cmd = ('$(location c_client) -c "libxcb 1.17" ' +
+           '-l "X Version 11" ' +
+           '-s "3" ' +
+           "-p $$(dirname $(location @xcb-proto//:xcbgen/state.py)) " +
+           "$(location @xcb-proto//:src/{extension}.xml) && " +
+           "mv {extension}.c $(location {extension}.c) && " +
+           "mv {extension}.h $(location {extension}.h)").format(
+        extension = extension,
+    ),
+    tools = [
+        "c_client",
+        "@xcb-proto//:py_xcbgen",
+        "@xcb-proto//:xcbgen/state.py",
+    ],
+) for extension in EXTENSIONS]
+
+[genrule(
+    name = "headermove_{}".format(x),
+    srcs = ["src/{}".format(x)],
+    outs = ["xcb/{}".format(x)],
+    cmd = "cp $< $@",
+) for x in [
+    "xcb.h",
+    "xcbext.h",
+]]
+
+UPSTREAM_VERSION = module_version().split(".bcr.", 1)[0]
+
+UPSTREAM_VERSION_MAJOR = UPSTREAM_VERSION.split(".")[0]
+
+UPSTREAM_VERSION_MINOR = UPSTREAM_VERSION.split(".")[1]
+
+UPSTREAM_VERSION_PATCH = UPSTREAM_VERSION.split(".")[2]
+
+expand_template(
+    name = "config_h",
+    out = "src/config.h",
+    substitutions = {
+        "{LIBXCB_VERSION}": UPSTREAM_VERSION,
+        "{LIBXCB_VERSION_MAJOR}": UPSTREAM_VERSION_MAJOR,
+        "{LIBXCB_VERSION_MINOR}": UPSTREAM_VERSION_MINOR,
+        "{LIBXCB_VERSION_PATCH}": UPSTREAM_VERSION_PATCH,
+    },
+    template = "src/config.h.in",
+)
+
+cc_library(
+    name = "xcb",
+    srcs = (
+        ["{}.c".format(x) for x in EXTENSIONS] +
+        ["{}.h".format(x) for x in EXTENSIONS] +
+        ["src/" + x for x in [
+            "xcb_auth.c",
+            "xcb_conn.c",
+            "xcb_ext.c",
+            "xcb_in.c",
+            "xcb_list.c",
+            "xcb_out.c",
+            "xcb_xid.c",
+            "xcb_util.c",
+            "xcbint.h",
+        ]]
+    ) + ["//:config_h"],
+    hdrs = [
+        "src/xcb.h",
+        "src/xcbext.h",
+    ],
+    copts = [
+        "-DHAVE_CONFIG_H",
+    ],
+    defines = select({
+        "@platforms//os:macos": ["HAVE_SOCKADDR_SUN_LEN"],
+        "//conditions:default": [],
+    }),
+    include_prefix = "xcb",
+    includes = ["src"],
+    strip_include_prefix = "src",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@libxau",
+    ],
+)
+
+alias(
+    name = "libxcb",
+    actual = ":xcb",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libxcb/1.17.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/libxcb/1.17.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/libxcb/1.17.0.bcr.1/overlay/src/config.h.in
+++ b/modules/libxcb/1.17.0.bcr.1/overlay/src/config.h.in
@@ -1,0 +1,219 @@
+/* src/config.h.  Generated from config.h.in by configure.  */
+/* src/config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Defined if GCC supports the visibility feature */
+#define GCC_HAS_VISIBILITY /**/
+
+/* Has Wraphelp.c needed for XDM AUTH protocols */
+/* #undef HASXDMAUTH */
+
+/* Define if your platform supports abstract sockets */
+/* #undef HAVE_ABSTRACT_SOCKETS */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* getaddrinfo() function is available */
+#define HAVE_GETADDRINFO 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the 'is_system_labeled' function. */
+/* #undef HAVE_IS_SYSTEM_LABELED */
+
+/* Define to 1 if you have the 'ws2_32' library (-lws2_32). */
+/* #undef HAVE_LIBWS2_32 */
+
+/* Define to 1 if you have the <minix/config.h> header file. */
+/* #undef HAVE_MINIX_CONFIG_H */
+
+/* Define if your platform supports sendmsg */
+#define HAVE_SENDMSG 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <tsol/label.h> header file. */
+/* #undef HAVE_TSOL_LABEL_H */
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the <wchar.h> header file. */
+#define HAVE_WCHAR_H 1
+
+/* Define if not provided by <limits.h> */
+/* #undef IOV_MAX */
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "libxcb"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "https://gitlab.freedesktop.org/xorg/lib/libxcb/-/issues"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libxcb"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libxcb 1.17.0"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libxcb"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "{LIBXCB_VERSION}"
+
+/* Major version of this package */
+#define PACKAGE_VERSION_MAJOR {LIBXCB_VERSION_MAJOR}
+
+/* Minor version of this package */
+#define PACKAGE_VERSION_MINOR {LIBXCB_VERSION_MINOR}
+
+/* Patch version of this package */
+#define PACKAGE_VERSION_PATCHLEVEL {LIBXCB_VERSION_PATCH}
+
+/* Define to 1 if all of the C89 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* poll() function is available */
+#define USE_POLL 1
+
+/* Enable extensions on AIX, Interix, z/OS.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable general extensions on macOS.  */
+#ifndef _DARWIN_C_SOURCE
+# define _DARWIN_C_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable X/Open compliant socket functions that do not require linking
+   with -lxnet on HP-UX 11.11.  */
+#ifndef _HPUX_ALT_XOPEN_SOCKET_API
+# define _HPUX_ALT_XOPEN_SOCKET_API 1
+#endif
+/* Identify the host operating system as Minix.
+   This macro does not affect the system headers' behavior.
+   A future release of Autoconf may stop defining this macro.  */
+#ifndef _MINIX
+/* # undef _MINIX */
+#endif
+/* Enable general extensions on NetBSD.
+   Enable NetBSD compatibility extensions on Minix.  */
+#ifndef _NETBSD_SOURCE
+# define _NETBSD_SOURCE 1
+#endif
+/* Enable OpenBSD compatibility extensions on NetBSD.
+   Oddly enough, this does nothing on OpenBSD.  */
+#ifndef _OPENBSD_SOURCE
+# define _OPENBSD_SOURCE 1
+#endif
+/* Define to 1 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_SOURCE
+/* # undef _POSIX_SOURCE */
+#endif
+/* Define to 2 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_1_SOURCE
+/* # undef _POSIX_1_SOURCE */
+#endif
+/* Enable POSIX-compatible threading on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-5:2014.  */
+#ifndef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
+# define __STDC_WANT_IEC_60559_ATTRIBS_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-1:2014.  */
+#ifndef __STDC_WANT_IEC_60559_BFP_EXT__
+# define __STDC_WANT_IEC_60559_BFP_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-2:2015.  */
+#ifndef __STDC_WANT_IEC_60559_DFP_EXT__
+# define __STDC_WANT_IEC_60559_DFP_EXT__ 1
+#endif
+/* Enable extensions specified by C23 Annex F.  */
+#ifndef __STDC_WANT_IEC_60559_EXT__
+# define __STDC_WANT_IEC_60559_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-4:2015.  */
+#ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__
+# define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1
+#endif
+/* Enable extensions specified by C23 Annex H and ISO/IEC TS 18661-3:2015.  */
+#ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
+# define __STDC_WANT_IEC_60559_TYPES_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TR 24731-2:2010.  */
+#ifndef __STDC_WANT_LIB_EXT2__
+# define __STDC_WANT_LIB_EXT2__ 1
+#endif
+/* Enable extensions specified by ISO/IEC 24747:2009.  */
+#ifndef __STDC_WANT_MATH_SPEC_FUNCS__
+# define __STDC_WANT_MATH_SPEC_FUNCS__ 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable X/Open extensions.  Define to 500 only if necessary
+   to make mbstate_t available.  */
+#ifndef _XOPEN_SOURCE
+/* # undef _XOPEN_SOURCE */
+#endif
+
+
+/* Version number of package */
+#define VERSION "{LIBXCB_VERSION}"
+
+/* XCB buffer queue size */
+#define XCB_QUEUE_BUFFER_SIZE 16384
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* Define to 1 on platforms where this makes off_t a 64-bit type. */
+/* #undef _LARGE_FILES */
+
+/* Number of bits in time_t, on hosts where this is settable. */
+/* #undef _TIME_BITS */
+
+/* Defined if needed to expose struct msghdr.msg_control */
+/* #undef _XOPEN_SOURCE */
+
+/* Define to 1 on platforms where this makes time_t a 64-bit type. */
+/* #undef __MINGW_USE_VC2005_COMPAT */

--- a/modules/libxcb/1.17.0.bcr.1/presubmit.yml
+++ b/modules/libxcb/1.17.0.bcr.1/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - ubuntu2404
+  - macos
+  - macos_arm64
+  - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@libxcb'

--- a/modules/libxcb/1.17.0.bcr.1/source.json
+++ b/modules/libxcb/1.17.0.bcr.1/source.json
@@ -1,0 +1,11 @@
+{
+    "integrity": "sha256-ETpvj2FOA3/wPK0hjNy/4wffydkJqEKxcnamlEdu1jk=",
+    "strip_prefix": "libxcb-libxcb-1.17.0",
+    "url": "https://gitlab.freedesktop.org/xorg/lib/libxcb/-/archive/libxcb-1.17.0/libxcb-libxcb-1.17.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-CQXAPVVBxuFfxsH2WlFi/S89NmTutLO88+bBRwuK7NU=",
+        "MODULE.bazel": "sha256-1FRop0O5PF94CXlcKQxekeUtE3ZUx/0w/yTq0auXKw0=",
+        "src/config.h.in": "sha256-uyBWngCnRn6xrJlW59dej3tO/9HOhU3K99ScTOKXi2k="
+    }
+}

--- a/modules/libxcb/1.17.0.bcr.1/source.json
+++ b/modules/libxcb/1.17.0.bcr.1/source.json
@@ -1,5 +1,5 @@
 {
-    "integrity": "sha256-88pr1huKqfosKHDbuQXN5ynrT+94VRqRvxhet5k1Vs4=",
+    "integrity": "sha256-lhdy5vv9TwuZEXk1dEiBYBA8JM+9FxJ+KMrxpKklIqE=",
     "strip_prefix": "libxcb-libxcb-1.17.0",
     "url": "https://gitlab.freedesktop.org/xorg/lib/libxcb/-/archive/libxcb-1.17.0/libxcb-libxcb-1.17.0.tar.gz",
     "patch_strip": 0,

--- a/modules/libxcb/1.17.0.bcr.1/source.json
+++ b/modules/libxcb/1.17.0.bcr.1/source.json
@@ -1,5 +1,5 @@
 {
-    "integrity": "sha256-ETpvj2FOA3/wPK0hjNy/4wffydkJqEKxcnamlEdu1jk=",
+    "integrity": "sha256-88pr1huKqfosKHDbuQXN5ynrT+94VRqRvxhet5k1Vs4=",
     "strip_prefix": "libxcb-libxcb-1.17.0",
     "url": "https://gitlab.freedesktop.org/xorg/lib/libxcb/-/archive/libxcb-1.17.0/libxcb-libxcb-1.17.0.tar.gz",
     "patch_strip": 0,

--- a/modules/libxcb/metadata.json
+++ b/modules/libxcb/metadata.json
@@ -12,7 +12,8 @@
         "https://gitlab.freedesktop.org/xorg/lib/libxcb"
     ],
     "versions": [
-        "1.17.0"
+        "1.17.0",
+        "1.17.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Applies the fix proposed by [calebzulawski](https://github.com/calebzulawski)  in https://github.com/bazelbuild/bazel-central-registry/issues/4991

Fixes https://github.com/bazelbuild/bazel-central-registry/issues/4991

Bumps libxcb version to 1.17.0.bcr.1.