### PR TITLE
feat: add `pre-commit` module

### DIFF
--- a/modules/pre-commit/1.0.9/MODULE.bazel
+++ b/modules/pre-commit/1.0.9/MODULE.bazel
@@ -1,0 +1,107 @@
+module(
+    name = "pre-commit",
+    version = "1.0.9",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_diff", version = "1.0.0")
+bazel_dep(name = "toolchain_utils", version = "1.2.0")
+bazel_dep(name = "download_utils", version = "1.0.1")
+bazel_dep(name = "ape", version = "1.0.1")
+
+# TODO: Remove this in favour of `rules_python//uv:lock.bzl` when released
+bazel_dep(name = "rules_uv", version = "0.56.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.0.1", dev_dependency = True)
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0", dev_dependency = True)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    # TODO: remove this when `ignore_root_user_error` is hermetic
+    # https://github.com/bazelbuild/rules_python/issues/2016
+    ignore_root_user_error = True,
+    python_version = "3.13",
+)
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
+# Ensure there is a `pip` hub for each Python version
+# The project performs a `select` to grab the correct packages for the executing Python
+# This is important to provide Python package aliases downstream such as `//pre-commit:pkg`
+[
+    (
+        pip.parse(
+            experimental_index_url = "https://pypi.org/simple",
+            hub_name = "pre-commit-{}".format(version),
+            python_version = version,
+            requirements_lock = "//pre-commit/requirements:lock.txt",
+        ),
+        pip.parse(
+            experimental_index_url = "https://pypi.org/simple",
+            hub_name = "pre-commit-hook-{}".format(version),
+            python_version = version,
+            requirements_by_platform = {
+                "//pre-commit/hook/requirements:lock.txt": "linux_*,osx_*,windows_*",
+            },
+        ),
+        pip.parse(
+            experimental_index_url = "https://pypi.org/simple",
+            hub_name = "pre-commit-config-{}".format(version),
+            python_version = version,
+            requirements_lock = "//pre-commit/config/requirements:lock.txt",
+        ),
+        use_repo(
+            pip,
+            "pre-commit-{}".format(version),
+            "pre-commit-hook-{}".format(version),
+            "pre-commit-config-{}".format(version),
+        ),
+    )
+    # Keep this in sync with `//pre-commit/python:versions.bzl`
+    # TODO: load from `//pre-commit/python:version.bzl` when possible
+    for version in ("3.10", "3.11", "3.12", "3.13")
+]
+
+download_file = use_repo_rule("@download_utils//download/file:defs.bzl", "download_file")
+
+download_archive = use_repo_rule("@download_utils//download/archive:defs.bzl", "download_archive")
+
+# Bazelisk binaries
+[
+    download_file(
+        name = "bazelisk-{}".format(name),
+        executable = True,
+        integrity = integrity,
+        output = "bazelisk.exe" if ".exe" in suffix else "bazelisk",
+        urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-{}".format(suffix)],
+    )
+    for name, suffix, integrity in (
+        ("amd64-linux", "linux-amd64", "sha256-/Y/f9BihdYiHUg+kLafmrjmu/HiM9ef3u422k00nn8Q="),
+        ("arm64-linux", "linux-arm64", "sha256-TI2WbkCsLE78x/Glpczu8sCi8WuVfnkfp6hnzOMej8s="),
+        ("amd64-macos", "darwin-amd64", "sha256-CvAZ7rZC+nB0RBnQKqMt9V5ueghBBdSfsmgBpmCqVtM="),
+        ("arm64-macos", "darwin-arm64", "sha256-sT3YnG7NkJRMo1OfWixxWhj2m3RYh4xHGpAqjkgs60s="),
+        ("amd64-windows", "windows-amd64.exe", "sha256-ZBo9/r1xdwNnX5EpF3NcRLRc9jAL/fuSRTfzz7/83ZI="),
+        ("arm64-windows", "bazelisk-windows-arm64.exe", "sha256-4FYwZnOIMzRNHbFatBB9L2L4nkphZJ1SF/Bw0l8NyNc="),
+    )
+]
+
+# Ruff binaries
+[
+    download_archive(
+        name = "ruff-{}".format(name),
+        integrity = integrity,
+        strip_prefix = "ruff-{}".format(triplet) if ext != ".zip" else "",
+        urls = ["https://github.com/astral-sh/ruff/releases/download/0.9.7/ruff-{}{}".format(triplet, ext)],
+    )
+    for name, triplet, ext, integrity in (
+        ("amd64-linux", "x86_64-unknown-linux-musl", ".tar.gz", "sha256-8LfHpa5EZzCsERkEpQTLlnicwcgrmWa1W+3Yim0+wHc="),
+        ("arm64-linux", "aarch64-unknown-linux-musl", ".tar.gz", "sha256-uUrZS8DPFKEqcl/PI4PtBHtTcGj0szvwgV6LrzXm7Fw="),
+        ("amd64-macos", "x86_64-apple-darwin", ".tar.gz", "sha256-Kg/RLNZtIKiCypcBWe82HV85e5OKWrnXYZ3sDxUVL1M="),
+        ("arm64-macos", "aarch64-apple-darwin", ".tar.gz", "sha256-8UQ35xOZ4UMCvfXOkQ49+avJoiP+D/XWsC6wg8Ofows="),
+        ("amd64-windows", "x86_64-pc-windows-msvc", ".zip", "sha256-I2xp7VEKMwL0C14Owc3gzHU1FGzTdljm0xaMhelOMIo="),
+        ("arm64-windows", "aarch64-pc-windows-msvc", ".zip", "sha256-ckodh0IeEldZ6bfbqxak0QNIks5BgKqvYePrvn5nr6I="),
+    )
+]

