### PR TITLE
Fix boost@1.88.0.bcr.1 compatibility level

### DIFF
--- a/modules/boost.algorithm/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.algorithm/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.algorithm",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.array", version = "1.88.0.bcr.1")

--- a/modules/boost.algorithm/1.88.0.bcr.1/source.json
+++ b/modules/boost.algorithm/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-Hu1ydcHfROdY89dB0RIJIdMPIuibcxMZW+95AlsY8RU=",
-        "MODULE.bazel": "sha256-prXiXnDYI07AM4t4JBQZRFn+GeqRZ3WLNBQVFz/Bik4="
+        "MODULE.bazel": "sha256-chL/wMGEjjagB1hsGhIlDsdwWLjNeSrmIQ/QZ2Rcm0A="
     }
 }

--- a/modules/boost.any/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.any/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.any",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.any/1.88.0.bcr.1/source.json
+++ b/modules/boost.any/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-aCIDwt/VaA520LMR/ZVYZSPjEwJZWon+j/fFBsWMWLU=",
-        "MODULE.bazel": "sha256-jTXxSaRPlOVN7j6xNA/h08xFOBv4uxJ6xGqvmEo1jNM="
+        "MODULE.bazel": "sha256-/b4rnbDROHNzZKY2G6m07NDWK74Fv4KWaxCRKkTLiFQ="
     }
 }

--- a/modules/boost.asio/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.asio/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.asio",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.8.1")

--- a/modules/boost.asio/1.88.0.bcr.1/source.json
+++ b/modules/boost.asio/1.88.0.bcr.1/source.json
@@ -5,9 +5,9 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-t2ojzIKONAukJcS47yVCeoPxWIsutEk/8Ih7XIuJmoE=",
-        "MODULE.bazel": "sha256-dbeZsTXdAMMpKvIOpTwyXHvkht2geqGJCTDNplfNIwE=",
-        "test/archetypes/BUILD.bazel": "sha256-d5MKVHwxKqaRPwR2x7feBKD6ovoOFZW9jzJSKwIRgdg=",
+        "MODULE.bazel": "sha256-pASf5rCZkSkKbGUCxtjevXxh9xQi+Ue1n8ELllJz12Y=",
         "test/BUILD.bazel": "sha256-8fcIeYXVWHay4eYnKwdrvdtlPAEtVEqqBlUKdwZcCDY=",
-        "test/MODULE.bazel": "sha256-EdjzngQk6G5bRRGF+JcQ2IKT4O+CSQiNKaaKgAMXvsM="
+        "test/MODULE.bazel": "sha256-EdjzngQk6G5bRRGF+JcQ2IKT4O+CSQiNKaaKgAMXvsM=",
+        "test/archetypes/BUILD.bazel": "sha256-d5MKVHwxKqaRPwR2x7feBKD6ovoOFZW9jzJSKwIRgdg="
     }
 }

--- a/modules/boost.assign/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.assign/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.assign",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.array", version = "1.88.0.bcr.1")

--- a/modules/boost.assign/1.88.0.bcr.1/source.json
+++ b/modules/boost.assign/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-4sK0cvr7sXur/5hXF3kxdFaMrCELsH+UAvx/W74MT8I=",
-        "MODULE.bazel": "sha256-OqwutFljRzbktCxQv8DR4BROFegFtjPTRhCPSTIJRcY="
+        "MODULE.bazel": "sha256-nvvvjvoaaVtH1c/36if+H7HsyWrory2f0b5DFMDhAVA="
     }
 }

--- a/modules/boost.atomic/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.atomic/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.atomic",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.align", version = "1.88.0.bcr.1")

--- a/modules/boost.atomic/1.88.0.bcr.1/source.json
+++ b/modules/boost.atomic/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-K2pUhUEFZ68t1H1tSd16TEmEZClOh3ZkOv9Cx2siDkU=",
-        "MODULE.bazel": "sha256-5q4n+YnSyDUVo+paghEoGd66rw/IvkTSoBRooeKuEKQ="
+        "MODULE.bazel": "sha256-OowKXs6XTigmJooFM2KtMTvn+DSFH7swboST2F23BEI="
     }
 }

--- a/modules/boost.bimap/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.bimap/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.bimap",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.concept_check", version = "1.88.0.bcr.1")

--- a/modules/boost.bimap/1.88.0.bcr.1/source.json
+++ b/modules/boost.bimap/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-NJEjqGOjhOOX5UCkz2KbgMGoQObS9EgvT2/H/T0JB/8=",
-        "MODULE.bazel": "sha256-Ih2WT7o2Vu6WnR9AxHczCHIWun+zGli7sSwwqxdi4z0="
+        "MODULE.bazel": "sha256-1RqpXqSSFZWRxcxJ3oyPLK4rvZ3mAuupPQAJhh+h50I="
     }
 }

