### PR TITLE
Revert "Update user-agent header for bcr_validation downloads"

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -72,7 +72,7 @@ def download(url):
     opener = urllib.request.build_opener(Github404ErrorProcessor)
     urllib.request.install_opener(opener)
     parts = urllib.parse.urlparse(url)
-    headers = {"User-Agent": "curl/8.7.1"}  # Set the User-Agent header
+    headers = {"User-Agent": "Mozilla/5.0"}  # Set the User-Agent header
     try:
         authenticators = netrc.netrc().authenticators(parts.netloc)
     except FileNotFoundError:


### PR DESCRIPTION
Reverts bazelbuild/bazel-central-registry#5383

I suspect this to be the cause of https://buildkite.com/bazel/bcr-presubmit/builds/17331#01985ce3-5124-4943-9e63-fd7ac52f1e81.