### PR TITLE
Fix MODULE typo in Postgres 14.18

### DIFF
--- a/modules/postgres/14.18/MODULE.bazel
+++ b/modules/postgres/14.18/MODULE.bazel
@@ -1,7 +1,7 @@
 """https://www.postgresql.org/"""
 
 module(
-    name = "postgres14",
+    name = "postgres",
     version = "14.18",
     bazel_compatibility = [">=7.2.1"],
 )

--- a/modules/postgres/14.18/source.json
+++ b/modules/postgres/14.18/source.json
@@ -4,6 +4,6 @@
     "strip_prefix": "postgresql-14.18",
     "overlay": {
         "BUILD.bazel": "sha256-BBEeL1wX1hUalXRg0jL2WKJF2BBW7LJRRNrclx94WCY=",
-        "MODULE.bazel": "sha256-BHR5WDAPkANhCkYbYGwleK+BhB2RjfALsaEZbN4yxtM="
+        "MODULE.bazel": "sha256-+WJIzQ8IPjLUsKDo5oRZerh07O8mpE1jlXrJDqmikmI="
     }
 }


### PR DESCRIPTION
It turns out that I made a typo in the previous release:
- https://github.com/bazelbuild/bazel-central-registry/pull/5206

**This typo prevents dependents from using the target at the version**

The module name should match the BCR name (postgres instead of postgres14).

I'm not sure how the previous validation ran successfully.

## Validations

Ran: 

```
bazel run -- //tools:bcr_validation --check=postgres@14.18
```

Also made a temp project with `MODULE.bazel` declaring `bazel_dep(name = "postgres", version = "14.18")` and:
```
bazel clean --expunge && bazel build   --discard_analysis_cache   --disk_cache="" --enable_bzlmod     --registry="file:///<MY_LOCAL_REPO_DIR>"   --lockfile_mode=off   @postgres//...
```

## Note

If we don't like that we're editing the module here, I've made postgres v14.18.bcr.1:
- https://github.com/bazelbuild/bazel-central-registry/pull/5465

We should prefer to remove this module since it won't build for dependents though.