--- a/modules/boost.chrono/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.chrono/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.chrono",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.chrono/1.88.0.bcr.1/source.json
+++ b/modules/boost.chrono/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-XfVqeLmhZowgxXK8DJgUniRI9D5demeYPuq9TszEdWY=",
-        "MODULE.bazel": "sha256-MtLz7GsLC+VqWPYxAWcuYBJOT4TmiZuCERAeeMHQgVw="
+        "MODULE.bazel": "sha256-ldfIqkwGlfYGsLq6ProNChlJ7r/SU7ghiktQwluCby0="
     }
 }

--- a/modules/boost.container/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.container/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.container",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.container/1.88.0.bcr.1/source.json
+++ b/modules/boost.container/1.88.0.bcr.1/source.json
@@ -5,7 +5,7 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-h+K0GEk5KIJGSoRHgoxkFCeVx7wYyE2Z7d1v2VCVUYw=",
-        "MODULE.bazel": "sha256-uQen17UkrpSpOoD291eX7PJWiE/NWSOWzx3T8rniAXk=",
+        "MODULE.bazel": "sha256-Ig1Z4SUQx2mrUqtaCEkDsu9t3N2UzUhH4ZVPQ/weT5M=",
         "test/BUILD.bazel": "sha256-QBcjVrrezGF4hb6bt4tgkGVp1nVPqty/ulOs4VegHSI=",
         "test/MODULE.bazel": "sha256-qcY5Nc5qXujcva5VO41vCWykwV/uDt6TZ5pYY57wMN4=",
         "test/gen_test_targets.bzl": "sha256-y85nyalenObTgbO4Wm2GHnAkrWwpVSyNnAxvMiEx2Ko="

--- a/modules/boost.context/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.context/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.context",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.8.1")

--- a/modules/boost.context/1.88.0.bcr.1/source.json
+++ b/modules/boost.context/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-hNhrbXrH4mfmM8+WmEl5K+J7s9iqsrG3Aw8KyjKBaD0=",
-        "MODULE.bazel": "sha256-4ESpbJIVlgQyuSsQgIXqgIIbM6nogkZ1/vC9ug0KP6A="
+        "MODULE.bazel": "sha256-PD5IYK7N2/ZME/sY2t4FFrRimtXbVoDMrjZ+UU3Ia3o="
     }
 }

--- a/modules/boost.conversion/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.conversion/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.conversion",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.conversion/1.88.0.bcr.1/source.json
+++ b/modules/boost.conversion/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-lBfqx6SIMzj6Ox75h1vZaRThgwfJEOtYUfcZYx2vR88=",
-        "MODULE.bazel": "sha256-IhNKs+f4ijq55UMpC0rqnKxc73wfFIHAKmmROCSLvaA="
+        "MODULE.bazel": "sha256-IXkjSNzaSqkM1jRjl7JBs0xpq2hYviP18t95Gmp+dko="
     }
 }

--- a/modules/boost.coroutine/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.coroutine/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.coroutine",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.coroutine/1.88.0.bcr.1/source.json
+++ b/modules/boost.coroutine/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-/Ti1rqYU8UxIkOe0qMDCHWRdjloLop9LkP6xn5xH69w=",
-        "MODULE.bazel": "sha256-iA0L9y3rdAH4v/RPslmhO7xdsFovL1N8MnslGJFaEfw="
+        "MODULE.bazel": "sha256-BXZGbyMv2G24lWRz8nF5JvcLa7lEInF6Nh3/1OEzyzo="
     }
 }

--- a/modules/boost.crc/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.crc/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.crc",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.pin_version", version = "1.88.0.bcr.1")

--- a/modules/boost.crc/1.88.0.bcr.1/source.json
+++ b/modules/boost.crc/1.88.0.bcr.1/source.json
@@ -5,7 +5,7 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-t/N72DyjpPv/sATUkx1ff61cgwhNej5aCHwoqzbLh/Q=",
-        "MODULE.bazel": "sha256-g5VOwwYJokwjnn9P4D9BFMw0hf3hX9/ww/sndXygDqQ=",
+        "MODULE.bazel": "sha256-cCXyohWu/CEAUD2S9R8R/k71ysfyFy7arfcsjM0KSp0=",
         "test/BUILD.bazel": "sha256-edbXChaSDKA982QveKKBPQp8jAMwYmAf2WrCITikR+A=",
         "test/MODULE.bazel": "sha256-bnCtS5ZpwcEf/L4lKHdebDuhxaOZbmaPAp0qlVjeSJA="
     }

--- a/modules/boost.date_time/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.date_time/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.date_time",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.algorithm", version = "1.88.0.bcr.1")

--- a/modules/boost.date_time/1.88.0.bcr.1/source.json
+++ b/modules/boost.date_time/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-5EknWsVaubiOx0+EdCQ334u9heUw5a8Comc1RxVvZH8=",
-        "MODULE.bazel": "sha256-JbdwRCW4C6B4dRXovcFyiX3uSAVkoov6370NUtlvuMo="
+        "MODULE.bazel": "sha256-rGDsKjXhUkk96kLusediA+PUgn4K5Lxi/he00PCqbUs="
     }
 }