--- a/modules/pre-commit/1.0.9/presubmit.yml
+++ b/modules/pre-commit/1.0.9/presubmit.yml
@@ -1,0 +1,19 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+      - 8.x
+    platform:
+      - debian11
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/pre-commit/1.0.9/source.json
+++ b/modules/pre-commit/1.0.9/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/pre-commit/-/releases/v1.0.9/downloads/src.tar.gz",
+  "integrity": "sha512-F82M1rHKnN1j9J3asr+kFozAsXsNumXktbScGd7m9I5ZmicWkYuFtyxLOMnYdMl1TfGH1SKz+PRan9ZdeXhRiw==",
+  "strip_prefix": "pre-commit-v1.0.9"
+}

--- a/modules/pre-commit/metadata.json
+++ b/modules/pre-commit/metadata.json
@@ -1,0 +1,16 @@
+{
+  "homepage": "https://gitlab.arm.com/bazel/pre-commit",
+  "repository": [
+    "https://gitlab.arm.com/bazel/pre-commit"
+  ],
+  "versions": [
+    "1.0.9"
+  ],
+  "maintainers": [
+    {
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson",
+      "github_user_id": 1081113
+    }
+  ]
+}


### PR DESCRIPTION
> A module to integrate between Bazel and the `pre-commit` framework

[pre-commit] is great, it can manage `git` hooks with a lovely interface.

It maintains a cache of various language toolchains.

Bazel also manages a cache of various language toolchains.

This project provides Bazel rules to leverage the Bazel caching mechanism with `pre-commit`.

Hooks can be easily shared between Bazel projects.

Caching of the hooks can be shared with a Bazel remote cache.

Hooks use `language: system` to call into Bazel when a hook is executed.

The project uses a `@pre-commit` binary that includes a hermetic `git` and `bazel`.

Add the following to `MODULE.bazel`:

```py
bazel_dep("pre-commit", version = "<version>")
```

Create a `hooks` directory to create the `pre-commit` setup:

```py
load("@pre-commit//pre-commit:defs.bzl", "pre_commit")
load("@pre-commit//pre-commit/hook:defs.bzl", "pre_commit_hook")

pre_commit_hook(
    name = "commitlint",
    stages = ["@pre-commit//pre-commit/stage:commit-msg"],
    src = "@commitlint",
    summary = "Validate commit message",
    description = "Runs `commitlint` against each commit message to validate it conforms.",
)

pre_commit(
   name = "hooks",
   # Use externally defined collection of hooks that provides `pre_commit_hooks` rule
   srcs = [":commitlint", "@pre-commit-hooks"],
)
```

Generate the `hooks/.pre-commit-config.yaml` file with `bazel run hooks:config`.

Add a `pre-commit` configuration in `.bazelrc`:

```
common:pre-commit --ui_event_filters=-info,-stdout,-stderr
common:pre-commit --noshow_progress
common:pre-commit --lockfile_mode=off
```

This project uses the `pre_commit` macro, see the [hooks](https://gitlab.arm.com/bazel/pre-commit/-/blob/v1.0.9/hooks/BUILD.bazel?ref_type=tags) for example usage.

Hooks can be created with the `pre_commit_hook` macro.

By default, the hook defaults to the `run` Bazel command.

An executable target must be provided via the `src` attribute.

The executable target _must_ accept multiple file paths as each hook runs serially to avoid locking contention on the Bazel server.

If an upstream tool does not support multiple file paths, create a Bazel executable wrapper that does and provide that to the `src` attribute.

See [//pre-commit/hook/check-newline-at-end-of-file](https://gitlab.arm.com/bazel/pre-commit/-/blob/v1.0.9/pre-commit/hook/check-newline-at-end-of-file/BUILD.bazel?ref_type=tags) for an example of a single hook.

Multiple hooks can be bundled together with `pre_commit_hooks`.

Setting the visibility of that target to `//visibility:public` will allow downstream users to include the target in `pre_commit_config#srcs`.

See [//pre-commit/hook/buildifier](https://gitlab.arm.com/bazel/pre-commit/-/blob/v1.0.9/pre-commit/hook/buildifier/BUILD.bazel?ref_type=tags) for an example of bundled hooks, albeit without public visibility.

Install the hooks with `bazel run hooks:install`.

Run the hooks with `bazel run hooks:run`.

The project uses `rules_python` which is hermetic when `--@rules_python//python/config_settings:bootstrap_impl` is set to `script`.

Otherwise, the operation of `pre-commit` is hermetic using a hermetic `git` and `bazelisk` implementation to run the hooks.

The hermeticity of each individual hook is not controlled by this project.

[pre-commit]: https://pre-commit.com