### PR TITLE
Update user-agent header for bcr_validation downloads

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -72,7 +72,7 @@ def download(url):
     opener = urllib.request.build_opener(Github404ErrorProcessor)
     urllib.request.install_opener(opener)
     parts = urllib.parse.urlparse(url)
-    headers = {"User-Agent": "Mozilla/5.0"}  # Set the User-Agent header
+    headers = {"User-Agent": "curl/8.7.1"}  # Set the User-Agent header
     try:
         authenticators = netrc.netrc().authenticators(parts.netloc)
     except FileNotFoundError:


### PR DESCRIPTION
This change addresses the issue identified on https://github.com/bazelbuild/bazel-central-registry/pull/5369 where downloads from https://sourceforge.net/ would be sent back html documents instead of the target files.