--- a/modules/boost.detail/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.detail/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.detail",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.detail/1.88.0.bcr.1/source.json
+++ b/modules/boost.detail/1.88.0.bcr.1/source.json
@@ -5,7 +5,7 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-T7kZW8Rc6sY6mP5UKJfaoHjggqC61L7sDvzT28gHOg4=",
-        "MODULE.bazel": "sha256-GqCH0N2kdeRt3cOVq6B59GF1+Df+JAueadW5D2YLcXI=",
+        "MODULE.bazel": "sha256-ZcDwuRgSp54IgT6pu+xTFWdz1OuV1wKpRrHoMLQSRnE=",
         "test/BUILD.bazel": "sha256-SFpZRRzwociPZiNFNEn2xX3RiUPdC4YoQwqOolx8mV0=",
         "test/MODULE.bazel": "sha256-b9pKFJq886uGeyS/D6jJC5JZNbn2TO0H0sLJlF9wV1k="
     }

--- a/modules/boost.dynamic_bitset/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.dynamic_bitset/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.dynamic_bitset",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.dynamic_bitset/1.88.0.bcr.1/source.json
+++ b/modules/boost.dynamic_bitset/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-06+rh/4b6Ka02HI72BndrOAe1MW6wxfSN/H2JAOB8YQ=",
-        "MODULE.bazel": "sha256-eMfhzzbdAlBXfnMswZe8A/Ofn73NAO4LF+Y+KNFwY90="
+        "MODULE.bazel": "sha256-zBIRhrfBGRuiZtY+RoqU2IWWUhHNVDb4FIRbvaISghI="
     }
 }

--- a/modules/boost.exception/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.exception/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.exception",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.exception/1.88.0.bcr.1/source.json
+++ b/modules/boost.exception/1.88.0.bcr.1/source.json
@@ -5,7 +5,7 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-Xp4kzMDKIryD3JnmzXaBCZId83XAeGNmI55oNvOPCek=",
-        "MODULE.bazel": "sha256-8lB7dvqNPizxQmjUiUBv/5uV6Pna+b2cmtDxWTH3HGY=",
+        "MODULE.bazel": "sha256-swdqLwrGMEXzwqiYb+VO8qVLUBvFbV7Bs0KAN7XtDbM=",
         "test/BUILD.bazel": "sha256-P3jQlT3yvOIZEs9MDS2QVGvIFshjpgelvlpPgfkkN0Q=",
         "test/MODULE.bazel": "sha256-Mv4cyjNsxQYH/PB1nkXQp02bV0oC634sMgsalpvlxvE="
     }

--- a/modules/boost.format/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.format/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.format",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.format/1.88.0.bcr.1/source.json
+++ b/modules/boost.format/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-BIhkzV/EvFKZGKde47l40MGPetwknr113dzuOGqDK0s=",
-        "MODULE.bazel": "sha256-R6TaNyIyPiBxcIOWNTQ9M1YD87qZpE8vo6N7k3gt1es="
+        "MODULE.bazel": "sha256-FvqG3gcg1h/BxYCW+uT57CEqKn2AKNGxvgcuPIOCD30="
     }
 }

--- a/modules/boost.function/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.function/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.function",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.function/1.88.0.bcr.1/source.json
+++ b/modules/boost.function/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-nTJ3JEBnQ9NFjuvUx9t/u+uJMnI1iDrDTvv3Ff0A0OQ=",
-        "MODULE.bazel": "sha256-Bu8IE69ZZRrJ/YFmDLyZCaXkJnF2GOS9kDREtxm3SC8="
+        "MODULE.bazel": "sha256-6w4mqz9jBsriGfGgTAyVaDktV+iU61ddzAMigtDBYdM="
     }
 }

--- a/modules/boost.function_types/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.function_types/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.function_types",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.function_types/1.88.0.bcr.1/source.json
+++ b/modules/boost.function_types/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-uPw3XCBgPfJQuDjwQMFaK5e4HfV20nL97s+q7iDjPdc=",
-        "MODULE.bazel": "sha256-0ZLDKoZHYDyGBbPltbZuag1ECExE7Avn7dUzNfXLdIo="
+        "MODULE.bazel": "sha256-faRp0uIuql3nTi5ApltEnueizjheTJL19eIe2OYLaRM="
     }
 }

--- a/modules/boost.functional/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.functional/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.functional",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.functional/1.88.0.bcr.1/source.json
+++ b/modules/boost.functional/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-uYlCSIF7svTKnurlkOQ8EwbnHWKCqAvJ/A0wjplebNM=",
-        "MODULE.bazel": "sha256-eSsnQXSoFK8DDTS64AG23OoG4fb5f6+6ISZA9CMrvf8="
+        "MODULE.bazel": "sha256-8eHhVRNtIF3boIM0dgCk9Dl3uhd3KCh1WoNUYiKshkc="
     }
 }

