### PR TITLE
Fix typo for incompatible flags

### DIFF
--- a/incompatible_flags.yml
+++ b/incompatible_flags.yml
@@ -28,7 +28,7 @@ incompatible_flags:
     - last_green
     - rolling
   # https://github.com/bazelbuild/bazel/issues/7026
-  "--incompatible_strict_action_env"
+  "--incompatible_strict_action_env":
     - 6.x
     - 7.x
     - 8.x


### PR DESCRIPTION
Fixes broken CI (https://github.com/bazelbuild/bazel-central-registry/pull/5319 missed ":").