### PR TITLE
feat: add google_cloud_cpp@3.0.0-rc1

### DIFF
--- a/modules/google_cloud_cpp/3.0.0-rc1/MODULE.bazel
+++ b/modules/google_cloud_cpp/3.0.0-rc1/MODULE.bazel
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/google_cloud_cpp/3.0.0-rc1/MODULE.bazel
+++ b/modules/google_cloud_cpp/3.0.0-rc1/MODULE.bazel
@@ -1,0 +1,58 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Idiomatic C++ client libraries for Google Cloud Platform."""
+
+module(
+    name = "google_cloud_cpp",
+    version = "3.0.0-rc1",  # Updated by CMake
+    compatibility_level = 3,  # Updated by CMake
+)
+
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "rules_cc", version = "0.1.4")
+bazel_dep(name = "abseil-cpp", version = "20250127.1")
+bazel_dep(name = "protobuf", version = "31.1")
+bazel_dep(name = "boringssl", version = "0.0.0-20230215-5c22014")
+bazel_dep(name = "nlohmann_json", version = "3.11.3")
+bazel_dep(name = "curl", version = "8.8.0.bcr.3")
+bazel_dep(name = "crc32c", version = "1.1.0")
+bazel_dep(name = "opentelemetry-cpp", version = "1.19.0")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_python", version = "1.4.1")
+bazel_dep(name = "rules_apple", version = "3.16.0")
+bazel_dep(name = "googletest", version = "1.15.2")
+
+bazel_dep(name = "google_benchmark", version = "1.9.2", dev_dependency = True, repo_name = "com_google_benchmark")
+bazel_dep(name = "yaml-cpp", version = "0.8.0", dev_dependency = True, repo_name = "com_github_jbeder_yaml_cpp")
+bazel_dep(name = "pugixml", version = "1.15", dev_dependency = True, repo_name = "com_github_zeux_pugixml")
+
+# Our `curl.BUILD` file uses these.
+bazel_dep(name = "zlib", version = "1.3.1.bcr.6")
+bazel_dep(name = "c-ares", version = "1.19.1.bcr.1", repo_name = "com_github_cares_cares")
+
+# Pin this to fix a break in bazel/deps-cache.py
+bazel_dep(name = "protoc-gen-validate", version = "1.2.1.bcr.1", dev_dependency = True, repo_name = "com_envoyproxy_protoc_gen_validate")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    ignore_root_user_error = True,
+    python_version = "3.11",
+)
+
+bazel_dep(name = "grpc", version = "1.72.0")
+bazel_dep(name = "googleapis", version = "0.0.0-20250703-f9d6fe4a")
+bazel_dep(name = "googleapis-cc", version = "1.0.0")
+bazel_dep(name = "googleapis-grpc-cc", version = "1.0.0")

--- a/modules/google_cloud_cpp/3.0.0-rc1/patches/copyright.patch
+++ b/modules/google_cloud_cpp/3.0.0-rc1/patches/copyright.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,4 +1,4 @@
+-# Copyright 2024 Google LLC
++# Copyright 2025 Google LLC
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.

--- a/modules/google_cloud_cpp/3.0.0-rc1/presubmit.yml
+++ b/modules/google_cloud_cpp/3.0.0-rc1/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform: ["debian11", "macos", "windows"]
+  bazel: ["7.x", "8.x"]
+tasks:
+  build_targets:
+    name: "Build"
+    bazel: ${{ bazel }}
+    platform: ${{ platform }}
+    targets:
+      - "//..."
+  test_targets:
+    name: "Test"
+    bazel: ${{ bazel }}
+    platform: ${{ platform }}
+    targets:
+      - "//..."

--- a/modules/google_cloud_cpp/3.0.0-rc1/source.json
+++ b/modules/google_cloud_cpp/3.0.0-rc1/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v3.0.0-rc1.tar.gz",
+    "integrity": "sha256-rZn7L7DgQjmogsU1icsVe3Lg49226RbLWpSA6QLQruw=",
+    "strip_prefix": "google-cloud-cpp-3.0.0-rc1"
+}

--- a/modules/google_cloud_cpp/3.0.0-rc1/source.json
+++ b/modules/google_cloud_cpp/3.0.0-rc1/source.json
@@ -1,5 +1,9 @@
 {
     "url": "https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v3.0.0-rc1.tar.gz",
     "integrity": "sha256-rZn7L7DgQjmogsU1icsVe3Lg49226RbLWpSA6QLQruw=",
-    "strip_prefix": "google-cloud-cpp-3.0.0-rc1"
+    "strip_prefix": "google-cloud-cpp-3.0.0-rc1",
+    "patch_strip": 0,
+    "patches": {
+        "copyright.patch": "sha256-qITPA+QfNNAlErCIuUMoQeZ4e9sCEEAWmeTehRfLO+I="
+    }
 }

--- a/modules/google_cloud_cpp/metadata.json
+++ b/modules/google_cloud_cpp/metadata.json
@@ -26,7 +26,8 @@
         "github:googleapis/google-cloud-cpp"
     ],
     "versions": [
-        "3.0.0-rc0"
+        "3.0.0-rc0",
+        "3.0.0-rc1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This pull request adds google-cloud-cpp@3.0.0-rc1 to the Bazel Central Registry.

This is the next release candidate for our upcoming v3.0.0 major version. We are publishing this pre-release to the BCR to continue testing our new Bzlmod support and allow customers to begin previewing the integration.