--- a/modules/boost.fusion/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.fusion/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.fusion",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.fusion/1.88.0.bcr.1/source.json
+++ b/modules/boost.fusion/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-zpBwOXrv6h9dF+K4za3oP9NaXSzGYGXaYN8UCtw38+Q=",
-        "MODULE.bazel": "sha256-j1zNuyJj112Q8cPUjW2yjWWKpO6HvVx6VRvnyTx2B0c="
+        "MODULE.bazel": "sha256-pLQCJcg/asdcjZNb+cjqNxMmq6ULcheHdDgN9no6D+M="
     }
 }

--- a/modules/boost.hash2/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.hash2/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.hash2",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.hash2/1.88.0.bcr.1/source.json
+++ b/modules/boost.hash2/1.88.0.bcr.1/source.json
@@ -5,7 +5,7 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-5FxqI6l4Q0gpfDgM72FjKCjzsUYkg19FnHZIS2w/CHA=",
-        "MODULE.bazel": "sha256-sAEF+3xPYg20d3MAxiXMO55AX4EnYCs0l/UvDYqUrxs=",
+        "MODULE.bazel": "sha256-n+GXaV6+5xm/Qb2VqJ0aVwZFraJUjNb20nc3Pe31qws=",
         "test/BUILD.bazel": "sha256-CceEvcQuq2NGnOyuS3DjpqPqsixVCpEMSxNe2e7uC0M=",
         "test/MODULE.bazel": "sha256-w/WdLLFVkVsJVArrtY5C4p9t8DxLt5fpGpjLDYxtLjs="
     }

--- a/modules/boost.interprocess/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.interprocess/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.interprocess",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.interprocess/1.88.0.bcr.1/source.json
+++ b/modules/boost.interprocess/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-U+eXUQ+vomwQbUoYp2mgZ4Ol+Lu/+4z4jmxhHjhcxoI=",
-        "MODULE.bazel": "sha256-72PSvJdbOAM+OYMq61O0b7w6WMi9e52FMImCT5/LX2Q="
+        "MODULE.bazel": "sha256-pOx242xtDhyYHCjN9xbO8wEVFmj4cRHfZlbGkTgKunQ="
     }
 }

--- a/modules/boost.iostreams/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.iostreams/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.iostreams",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.iostreams/1.88.0.bcr.1/source.json
+++ b/modules/boost.iostreams/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-RhsFu5Ltv35IabrQ+7TQeNIdfu4QURiLddsNY77bXiw=",
-        "MODULE.bazel": "sha256-2tKv8/juT+zHbyZOkQeUyaqtXhX7VRcukWQ137cYXJY="
+        "MODULE.bazel": "sha256-bL8yqIwvDKm/Zd2T2EklQZ3fNY+6DwbY3kd3nSXuWz4="
     }
 }

--- a/modules/boost.iterator/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.iterator/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.iterator",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.concept_check", version = "1.88.0.bcr.1")

--- a/modules/boost.iterator/1.88.0.bcr.1/source.json
+++ b/modules/boost.iterator/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-cJgErOt24C9JKvdR+FRF5n/M3Bl683WDNqB20l9Wwgw=",
-        "MODULE.bazel": "sha256-MpVFR0LBoKnUtvzVYgQv0zW/vPkcuSo/i4k15+I/R+0="
+        "MODULE.bazel": "sha256-sdKSm31lRnqaz/eoidOd7vIKatN/j5JN3+AyIVGpEFs="
     }
 }

--- a/modules/boost.json/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.json/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.json",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.align", version = "1.88.0.bcr.1")

--- a/modules/boost.json/1.88.0.bcr.1/source.json
+++ b/modules/boost.json/1.88.0.bcr.1/source.json
@@ -5,7 +5,7 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-gdU/Hh42PKebH5cb/DhpX41oAu5pxm/kKdpkO/HSaeM=",
-        "MODULE.bazel": "sha256-TiBPw0zcoKX7RHkXbY9w2/gHlbni1PB6VWDBsugBJ8M=",
+        "MODULE.bazel": "sha256-THvlQ+iGpUxfql6htzXNj2HGz0v+6XUHynt9OpFt0C0=",
         "boost.json.cpp": "sha256-zwQ02Yb36UAL6C0lDCdrePCCkBL4ddAVScx9nOai4Lg="
     }
 }

--- a/modules/boost.lambda/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.lambda/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.lambda",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.bind", version = "1.88.0.bcr.1")

--- a/modules/boost.lambda/1.88.0.bcr.1/source.json
+++ b/modules/boost.lambda/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-mpgVbyWT0Nzg9VIBJFlb9Ed3uBxyhe/XR9KI4m27ZXw=",
-        "MODULE.bazel": "sha256-F9ooOEw0C6OoQZWg8QXEl/RQvrfLcrflLxaL3aH0tg8="
+        "MODULE.bazel": "sha256-my/CcTmAp/ByioM9Q9Ebm63ksO3ev0RWcC1TDwV0Hy8="
     }
 }

--- a/modules/boost.lexical_cast/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.lexical_cast/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.lexical_cast",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.lexical_cast/1.88.0.bcr.1/source.json
+++ b/modules/boost.lexical_cast/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-ww6jMyKn3rczeF9kSs4mmu1w083V6BeX2WmNCOPaTUw=",
-        "MODULE.bazel": "sha256-VnVzmLntD0kc1CjLg2BETowNXbwoT17MauhUNdD5eDU="
+        "MODULE.bazel": "sha256-dib1xf3aUyg2MABFGaMFI1KFTzyv2l99jpQr3bODLA0="
     }
 }

