### PR TITLE
Publish rules_autoconf@0.0.5

### DIFF
--- a/modules/rules_autoconf/0.0.5/MODULE.bazel
+++ b/modules/rules_autoconf/0.0.5/MODULE.bazel
@@ -1,0 +1,8 @@
+module(name = "rules_autoconf",
+    version = "0.0.5",
+)
+
+bazel_dep(name = "aspect_bazel_lib", version = "2.20.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.1.4")

--- a/modules/rules_autoconf/0.0.5/patches/module_dot_bazel_version.patch
+++ b/modules/rules_autoconf/0.0.5/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,5 +1,7 @@
+-module(name = "rules_autoconf")
++module(name = "rules_autoconf",
++    version = "0.0.5",
++)
+ 
+ bazel_dep(name = "aspect_bazel_lib", version = "2.20.0")
+ bazel_dep(name = "bazel_skylib", version = "1.8.1")
+ bazel_dep(name = "platforms", version = "1.0.0")

--- a/modules/rules_autoconf/0.0.5/presubmit.yml
+++ b/modules/rules_autoconf/0.0.5/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "."
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x, 8.x]
+  tasks:
+    verify_targets:
+      name: "Verify build targets"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."

--- a/modules/rules_autoconf/0.0.5/source.json
+++ b/modules/rules_autoconf/0.0.5/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-/89vatkXv/J8rAKqOz5NI8Qso/Nj+7x3FTZNEGaxh40=",
+    "strip_prefix": "rules_autoconf-0.0.5",
+    "url": "https://github.com/dzbarsky/rules_autoconf/archive/refs/tags/v0.0.5.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-SSPS3eLOATidbqQSSYUwaUKHUzAgiDBCr+0Cxjb3aag="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_autoconf/metadata.json
+++ b/modules/rules_autoconf/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/dzbarsky/rules_autoconf",
+    "maintainers": [
+        {
+            "name": "David Zbarsky",
+            "email": "dzbarsky@gmail.com",
+            "github": "dzbarsky",
+            "github_user_id": 1565842
+        }
+    ],
+    "repository": [
+        "github:dzbarsky/rules_autoconf"
+    ],
+    "versions": [
+        "0.0.5"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/dzbarsky/rules_autoconf/releases/tag/v0.0.5

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_