### PR TITLE
Update MODULE.bazel to refer to the latest bazelci.py

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,18 +43,18 @@ use_repo(npm, "npm")
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
-BAZEL_CI_COMMIT = "3c2bc5dc463e7d35b0d14faca4e1aa0b2c04bfa9"
+BAZEL_CI_COMMIT = "3057a5e4fe524779f8b294496786204b0dd8b842"
 
 http_file(
     name = "bazelci_py_file",
-    integrity = "sha256-7RzwSiBqmEUM87qAgPpAKA28v1MWWmjP22FLp8qSU0s=",
+    integrity = "sha256-Q97YRuiU/ELF8gWVRjAl3uD11QxptFubBfpgnpG4rvg=",
     downloaded_file_path = "bazelci.py",
     urls = ["https://raw.githubusercontent.com/bazelbuild/continuous-integration/%s/buildkite/bazelci.py" % BAZEL_CI_COMMIT],
 )
 
 http_file(
     name = "bcr_presubmit_py_file",
-    integrity = "sha256-ksWL3Jl4IOcGs1f5uZpvtw/Qb/F5EWEL6khv3G5ATcA=",
+    integrity = "sha256-McLGGMdZzkWg38fujKohLuPjyI/EyU7RDJIfsByDk9k=",
     downloaded_file_path = "bcr_presubmit.py",
     urls = ["https://raw.githubusercontent.com/bazelbuild/continuous-integration/%s/buildkite/bazel-central-registry/bcr_presubmit.py" % BAZEL_CI_COMMIT],
 )


### PR DESCRIPTION
This affects `//tools:setup_presubmit_repos` only.