--- a/modules/boost.math/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.math/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.math",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.math/1.88.0.bcr.1/source.json
+++ b/modules/boost.math/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-3dtk6X0JmB1tEIzccnbcKM0zfQkxfuYLS8JaRrNq484=",
-        "MODULE.bazel": "sha256-I0DhchhvqFSvpFZYCT/A87hHqApANkcxJCT/pgH0lRk="
+        "MODULE.bazel": "sha256-0Oi4BLgBrQfbgymkpTFEqrTklmpEuBdCrYV7mYWXwHs="
     }
 }

--- a/modules/boost.mpl/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.mpl/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.mpl",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.mpl/1.88.0.bcr.1/source.json
+++ b/modules/boost.mpl/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-qXn0RW7LwfpoowWhqa04QvkG02fzeD/9UTWgtCVqgDg=",
-        "MODULE.bazel": "sha256-qrHfdquwCvDyihPwgAOirhHRU5krEAeqp/mHQQobTSk="
+        "MODULE.bazel": "sha256-ssiBY1KRyVfcHWyL7DLQmkN5wE38gJF+EUoucI82kGs="
     }
 }

--- a/modules/boost.multi_array/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.multi_array/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.multi_array",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.array", version = "1.88.0.bcr.1")

--- a/modules/boost.multi_array/1.88.0.bcr.1/source.json
+++ b/modules/boost.multi_array/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-kgH7CW4RPVevz+SO74pI/cJkBKWHPazjiyIDHPe28nQ=",
-        "MODULE.bazel": "sha256-+Gfe2pEvT9uGJ92YmNDR8a3tB+9uQWxQVSxVltkoKuc="
+        "MODULE.bazel": "sha256-sA0U05vwuTHgjyanpYXH5qhE6lo8rrD3LxyLmlzzNIk="
     }
 }

--- a/modules/boost.multi_index/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.multi_index/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.multi_index",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.multi_index/1.88.0.bcr.1/source.json
+++ b/modules/boost.multi_index/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-qQbAdLUTRb+H1WqsUhpehZoxX2fJTylFj3WRyVIlzz8=",
-        "MODULE.bazel": "sha256-U+2c8xxtNDLakpicwXI6mpco+EvhKD4MHTUcSH8luqE="
+        "MODULE.bazel": "sha256-YdY2ulRJxUI1zeuY+hqTiwWdF3MzfD0W/4sHnZJc0Po="
     }
 }

--- a/modules/boost.multiprecision/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.multiprecision/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.multiprecision",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.multiprecision/1.88.0.bcr.1/source.json
+++ b/modules/boost.multiprecision/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-KNdN78N85EZFbL4I9wYLFqzAPZGJ2IBouSptLh/XO5g=",
-        "MODULE.bazel": "sha256-vnlsiq0imxEberpkUMspI9e25tUcVIymWVeMQE/3tDU="
+        "MODULE.bazel": "sha256-Zz9EqMYXn6CJHiUO7Hsf8aQ5YSMwTEpXdMOOntvEOSM="
     }
 }

--- a/modules/boost.numeric_conversion/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.numeric_conversion/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.numeric_conversion",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.numeric_conversion/1.88.0.bcr.1/source.json
+++ b/modules/boost.numeric_conversion/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-zjAHOXLi/quFqI2RUM7VUUTSFVkzy046/Rf45n5q2Ug=",
-        "MODULE.bazel": "sha256-LlhCmDWM6uPbc++aXUQBQ3CGQkh1p/SDUosl9ImfvYM="
+        "MODULE.bazel": "sha256-G3BiP7krLHEr9c9SC+hU4Zuknf+5xbT/tt//5KBIQOo="
     }
 }

--- a/modules/boost.optional/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.optional/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.optional",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.optional/1.88.0.bcr.1/source.json
+++ b/modules/boost.optional/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-hlVbu4a7lwlEx/UeRpWsmBIiqcD6LLmy0HCCV54tCxI=",
-        "MODULE.bazel": "sha256-F38Bz5GVICLbiCmgqGvjgv2ouyDL6aT2t+1Mph90Zag="
+        "MODULE.bazel": "sha256-GCCywk303073oJ60pVuaHWUf6fpwUNPNkesR2mDR7RA="
     }
 }

--- a/modules/boost.parameter/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.parameter/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.parameter",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.parameter/1.88.0.bcr.1/source.json
+++ b/modules/boost.parameter/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-2ldwjdYYhHNePokqNfu/rVb/e4WWqIIiqKP6aWu/jZY=",
-        "MODULE.bazel": "sha256-tvAUw5WEVbeKmuPGrr/Y4cAL7lI/q7UkzN7vXHkiOMA="
+        "MODULE.bazel": "sha256-KvnJbuEbJwDnkvYq/3F7o6J+Q2NMsOUt4Hi4OI4z58Y="
     }
 }

