### PR TITLE
Publish rules_devicetree@0.1.2

### DIFF
--- a/modules/rules_devicetree/0.1.2/MODULE.bazel
+++ b/modules/rules_devicetree/0.1.2/MODULE.bazel
@@ -1,0 +1,50 @@
+"Bazel dependencies"
+
+module(
+    name = "rules_devicetree",
+
+    # NOTE:
+    version = "0.1.2",
+    #
+    # Always leave version unset or set to "" (the default). The default value
+    # can prevent issues when the module is used via non-registry overrides
+    # (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).
+    #
+    # The publish.yaml GitHub Action sets the version in the registry to the
+    # release version by patching this MODULE.bazel file in the pull request to
+    # the BCR.
+    #
+    # For more info, see this Slack thread:
+    # https://bazelbuild.slack.com/archives/CA31HN1T3/p1750406404452179
+
+    # NOTE:
+    # compatibility_level = 0,
+    #
+    # Bumping compatibility_level too frequently is discouraged because it's
+    # very disruptive: as soon as a module is requested at two different
+    # compatibility levels in the dependency tree, users will see an error.
+    #
+    # As such, the compatibility_level (1) should be bumped *only* when the
+    # breaking change affects most use cases and isn't easy to migrate and/or
+    # work-around, and (2) *in the same commit* that introduces an incompatible
+    # (breaking) change.
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.0")
+bazel_dep(name = "package_metadata", version = "0.0.2")
+bazel_dep(name = "platforms", version = "0.0.5")
+bazel_dep(name = "rules_cc", version = "0.0.16")
+
+bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.19.4", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "1.5.0", dev_dependency = True)
+
+autodetected_toolchain_repo = use_repo_rule("//devicetree/private:autodetected_toolchain_repo.bzl", "autodetected_toolchain_repo")
+
+autodetected_toolchain_repo(
+    name = "autodetected_toolchain",
+)
+
+register_toolchains("@autodetected_toolchain//:all")

--- a/modules/rules_devicetree/0.1.2/attestations.json
+++ b/modules/rules_devicetree/0.1.2/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/bazel-contrib/rules_devicetree/releases/download/v0.1.2/source.json.intoto.jsonl",
+            "integrity": "sha256-cUVKhp3+XvxP8gxPVEgzij4VYhN/2uWZqCEApcUisoM="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/bazel-contrib/rules_devicetree/releases/download/v0.1.2/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-Slb88mXHfdy7b3AN7ZUAiWhhko+u7iVVPT++PsKU3RM="
+        },
+        "rules_devicetree-v0.1.2.tar.gz": {
+            "url": "https://github.com/bazel-contrib/rules_devicetree/releases/download/v0.1.2/rules_devicetree-v0.1.2.tar.gz.intoto.jsonl",
+            "integrity": "sha256-Qz2gaHOOKAJqnB11vbrqlhkQbb3DTpJhWDCUvyodEDo="
+        }
+    }
+}

--- a/modules/rules_devicetree/0.1.2/patches/module_dot_bazel_version.patch
+++ b/modules/rules_devicetree/0.1.2/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -3,9 +3,9 @@
+ module(
+     name = "rules_devicetree",
+ 
+     # NOTE:
+-    version = "",
++    version = "0.1.2",
+     #
+     # Always leave version unset or set to "" (the default). The default value
+     # can prevent issues when the module is used via non-registry overrides
+     # (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).

--- a/modules/rules_devicetree/0.1.2/presubmit.yml
+++ b/modules/rules_devicetree/0.1.2/presubmit.yml
@@ -1,0 +1,15 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian10", "ubuntu2004"]
+    bazel: ["8.x", "7.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      shell_commands:
+        - sudo apt-get update
+        - sudo apt-get install device-tree-compiler
+      test_targets:
+        - "//..."

--- a/modules/rules_devicetree/0.1.2/source.json
+++ b/modules/rules_devicetree/0.1.2/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-8R2rIrgVk2Q/Asnt3vbjE+0/PiKo2z1uR7I6eo0fKyo=",
+    "strip_prefix": "rules_devicetree-0.1.2",
+    "url": "https://github.com/bazel-contrib/rules_devicetree/releases/download/v0.1.2/rules_devicetree-v0.1.2.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-/xMO1XNz9HCtFgFCQ4qQVLXUkPa62RNqxyjVr1IpEdU="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_devicetree/metadata.json
+++ b/modules/rules_devicetree/metadata.json
@@ -1,0 +1,20 @@
+{
+    "homepage": "https://github.com/bazel-contrib/rules_devicetree",
+    "maintainers": [
+        {
+            "github": "jacky8hyf",
+            "github_user_id": 5271176
+        },
+        {
+            "github": "Gansito144",
+            "github_user_id": 10478507
+        }
+    ],
+    "repository": [
+        "github:bazel-contrib/rules_devicetree"
+    ],
+    "versions": [
+        "0.1.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/bazel-contrib/rules_devicetree/releases/tag/v0.1.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_
