### PR TITLE
boost.log@1.87.0.bcr.1

### DIFF
--- a/modules/boost.log/1.87.0.bcr.1/MODULE.bazel
+++ b/modules/boost.log/1.87.0.bcr.1/MODULE.bazel
@@ -1,0 +1,34 @@
+module(
+    name = "boost.log",
+    version = "1.87.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 108700,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "boost.align", version = "1.87.0")
+bazel_dep(name = "boost.asio", version = "1.87.0.bcr.1")
+bazel_dep(name = "boost.assert", version = "1.87.0")
+bazel_dep(name = "boost.atomic", version = "1.87.0")
+bazel_dep(name = "boost.bind", version = "1.87.0")
+bazel_dep(name = "boost.config", version = "1.87.0")
+bazel_dep(name = "boost.core", version = "1.87.0")
+bazel_dep(name = "boost.exception", version = "1.87.0")
+bazel_dep(name = "boost.filesystem", version = "1.87.0")
+bazel_dep(name = "boost.fusion", version = "1.87.0")
+bazel_dep(name = "boost.interprocess", version = "1.87.0")
+bazel_dep(name = "boost.iterator", version = "1.87.0")
+bazel_dep(name = "boost.move", version = "1.87.0")
+bazel_dep(name = "boost.mpl", version = "1.87.0")
+bazel_dep(name = "boost.optional", version = "1.87.0")
+bazel_dep(name = "boost.parameter", version = "1.87.0")
+bazel_dep(name = "boost.phoenix", version = "1.87.0")
+bazel_dep(name = "boost.preprocessor", version = "1.87.0")
+bazel_dep(name = "boost.property_tree", version = "1.87.0")
+bazel_dep(name = "boost.random", version = "1.87.0")
+bazel_dep(name = "boost.smart_ptr", version = "1.87.0")
+bazel_dep(name = "boost.thread", version = "1.87.0")
+bazel_dep(name = "boost.throw_exception", version = "1.87.0")
+bazel_dep(name = "boost.type_traits", version = "1.87.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/boost.log/1.87.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.log/1.87.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,145 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# See https://www.boost.org/doc/libs/1_87_0/libs/log/doc/html/log/installation/config.html
+
+_TEXTUAL_HDRS = [
+    "include/boost/log/detail/adaptive_mutex.hpp",
+    "include/boost/log/detail/attribute_get_value_impl.hpp",
+    "include/boost/log/detail/footer.hpp",
+    "include/boost/log/detail/generate_overloads.hpp",
+    "include/boost/log/detail/light_function_pp.hpp",
+    "include/boost/log/detail/named_scope_fmt_pp.hpp",
+    "include/boost/log/detail/trivial_keyword.hpp",
+]
+
+bool_flag(
+    name = "use_avx2",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "use_avx2_setting",
+    constraint_values = ["@platforms//cpu:x86_64"],
+    flag_values = {":use_avx2": "true"},
+)
+
+cc_library(
+    name = "boost.log",
+    srcs = glob(
+        [
+            "src/*.*pp",
+            "src/setup/*.*pp",
+        ],
+        exclude = [
+            "src/dump_avx2.cpp",
+            "src/dump_ssse3.cpp",
+        ],
+    ) + select({
+        "@platforms//os:linux": glob(["src/posix/*.*pp"]),
+        "@platforms//os:windows": glob(["src/windows/*.*pp"]),
+        "//conditions:default": [],
+    }) + select({
+        "@platforms//cpu:x86_64": ["src/dump_ssse3.cpp"],
+        "//conditions:default": [],
+    }) + select({
+        ":use_avx2_setting": ["src/dump_avx2.cpp"],
+        "//conditions:default": [],
+    }),
+    hdrs = glob(
+        ["include/**/*.hpp"],
+        exclude = [
+            "include/boost/log/support/xpressive.hpp",
+            "include/boost/log/support/spirit_classic.hpp",
+            "include/boost/log/support/spirit_qi.hpp",
+        ] + _TEXTUAL_HDRS,
+    ),
+    copts = select({
+        "@platforms//cpu:x86_64": ["-mssse3"],
+        "//conditions:default": [],
+    }) + select({
+        ":use_avx2_setting": ["-mavx2"],
+        "//conditions:default": [],
+    }),
+    defines = ["BOOST_LOG_NO_LIB"],
+    features = ["parse_headers"],
+    includes = [
+        "include",
+        "src",
+    ],
+    linkopts = select({
+        "@platforms//os:linux": ["-lrt"],
+        "@platforms//os:windows": [
+            "secur32.lib",
+            "psapi.lib",
+            "ws2_32.lib",
+            "mswsock.lib",
+            "advapi32.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    local_defines = [
+        "__STDC_CONSTANT_MACROS",
+        "BOOST_LOG_BUILDING_THE_LIB",
+        "BOOST_LOG_SETUP_BUILDING_THE_LIB",
+        "BOOST_LOG_USE_STD_REGEX",
+        "BOOST_SPIRIT_USE_PHOENIX_V3=1",
+        "BOOST_THREAD_DONT_USE_CHRONO",
+    ] + select({
+        "@platforms//cpu:x86_64": ["BOOST_LOG_USE_SSSE3"],
+        "//conditions:default": [],
+    }) + select({
+        ":use_avx2_setting": ["BOOST_LOG_USE_AVX2"],
+        "//conditions:default": [],
+    }) + select({
+        "@platforms//os:linux": [
+            "BOOST_LOG_USE_NATIVE_SYSLOG",
+            "_XOPEN_SOURCE=600",
+        ],
+        "@platforms//os:macos": [
+            "BOOST_LOG_USE_NATIVE_SYSLOG",
+            "BOOST_LOG_WITHOUT_IPC",  # TODO: ld: symbol(s) not found for architecture
+        ],
+        "@platforms//os:windows": [
+            "_CRT_SECURE_NO_DEPRECATE",
+            "_CRT_SECURE_NO_WARNINGS",
+            "_SCL_SECURE_NO_DEPRECATE",
+            "_SCL_SECURE_NO_WARNINGS",
+            "BOOST_LOG_WITHOUT_EVENT_LOG",  # TODO: compile simple_event_log.mc
+            "BOOST_USE_WINDOWS_H",
+            "NOMINMAX",
+            "SECURITY_WIN32",
+            "WIN32_LEAN_AND_MEAN",
+        ],
+        "//conditions:default": [],
+    }),
+    textual_hdrs = _TEXTUAL_HDRS,
+    deps = [
+        "@boost.align",
+        "@boost.asio",
+        "@boost.assert",
+        "@boost.atomic",
+        "@boost.bind",
+        "@boost.config",
+        "@boost.core",
+        "@boost.exception",
+        "@boost.filesystem",
+        "@boost.fusion",
+        "@boost.interprocess",
+        "@boost.iterator",
+        "@boost.move",
+        "@boost.mpl",
+        "@boost.optional",
+        "@boost.parameter",
+        "@boost.phoenix",
+        "@boost.preprocessor",
+        "@boost.property_tree",
+        "@boost.random",
+        "@boost.smart_ptr",
+        "@boost.thread",
+        "@boost.throw_exception",
+        "@boost.type_traits",
+    ],
+)

--- a/modules/boost.log/1.87.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/boost.log/1.87.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/boost.log/1.87.0.bcr.1/overlay/test/BUILD.bazel
+++ b/modules/boost.log/1.87.0.bcr.1/overlay/test/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "common",
+    hdrs = glob(["common/*.hpp"]),
+    includes = ["common"],
+    deps = [
+        "@boost.log",
+        "@boost.move",
+        "@boost.mpl",
+    ],
+)
+
+[cc_test(
+    name = "test_" + test,
+    timeout = "short",
+    srcs = [test],
+    local_defines = select({
+        "@platforms//os:macos": ["BOOST_LOG_WITHOUT_IPC"],  # TODO: ld: symbol(s) not found for architecture
+        "@platforms//os:windows": ["BOOST_LOG_WITHOUT_EVENT_LOG"],  # TODO: compile simple_event_log.mc
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":common",
+        "@boost.log",
+        "@boost.test",
+        "@boost.test//:unit_test_main",
+        "@boost.thread",
+    ],
+) for test in glob(
+    ["run/*.*pp"],
+    exclude = [
+        "run/filt_matches_spirit_classic.cpp",
+        "run/filt_matches_spirit_qi.cpp",
+        "run/filt_matches_xpressive.cpp",
+    ],
+)]
+
+[cc_test(
+    name = "test_" + test,
+    timeout = "short",
+    srcs = [test],
+    deps = [
+        "@boost.assert",
+        "@boost.log",
+        "@boost.type_traits",
+    ],
+) for test in glob(
+    ["compile/*.*pp"],
+    exclude = ["compile/self_contained_header.cpp"],
+)]

--- a/modules/boost.log/1.87.0.bcr.1/overlay/test/MODULE.bazel
+++ b/modules/boost.log/1.87.0.bcr.1/overlay/test/MODULE.bazel
@@ -1,0 +1,14 @@
+bazel_dep(name = "boost.log")
+local_path_override(
+    module_name = "boost.log",
+    path = "..",
+)
+
+bazel_dep(name = "boost.assert", version = "1.87.0")
+bazel_dep(name = "boost.move", version = "1.87.0")
+bazel_dep(name = "boost.mpl", version = "1.87.0")
+bazel_dep(name = "boost.test", version = "1.87.0")
+bazel_dep(name = "boost.thread", version = "1.87.0")
+bazel_dep(name = "boost.type_traits", version = "1.87.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/boost.log/1.87.0.bcr.1/presubmit.yml
+++ b/modules/boost.log/1.87.0.bcr.1/presubmit.yml
@@ -1,0 +1,44 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.log'
+bcr_test_module:
+  module_path: test
+  matrix:
+    platform:
+      - debian10
+      - debian11
+      - macos
+      - macos_arm64
+      - ubuntu2004
+      - ubuntu2204
+      - ubuntu2404
+      - windows
+    bazel: [7.x, 8.x, rolling]
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - '--process_headers_in_dependencies'
+      build_targets:
+        - //...
+      test_targets:
+        - //...

--- a/modules/boost.log/1.87.0.bcr.1/source.json
+++ b/modules/boost.log/1.87.0.bcr.1/source.json
@@ -1,0 +1,12 @@
+{
+    "integrity": "sha256-Vyz0hYCAvhTwlgNIJ5++X0/EnoibA0niz/kVx2Gdsjc=",
+    "strip_prefix": "log-boost-1.87.0",
+    "url": "https://github.com/boostorg/log/archive/refs/tags/boost-1.87.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-Y10/27pyGDOAdYsIecC7wJp0gxhWdZrWb7iWEaXmiHQ=",
+        "MODULE.bazel": "sha256-chF0paUlexP1UK40YwInekGFPY87o10CwXYAtJS+ngI=",
+        "test/BUILD.bazel": "sha256-UglgRNS/GpCa9AQIdpCFFudeYjci8GZUxOhG5V3Xq0U=",
+        "test/MODULE.bazel": "sha256-NL/wwMYeJLTdXn3sWPxlCk3t4spijqLFpQayvBgftHI="
+    }
+}

--- a/modules/boost.log/metadata.json
+++ b/modules/boost.log/metadata.json
@@ -24,7 +24,8 @@
         "github:boostorg/log"
     ],
     "versions": [
-        "1.87.0"
+        "1.87.0",
+        "1.87.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Add `use_avx2` flag and disable by default.

I got "illegal instruction" on an old machine. AVX2 is not always good, e.g. it could cause the CPU to run at a lower frequency, hence disabling by default.