--- a/modules/boost.polygon/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.polygon/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.polygon",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.polygon/1.88.0.bcr.1/source.json
+++ b/modules/boost.polygon/1.88.0.bcr.1/source.json
@@ -5,7 +5,7 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-080Wv2nhyRnHbe577iUz+y+Asddaqp382InfWNXHxfg=",
-        "MODULE.bazel": "sha256-QO1Svq6EkOu6TF/zBW0DZylvSav5gkXyCuY6i+NtKzA=",
+        "MODULE.bazel": "sha256-Z3h24+y1Ga2cJQ1pTU2YM/IRm+WUXEklVIhIwCKLnw8=",
         "test/BUILD.bazel": "sha256-a7qoG55R02MW/aL4rKrJGFku6kz87h5gPxZ7XoRof1o=",
         "test/MODULE.bazel": "sha256-UtHLwieyE3XmHxerE/B0mxaJgM4sV+UrLowSMjL4p9o="
     }

--- a/modules/boost.pool/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.pool/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.pool",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.pool/1.88.0.bcr.1/source.json
+++ b/modules/boost.pool/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-6OQoyIIZqmXAib6h0DFAssS7vjAueBIGI9HB+czofqw=",
-        "MODULE.bazel": "sha256-X6b5Ep4ESbLEq+BUAVD9Qqg9pNAyB+KnW1x2IeJTnRo="
+        "MODULE.bazel": "sha256-vLUzsl79bP+HvZhCNFtXMQWb9IeJI5Y39eTai7Qp1zI="
     }
 }

--- a/modules/boost.program_options/metadata.json
+++ b/modules/boost.program_options/metadata.json
@@ -4,14 +4,14 @@
         {
             "email": "daisuke.nishimatsu1021@gmail.com",
             "github": "wep21",
-            "name": "Daisuke Nishimatsu",
-            "github_user_id": 42202095
+            "github_user_id": 42202095,
+            "name": "Daisuke Nishimatsu"
         },
         {
             "email": "julian.amann@tum.de",
             "github": "Vertexwahn",
-            "name": "Julian Amann",
-            "github_user_id": 3775001
+            "github_user_id": 3775001,
+            "name": "Julian Amann"
         }
     ],
     "repository": [

--- a/modules/boost.property_map/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.property_map/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.property_map",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.any", version = "1.88.0.bcr.1")

--- a/modules/boost.property_map/1.88.0.bcr.1/source.json
+++ b/modules/boost.property_map/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-sKRxI7yiqRLpQ+mvOLI7+JTSKtr1YU1zAdtnVzb5W5c=",
-        "MODULE.bazel": "sha256-EHSXoQI4Z5nWfNv+fwv7VFOSWj26OiVTuZM16I6lmxA="
+        "MODULE.bazel": "sha256-nfzJpQtpZhavZv2HZyTBLJxL3X89nIsM6baDKQHW7Ps="
     }
 }

--- a/modules/boost.proto/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.proto/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.proto",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.proto/1.88.0.bcr.1/source.json
+++ b/modules/boost.proto/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-ZE9QhLFFvn2p9667VKldLxIK7Ng1sd5PiDX37EmLXQI=",
-        "MODULE.bazel": "sha256-mOZxYWL73dwb1UiYExNSOYMMfLM2jN0twwpuKe2D/4k="
+        "MODULE.bazel": "sha256-D/MkCNPvM37XCKIbpzt+B5s/TyjLCd2y2DklPCPL4/g="
     }
 }

--- a/modules/boost.ptr_container/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.ptr_container/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.ptr_container",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.array", version = "1.88.0.bcr.1")

--- a/modules/boost.ptr_container/1.88.0.bcr.1/source.json
+++ b/modules/boost.ptr_container/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-yYK4l+vgngYkpqqpPhyJYK1ytXqIpT+M7eXV9KFg/zA=",
-        "MODULE.bazel": "sha256-O+mBpgzakH+Bd1vXr0MX4sJSiJ03TY2CTuRu5WOb8U0="
+        "MODULE.bazel": "sha256-2yDW6kZ0ZB3YSUOx/j/PAXoVko0POV869/rxFcLY+XU="
     }
 }

--- a/modules/boost.random/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.random/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.random",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.random/1.88.0.bcr.1/source.json
+++ b/modules/boost.random/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-O71pYDPUlXJScleCDvE14HXzkWtZ2Fsx94yN4yWj89w=",
-        "MODULE.bazel": "sha256-+gfx9skZlEVCXSvX/PWGWMI2YR7/Gac1Akk5Ys7MW9k="
+        "MODULE.bazel": "sha256-85HHOGqkwf1bwWKFmOj1Hinpp5+dmUKAMyDfiRHzLrs="
     }
 }

--- a/modules/boost.range/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.range/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.range",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.array", version = "1.88.0.bcr.1")

