### PR TITLE
feat: add `download_utils@1.2.0`

### DIFF
--- a/modules/download_utils/1.2.0/MODULE.bazel
+++ b/modules/download_utils/1.2.0/MODULE.bazel
@@ -1,0 +1,45 @@
+module(
+    name = "download_utils",
+    version = "1.2.0",
+    bazel_compatibility = [
+        ">=7.1.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+
+bazel_dep(name = "toolchain_utils", version = "1.0.2", dev_dependency = True)
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0", dev_dependency = True)
+
+# We have to avoid the `chmod`/`chown`/`id` unhermetic-ness
+# TODO: remove this when `ignore_root_user_error` is hermetic
+dev = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
+dev.toolchain(
+    # TODO: remove this when `ignore_root_user_error` is hermetic
+    # https://github.com/bazelbuild/rules_python/issues/2016
+    ignore_root_user_error = True,
+    python_version = "3.13",
+)
+
+separator = use_repo_rule("//lib:separator.bzl", "separator")
+
+separator(name = "separator")
+
+download = use_extension("//download/template:defs.bzl", "download_template")
+download.substitutions(
+    srcs = [
+        "//download/template:rust.json",
+        "//download/template:triplet.json",
+    ],
+)
+download.substitution(
+    key = "executable.extension",
+    match = "{os}",
+    select = {
+        "windows": ".exe",
+        "//conditions:default": "",
+    },
+)

--- a/modules/download_utils/1.2.0/presubmit.yml
+++ b/modules/download_utils/1.2.0/presubmit.yml
@@ -1,0 +1,20 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+      - 8.x
+    platform:
+      - debian11
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/download_utils/1.2.0/source.json
+++ b/modules/download_utils/1.2.0/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/download_utils/-/releases/v1.2.0/downloads/src.tar.gz",
+  "integrity": "sha512-bPVWJnOYuxgWdz9EQQEQSs6Vm0kuLcK/Z/iZRHofScBomuBzEu1PhaAMpNJ8g1L6PSnEifJ9TpaMSD9pf9A2fQ==",
+  "strip_prefix": "download_utils-v1.2.0"
+}

--- a/modules/download_utils/metadata.json
+++ b/modules/download_utils/metadata.json
@@ -1,21 +1,21 @@
 {
-    "homepage": "https://gitlab.arm.com/bazel/download_utils",
-    "repository": [
-        "https://gitlab.arm.com/bazel/download_utils"
-    ],
-    "versions": [
-        "1.0.0-beta.1",
-        "1.0.0-beta.2",
-        "1.0.0-beta.4",
-        "1.0.0-beta.5",
-        "1.0.1"
-    ],
-    "maintainers": [
-        {
-            "email": "matthew.clarkson@arm.com",
-            "name": "Matt Clarkson",
-            "github": "mattyclarkson",
-            "github_user_id": 1081113
-        }
-    ]
+  "homepage": "https://gitlab.arm.com/bazel/download_utils",
+  "repository": [
+    "https://gitlab.arm.com/bazel/download_utils"
+  ],
+  "versions": [
+    "1.0.0-beta.1",
+    "1.0.0-beta.2",
+    "1.0.0-beta.4",
+    "1.0.0-beta.5",
+    "1.0.1",
+    "1.2.0"
+  ],
+  "maintainers": [
+    {
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson",
+      "github_user_id": 1081113
+    }
+  ]
 }


### PR DESCRIPTION
Includes a new download extension that can template the download URLs based on substitutions:

```py
download = use_extension("@download_utils//download/template:defs.bzl", "download_template")

# Ruff binaries
download.archive(
    name = "pre-commit-hooks-ruff-{cpu}-{os}",
    srcs = ["ruff{executable.extension}"],
    lock = "//ruff:lock.json",
    strip_prefix = "ruff-{rust.triplet}",
    substitutions = {
        "version": [
            "0.9.7",
        ],
        "triplet": [
            "amd64-linux-musl",
            "arm64-linux-musl",
            "amd64-windows-msvc",
            "arm64-windows-msvc",
            "amd64-macos-darwin",
            "arm64-macos-darwin",
        ],
    },
    uploads = [
        "https://gitlab.arm.com/api/v4/projects/bazel%2Fpre-commit-hooks/packages/generic/ruff/{version}/{rust.archive.basename}",
    ],
    urls = [
        "https://gitlab.arm.com/api/v4/projects/bazel%2Fpre-commit-hooks/packages/generic/ruff/{version}/{rust.archive.basename}",
        "https://github.com/astral-sh/ruff/releases/download/{version}/ruff-{rust.archive.basename}",
    ],
)
```

This was introduced in `1.1.0` but we failed to get around to upstream that. `1.2.0` learnt `repo_metadata#reproducible`.

---

# [1.2.0](https://git.gitlab.arm.com/bazel/download_utils/compare/v1.1.0...v1.2.0) (2025-08-20)

### Bug Fixes

* ensure to return canonical attributes when `metadata` is set ([4e0b33d](https://git.gitlab.arm.com/bazel/download_utils/commit/4e0b33d3a2e092e2ac3a1930f28f58374ac2cd11))
* respect `BAZEL_HTTP_RULES_URLS_AS_DEFAULT_CANONICAL_ID` ([e1f8cc0](https://git.gitlab.arm.com/bazel/download_utils/commit/e1f8cc0430e79bc738b1c305eb4f5c09e62a119d))
* **template:** correct error string formatting ([8b6ff66](https://git.gitlab.arm.com/bazel/download_utils/commit/8b6ff66ec96b6ea88ad8ef269ff9dda5d92a3268))
* upgrade to `pre-commit@1.0.9` ([be86724](https://git.gitlab.arm.com/bazel/download_utils/commit/be86724365179c3105f7676bc3d7953fa1c75852))
* **upload:** combine both download/upload substitution dictionaries ([91d1bed](https://git.gitlab.arm.com/bazel/download_utils/commit/91d1bed8dbc44bd9cdc7ef6ce78a7296f2c8366f))
* **upload:** continue to flatten substitutions dictionaries ([9d9bd00](https://git.gitlab.arm.com/bazel/download_utils/commit/9d9bd005c617ddeaaa706f371de2efca7d46c4aa))


### Features

* support `repo_metadata#reproducible` ([789f897](https://git.gitlab.arm.com/bazel/download_utils/commit/789f89704a477dedb343815be0b4b3fafc1cad55))

---

# [1.1.0](https://git.gitlab.arm.com/bazel/download_utils/compare/v1.0.1...v1.1.0) (2025-06-26)


### Bug Fixes

* add `links` to `{srcs}` replacement ([7cdde03](https://git.gitlab.arm.com/bazel/download_utils/commit/7cdde03d46f62f4d70076cb829477b02957ac834))
* append canonical arguments to `WORKSPACE` if it exists ([86b169d](https://git.gitlab.arm.com/bazel/download_utils/commit/86b169d04841489f83c13a64a8b48dd24f0e3fad))
* **archive:** allow empty string for `extension` attribute ([e0fa71a](https://git.gitlab.arm.com/bazel/download_utils/commit/e0fa71aec075840a59fa179ccc615d125db11049))
* do not write `WORKSPACE` if `metadata` attribute is set ([1dc4fb7](https://git.gitlab.arm.com/bazel/download_utils/commit/1dc4fb7fc1b7b0e92cdfa4d9693e5df5b17ed4b6))


### Features

* add `download_template` extension ([32479b1](https://git.gitlab.arm.com/bazel/download_utils/commit/32479b12a3a18b97f5b58a1c1ab73fbe3f896a2c))
* add pre-commit hooks ([062cad4](https://git.gitlab.arm.com/bazel/download_utils/commit/062cad437b5d44190594a1365d46586627c8f714))
* allow custom metadata files ([ea05186](https://git.gitlab.arm.com/bazel/download_utils/commit/ea05186e72848a1dca7348f035989cf40d7ab91c))