### PR TITLE
Add poco

### DIFF
--- a/modules/poco/1.14.2-20250528/MODULE.bazel
+++ b/modules/poco/1.14.2-20250528/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "poco",
+    version = "1.14.2-20250528",
+    bazel_compatibility = [">=7.2.1"],
+)
+bazel_dep(name = "rules_cc", version = "0.2.0")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/poco/1.14.2-20250528/overlay/BUILD
+++ b/modules/poco/1.14.2-20250528/overlay/BUILD
@@ -1,0 +1,85 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(["LICENSE"])
+
+license(
+    name = "license",
+    package_name = "poco",
+    license_kinds = ["@rules_license//licenses/spdx:BSL-1.0"],
+    license_text = "LICENSE",
+    package_url = "https://github.com/pocoproject/poco",
+)
+
+cc_library(
+    name = "PocoFoundation",
+    srcs = glob(
+        ["Foundation/src/*.cpp"],
+        exclude = [
+            "Foundation/src/DirectoryIterator_*.cpp",
+            "Foundation/src/Environment_*.cpp",
+            "Foundation/src/Event_*.cpp",
+            "Foundation/src/EventLogChannel.cpp",
+            "Foundation/src/FPEnvironment_*.cpp",
+            "Foundation/src/FileStream_*.cpp",
+            "Foundation/src/FileStreamRWLock*.cpp",
+            "Foundation/src/File_*.cpp",
+            "Foundation/src/Mutex_*.cpp",
+            "Foundation/src/NamedEvent_*.cpp",
+            "Foundation/src/NamedMutex_*.cpp",
+            "Foundation/src/NumericString.cpp",
+            "Foundation/src/Path_*.cpp",
+            "Foundation/src/PipeImpl_*.cpp",
+            "Foundation/src/Process_*.cpp",
+            "Foundation/src/RWLock_*.cpp",
+            "Foundation/src/Semaphore_*.cpp",
+            "Foundation/src/SharedLibrary_*.cpp",
+            "Foundation/src/SharedMemory_*.cpp",
+            "Foundation/src/Thread_*.cpp",
+            "Foundation/src/Timezone_*.cpp",
+            "Foundation/src/Var*.cpp",
+            "Foundation/src/Windows*.cpp",
+        ],
+    ),
+    hdrs = glob(
+        [
+            "Foundation/include/Poco/*.h",
+            "Foundation/src/*.h",
+            "Foundation/src/DirectoryIterator_*.cpp",
+            "Foundation/src/Environment_*.cpp",
+            "Foundation/src/Event_*.cpp",
+            "Foundation/src/FPEnvironment_*.cpp",
+            "Foundation/src/FileStream_*.cpp",
+            "Foundation/src/File_*.cpp",
+            "Foundation/src/Mutex_*.cpp",
+            "Foundation/src/NamedEvent_*.cpp",
+            "Foundation/src/NamedMutex_*.cpp",
+            "Foundation/src/Path_*.cpp",
+            "Foundation/src/PipeImpl_*.cpp",
+            "Foundation/src/Process_*.cpp",
+            "Foundation/src/RWLock_*.cpp",
+            "Foundation/src/Semaphore_*.cpp",
+            "Foundation/src/SharedLibrary_*.cpp",
+            "Foundation/src/SharedMemory_*.cpp",
+            "Foundation/src/Thread_*.cpp",
+            "Foundation/src/Timezone_*.cpp",
+        ],
+    ),
+    includes = ["Foundation/include"],
+)
+
+cc_library(
+    name = "PocoNet",
+    srcs = glob(["Net/src/*.cpp"]),
+    hdrs = glob(["Net/include/Poco/Net/*.h"]),
+    includes = [
+        "Foundation/include",
+        "Net/include",
+    ],
+    deps = [":PocoFoundation"],
+)

--- a/modules/poco/1.14.2-20250528/overlay/MODULE.bazel
+++ b/modules/poco/1.14.2-20250528/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/poco/1.14.2-20250528/presubmit.yml
+++ b/modules/poco/1.14.2-20250528/presubmit.yml
@@ -2,8 +2,6 @@ matrix:
   platform:
   - debian11
   - ubuntu2204
-  - macos
-  - macos_arm64
   bazel:
   - 8.x
 tasks:

--- a/modules/poco/1.14.2-20250528/presubmit.yml
+++ b/modules/poco/1.14.2-20250528/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@poco//:PocoFoundation'
+    - '@poco//:PocoNet'

--- a/modules/poco/1.14.2-20250528/source.json
+++ b/modules/poco/1.14.2-20250528/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/pocoproject/poco/archive/15d987fbb076d5810faf39f1e9a67b5025281bb8.tar.gz",
+    "integrity": "sha256-TaUGgTng2YRE3i7TyFy3IlhOJdpdRevmO4jwSMV3SwA=",
+    "strip_prefix": "poco-15d987fbb076d5810faf39f1e9a67b5025281bb8",
+    "overlay": {
+        "BUILD": "sha256-YEY/pKcBeW+b25seokdqPfj2eIiHct2eVcNaqS8LwCk=",
+        "MODULE.bazel": "sha256-AK42l3B0PSn0OoNsZDWYSYZh+Ds+Em8sYGksnrCfwos="
+    }
+}

--- a/modules/poco/metadata.json
+++ b/modules/poco/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://pocoproject.org/",
+    "maintainers": [
+        {
+            "email": "alexanderfaxa@intrinsic.ai",
+            "github": "faximan",
+            "github_user_id": 207300,
+            "name": "Alex Faxa"
+        }
+    ],
+    "repository": [
+        "https://github.com/pocoproject/poco"
+    ],
+    "versions": [
+        "1.14.2-20250528"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
I could not add an existing release because our build requires https://github.com/pocoproject/poco/pull/4956 which is not yet included in a release. Thus, I used the option of adding a date tag and pinning to a commit, which seemed cleaner than adding that PR as a bunch of patch files.

This does not come with Windows or macOS support, which I have not bothered to add.