--- a/modules/boost.range/1.88.0.bcr.1/source.json
+++ b/modules/boost.range/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-qVZqIntV5I3DOJ+ua3vE5mihAxQEdvLyJh2xD0C3L7M=",
-        "MODULE.bazel": "sha256-jP7JQpyszwXQrqjlooy+YKF6t6tVZomIpVkOC9/GNYs="
+        "MODULE.bazel": "sha256-L4vejzc3TI20NX1CLDq9i/9pdmD1CcOZEg6pI46zTMc="
     }
 }

--- a/modules/boost.rational/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.rational/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.rational",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.rational/1.88.0.bcr.1/source.json
+++ b/modules/boost.rational/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-QyMca7qEP25v/Ss+tuDahlCN81zqlNYi3UIuL4Xmh0w=",
-        "MODULE.bazel": "sha256-oNj91UQBIKmfiC2PoknAM7TCWwB2WkdcOXst50zBXiI="
+        "MODULE.bazel": "sha256-/95skscIIpamh6FDiVgoFH+hRzNbUEXmIYh/vbvIZjM="
     }
 }

--- a/modules/boost.regex/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.regex/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.regex",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.regex/1.88.0.bcr.1/source.json
+++ b/modules/boost.regex/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-EWXmX1qpN/2y/xsWi68+/mHLoo1TJSj9Ve3Q4IH/wCA=",
-        "MODULE.bazel": "sha256-4vdo1iV0rH2UZ20gf8AtJA0liUML5EZ4SL1jfmMy9a0="
+        "MODULE.bazel": "sha256-gqWswmag5dsVbszd0VvRwxtYO3tj414iptHej2V3Dng="
     }
 }

--- a/modules/boost.scope_exit/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.scope_exit/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.scope_exit",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.scope_exit/1.88.0.bcr.1/source.json
+++ b/modules/boost.scope_exit/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-qK1014gGkRQAG4nBGy7trliTBu2mf08X0Pew/QVID+c=",
-        "MODULE.bazel": "sha256-GGINrOcgNw/41ERDal/nLba809tSH+OzGJIxLzjmqNY="
+        "MODULE.bazel": "sha256-w5W/+BPUR3OCgN6U6nafhLJTCv5Iv7r7yDduyspKY9k="
     }
 }

--- a/modules/boost.smart_ptr/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.smart_ptr/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.smart_ptr",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.smart_ptr/1.88.0.bcr.1/source.json
+++ b/modules/boost.smart_ptr/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-aYw7QHvpDo8VmkcKQSBMNRo/Iphn/YAWnTXbeJhNg5M=",
-        "MODULE.bazel": "sha256-0+w1Cvf/T42v+UglFwHwu1VFCB652HIIVzjSVv5wdQ0="
+        "MODULE.bazel": "sha256-UEYO3unspKC2/BaHzk6ydPiT92ifi0rjrmoY+x77eOU="
     }
 }

--- a/modules/boost.stacktrace/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.stacktrace/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.stacktrace",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.stacktrace/1.88.0.bcr.1/source.json
+++ b/modules/boost.stacktrace/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-7AkhDhy4llSsVV9EsaSf14euhdzQ+0/n6Th/si6FyoE=",
-        "MODULE.bazel": "sha256-vmliK/KXij2y0zObwv4LsM/lsSExqJEXy1dwblSzsfA="
+        "MODULE.bazel": "sha256-JrDwXe9w5j+Y6D6/qay+/xqcIOUauBO3g0KK6e+zYvk="
     }
 }

--- a/modules/boost.static_string/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.static_string/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.static_string",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.static_string/1.88.0.bcr.1/source.json
+++ b/modules/boost.static_string/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-f0vtebdg51CK7XhGwL8Rq1SBH0fIZFDkrEzW9WGSoy8=",
-        "MODULE.bazel": "sha256-vJkcAW5/lZKwOgea5CWcjZIqYvKS+xbqYK0NEd7ucWY="
+        "MODULE.bazel": "sha256-nA4apMYtD5N3FwYB5+95RC8hoCba9X5qaVsnNKrRXAY="
     }
 }

--- a/modules/boost.system/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.system/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.system",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.system/1.88.0.bcr.1/source.json
+++ b/modules/boost.system/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-+v0tH9m3wqjEO7fZGOsOrkf5EfR5jYjgw+qNJiYmvWY=",
-        "MODULE.bazel": "sha256-IarUQJ13sE5sFKGASegGrOFQP+P0Mv310r2HkC6/T5s="
+        "MODULE.bazel": "sha256-5dfSwlGloBUfJsFRpSQwsZQQego7gbUVZTRVYeHblHo="
     }
 }

--- a/modules/boost.timer/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.timer/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.timer",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.timer/1.88.0.bcr.1/source.json
+++ b/modules/boost.timer/1.88.0.bcr.1/source.json
@@ -5,7 +5,7 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-DSrzXbQEVU+hNq3tpohkIcN13mMnGxyXoznXmhHXk5g=",
-        "MODULE.bazel": "sha256-Ls2HZs4sX73+4/V3VNPIxRLJw4pxvfd7Dc9ClsG1EGs=",
+        "MODULE.bazel": "sha256-DUSgV5DFanNBOj5t6dcg8gg8q68THOZDqqPNRRPKieY=",
         "test/BUILD.bazel": "sha256-/0vICrdA8T2k2ddbd9//Mgosv8nkcwYefCd0I2kQQwQ=",
         "test/MODULE.bazel": "sha256-pl+Uy+FnxCjdGO+erViIDK5YPznkL7L5gLSWLweyfBE="
     }

