### PR TITLE
Fix #5513, [Bug]: can't fetch gawk because https://ftp.gnu.org is down

### DIFF
--- a/modules/gawk/5.3.2.bcr.1/source.json
+++ b/modules/gawk/5.3.2.bcr.1/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://ftp.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz",
+    "url": "https://ftpmirror.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz",
     "strip_prefix": "gawk-5.3.2",
     "integrity": "sha256-+MNIZQnecFGSE4sA7ywAu73Q6Eww1cB9I/xzqdxMycw=",
     "overlay": {

--- a/modules/gawk/5.3.2/source.json
+++ b/modules/gawk/5.3.2/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://ftp.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz",
+    "url": "https://ftpmirror.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz",
     "strip_prefix": "gawk-5.3.2",
     "integrity": "sha256-+MNIZQnecFGSE4sA7ywAu73Q6Eww1cB9I/xzqdxMycw=",
     "overlay": {

--- a/modules/gawk/metadata.json
+++ b/modules/gawk/metadata.json
@@ -15,7 +15,7 @@
         }
     ],
     "repository": [
-        "https://ftp.gnu.org/gnu/gawk/"
+        "https://ftpmirror.gnu.org/gnu/gawk/"
     ],
     "versions": [
         "5.3.2",

--- a/modules/glpk/5.0.bcr.1/source.json
+++ b/modules/glpk/5.0.bcr.1/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "http://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
+    "url": "http://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
     "integrity": "sha256-ShAT7rtQ9yj8YBvdgzsLKHAzPDs+WoFu66kh2VvsbxU=",
     "strip_prefix": "glpk-5.0",
     "patches": {

--- a/modules/glpk/5.0.bcr.2/source.json
+++ b/modules/glpk/5.0.bcr.2/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "http://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
+    "url": "http://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
     "integrity": "sha256-ShAT7rtQ9yj8YBvdgzsLKHAzPDs+WoFu66kh2VvsbxU=",
     "strip_prefix": "glpk-5.0",
     "patches": {

--- a/modules/glpk/5.0.bcr.3/source.json
+++ b/modules/glpk/5.0.bcr.3/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "http://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
+    "url": "http://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
     "integrity": "sha256-ShAT7rtQ9yj8YBvdgzsLKHAzPDs+WoFu66kh2VvsbxU=",
     "strip_prefix": "glpk-5.0",
     "overlay": {

--- a/modules/glpk/5.0.bcr.4/source.json
+++ b/modules/glpk/5.0.bcr.4/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
+    "url": "https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
     "integrity": "sha256-ShAT7rtQ9yj8YBvdgzsLKHAzPDs+WoFu66kh2VvsbxU=",
     "strip_prefix": "glpk-5.0",
     "overlay": {

--- a/modules/glpk/5.0/source.json
+++ b/modules/glpk/5.0/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "http://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
+    "url": "http://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
     "integrity": "sha256-ShAT7rtQ9yj8YBvdgzsLKHAzPDs+WoFu66kh2VvsbxU=",
     "strip_prefix": "glpk-5.0",
     "patches": {

--- a/modules/glpk/metadata.json
+++ b/modules/glpk/metadata.json
@@ -7,7 +7,7 @@
         }
     ],
     "repository": [
-        "https://ftp.gnu.org/gnu/glpk"
+        "https://ftpmirror.gnu.org/gnu/glpk"
     ],
     "versions": [
         "5.0",

--- a/modules/gperf/3.1/source.json
+++ b/modules/gperf/3.1/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz",
+    "url": "http://ftpmirror.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz",
     "integrity": "sha256-WIVGuUW7pLcLajphboC0q0ZuPzMCSjUvwhmBEs27OuI=",
     "strip_prefix": "gperf-3.1",
     "patches": {

--- a/modules/gperf/metadata.json
+++ b/modules/gperf/metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "repository": [
-        "http://ftp.gnu.org/pub/gnu/gperf"
+        "http://ftpmirror.gnu.org/pub/gnu/gperf"
     ],
     "versions": [
         "3.1"

--- a/modules/llvm-project/17.0.3.bcr.1/patches/0002-Add-LLVM-Bazel-overlay-files.patch
+++ b/modules/llvm-project/17.0.3.bcr.1/patches/0002-Add-LLVM-Bazel-overlay-files.patch
@@ -893,7 +893,7 @@ index c33465825..000000000
 -    strip_prefix = "gmp-6.2.1",
 -    urls = [
 -        "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz",
--        "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz",
+-        "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz",
 -    ],
 -)
 -

--- a/modules/llvm-project/17.0.3.bcr.2/patches/0002-Add-LLVM-Bazel-overlay-files.patch
+++ b/modules/llvm-project/17.0.3.bcr.2/patches/0002-Add-LLVM-Bazel-overlay-files.patch
@@ -893,7 +893,7 @@ index c33465825..000000000
 -    strip_prefix = "gmp-6.2.1",
 -    urls = [
 -        "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz",
--        "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz",
+-        "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz",
 -    ],
 -)
 -

--- a/modules/llvm-project/17.0.3/patches/0002-Add-LLVM-Bazel-overlay-files.patch
+++ b/modules/llvm-project/17.0.3/patches/0002-Add-LLVM-Bazel-overlay-files.patch
@@ -893,7 +893,7 @@ index c33465825..000000000
 -    strip_prefix = "gmp-6.2.1",
 -    urls = [
 -        "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz",
--        "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz",
+-        "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz",
 -    ],
 -)
 -

--- a/modules/readline/8.2.bcr.1/source.json
+++ b/modules/readline/8.2.bcr.1/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://ftp.gnu.org/pub/gnu/readline/readline-8.2.tar.gz",
+    "url": "https://ftpmirror.gnu.org/pub/gnu/readline/readline-8.2.tar.gz",
     "strip_prefix": "readline-8.2",
     "integrity": "sha256-P+txcfFqhO6CyhijbXub4QmlLAT0kqBTMx19EJUAfDU=",
     "overlay": {

--- a/modules/readline/8.2.bcr.2/source.json
+++ b/modules/readline/8.2.bcr.2/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://ftp.gnu.org/pub/gnu/readline/readline-8.2.tar.gz",
+    "url": "https://ftpmirror.gnu.org/pub/gnu/readline/readline-8.2.tar.gz",
     "strip_prefix": "readline-8.2",
     "integrity": "sha256-P+txcfFqhO6CyhijbXub4QmlLAT0kqBTMx19EJUAfDU=",
     "overlay": {

--- a/modules/readline/8.2/source.json
+++ b/modules/readline/8.2/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://ftp.gnu.org/pub/gnu/readline/readline-8.2.tar.gz",
+    "url": "https://ftpmirror.gnu.org/pub/gnu/readline/readline-8.2.tar.gz",
     "strip_prefix": "readline-8.2",
     "integrity": "sha256-P+txcfFqhO6CyhijbXub4QmlLAT0kqBTMx19EJUAfDU=",
     "overlay": {

--- a/modules/readline/metadata.json
+++ b/modules/readline/metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "repository": [
-        "https://ftp.gnu.org/"
+        "https://ftpmirror.gnu.org/"
     ],
     "versions": [
         "8.2",

--- a/modules/sed/4.9.bcr.1/source.json
+++ b/modules/sed/4.9.bcr.1/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://ftp.gnu.org/gnu/sed/sed-4.9.tar.xz",
+    "url": "https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.xz",
     "strip_prefix": "sed-4.9",
     "integrity": "sha256-biJrcy4c1zlGStaGK9Ghq6QteYKSLaelNRljHSSXUYE=",
     "overlay": {

--- a/modules/sed/4.9.bcr.2/source.json
+++ b/modules/sed/4.9.bcr.2/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://ftp.gnu.org/gnu/sed/sed-4.9.tar.xz",
+    "url": "https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.xz",
     "strip_prefix": "sed-4.9",
     "integrity": "sha256-biJrcy4c1zlGStaGK9Ghq6QteYKSLaelNRljHSSXUYE=",
     "overlay": {

--- a/modules/sed/4.9/source.json
+++ b/modules/sed/4.9/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://ftp.gnu.org/gnu/sed/sed-4.9.tar.xz",
+    "url": "https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.xz",
     "strip_prefix": "sed-4.9",
     "integrity": "sha256-biJrcy4c1zlGStaGK9Ghq6QteYKSLaelNRljHSSXUYE=",
     "overlay": {

--- a/modules/sed/metadata.json
+++ b/modules/sed/metadata.json
@@ -9,7 +9,7 @@
         }
     ],
     "repository": [
-        "https://ftp.gnu.org/gnu/sed/"
+        "https://ftpmirror.gnu.org/gnu/sed/"
     ],
     "versions": [
         "4.9",


### PR DESCRIPTION
Fixes #5513

This changes all occurrences of http://ftp.gnu.org/ and https://ftp.gnu.org/ over to ftpmirror.gnu.org alternatives.

http://ftp.gnu.org/ and https://ftp.gnu.org/ have been down for an extended period of time. https://www.gnu.org/prep/ftp.en.html says:

> please try to use one of the many mirrors of our site listed below: the mirrors will give you faster response.

and

> You can use the generic URLs https://ftpmirror.gnu.org/ and http://ftpmirror.gnu.org/ to automatically choose a nearby and up-to-date mirror.