### PR TITLE
Fix Boost date time 1.88.0.bcr.1

### DIFF
--- a/modules/boost.date_time/1.88.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.date_time/1.88.0.bcr.1/overlay/BUILD.bazel
@@ -16,6 +16,7 @@ cc_library(
     textual_hdrs = [
         "include/boost/date_time/gregorian_calendar.ipp",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "@boost.algorithm",
         "@boost.assert",

--- a/modules/boost.date_time/1.88.0.bcr.1/source.json
+++ b/modules/boost.date_time/1.88.0.bcr.1/source.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/boostorg/date_time/archive/refs/tags/boost-1.88.0.tar.gz",
     "patch_strip": 0,
     "overlay": {
-        "BUILD.bazel": "sha256-g5Y/imdkjVK9erW6jAJZ4sVpg9L76hYPttuKt0zJSHc=",
+        "BUILD.bazel": "sha256-5EknWsVaubiOx0+EdCQ334u9heUw5a8Comc1RxVvZH8=",
         "MODULE.bazel": "sha256-JbdwRCW4C6B4dRXovcFyiX3uSAVkoov6370NUtlvuMo="
     }
 }


### PR DESCRIPTION
This PR fixes the visibility of Boost `date_time@1.88.0.bcr.1`. I know there is a guideline and good reasons why existing modules should not be changed.

Nevertheless, without this fix, it would be necessary to introduce `1.88.0.bcr.2` - This will force me to introduce also `boost_pin@1.88.0.bcr.2`, and this in turn will force me to update all 80 libs that are currently referenced by `boost_pin@1.88.0.bcr.1`. I have some scripting on my side to automate this, but I think this will lead to many non-sense boost versions, until I get it right.

A user can currently not depend on the `date_time@1.88.0.bcr.1` module, since nothing is visible from outside.

The do not use "nodep" deps feature is hard to handle for libs such Boost.

@fmeum @meteorcloudy @Wyverald @kotlaja 