--- a/modules/boost.tti/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.tti/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.tti",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.config", version = "1.88.0.bcr.1")

--- a/modules/boost.tti/1.88.0.bcr.1/source.json
+++ b/modules/boost.tti/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-xouz48XjDgYag9YfsDa5AcjgyNZQ0hU3OVlfiv9srag=",
-        "MODULE.bazel": "sha256-6uVG14hxAD/J3VJCBzKLCAUrvRh2wjzal6T7HlyDwqo="
+        "MODULE.bazel": "sha256-A2NCG25r13AtsMoF6cEiTxT7YXP8p9w9n0s8qYJjh1A="
     }
 }

--- a/modules/boost.units/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.units/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.units",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.units/1.88.0.bcr.1/source.json
+++ b/modules/boost.units/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-Kpj3ypSUIfOEBISTak1jAE/NqwJpp70/ewNUIKmaifo=",
-        "MODULE.bazel": "sha256-cfba66f2OyT+2TggxyxkMAKZ8ZjOkryah6ysAK5S5AQ="
+        "MODULE.bazel": "sha256-qUPexRktxTTfLX9Nz/Umv8UvzXacWbIXSKk8urO9QAQ="
     }
 }

--- a/modules/boost.unordered/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.unordered/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.unordered",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.unordered/1.88.0.bcr.1/source.json
+++ b/modules/boost.unordered/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-YxL0E6LxYR+n3xNTzcXAKrnOQgDko4mfjrhKQwEhO5g=",
-        "MODULE.bazel": "sha256-qd1fgLH17Sp1e7kXF+bExCMM3wx1/hSJQd2h0HB78Ro="
+        "MODULE.bazel": "sha256-iawsaEKR2+/aYeeqcdLLa/6YrV0+xevP+xWhqp/H84o="
     }
 }

--- a/modules/boost.uuid/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.uuid/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.uuid",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.uuid/1.88.0.bcr.1/source.json
+++ b/modules/boost.uuid/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-aA86ocbZ2j6wUQwApeqPjh3yHWQ06b1/UViLc2RiNjA=",
-        "MODULE.bazel": "sha256-lCeUJND6s963S99oUMT086rBA4jxKRqufs5SDcMk0TQ="
+        "MODULE.bazel": "sha256-KAkhfwCMnfKaTWukUx5fwoKgj+2Fq2g1+h5bMBe/HAg="
     }
 }

--- a/modules/boost.uuid/metadata.json
+++ b/modules/boost.uuid/metadata.json
@@ -4,8 +4,8 @@
         {
             "email": "daisuke.nishimatsu1021@gmail.com",
             "github": "wep21",
-            "name": "Daisuke Nishimatsu",
-            "github_user_id": 42202095
+            "github_user_id": 42202095,
+            "name": "Daisuke Nishimatsu"
         },
         {
             "email": "julian.amann@tum.de",

--- a/modules/boost.variant/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.variant/1.88.0.bcr.1/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "boost.variant",
     version = "1.88.0.bcr.1",
     bazel_compatibility = [">=7.6.0"],
-    compatibility_level = 118800,
+    compatibility_level = 108800,
 )
 
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")

--- a/modules/boost.variant/1.88.0.bcr.1/source.json
+++ b/modules/boost.variant/1.88.0.bcr.1/source.json
@@ -5,6 +5,6 @@
     "patch_strip": 0,
     "overlay": {
         "BUILD.bazel": "sha256-1jTYlAenKNuBQkNHdcrnx5n0Q8Hvl81u9ADTee6Gd7I=",
-        "MODULE.bazel": "sha256-8+iFOoa821Kdt7ZLJ/xPyL2+C5xgmCAypCRQhTELnDc="
+        "MODULE.bazel": "sha256-Xcb5NzjDtFTcVXZNI38AuBXhqdSuClQ5ZoMEDed48to="
     }
 }


### PR DESCRIPTION
WARNING: This PR modifies existing modules.

This PR fixes the `compatibility_level` for Boost 1.88.0. For some unknown reason for Boost 1.88.0 the compatiblity level `108800` and `1108800` has been used. It should be `108800` to fit into the scheme - at least it should not differ:

| Boost version | compatibility_level |
|---------------|---------------------|
| 1.83.0        | 108300              |
| 1.83.0.bcr.1  | 108300              |
| 1.87.0        | 108700              |
| 1.88.0    | 108800              |
| 1.88.0.bcr.1  | 108800              |

First discoverd this issue with the compatible_level in https://github.com/bazelbuild/bazel-central-registry/pull/5565

@fmeum @Wyverald @kotlaja @meteorcloudy 