### PR TITLE
fix poco on BCR

### DIFF
--- a/modules/poco/1.14.2-20250528.bcr.1/MODULE.bazel
+++ b/modules/poco/1.14.2-20250528.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "poco",
+    version = "1.14.2-20250528.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+bazel_dep(name = "pcre2", version = "10.45")
+bazel_dep(name = "rules_cc", version = "0.2.0")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/poco/1.14.2-20250528.bcr.1/overlay/BUILD
+++ b/modules/poco/1.14.2-20250528.bcr.1/overlay/BUILD
@@ -1,0 +1,86 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(["LICENSE"])
+
+license(
+    name = "license",
+    package_name = "poco",
+    license_kinds = ["@rules_license//licenses/spdx:BSL-1.0"],
+    license_text = "LICENSE",
+    package_url = "https://github.com/pocoproject/poco",
+)
+
+cc_library(
+    name = "PocoFoundation",
+    srcs = glob(
+        ["Foundation/src/*.cpp"],
+        exclude = [
+            "Foundation/src/DirectoryIterator_*.cpp",
+            "Foundation/src/Environment_*.cpp",
+            "Foundation/src/Event_*.cpp",
+            "Foundation/src/EventLogChannel.cpp",
+            "Foundation/src/FPEnvironment_*.cpp",
+            "Foundation/src/FileStream_*.cpp",
+            "Foundation/src/FileStreamRWLock*.cpp",
+            "Foundation/src/File_*.cpp",
+            "Foundation/src/Mutex_*.cpp",
+            "Foundation/src/NamedEvent_*.cpp",
+            "Foundation/src/NamedMutex_*.cpp",
+            "Foundation/src/Path_*.cpp",
+            "Foundation/src/PipeImpl_*.cpp",
+            "Foundation/src/Process_*.cpp",
+            "Foundation/src/RWLock_*.cpp",
+            "Foundation/src/Semaphore_*.cpp",
+            "Foundation/src/SharedLibrary_*.cpp",
+            "Foundation/src/SharedMemory_*.cpp",
+            "Foundation/src/Thread_*.cpp",
+            "Foundation/src/Timezone_*.cpp",
+            "Foundation/src/Var*.cpp",
+            "Foundation/src/WindowsConsoleChannel.cpp",
+        ],
+    ),
+    hdrs = glob(
+        [
+            "Foundation/include/Poco/*.h",
+            "Foundation/src/*.cc",
+            "Foundation/src/*.h",
+            "Foundation/src/DirectoryIterator_*.cpp",
+            "Foundation/src/Environment_*.cpp",
+            "Foundation/src/Event_*.cpp",
+            "Foundation/src/FPEnvironment_*.cpp",
+            "Foundation/src/FileStream_*.cpp",
+            "Foundation/src/File_*.cpp",
+            "Foundation/src/Mutex_*.cpp",
+            "Foundation/src/NamedEvent_*.cpp",
+            "Foundation/src/NamedMutex_*.cpp",
+            "Foundation/src/Path_*.cpp",
+            "Foundation/src/PipeImpl_*.cpp",
+            "Foundation/src/Process_*.cpp",
+            "Foundation/src/RWLock_*.cpp",
+            "Foundation/src/Semaphore_*.cpp",
+            "Foundation/src/SharedLibrary_*.cpp",
+            "Foundation/src/SharedMemory_*.cpp",
+            "Foundation/src/Thread_*.cpp",
+            "Foundation/src/Timezone_*.cpp",
+        ],
+    ),
+    deps = ["@pcre2"],
+    includes = ["Foundation/include"],
+)
+
+cc_library(
+    name = "PocoNet",
+    srcs = glob(["Net/src/*.cpp"]),
+    hdrs = glob(["Net/include/Poco/Net/*.h"]),
+    includes = [
+        "Foundation/include",
+        "Net/include",
+    ],
+    deps = [":PocoFoundation"],
+)

--- a/modules/poco/1.14.2-20250528.bcr.1/overlay/MODULE.bazel
+++ b/modules/poco/1.14.2-20250528.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/poco/1.14.2-20250528.bcr.1/presubmit.yml
+++ b/modules/poco/1.14.2-20250528.bcr.1/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  bazel:
+  - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@poco//:PocoFoundation'
+    - '@poco//:PocoNet'

--- a/modules/poco/1.14.2-20250528.bcr.1/source.json
+++ b/modules/poco/1.14.2-20250528.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/pocoproject/poco/archive/15d987fbb076d5810faf39f1e9a67b5025281bb8.tar.gz",
+    "integrity": "sha256-TaUGgTng2YRE3i7TyFy3IlhOJdpdRevmO4jwSMV3SwA=",
+    "strip_prefix": "poco-15d987fbb076d5810faf39f1e9a67b5025281bb8",
+    "overlay": {
+        "BUILD": "sha256-S73udqySoU5/Z9VbM6quVwYZzneQvvTq0GMJisJ3Ph4=",
+        "MODULE.bazel": "sha256-LEKNEWhavNCscebgTN4pG/Ug9pc4kj5btV6V+2lLLew="
+    }
+}

--- a/modules/poco/metadata.json
+++ b/modules/poco/metadata.json
@@ -12,7 +12,8 @@
         "https://github.com/pocoproject/poco"
     ],
     "versions": [
-        "1.14.2-20250528"
+        "1.14.2-20250528",
+        "1.14.2-20250528.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
#5579 is not great, because some included symbols are not defined, leading to errors of the form
```
ld.lld: error: undefined symbol: Poco::floatToFixedStr(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, float, int, int, char, char)
>>> referenced by NumberFormatter.cpp
>>>               bazel-out/haswell-fastbuild/bin/external/poco+/_objs/PocoFoundation/NumberFormatter.pic.o:(Poco::NumberFormatter::append(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, float, int, int))
```
This might not be a problem when building with `-c opt`, depending on which parts of the library is used, as optimization flags will delete unused code.

This fixes those issues (verified by building with `-c fastbuild`).