### PR TITLE
Rehost rules_{multitool,mypy,pydeps,uv} on bazel-contrib/

### DIFF
--- a/modules/rules_multitool/0.0.10/presubmit.yml
+++ b/modules/rules_multitool/0.0.10/presubmit.yml
@@ -4,9 +4,12 @@ matrix:
   - ubuntu2004
   - macos
   - macos_arm64
+  bazel:
+  - 7.x
 tasks:
   verify_targets:
     name: Verify build targets
     platform: ${{ platform }}
+    bazel: ${{ bazel }}
     build_targets:
     - '@rules_multitool//...'

--- a/modules/rules_multitool/0.0.10/source.json
+++ b/modules/rules_multitool/0.0.10/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.0.10/rules_multitool-0.0.10.tar.gz",
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.0.10/rules_multitool-0.0.10.tar.gz",
     "integrity": "sha256-QfsRi4qAUF6qrlLfaTxzaCxXl1pbZqdIxnFodXf9tUA=",
     "strip_prefix": "rules_multitool-0.0.10"
 }

--- a/modules/rules_multitool/0.0.10/source.json
+++ b/modules/rules_multitool/0.0.10/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.0.10/rules_multitool-0.0.10.tar.gz",
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.0.10/rules_multitool-0.0.10.tar.gz",
     "integrity": "sha256-QfsRi4qAUF6qrlLfaTxzaCxXl1pbZqdIxnFodXf9tUA=",
     "strip_prefix": "rules_multitool-0.0.10"
 }

--- a/modules/rules_multitool/0.1.1/presubmit.yml
+++ b/modules/rules_multitool/0.1.1/presubmit.yml
@@ -4,9 +4,12 @@ matrix:
   - ubuntu2004
   - macos
   - macos_arm64
+  bazel:
+  - 7.x
 tasks:
   verify_targets:
     name: Verify build targets
     platform: ${{ platform }}
+    bazel: ${{ bazel }}
     build_targets:
     - '@rules_multitool//...'

--- a/modules/rules_multitool/0.1.1/source.json
+++ b/modules/rules_multitool/0.1.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-SVY5sRDQN0hp6PaHCU++JkZkEPMf3cASclxfQGsE85Q=",
     "strip_prefix": "rules_multitool-0.1.1",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.1.1/rules_multitool-0.1.1.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.1.1/rules_multitool-0.1.1.tar.gz"
 }

--- a/modules/rules_multitool/0.1.1/source.json
+++ b/modules/rules_multitool/0.1.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-SVY5sRDQN0hp6PaHCU++JkZkEPMf3cASclxfQGsE85Q=",
     "strip_prefix": "rules_multitool-0.1.1",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.1.1/rules_multitool-0.1.1.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.1.1/rules_multitool-0.1.1.tar.gz"
 }

--- a/modules/rules_multitool/0.10.0/source.json
+++ b/modules/rules_multitool/0.10.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-eoa0ZTtGpXOlzCX1ovBfEE8cvHOkJ6uJdyk+qwiFokE=",
     "strip_prefix": "rules_multitool-0.10.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.10.0/rules_multitool-0.10.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.10.0/rules_multitool-0.10.0.tar.gz"
 }

--- a/modules/rules_multitool/0.10.0/source.json
+++ b/modules/rules_multitool/0.10.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-eoa0ZTtGpXOlzCX1ovBfEE8cvHOkJ6uJdyk+qwiFokE=",
     "strip_prefix": "rules_multitool-0.10.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.10.0/rules_multitool-0.10.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.10.0/rules_multitool-0.10.0.tar.gz"
 }

--- a/modules/rules_multitool/0.11.0/source.json
+++ b/modules/rules_multitool/0.11.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-rJfzqyhp0UkBMOaCgDZtRVlRAmalshXGKMWv1L0kXU4=",
     "strip_prefix": "rules_multitool-0.11.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.11.0/rules_multitool-0.11.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.11.0/rules_multitool-0.11.0.tar.gz"
 }

--- a/modules/rules_multitool/0.11.0/source.json
+++ b/modules/rules_multitool/0.11.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-rJfzqyhp0UkBMOaCgDZtRVlRAmalshXGKMWv1L0kXU4=",
     "strip_prefix": "rules_multitool-0.11.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.11.0/rules_multitool-0.11.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.11.0/rules_multitool-0.11.0.tar.gz"
 }

--- a/modules/rules_multitool/0.12.0/source.json
+++ b/modules/rules_multitool/0.12.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-m2hc6ORUyTjb7lRIj3w2vt18HDnbigyYDBHCEVyyY4g=",
     "strip_prefix": "rules_multitool-0.12.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.12.0/rules_multitool-0.12.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.12.0/rules_multitool-0.12.0.tar.gz"
 }

--- a/modules/rules_multitool/0.12.0/source.json
+++ b/modules/rules_multitool/0.12.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-m2hc6ORUyTjb7lRIj3w2vt18HDnbigyYDBHCEVyyY4g=",
     "strip_prefix": "rules_multitool-0.12.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.12.0/rules_multitool-0.12.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.12.0/rules_multitool-0.12.0.tar.gz"
 }

--- a/modules/rules_multitool/0.13.0/source.json
+++ b/modules/rules_multitool/0.13.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-7cnyEhY8hZbTz9zByqSuHOGyKAHvaIwHjvHMbNpWQS0=",
     "strip_prefix": "rules_multitool-0.13.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.13.0/rules_multitool-0.13.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.13.0/rules_multitool-0.13.0.tar.gz"
 }

--- a/modules/rules_multitool/0.13.0/source.json
+++ b/modules/rules_multitool/0.13.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-7cnyEhY8hZbTz9zByqSuHOGyKAHvaIwHjvHMbNpWQS0=",
     "strip_prefix": "rules_multitool-0.13.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.13.0/rules_multitool-0.13.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.13.0/rules_multitool-0.13.0.tar.gz"
 }

--- a/modules/rules_multitool/0.15.0/source.json
+++ b/modules/rules_multitool/0.15.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-4d5a2lsDKxjgqFtHkaBpOVaOtRXR7RsrLJ2o2SK7Vjs=",
     "strip_prefix": "rules_multitool-0.15.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.15.0/rules_multitool-0.15.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.15.0/rules_multitool-0.15.0.tar.gz"
 }

--- a/modules/rules_multitool/0.15.0/source.json
+++ b/modules/rules_multitool/0.15.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-4d5a2lsDKxjgqFtHkaBpOVaOtRXR7RsrLJ2o2SK7Vjs=",
     "strip_prefix": "rules_multitool-0.15.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.15.0/rules_multitool-0.15.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.15.0/rules_multitool-0.15.0.tar.gz"
 }

--- a/modules/rules_multitool/0.2.0/source.json
+++ b/modules/rules_multitool/0.2.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-BDELqiHzGqErU6oMrG0rizyAq0QGDQpPxIwBX1j6Ux8=",
     "strip_prefix": "rules_multitool-0.2.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.2.0/rules_multitool-0.2.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.2.0/rules_multitool-0.2.0.tar.gz"
 }

--- a/modules/rules_multitool/0.2.0/source.json
+++ b/modules/rules_multitool/0.2.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-BDELqiHzGqErU6oMrG0rizyAq0QGDQpPxIwBX1j6Ux8=",
     "strip_prefix": "rules_multitool-0.2.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.2.0/rules_multitool-0.2.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.2.0/rules_multitool-0.2.0.tar.gz"
 }

--- a/modules/rules_multitool/0.3.0/source.json
+++ b/modules/rules_multitool/0.3.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ecka41IXTFdtSKBSho5OU7ftDweV2226Xmu7Om2Qzww=",
     "strip_prefix": "rules_multitool-0.3.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.3.0/rules_multitool-0.3.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.3.0/rules_multitool-0.3.0.tar.gz"
 }

--- a/modules/rules_multitool/0.3.0/source.json
+++ b/modules/rules_multitool/0.3.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ecka41IXTFdtSKBSho5OU7ftDweV2226Xmu7Om2Qzww=",
     "strip_prefix": "rules_multitool-0.3.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.3.0/rules_multitool-0.3.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.3.0/rules_multitool-0.3.0.tar.gz"
 }

--- a/modules/rules_multitool/0.4.0/source.json
+++ b/modules/rules_multitool/0.4.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-eTEF6ku4nPnYJBHL7kC2h0CF9TAxRgCIdTniFOSXCjo=",
     "strip_prefix": "rules_multitool-0.4.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.4.0/rules_multitool-0.4.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.4.0/rules_multitool-0.4.0.tar.gz"
 }

--- a/modules/rules_multitool/0.4.0/source.json
+++ b/modules/rules_multitool/0.4.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-eTEF6ku4nPnYJBHL7kC2h0CF9TAxRgCIdTniFOSXCjo=",
     "strip_prefix": "rules_multitool-0.4.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.4.0/rules_multitool-0.4.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.4.0/rules_multitool-0.4.0.tar.gz"
 }

--- a/modules/rules_multitool/0.5.0/source.json
+++ b/modules/rules_multitool/0.5.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-pmB/ykKGkE7U6d2nOIrfbA58EqNptK9d0I2TXMS6gGA=",
     "strip_prefix": "rules_multitool-0.5.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.5.0/rules_multitool-0.5.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.5.0/rules_multitool-0.5.0.tar.gz"
 }

--- a/modules/rules_multitool/0.5.0/source.json
+++ b/modules/rules_multitool/0.5.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-pmB/ykKGkE7U6d2nOIrfbA58EqNptK9d0I2TXMS6gGA=",
     "strip_prefix": "rules_multitool-0.5.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.5.0/rules_multitool-0.5.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.5.0/rules_multitool-0.5.0.tar.gz"
 }

--- a/modules/rules_multitool/0.6.0/source.json
+++ b/modules/rules_multitool/0.6.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-VXtxt9jZl1r8f8I4HEwOQiDUOlgfsBkhfKCgQNbL6/8=",
     "strip_prefix": "rules_multitool-0.6.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.6.0/rules_multitool-0.6.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.6.0/rules_multitool-0.6.0.tar.gz"
 }

--- a/modules/rules_multitool/0.6.0/source.json
+++ b/modules/rules_multitool/0.6.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-VXtxt9jZl1r8f8I4HEwOQiDUOlgfsBkhfKCgQNbL6/8=",
     "strip_prefix": "rules_multitool-0.6.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.6.0/rules_multitool-0.6.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.6.0/rules_multitool-0.6.0.tar.gz"
 }

--- a/modules/rules_multitool/0.7.1/source.json
+++ b/modules/rules_multitool/0.7.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-s1S+UnjvMm2/YT5dUqxdiXwLQQvNwrV3uKemgu0cWjc=",
     "strip_prefix": "rules_multitool-0.7.1",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.7.1/rules_multitool-0.7.1.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.7.1/rules_multitool-0.7.1.tar.gz"
 }

--- a/modules/rules_multitool/0.7.1/source.json
+++ b/modules/rules_multitool/0.7.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-s1S+UnjvMm2/YT5dUqxdiXwLQQvNwrV3uKemgu0cWjc=",
     "strip_prefix": "rules_multitool-0.7.1",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.7.1/rules_multitool-0.7.1.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.7.1/rules_multitool-0.7.1.tar.gz"
 }

--- a/modules/rules_multitool/0.8.0/source.json
+++ b/modules/rules_multitool/0.8.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-SR5/e/6QMgJ+iPyDXpspUU+JxkIiEAp6Fqcikbx34iQ=",
     "strip_prefix": "rules_multitool-0.8.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.8.0/rules_multitool-0.8.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.8.0/rules_multitool-0.8.0.tar.gz"
 }

--- a/modules/rules_multitool/0.8.0/source.json
+++ b/modules/rules_multitool/0.8.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-SR5/e/6QMgJ+iPyDXpspUU+JxkIiEAp6Fqcikbx34iQ=",
     "strip_prefix": "rules_multitool-0.8.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.8.0/rules_multitool-0.8.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.8.0/rules_multitool-0.8.0.tar.gz"
 }

--- a/modules/rules_multitool/0.9.0/source.json
+++ b/modules/rules_multitool/0.9.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-MU0Jd0xE4te98rX0XCFQkT6FMnDSR4dIB6AMHh5endY=",
     "strip_prefix": "rules_multitool-0.9.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.9.0/rules_multitool-0.9.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v0.9.0/rules_multitool-0.9.0.tar.gz"
 }

--- a/modules/rules_multitool/0.9.0/source.json
+++ b/modules/rules_multitool/0.9.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-MU0Jd0xE4te98rX0XCFQkT6FMnDSR4dIB6AMHh5endY=",
     "strip_prefix": "rules_multitool-0.9.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v0.9.0/rules_multitool-0.9.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v0.9.0/rules_multitool-0.9.0.tar.gz"
 }

--- a/modules/rules_multitool/1.0.0/source.json
+++ b/modules/rules_multitool/1.0.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-uaiSchQXM7qGnjWHJrUELGClNcHWlcl7nH35sFrjQCA=",
     "strip_prefix": "rules_multitool-1.0.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v1.0.0/rules_multitool-1.0.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.0.0/rules_multitool-1.0.0.tar.gz"
 }

--- a/modules/rules_multitool/1.0.0/source.json
+++ b/modules/rules_multitool/1.0.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-uaiSchQXM7qGnjWHJrUELGClNcHWlcl7nH35sFrjQCA=",
     "strip_prefix": "rules_multitool-1.0.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.0.0/rules_multitool-1.0.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v1.0.0/rules_multitool-1.0.0.tar.gz"
 }

--- a/modules/rules_multitool/1.1.0/source.json
+++ b/modules/rules_multitool/1.1.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-25fBXRgQGXihegTFX5wcSF6fW6uQtZl+UL5aVVg0BLg=",
     "strip_prefix": "rules_multitool-1.1.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.1.0/rules_multitool-1.1.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v1.1.0/rules_multitool-1.1.0.tar.gz"
 }

--- a/modules/rules_multitool/1.1.0/source.json
+++ b/modules/rules_multitool/1.1.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-25fBXRgQGXihegTFX5wcSF6fW6uQtZl+UL5aVVg0BLg=",
     "strip_prefix": "rules_multitool-1.1.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v1.1.0/rules_multitool-1.1.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.1.0/rules_multitool-1.1.0.tar.gz"
 }

--- a/modules/rules_multitool/1.2.0/source.json
+++ b/modules/rules_multitool/1.2.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-DFrz8SQb33Th6PYrJI9XhVKU97qSQZvZcrK9G/+jGYc=",
     "strip_prefix": "rules_multitool-1.2.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.2.0/rules_multitool-1.2.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v1.2.0/rules_multitool-1.2.0.tar.gz"
 }

--- a/modules/rules_multitool/1.2.0/source.json
+++ b/modules/rules_multitool/1.2.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-DFrz8SQb33Th6PYrJI9XhVKU97qSQZvZcrK9G/+jGYc=",
     "strip_prefix": "rules_multitool-1.2.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v1.2.0/rules_multitool-1.2.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.2.0/rules_multitool-1.2.0.tar.gz"
 }

--- a/modules/rules_multitool/1.3.0/source.json
+++ b/modules/rules_multitool/1.3.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-OPN/e9B6Xl35RXmSfADdwtncDICgo2ME2Fi1LMlHXes=",
     "strip_prefix": "rules_multitool-1.3.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.3.0/rules_multitool-1.3.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v1.3.0/rules_multitool-1.3.0.tar.gz"
 }

--- a/modules/rules_multitool/1.3.0/source.json
+++ b/modules/rules_multitool/1.3.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-OPN/e9B6Xl35RXmSfADdwtncDICgo2ME2Fi1LMlHXes=",
     "strip_prefix": "rules_multitool-1.3.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v1.3.0/rules_multitool-1.3.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.3.0/rules_multitool-1.3.0.tar.gz"
 }

--- a/modules/rules_multitool/1.5.0/source.json
+++ b/modules/rules_multitool/1.5.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-J9crcsYQrUwE+b6DkOTO292gbJGW2Av052QFLgvlPYI=",
     "strip_prefix": "rules_multitool-1.5.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.5.0/rules_multitool-1.5.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v1.5.0/rules_multitool-1.5.0.tar.gz"
 }

--- a/modules/rules_multitool/1.5.0/source.json
+++ b/modules/rules_multitool/1.5.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-J9crcsYQrUwE+b6DkOTO292gbJGW2Av052QFLgvlPYI=",
     "strip_prefix": "rules_multitool-1.5.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v1.5.0/rules_multitool-1.5.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.5.0/rules_multitool-1.5.0.tar.gz"
 }

--- a/modules/rules_multitool/1.6.0/source.json
+++ b/modules/rules_multitool/1.6.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-GqZ4vXQIxW2LkLMByU9B8xTced+pkvF1rvTrqG93i/I=",
     "strip_prefix": "rules_multitool-1.6.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v1.6.0/rules_multitool-1.6.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.6.0/rules_multitool-1.6.0.tar.gz"
 }

--- a/modules/rules_multitool/1.6.0/source.json
+++ b/modules/rules_multitool/1.6.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-GqZ4vXQIxW2LkLMByU9B8xTced+pkvF1rvTrqG93i/I=",
     "strip_prefix": "rules_multitool-1.6.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.6.0/rules_multitool-1.6.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v1.6.0/rules_multitool-1.6.0.tar.gz"
 }

--- a/modules/rules_multitool/1.7.0/source.json
+++ b/modules/rules_multitool/1.7.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-knI5oFXSdkOta5cX2QHjxSnkea/stTePMKz+mjnP0WM=",
     "strip_prefix": "rules_multitool-1.7.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.7.0/rules_multitool-1.7.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v1.7.0/rules_multitool-1.7.0.tar.gz"
 }

--- a/modules/rules_multitool/1.7.0/source.json
+++ b/modules/rules_multitool/1.7.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-knI5oFXSdkOta5cX2QHjxSnkea/stTePMKz+mjnP0WM=",
     "strip_prefix": "rules_multitool-1.7.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v1.7.0/rules_multitool-1.7.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.7.0/rules_multitool-1.7.0.tar.gz"
 }

--- a/modules/rules_multitool/1.8.0/source.json
+++ b/modules/rules_multitool/1.8.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-LV3FZJiT5PmzE0XmU7/fxIZ8fNB5LMCqduVmY61Qd3g=",
     "strip_prefix": "rules_multitool-1.8.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v1.8.0/rules_multitool-1.8.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.8.0/rules_multitool-1.8.0.tar.gz"
 }

--- a/modules/rules_multitool/1.8.0/source.json
+++ b/modules/rules_multitool/1.8.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-LV3FZJiT5PmzE0XmU7/fxIZ8fNB5LMCqduVmY61Qd3g=",
     "strip_prefix": "rules_multitool-1.8.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.8.0/rules_multitool-1.8.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v1.8.0/rules_multitool-1.8.0.tar.gz"
 }

--- a/modules/rules_multitool/1.9.0/source.json
+++ b/modules/rules_multitool/1.9.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-dvxe7nJYazzf/WbqCx+XWUiTQ2EkKKsOp52pTT9qSB8=",
     "strip_prefix": "rules_multitool-1.9.0",
-    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.9.0/rules_multitool-1.9.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_multitool/releases/download/v1.9.0/rules_multitool-1.9.0.tar.gz"
 }

--- a/modules/rules_multitool/1.9.0/source.json
+++ b/modules/rules_multitool/1.9.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-dvxe7nJYazzf/WbqCx+XWUiTQ2EkKKsOp52pTT9qSB8=",
     "strip_prefix": "rules_multitool-1.9.0",
-    "url": "https://github.com/theoremlp/rules_multitool/releases/download/v1.9.0/rules_multitool-1.9.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_multitool/releases/download/v1.9.0/rules_multitool-1.9.0.tar.gz"
 }

--- a/modules/rules_multitool/metadata.json
+++ b/modules/rules_multitool/metadata.json
@@ -1,22 +1,14 @@
 {
-    "homepage": "https://github.com/theoremlp/rules_multitool",
+    "homepage": "https://github.com/markelliot/rules_multitool",
     "maintainers": [
         {
-            "email": "123787712+mark-thm@users.noreply.github.com",
-            "github": "mark-thm",
+            "email": "685891+markelliot@users.noreply.github.com",
+            "github": "markelliot",
             "name": "Mark Elliot",
-            "github_user_id": 123787712
-        },
-        {
-            "email": "bazel-maintainers@theoremlp.com",
-            "github": "theoremlp",
-            "name": "Theorem Bazel Maintainers",
-            "github_user_id": 84351796
+            "github_user_id": 685891
         }
     ],
-    "repository": [
-        "github:theoremlp/rules_multitool"
-    ],
+    "repository": ["github:markelliot/rules_multitool"],
     "versions": [
         "0.0.10",
         "0.1.1",

--- a/modules/rules_multitool/metadata.json
+++ b/modules/rules_multitool/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/markelliot/rules_multitool",
+    "homepage": "https://github.com/bazel-contrib/rules_multitool",
     "maintainers": [
         {
             "email": "685891+markelliot@users.noreply.github.com",

--- a/modules/rules_mypy/0.1.1/source.json
+++ b/modules/rules_mypy/0.1.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-W1jcbmD3EVSKu5jPT7ceqINnXfpiJgJ1Ffp1xGpmoug=",
     "strip_prefix": "rules_mypy-0.1.1",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.1.1/rules_mypy-0.1.1.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.1.1/rules_mypy-0.1.1.tar.gz"
 }

--- a/modules/rules_mypy/0.1.1/source.json
+++ b/modules/rules_mypy/0.1.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-W1jcbmD3EVSKu5jPT7ceqINnXfpiJgJ1Ffp1xGpmoug=",
     "strip_prefix": "rules_mypy-0.1.1",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.1.1/rules_mypy-0.1.1.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.1.1/rules_mypy-0.1.1.tar.gz"
 }

--- a/modules/rules_mypy/0.10.0/source.json
+++ b/modules/rules_mypy/0.10.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-YDqywTA79tsbSu4lqzQMLdqJSqFE4q5eGuVrTmgxHgw=",
     "strip_prefix": "rules_mypy-0.10.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.10.0/rules_mypy-0.10.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.10.0/rules_mypy-0.10.0.tar.gz"
 }

--- a/modules/rules_mypy/0.10.0/source.json
+++ b/modules/rules_mypy/0.10.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-YDqywTA79tsbSu4lqzQMLdqJSqFE4q5eGuVrTmgxHgw=",
     "strip_prefix": "rules_mypy-0.10.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.10.0/rules_mypy-0.10.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.10.0/rules_mypy-0.10.0.tar.gz"
 }

--- a/modules/rules_mypy/0.11.0/source.json
+++ b/modules/rules_mypy/0.11.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-A6wdB2MepA8rJllI1e4nznjNj5VeD1PGQA/rXxu3kCQ=",
     "strip_prefix": "rules_mypy-0.11.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.11.0/rules_mypy-0.11.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.11.0/rules_mypy-0.11.0.tar.gz"
 }

--- a/modules/rules_mypy/0.11.0/source.json
+++ b/modules/rules_mypy/0.11.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-A6wdB2MepA8rJllI1e4nznjNj5VeD1PGQA/rXxu3kCQ=",
     "strip_prefix": "rules_mypy-0.11.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.11.0/rules_mypy-0.11.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.11.0/rules_mypy-0.11.0.tar.gz"
 }

--- a/modules/rules_mypy/0.14.0/source.json
+++ b/modules/rules_mypy/0.14.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-1YeuM13Q4/4aV/YN6gtO2TbvTHtkWpfq8wydEzkMGNk=",
     "strip_prefix": "rules_mypy-0.14.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.14.0/rules_mypy-0.14.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.14.0/rules_mypy-0.14.0.tar.gz"
 }

--- a/modules/rules_mypy/0.14.0/source.json
+++ b/modules/rules_mypy/0.14.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-1YeuM13Q4/4aV/YN6gtO2TbvTHtkWpfq8wydEzkMGNk=",
     "strip_prefix": "rules_mypy-0.14.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.14.0/rules_mypy-0.14.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.14.0/rules_mypy-0.14.0.tar.gz"
 }

--- a/modules/rules_mypy/0.15.0/source.json
+++ b/modules/rules_mypy/0.15.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-N+GJCfIBI4vEnyLrJFtyNA86nmqEmnVj/vab7dJcY7M=",
     "strip_prefix": "rules_mypy-0.15.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.15.0/rules_mypy-0.15.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.15.0/rules_mypy-0.15.0.tar.gz"
 }

--- a/modules/rules_mypy/0.15.0/source.json
+++ b/modules/rules_mypy/0.15.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-N+GJCfIBI4vEnyLrJFtyNA86nmqEmnVj/vab7dJcY7M=",
     "strip_prefix": "rules_mypy-0.15.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.15.0/rules_mypy-0.15.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.15.0/rules_mypy-0.15.0.tar.gz"
 }

--- a/modules/rules_mypy/0.16.0/source.json
+++ b/modules/rules_mypy/0.16.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-IgcxWBIeSUS//Nc59G0GYVwgvf/rnB5hk9w9a+u1UyU=",
     "strip_prefix": "rules_mypy-0.16.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.16.0/rules_mypy-0.16.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.16.0/rules_mypy-0.16.0.tar.gz"
 }

--- a/modules/rules_mypy/0.16.0/source.json
+++ b/modules/rules_mypy/0.16.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-IgcxWBIeSUS//Nc59G0GYVwgvf/rnB5hk9w9a+u1UyU=",
     "strip_prefix": "rules_mypy-0.16.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.16.0/rules_mypy-0.16.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.16.0/rules_mypy-0.16.0.tar.gz"
 }

--- a/modules/rules_mypy/0.17.0/source.json
+++ b/modules/rules_mypy/0.17.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-txzN60Q02I6o+qsz0Thxsrcg1SIOEqhTk1xnDa+0/JE=",
     "strip_prefix": "rules_mypy-0.17.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.17.0/rules_mypy-0.17.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.17.0/rules_mypy-0.17.0.tar.gz"
 }

--- a/modules/rules_mypy/0.17.0/source.json
+++ b/modules/rules_mypy/0.17.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-txzN60Q02I6o+qsz0Thxsrcg1SIOEqhTk1xnDa+0/JE=",
     "strip_prefix": "rules_mypy-0.17.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.17.0/rules_mypy-0.17.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.17.0/rules_mypy-0.17.0.tar.gz"
 }

--- a/modules/rules_mypy/0.18.0/source.json
+++ b/modules/rules_mypy/0.18.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-MKRpDxKHD1FjVHrzz9FJzn9Bergs7fbP6HZ363n1FWE=",
     "strip_prefix": "rules_mypy-0.18.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.18.0/rules_mypy-0.18.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.18.0/rules_mypy-0.18.0.tar.gz"
 }

--- a/modules/rules_mypy/0.18.0/source.json
+++ b/modules/rules_mypy/0.18.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-MKRpDxKHD1FjVHrzz9FJzn9Bergs7fbP6HZ363n1FWE=",
     "strip_prefix": "rules_mypy-0.18.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.18.0/rules_mypy-0.18.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.18.0/rules_mypy-0.18.0.tar.gz"
 }

--- a/modules/rules_mypy/0.19.0/source.json
+++ b/modules/rules_mypy/0.19.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-JjHvNk5TFQPsPH6Uh9o/pSOZ47YFduN5pknfTpq80j4=",
     "strip_prefix": "rules_mypy-0.19.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.19.0/rules_mypy-0.19.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.19.0/rules_mypy-0.19.0.tar.gz"
 }

--- a/modules/rules_mypy/0.19.0/source.json
+++ b/modules/rules_mypy/0.19.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-JjHvNk5TFQPsPH6Uh9o/pSOZ47YFduN5pknfTpq80j4=",
     "strip_prefix": "rules_mypy-0.19.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.19.0/rules_mypy-0.19.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.19.0/rules_mypy-0.19.0.tar.gz"
 }

--- a/modules/rules_mypy/0.2.0/source.json
+++ b/modules/rules_mypy/0.2.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-2mQ/xF8yyluA+UDIJ3hYXLHpc2mfFTGebnY0Dyw/Z/Q=",
     "strip_prefix": "rules_mypy-0.2.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.2.0/rules_mypy-0.2.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.2.0/rules_mypy-0.2.0.tar.gz"
 }

--- a/modules/rules_mypy/0.2.0/source.json
+++ b/modules/rules_mypy/0.2.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-2mQ/xF8yyluA+UDIJ3hYXLHpc2mfFTGebnY0Dyw/Z/Q=",
     "strip_prefix": "rules_mypy-0.2.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.2.0/rules_mypy-0.2.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.2.0/rules_mypy-0.2.0.tar.gz"
 }

--- a/modules/rules_mypy/0.20.0/source.json
+++ b/modules/rules_mypy/0.20.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-WzgqerCgruMfeYtAAYnEmYwSVf/N/6WPgo0bhkep7gg=",
     "strip_prefix": "rules_mypy-0.20.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.20.0/rules_mypy-0.20.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.20.0/rules_mypy-0.20.0.tar.gz"
 }

--- a/modules/rules_mypy/0.20.0/source.json
+++ b/modules/rules_mypy/0.20.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-WzgqerCgruMfeYtAAYnEmYwSVf/N/6WPgo0bhkep7gg=",
     "strip_prefix": "rules_mypy-0.20.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.20.0/rules_mypy-0.20.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.20.0/rules_mypy-0.20.0.tar.gz"
 }

--- a/modules/rules_mypy/0.21.0/source.json
+++ b/modules/rules_mypy/0.21.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-hsASd41VZLoOQPWPLSbn7c5GPsOtx4+YKiENfS8UZ8E=",
     "strip_prefix": "rules_mypy-0.21.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.21.0/rules_mypy-0.21.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.21.0/rules_mypy-0.21.0.tar.gz"
 }

--- a/modules/rules_mypy/0.21.0/source.json
+++ b/modules/rules_mypy/0.21.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-hsASd41VZLoOQPWPLSbn7c5GPsOtx4+YKiENfS8UZ8E=",
     "strip_prefix": "rules_mypy-0.21.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.21.0/rules_mypy-0.21.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.21.0/rules_mypy-0.21.0.tar.gz"
 }

--- a/modules/rules_mypy/0.22.0/source.json
+++ b/modules/rules_mypy/0.22.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-xexBm3pQ8wuaXRF53CeDYKJDwzXKA2qBq+OTQ/bPPd4=",
     "strip_prefix": "rules_mypy-0.22.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.22.0/rules_mypy-0.22.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.22.0/rules_mypy-0.22.0.tar.gz"
 }

--- a/modules/rules_mypy/0.22.0/source.json
+++ b/modules/rules_mypy/0.22.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-xexBm3pQ8wuaXRF53CeDYKJDwzXKA2qBq+OTQ/bPPd4=",
     "strip_prefix": "rules_mypy-0.22.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.22.0/rules_mypy-0.22.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.22.0/rules_mypy-0.22.0.tar.gz"
 }

--- a/modules/rules_mypy/0.23.0/source.json
+++ b/modules/rules_mypy/0.23.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-2zaQI+5E7sQhETGiG2Ezf33wnj9G1VPzePTWbXziICo=",
     "strip_prefix": "rules_mypy-0.23.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.23.0/rules_mypy-0.23.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.23.0/rules_mypy-0.23.0.tar.gz"
 }

--- a/modules/rules_mypy/0.23.0/source.json
+++ b/modules/rules_mypy/0.23.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-2zaQI+5E7sQhETGiG2Ezf33wnj9G1VPzePTWbXziICo=",
     "strip_prefix": "rules_mypy-0.23.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.23.0/rules_mypy-0.23.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.23.0/rules_mypy-0.23.0.tar.gz"
 }

--- a/modules/rules_mypy/0.24.0/source.json
+++ b/modules/rules_mypy/0.24.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-FOzJlmHgVeyvyIQpAtHtNpljXp0dfrga/skRMgNYvtU=",
     "strip_prefix": "rules_mypy-0.24.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.24.0/rules_mypy-0.24.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.24.0/rules_mypy-0.24.0.tar.gz"
 }

--- a/modules/rules_mypy/0.24.0/source.json
+++ b/modules/rules_mypy/0.24.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-FOzJlmHgVeyvyIQpAtHtNpljXp0dfrga/skRMgNYvtU=",
     "strip_prefix": "rules_mypy-0.24.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.24.0/rules_mypy-0.24.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.24.0/rules_mypy-0.24.0.tar.gz"
 }

--- a/modules/rules_mypy/0.26.0/source.json
+++ b/modules/rules_mypy/0.26.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-NldpYI7DlclGJlwuW2DjFUPDacHdHDg8JZrGnLcn+IA=",
     "strip_prefix": "rules_mypy-0.26.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.26.0/rules_mypy-0.26.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.26.0/rules_mypy-0.26.0.tar.gz"
 }

--- a/modules/rules_mypy/0.26.0/source.json
+++ b/modules/rules_mypy/0.26.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-NldpYI7DlclGJlwuW2DjFUPDacHdHDg8JZrGnLcn+IA=",
     "strip_prefix": "rules_mypy-0.26.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.26.0/rules_mypy-0.26.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.26.0/rules_mypy-0.26.0.tar.gz"
 }

--- a/modules/rules_mypy/0.28.0/source.json
+++ b/modules/rules_mypy/0.28.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-w+LIdouizDNewk38DPravt86lBVtJdi6m05nihqRv88=",
     "strip_prefix": "rules_mypy-0.28.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.28.0/rules_mypy-0.28.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.28.0/rules_mypy-0.28.0.tar.gz"
 }

--- a/modules/rules_mypy/0.28.0/source.json
+++ b/modules/rules_mypy/0.28.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-w+LIdouizDNewk38DPravt86lBVtJdi6m05nihqRv88=",
     "strip_prefix": "rules_mypy-0.28.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.28.0/rules_mypy-0.28.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.28.0/rules_mypy-0.28.0.tar.gz"
 }

--- a/modules/rules_mypy/0.29.0/source.json
+++ b/modules/rules_mypy/0.29.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-olq2bZJTFrXZmkEMTmd8bwVcloCFkG2wIOgKnbF7Z1s=",
     "strip_prefix": "rules_mypy-0.29.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.29.0/rules_mypy-0.29.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.29.0/rules_mypy-0.29.0.tar.gz"
 }

--- a/modules/rules_mypy/0.29.0/source.json
+++ b/modules/rules_mypy/0.29.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-olq2bZJTFrXZmkEMTmd8bwVcloCFkG2wIOgKnbF7Z1s=",
     "strip_prefix": "rules_mypy-0.29.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.29.0/rules_mypy-0.29.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.29.0/rules_mypy-0.29.0.tar.gz"
 }

--- a/modules/rules_mypy/0.3.1/source.json
+++ b/modules/rules_mypy/0.3.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-fZd6Bj8auRo7+lZZxbp44ShCzyQM60HCdjalJWSwlLs=",
     "strip_prefix": "rules_mypy-0.3.1",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.3.1/rules_mypy-0.3.1.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.3.1/rules_mypy-0.3.1.tar.gz"
 }

--- a/modules/rules_mypy/0.3.1/source.json
+++ b/modules/rules_mypy/0.3.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-fZd6Bj8auRo7+lZZxbp44ShCzyQM60HCdjalJWSwlLs=",
     "strip_prefix": "rules_mypy-0.3.1",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.3.1/rules_mypy-0.3.1.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.3.1/rules_mypy-0.3.1.tar.gz"
 }

--- a/modules/rules_mypy/0.30.0/source.json
+++ b/modules/rules_mypy/0.30.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-9hATk/lfKmb0mhVpil1XysEFTsAHft+YMTbhgICCQOk=",
     "strip_prefix": "rules_mypy-0.30.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.30.0/rules_mypy-0.30.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.30.0/rules_mypy-0.30.0.tar.gz"
 }

--- a/modules/rules_mypy/0.30.0/source.json
+++ b/modules/rules_mypy/0.30.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-9hATk/lfKmb0mhVpil1XysEFTsAHft+YMTbhgICCQOk=",
     "strip_prefix": "rules_mypy-0.30.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.30.0/rules_mypy-0.30.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.30.0/rules_mypy-0.30.0.tar.gz"
 }

--- a/modules/rules_mypy/0.31.0/source.json
+++ b/modules/rules_mypy/0.31.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-SVVctQV6nZvc+zGi/wSy3WttrXEBIuOYtANqcknGabA=",
     "strip_prefix": "rules_mypy-0.31.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.31.0/rules_mypy-0.31.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.31.0/rules_mypy-0.31.0.tar.gz"
 }

--- a/modules/rules_mypy/0.31.0/source.json
+++ b/modules/rules_mypy/0.31.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-SVVctQV6nZvc+zGi/wSy3WttrXEBIuOYtANqcknGabA=",
     "strip_prefix": "rules_mypy-0.31.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.31.0/rules_mypy-0.31.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.31.0/rules_mypy-0.31.0.tar.gz"
 }

--- a/modules/rules_mypy/0.32.0/source.json
+++ b/modules/rules_mypy/0.32.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-erQcjZ0t9T2qwcGSNxTk0e2DNnn2BJn4yTWou+rgARE=",
     "strip_prefix": "rules_mypy-0.32.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.32.0/rules_mypy-0.32.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.32.0/rules_mypy-0.32.0.tar.gz"
 }

--- a/modules/rules_mypy/0.32.0/source.json
+++ b/modules/rules_mypy/0.32.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-erQcjZ0t9T2qwcGSNxTk0e2DNnn2BJn4yTWou+rgARE=",
     "strip_prefix": "rules_mypy-0.32.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.32.0/rules_mypy-0.32.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.32.0/rules_mypy-0.32.0.tar.gz"
 }

--- a/modules/rules_mypy/0.36.0/source.json
+++ b/modules/rules_mypy/0.36.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-TebSygw/FCsvNnD8Cq4KZmx32HPeruW7BwqkZgE3DRQ=",
     "strip_prefix": "rules_mypy-0.36.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.36.0/rules_mypy-0.36.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.36.0/rules_mypy-0.36.0.tar.gz"
 }

--- a/modules/rules_mypy/0.36.0/source.json
+++ b/modules/rules_mypy/0.36.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-TebSygw/FCsvNnD8Cq4KZmx32HPeruW7BwqkZgE3DRQ=",
     "strip_prefix": "rules_mypy-0.36.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.36.0/rules_mypy-0.36.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.36.0/rules_mypy-0.36.0.tar.gz"
 }

--- a/modules/rules_mypy/0.38.0/source.json
+++ b/modules/rules_mypy/0.38.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-eyI6WrtYTFR1EmFEMfz1u7fzEPQAQQivXcvZvYPRsnc=",
     "strip_prefix": "rules_mypy-0.38.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.38.0/rules_mypy-0.38.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.38.0/rules_mypy-0.38.0.tar.gz"
 }

--- a/modules/rules_mypy/0.38.0/source.json
+++ b/modules/rules_mypy/0.38.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-eyI6WrtYTFR1EmFEMfz1u7fzEPQAQQivXcvZvYPRsnc=",
     "strip_prefix": "rules_mypy-0.38.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.38.0/rules_mypy-0.38.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.38.0/rules_mypy-0.38.0.tar.gz"
 }

--- a/modules/rules_mypy/0.39.0/source.json
+++ b/modules/rules_mypy/0.39.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-FEYTqIC7xWsc7eyeINzNyW2f9rY6rE8+owz44B/3wnI=",
     "strip_prefix": "rules_mypy-0.39.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.39.0/rules_mypy-0.39.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.39.0/rules_mypy-0.39.0.tar.gz"
 }

--- a/modules/rules_mypy/0.39.0/source.json
+++ b/modules/rules_mypy/0.39.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-FEYTqIC7xWsc7eyeINzNyW2f9rY6rE8+owz44B/3wnI=",
     "strip_prefix": "rules_mypy-0.39.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.39.0/rules_mypy-0.39.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.39.0/rules_mypy-0.39.0.tar.gz"
 }

--- a/modules/rules_mypy/0.4.0/source.json
+++ b/modules/rules_mypy/0.4.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-/t+Bmih3kY2cchZvrULcnLvUJmiHaz+BtyD1vb9vUuw=",
     "strip_prefix": "rules_mypy-0.4.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.4.0/rules_mypy-0.4.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.4.0/rules_mypy-0.4.0.tar.gz"
 }

--- a/modules/rules_mypy/0.4.0/source.json
+++ b/modules/rules_mypy/0.4.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-/t+Bmih3kY2cchZvrULcnLvUJmiHaz+BtyD1vb9vUuw=",
     "strip_prefix": "rules_mypy-0.4.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.4.0/rules_mypy-0.4.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.4.0/rules_mypy-0.4.0.tar.gz"
 }

--- a/modules/rules_mypy/0.40.0/source.json
+++ b/modules/rules_mypy/0.40.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-T9RCa87dYVKfXB31VOck2eU8bYSJ3XjvKEOehzzxQ6c=",
     "strip_prefix": "rules_mypy-0.40.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.40.0/rules_mypy-0.40.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.40.0/rules_mypy-0.40.0.tar.gz"
 }

--- a/modules/rules_mypy/0.40.0/source.json
+++ b/modules/rules_mypy/0.40.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-T9RCa87dYVKfXB31VOck2eU8bYSJ3XjvKEOehzzxQ6c=",
     "strip_prefix": "rules_mypy-0.40.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.40.0/rules_mypy-0.40.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.40.0/rules_mypy-0.40.0.tar.gz"
 }

--- a/modules/rules_mypy/0.5.0/source.json
+++ b/modules/rules_mypy/0.5.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-xKdp8awCkfFuEA38NYXOXETh1ZiwyUNE2nv8b1DtOCY=",
     "strip_prefix": "rules_mypy-0.5.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.5.0/rules_mypy-0.5.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.5.0/rules_mypy-0.5.0.tar.gz"
 }

--- a/modules/rules_mypy/0.5.0/source.json
+++ b/modules/rules_mypy/0.5.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-xKdp8awCkfFuEA38NYXOXETh1ZiwyUNE2nv8b1DtOCY=",
     "strip_prefix": "rules_mypy-0.5.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.5.0/rules_mypy-0.5.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.5.0/rules_mypy-0.5.0.tar.gz"
 }

--- a/modules/rules_mypy/0.6.0/source.json
+++ b/modules/rules_mypy/0.6.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-YRlHhkH3Qt9fUTIZKNy9RFkQ8RRuwvOz5+KxnKyOt7s=",
     "strip_prefix": "rules_mypy-0.6.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.6.0/rules_mypy-0.6.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.6.0/rules_mypy-0.6.0.tar.gz"
 }

--- a/modules/rules_mypy/0.6.0/source.json
+++ b/modules/rules_mypy/0.6.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-YRlHhkH3Qt9fUTIZKNy9RFkQ8RRuwvOz5+KxnKyOt7s=",
     "strip_prefix": "rules_mypy-0.6.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.6.0/rules_mypy-0.6.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.6.0/rules_mypy-0.6.0.tar.gz"
 }

--- a/modules/rules_mypy/0.7.0/source.json
+++ b/modules/rules_mypy/0.7.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Bl799fAt9hlBoes6eZHkyESwxPI64XEX8vvn2piLmoY=",
     "strip_prefix": "rules_mypy-0.7.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.7.0/rules_mypy-0.7.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.7.0/rules_mypy-0.7.0.tar.gz"
 }

--- a/modules/rules_mypy/0.7.0/source.json
+++ b/modules/rules_mypy/0.7.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Bl799fAt9hlBoes6eZHkyESwxPI64XEX8vvn2piLmoY=",
     "strip_prefix": "rules_mypy-0.7.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.7.0/rules_mypy-0.7.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.7.0/rules_mypy-0.7.0.tar.gz"
 }

--- a/modules/rules_mypy/0.9.0/source.json
+++ b/modules/rules_mypy/0.9.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-nrHY0Q/9OU18po76NQ+sexB1G6XaNspTHEzkqMxjV50=",
     "strip_prefix": "rules_mypy-0.9.0",
-    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.9.0/rules_mypy-0.9.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_mypy/releases/download/v0.9.0/rules_mypy-0.9.0.tar.gz"
 }

--- a/modules/rules_mypy/0.9.0/source.json
+++ b/modules/rules_mypy/0.9.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-nrHY0Q/9OU18po76NQ+sexB1G6XaNspTHEzkqMxjV50=",
     "strip_prefix": "rules_mypy-0.9.0",
-    "url": "https://github.com/theoremlp/rules_mypy/releases/download/v0.9.0/rules_mypy-0.9.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_mypy/releases/download/v0.9.0/rules_mypy-0.9.0.tar.gz"
 }

--- a/modules/rules_mypy/metadata.json
+++ b/modules/rules_mypy/metadata.json
@@ -1,22 +1,14 @@
 {
-    "homepage": "https://github.com/theoremlp/rules_mypy",
+    "homepage": "https://github.com/markelliot/rules_mypy",
     "maintainers": [
         {
-            "email": "123787712+mark-thm@users.noreply.github.com",
-            "github": "mark-thm",
+            "email": "685891+markelliot@users.noreply.github.com",
+            "github": "markelliot",
             "name": "Mark Elliot",
-            "github_user_id": 123787712
-        },
-        {
-            "email": "bazel-maintainers@theoremlp.com",
-            "github": "theoremlp",
-            "name": "Theorem Bazel Maintainers",
-            "github_user_id": 84351796
+            "github_user_id": 685891
         }
     ],
-    "repository": [
-        "github:theoremlp/rules_mypy"
-    ],
+    "repository": ["github:markelliot/rules_mypy"],
     "versions": [
         "0.1.1",
         "0.2.0",

--- a/modules/rules_mypy/metadata.json
+++ b/modules/rules_mypy/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/markelliot/rules_mypy",
+    "homepage": "https://github.com/bazel-contrib/rules_mypy",
     "maintainers": [
         {
             "email": "685891+markelliot@users.noreply.github.com",

--- a/modules/rules_pydeps/0.1.1/source.json
+++ b/modules/rules_pydeps/0.1.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-jj3+BEfyy+9DHe9w3W2LQKvNaDJQNmKPD+TFhnIaRps=",
     "strip_prefix": "rules_pydeps-0.1.1",
-    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.1.1/rules_pydeps-0.1.1.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_pydeps/releases/download/v0.1.1/rules_pydeps-0.1.1.tar.gz"
 }

--- a/modules/rules_pydeps/0.1.1/source.json
+++ b/modules/rules_pydeps/0.1.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-jj3+BEfyy+9DHe9w3W2LQKvNaDJQNmKPD+TFhnIaRps=",
     "strip_prefix": "rules_pydeps-0.1.1",
-    "url": "https://github.com/theoremlp/rules_pydeps/releases/download/v0.1.1/rules_pydeps-0.1.1.tar.gz"
+    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.1.1/rules_pydeps-0.1.1.tar.gz"
 }

--- a/modules/rules_pydeps/0.1.2/source.json
+++ b/modules/rules_pydeps/0.1.2/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-W5UXBVc0Sy07VLWvigFTvClIvvzKmTkLPxTfUcjd+Ko=",
     "strip_prefix": "rules_pydeps-0.1.2",
-    "url": "https://github.com/theoremlp/rules_pydeps/releases/download/v0.1.2/rules_pydeps-0.1.2.tar.gz"
+    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.1.2/rules_pydeps-0.1.2.tar.gz"
 }

--- a/modules/rules_pydeps/0.1.2/source.json
+++ b/modules/rules_pydeps/0.1.2/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-W5UXBVc0Sy07VLWvigFTvClIvvzKmTkLPxTfUcjd+Ko=",
     "strip_prefix": "rules_pydeps-0.1.2",
-    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.1.2/rules_pydeps-0.1.2.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_pydeps/releases/download/v0.1.2/rules_pydeps-0.1.2.tar.gz"
 }

--- a/modules/rules_pydeps/0.2.0/source.json
+++ b/modules/rules_pydeps/0.2.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-+SpMyPU0cn0jquh00zrjCWxnmw14Lz+xUCvFmN/p0Ew=",
     "strip_prefix": "rules_pydeps-0.2.0",
-    "url": "https://github.com/theoremlp/rules_pydeps/releases/download/v0.2.0/rules_pydeps-0.2.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.2.0/rules_pydeps-0.2.0.tar.gz"
 }

--- a/modules/rules_pydeps/0.2.0/source.json
+++ b/modules/rules_pydeps/0.2.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-+SpMyPU0cn0jquh00zrjCWxnmw14Lz+xUCvFmN/p0Ew=",
     "strip_prefix": "rules_pydeps-0.2.0",
-    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.2.0/rules_pydeps-0.2.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_pydeps/releases/download/v0.2.0/rules_pydeps-0.2.0.tar.gz"
 }

--- a/modules/rules_pydeps/0.3.0/source.json
+++ b/modules/rules_pydeps/0.3.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-C5PTJ+9RJ1NSEvdP90MynqipyiKlLHQGgQz20NVOiQc=",
     "strip_prefix": "rules_pydeps-0.3.0",
-    "url": "https://github.com/theoremlp/rules_pydeps/releases/download/v0.3.0/rules_pydeps-0.3.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.3.0/rules_pydeps-0.3.0.tar.gz"
 }

--- a/modules/rules_pydeps/0.3.0/source.json
+++ b/modules/rules_pydeps/0.3.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-C5PTJ+9RJ1NSEvdP90MynqipyiKlLHQGgQz20NVOiQc=",
     "strip_prefix": "rules_pydeps-0.3.0",
-    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.3.0/rules_pydeps-0.3.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_pydeps/releases/download/v0.3.0/rules_pydeps-0.3.0.tar.gz"
 }

--- a/modules/rules_pydeps/0.4.0/source.json
+++ b/modules/rules_pydeps/0.4.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-InbyhWu+d3hREkN2DHCUXIP5q7BP+ksIbUZzvKG6RK8=",
     "strip_prefix": "rules_pydeps-0.4.0",
-    "url": "https://github.com/theoremlp/rules_pydeps/releases/download/v0.4.0/rules_pydeps-0.4.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.4.0/rules_pydeps-0.4.0.tar.gz"
 }

--- a/modules/rules_pydeps/0.4.0/source.json
+++ b/modules/rules_pydeps/0.4.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-InbyhWu+d3hREkN2DHCUXIP5q7BP+ksIbUZzvKG6RK8=",
     "strip_prefix": "rules_pydeps-0.4.0",
-    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.4.0/rules_pydeps-0.4.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_pydeps/releases/download/v0.4.0/rules_pydeps-0.4.0.tar.gz"
 }

--- a/modules/rules_pydeps/0.5.0/source.json
+++ b/modules/rules_pydeps/0.5.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ugw9eFhVVWmqE0odC/Q4D73ZMoXgEqDCvZBQ+xj44uw=",
     "strip_prefix": "rules_pydeps-0.5.0",
-    "url": "https://github.com/theoremlp/rules_pydeps/releases/download/v0.5.0/rules_pydeps-0.5.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.5.0/rules_pydeps-0.5.0.tar.gz"
 }

--- a/modules/rules_pydeps/0.5.0/source.json
+++ b/modules/rules_pydeps/0.5.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ugw9eFhVVWmqE0odC/Q4D73ZMoXgEqDCvZBQ+xj44uw=",
     "strip_prefix": "rules_pydeps-0.5.0",
-    "url": "https://github.com/markelliot/rules_pydeps/releases/download/v0.5.0/rules_pydeps-0.5.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_pydeps/releases/download/v0.5.0/rules_pydeps-0.5.0.tar.gz"
 }

--- a/modules/rules_pydeps/metadata.json
+++ b/modules/rules_pydeps/metadata.json
@@ -1,29 +1,14 @@
 {
-    "homepage": "https://github.com/theoremlp/rules_pydeps",
+    "homepage": "https://github.com/markelliot/rules_pydeps",
     "maintainers": [
         {
-            "email": "123787712+mark-thm@users.noreply.github.com",
-            "github": "mark-thm",
+            "email": "685891+markelliot@users.noreply.github.com",
+            "github": "markelliot",
             "name": "Mark Elliot",
-            "github_user_id": 123787712
-        },
-        {
-            "email": "bazel-maintainers@theoremlp.com",
-            "github": "theoremlp",
-            "name": "Theorem Bazel Maintainers",
-            "github_user_id": 84351796
+            "github_user_id": 685891
         }
     ],
-    "repository": [
-        "github:theoremlp/rules_pydeps"
-    ],
-    "versions": [
-        "0.1.1",
-        "0.1.2",
-        "0.2.0",
-        "0.3.0",
-        "0.4.0",
-        "0.5.0"
-    ],
+    "repository": ["github:markelliot/rules_pydeps"],
+    "versions": ["0.1.1", "0.1.2", "0.2.0", "0.3.0", "0.4.0", "0.5.0"],
     "yanked_versions": {}
 }

--- a/modules/rules_pydeps/metadata.json
+++ b/modules/rules_pydeps/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/markelliot/rules_pydeps",
+    "homepage": "https://github.com/bazel-contrib/rules_pydeps",
     "maintainers": [
         {
             "email": "685891+markelliot@users.noreply.github.com",

--- a/modules/rules_uv/0.1.0/source.json
+++ b/modules/rules_uv/0.1.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-D8SIrG2ag8lH8GaRn/0rEWgrjCHfqHXimyzubowizlk=",
     "strip_prefix": "rules_uv-0.1.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.1.0/rules_uv-0.1.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.1.0/rules_uv-0.1.0.tar.gz"
 }

--- a/modules/rules_uv/0.1.0/source.json
+++ b/modules/rules_uv/0.1.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-D8SIrG2ag8lH8GaRn/0rEWgrjCHfqHXimyzubowizlk=",
     "strip_prefix": "rules_uv-0.1.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.1.0/rules_uv-0.1.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.1.0/rules_uv-0.1.0.tar.gz"
 }

--- a/modules/rules_uv/0.10.0/source.json
+++ b/modules/rules_uv/0.10.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-WFoPq/5DcTHpBUV3TMT/nGQaJt++IlOhx+uK1dVmTvw=",
     "strip_prefix": "rules_uv-0.10.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.10.0/rules_uv-0.10.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.10.0/rules_uv-0.10.0.tar.gz"
 }

--- a/modules/rules_uv/0.10.0/source.json
+++ b/modules/rules_uv/0.10.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-WFoPq/5DcTHpBUV3TMT/nGQaJt++IlOhx+uK1dVmTvw=",
     "strip_prefix": "rules_uv-0.10.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.10.0/rules_uv-0.10.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.10.0/rules_uv-0.10.0.tar.gz"
 }

--- a/modules/rules_uv/0.11.0/source.json
+++ b/modules/rules_uv/0.11.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-+zrOO0r2ua5AmJ7ADnY0VancvAz+aSt4P+o/tCM2GRE=",
     "strip_prefix": "rules_uv-0.11.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.11.0/rules_uv-0.11.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.11.0/rules_uv-0.11.0.tar.gz"
 }

--- a/modules/rules_uv/0.11.0/source.json
+++ b/modules/rules_uv/0.11.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-+zrOO0r2ua5AmJ7ADnY0VancvAz+aSt4P+o/tCM2GRE=",
     "strip_prefix": "rules_uv-0.11.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.11.0/rules_uv-0.11.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.11.0/rules_uv-0.11.0.tar.gz"
 }

--- a/modules/rules_uv/0.12.0/source.json
+++ b/modules/rules_uv/0.12.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Xaxw51QR4fFzuIBIxbe9kdtHRKbftwwu25Ca277w5Zc=",
     "strip_prefix": "rules_uv-0.12.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.12.0/rules_uv-0.12.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.12.0/rules_uv-0.12.0.tar.gz"
 }

--- a/modules/rules_uv/0.12.0/source.json
+++ b/modules/rules_uv/0.12.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Xaxw51QR4fFzuIBIxbe9kdtHRKbftwwu25Ca277w5Zc=",
     "strip_prefix": "rules_uv-0.12.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.12.0/rules_uv-0.12.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.12.0/rules_uv-0.12.0.tar.gz"
 }

--- a/modules/rules_uv/0.13.0/source.json
+++ b/modules/rules_uv/0.13.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-7Gx1i5Rtsf8K8K7E9LlsqRwvsN7W7JuMToFdFX3JcFs=",
     "strip_prefix": "rules_uv-0.13.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.13.0/rules_uv-0.13.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.13.0/rules_uv-0.13.0.tar.gz"
 }

--- a/modules/rules_uv/0.13.0/source.json
+++ b/modules/rules_uv/0.13.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-7Gx1i5Rtsf8K8K7E9LlsqRwvsN7W7JuMToFdFX3JcFs=",
     "strip_prefix": "rules_uv-0.13.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.13.0/rules_uv-0.13.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.13.0/rules_uv-0.13.0.tar.gz"
 }

--- a/modules/rules_uv/0.14.0/source.json
+++ b/modules/rules_uv/0.14.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-MboiK2lFoO/4icBHEZzL2RjchetnJRVkuAzvQQJy4rk=",
     "strip_prefix": "rules_uv-0.14.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.14.0/rules_uv-0.14.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.14.0/rules_uv-0.14.0.tar.gz"
 }

--- a/modules/rules_uv/0.14.0/source.json
+++ b/modules/rules_uv/0.14.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-MboiK2lFoO/4icBHEZzL2RjchetnJRVkuAzvQQJy4rk=",
     "strip_prefix": "rules_uv-0.14.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.14.0/rules_uv-0.14.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.14.0/rules_uv-0.14.0.tar.gz"
 }

--- a/modules/rules_uv/0.15.0/source.json
+++ b/modules/rules_uv/0.15.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-5bh30ThOX2dsSjdhZzoX2K8vPV0fPX1rgTjt9cB/ksI=",
     "strip_prefix": "rules_uv-0.15.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.15.0/rules_uv-0.15.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.15.0/rules_uv-0.15.0.tar.gz"
 }

--- a/modules/rules_uv/0.15.0/source.json
+++ b/modules/rules_uv/0.15.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-5bh30ThOX2dsSjdhZzoX2K8vPV0fPX1rgTjt9cB/ksI=",
     "strip_prefix": "rules_uv-0.15.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.15.0/rules_uv-0.15.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.15.0/rules_uv-0.15.0.tar.gz"
 }

--- a/modules/rules_uv/0.16.0/source.json
+++ b/modules/rules_uv/0.16.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-t660x/YWRvRUAXISh+6b9L66RTUS6jJ956BiijcEhOU=",
     "strip_prefix": "rules_uv-0.16.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.16.0/rules_uv-0.16.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.16.0/rules_uv-0.16.0.tar.gz"
 }

--- a/modules/rules_uv/0.16.0/source.json
+++ b/modules/rules_uv/0.16.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-t660x/YWRvRUAXISh+6b9L66RTUS6jJ956BiijcEhOU=",
     "strip_prefix": "rules_uv-0.16.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.16.0/rules_uv-0.16.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.16.0/rules_uv-0.16.0.tar.gz"
 }

--- a/modules/rules_uv/0.17.0/source.json
+++ b/modules/rules_uv/0.17.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-/q9niMptIqYq4/B8Z6YrbK3Q9o8fcx6ZPHg82nZk2l8=",
     "strip_prefix": "rules_uv-0.17.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.17.0/rules_uv-0.17.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.17.0/rules_uv-0.17.0.tar.gz"
 }

--- a/modules/rules_uv/0.17.0/source.json
+++ b/modules/rules_uv/0.17.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-/q9niMptIqYq4/B8Z6YrbK3Q9o8fcx6ZPHg82nZk2l8=",
     "strip_prefix": "rules_uv-0.17.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.17.0/rules_uv-0.17.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.17.0/rules_uv-0.17.0.tar.gz"
 }

--- a/modules/rules_uv/0.18.0/source.json
+++ b/modules/rules_uv/0.18.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-dvRZUesm6v9sIVaGRPWrbqaTk+q9Sen7KYr0mFg0AhU=",
     "strip_prefix": "rules_uv-0.18.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.18.0/rules_uv-0.18.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.18.0/rules_uv-0.18.0.tar.gz"
 }

--- a/modules/rules_uv/0.18.0/source.json
+++ b/modules/rules_uv/0.18.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-dvRZUesm6v9sIVaGRPWrbqaTk+q9Sen7KYr0mFg0AhU=",
     "strip_prefix": "rules_uv-0.18.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.18.0/rules_uv-0.18.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.18.0/rules_uv-0.18.0.tar.gz"
 }

--- a/modules/rules_uv/0.2.0/source.json
+++ b/modules/rules_uv/0.2.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-GhlmcDRZbLqFSyFE+X6eWzLJ4VYDuAj/V0uWrlWtbXA=",
     "strip_prefix": "rules_uv-0.2.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.2.0/rules_uv-0.2.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.2.0/rules_uv-0.2.0.tar.gz"
 }

--- a/modules/rules_uv/0.2.0/source.json
+++ b/modules/rules_uv/0.2.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-GhlmcDRZbLqFSyFE+X6eWzLJ4VYDuAj/V0uWrlWtbXA=",
     "strip_prefix": "rules_uv-0.2.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.2.0/rules_uv-0.2.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.2.0/rules_uv-0.2.0.tar.gz"
 }

--- a/modules/rules_uv/0.20.0/source.json
+++ b/modules/rules_uv/0.20.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-HtsDn/GqBB96rCfh7pNOMUFZJ+NsOxAqADmoSnbDX3k=",
     "strip_prefix": "rules_uv-0.20.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.20.0/rules_uv-0.20.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.20.0/rules_uv-0.20.0.tar.gz"
 }

--- a/modules/rules_uv/0.20.0/source.json
+++ b/modules/rules_uv/0.20.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-HtsDn/GqBB96rCfh7pNOMUFZJ+NsOxAqADmoSnbDX3k=",
     "strip_prefix": "rules_uv-0.20.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.20.0/rules_uv-0.20.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.20.0/rules_uv-0.20.0.tar.gz"
 }

--- a/modules/rules_uv/0.21.0/source.json
+++ b/modules/rules_uv/0.21.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-IsV19ArvWcQdqp7CjSPm4KUcBuGhqQqh91xAMIPiLh8=",
     "strip_prefix": "rules_uv-0.21.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.21.0/rules_uv-0.21.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.21.0/rules_uv-0.21.0.tar.gz"
 }

--- a/modules/rules_uv/0.21.0/source.json
+++ b/modules/rules_uv/0.21.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-IsV19ArvWcQdqp7CjSPm4KUcBuGhqQqh91xAMIPiLh8=",
     "strip_prefix": "rules_uv-0.21.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.21.0/rules_uv-0.21.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.21.0/rules_uv-0.21.0.tar.gz"
 }

--- a/modules/rules_uv/0.22.0/source.json
+++ b/modules/rules_uv/0.22.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-mpP5BFkk2rWewKsVsAw93mOz5ZxRYexqRHKNu5kN7RE=",
     "strip_prefix": "rules_uv-0.22.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.22.0/rules_uv-0.22.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.22.0/rules_uv-0.22.0.tar.gz"
 }

--- a/modules/rules_uv/0.22.0/source.json
+++ b/modules/rules_uv/0.22.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-mpP5BFkk2rWewKsVsAw93mOz5ZxRYexqRHKNu5kN7RE=",
     "strip_prefix": "rules_uv-0.22.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.22.0/rules_uv-0.22.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.22.0/rules_uv-0.22.0.tar.gz"
 }

--- a/modules/rules_uv/0.23.0/source.json
+++ b/modules/rules_uv/0.23.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Lsi8A80CQYFKgG7BI8JovZOjWFt/xeSeh1jSvSA/XH8=",
     "strip_prefix": "rules_uv-0.23.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.23.0/rules_uv-0.23.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.23.0/rules_uv-0.23.0.tar.gz"
 }

--- a/modules/rules_uv/0.23.0/source.json
+++ b/modules/rules_uv/0.23.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Lsi8A80CQYFKgG7BI8JovZOjWFt/xeSeh1jSvSA/XH8=",
     "strip_prefix": "rules_uv-0.23.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.23.0/rules_uv-0.23.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.23.0/rules_uv-0.23.0.tar.gz"
 }

--- a/modules/rules_uv/0.24.0/source.json
+++ b/modules/rules_uv/0.24.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ntSCMUswEQ0Sxsu3vMwR6x1fFF6nUvYaqFdyfilC08Y=",
     "strip_prefix": "rules_uv-0.24.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.24.0/rules_uv-0.24.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.24.0/rules_uv-0.24.0.tar.gz"
 }

--- a/modules/rules_uv/0.24.0/source.json
+++ b/modules/rules_uv/0.24.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ntSCMUswEQ0Sxsu3vMwR6x1fFF6nUvYaqFdyfilC08Y=",
     "strip_prefix": "rules_uv-0.24.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.24.0/rules_uv-0.24.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.24.0/rules_uv-0.24.0.tar.gz"
 }

--- a/modules/rules_uv/0.25.0/source.json
+++ b/modules/rules_uv/0.25.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-nlrlYubaIuW+BbFaFhcP9oeIMLPNEjEYegHgJrC2Zog=",
     "strip_prefix": "rules_uv-0.25.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.25.0/rules_uv-0.25.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.25.0/rules_uv-0.25.0.tar.gz"
 }

--- a/modules/rules_uv/0.25.0/source.json
+++ b/modules/rules_uv/0.25.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-nlrlYubaIuW+BbFaFhcP9oeIMLPNEjEYegHgJrC2Zog=",
     "strip_prefix": "rules_uv-0.25.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.25.0/rules_uv-0.25.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.25.0/rules_uv-0.25.0.tar.gz"
 }

--- a/modules/rules_uv/0.26.0/source.json
+++ b/modules/rules_uv/0.26.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-LdaGDL0ECXO/XLaCw3i3uOG0xpTLcPWRDjv7D5F5Njk=",
     "strip_prefix": "rules_uv-0.26.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.26.0/rules_uv-0.26.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.26.0/rules_uv-0.26.0.tar.gz"
 }

--- a/modules/rules_uv/0.26.0/source.json
+++ b/modules/rules_uv/0.26.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-LdaGDL0ECXO/XLaCw3i3uOG0xpTLcPWRDjv7D5F5Njk=",
     "strip_prefix": "rules_uv-0.26.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.26.0/rules_uv-0.26.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.26.0/rules_uv-0.26.0.tar.gz"
 }

--- a/modules/rules_uv/0.27.0/source.json
+++ b/modules/rules_uv/0.27.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-D5fayGpx9CgJ6S4Jwkb8bW5p8/ukVAQ66EDxNumWiFg=",
     "strip_prefix": "rules_uv-0.27.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.27.0/rules_uv-0.27.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.27.0/rules_uv-0.27.0.tar.gz"
 }

--- a/modules/rules_uv/0.27.0/source.json
+++ b/modules/rules_uv/0.27.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-D5fayGpx9CgJ6S4Jwkb8bW5p8/ukVAQ66EDxNumWiFg=",
     "strip_prefix": "rules_uv-0.27.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.27.0/rules_uv-0.27.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.27.0/rules_uv-0.27.0.tar.gz"
 }

--- a/modules/rules_uv/0.28.0/source.json
+++ b/modules/rules_uv/0.28.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-fVCpapyOz8Jda4SmWauS3LedhFPzjt3rHqiJmV7Ik/o=",
     "strip_prefix": "rules_uv-0.28.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.28.0/rules_uv-0.28.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.28.0/rules_uv-0.28.0.tar.gz"
 }

--- a/modules/rules_uv/0.28.0/source.json
+++ b/modules/rules_uv/0.28.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-fVCpapyOz8Jda4SmWauS3LedhFPzjt3rHqiJmV7Ik/o=",
     "strip_prefix": "rules_uv-0.28.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.28.0/rules_uv-0.28.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.28.0/rules_uv-0.28.0.tar.gz"
 }

--- a/modules/rules_uv/0.29.0/source.json
+++ b/modules/rules_uv/0.29.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-mKGe6Ct92AydQ7ZodhQRSziLnhuyzlr8g7eccecTNHs=",
     "strip_prefix": "rules_uv-0.29.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.29.0/rules_uv-0.29.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.29.0/rules_uv-0.29.0.tar.gz"
 }

--- a/modules/rules_uv/0.29.0/source.json
+++ b/modules/rules_uv/0.29.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-mKGe6Ct92AydQ7ZodhQRSziLnhuyzlr8g7eccecTNHs=",
     "strip_prefix": "rules_uv-0.29.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.29.0/rules_uv-0.29.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.29.0/rules_uv-0.29.0.tar.gz"
 }

--- a/modules/rules_uv/0.3.0/source.json
+++ b/modules/rules_uv/0.3.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-K1LiO8QYAGp5SY6o+cyR4tomln6MgBygTyx0pt1f6SY=",
     "strip_prefix": "rules_uv-0.3.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.3.0/rules_uv-0.3.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.3.0/rules_uv-0.3.0.tar.gz"
 }

--- a/modules/rules_uv/0.3.0/source.json
+++ b/modules/rules_uv/0.3.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-K1LiO8QYAGp5SY6o+cyR4tomln6MgBygTyx0pt1f6SY=",
     "strip_prefix": "rules_uv-0.3.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.3.0/rules_uv-0.3.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.3.0/rules_uv-0.3.0.tar.gz"
 }

--- a/modules/rules_uv/0.30.0/source.json
+++ b/modules/rules_uv/0.30.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-GAk4jrEDhFB4aNAJ5ZXrjpqkmjtL/bNgfFH7Xbfoj4I=",
     "strip_prefix": "rules_uv-0.30.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.30.0/rules_uv-0.30.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.30.0/rules_uv-0.30.0.tar.gz"
 }

--- a/modules/rules_uv/0.30.0/source.json
+++ b/modules/rules_uv/0.30.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-GAk4jrEDhFB4aNAJ5ZXrjpqkmjtL/bNgfFH7Xbfoj4I=",
     "strip_prefix": "rules_uv-0.30.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.30.0/rules_uv-0.30.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.30.0/rules_uv-0.30.0.tar.gz"
 }

--- a/modules/rules_uv/0.31.0/source.json
+++ b/modules/rules_uv/0.31.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ixkx8YjCWfcCc0yZdD3o849DjpdG3qqhZXxODRcPPfc=",
     "strip_prefix": "rules_uv-0.31.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.31.0/rules_uv-0.31.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.31.0/rules_uv-0.31.0.tar.gz"
 }

--- a/modules/rules_uv/0.31.0/source.json
+++ b/modules/rules_uv/0.31.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ixkx8YjCWfcCc0yZdD3o849DjpdG3qqhZXxODRcPPfc=",
     "strip_prefix": "rules_uv-0.31.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.31.0/rules_uv-0.31.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.31.0/rules_uv-0.31.0.tar.gz"
 }

--- a/modules/rules_uv/0.32.0/source.json
+++ b/modules/rules_uv/0.32.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-i4xno9ceFqz1rB6STtW1nCVubFK0TDgEqpfYV0u/2k8=",
     "strip_prefix": "rules_uv-0.32.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.32.0/rules_uv-0.32.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.32.0/rules_uv-0.32.0.tar.gz"
 }

--- a/modules/rules_uv/0.32.0/source.json
+++ b/modules/rules_uv/0.32.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-i4xno9ceFqz1rB6STtW1nCVubFK0TDgEqpfYV0u/2k8=",
     "strip_prefix": "rules_uv-0.32.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.32.0/rules_uv-0.32.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.32.0/rules_uv-0.32.0.tar.gz"
 }

--- a/modules/rules_uv/0.33.0/source.json
+++ b/modules/rules_uv/0.33.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-IpoMl33F3RsPze3xOIcGqf9N4WzSqE/82t1uNA1hX5k=",
     "strip_prefix": "rules_uv-0.33.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.33.0/rules_uv-0.33.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.33.0/rules_uv-0.33.0.tar.gz"
 }

--- a/modules/rules_uv/0.33.0/source.json
+++ b/modules/rules_uv/0.33.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-IpoMl33F3RsPze3xOIcGqf9N4WzSqE/82t1uNA1hX5k=",
     "strip_prefix": "rules_uv-0.33.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.33.0/rules_uv-0.33.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.33.0/rules_uv-0.33.0.tar.gz"
 }

--- a/modules/rules_uv/0.34.0/source.json
+++ b/modules/rules_uv/0.34.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-PCYpW4CaYF0N7hcX86S8IxtsST/4xMFplcJRIgTkLv8=",
     "strip_prefix": "rules_uv-0.34.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.34.0/rules_uv-0.34.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.34.0/rules_uv-0.34.0.tar.gz"
 }

--- a/modules/rules_uv/0.34.0/source.json
+++ b/modules/rules_uv/0.34.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-PCYpW4CaYF0N7hcX86S8IxtsST/4xMFplcJRIgTkLv8=",
     "strip_prefix": "rules_uv-0.34.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.34.0/rules_uv-0.34.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.34.0/rules_uv-0.34.0.tar.gz"
 }

--- a/modules/rules_uv/0.35.0/source.json
+++ b/modules/rules_uv/0.35.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-/Nm6ozYCVEWkTZFb9mcCE8wQDA+XNX2Kj9q7VIqtlBI=",
     "strip_prefix": "rules_uv-0.35.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.35.0/rules_uv-0.35.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.35.0/rules_uv-0.35.0.tar.gz"
 }

--- a/modules/rules_uv/0.35.0/source.json
+++ b/modules/rules_uv/0.35.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-/Nm6ozYCVEWkTZFb9mcCE8wQDA+XNX2Kj9q7VIqtlBI=",
     "strip_prefix": "rules_uv-0.35.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.35.0/rules_uv-0.35.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.35.0/rules_uv-0.35.0.tar.gz"
 }

--- a/modules/rules_uv/0.37.0/source.json
+++ b/modules/rules_uv/0.37.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-QSEz0CFxyqKjL2oTND+n3HdTd4QORF37NcWOcWGtdYQ=",
     "strip_prefix": "rules_uv-0.37.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.37.0/rules_uv-0.37.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.37.0/rules_uv-0.37.0.tar.gz"
 }

--- a/modules/rules_uv/0.37.0/source.json
+++ b/modules/rules_uv/0.37.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-QSEz0CFxyqKjL2oTND+n3HdTd4QORF37NcWOcWGtdYQ=",
     "strip_prefix": "rules_uv-0.37.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.37.0/rules_uv-0.37.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.37.0/rules_uv-0.37.0.tar.gz"
 }

--- a/modules/rules_uv/0.38.0/source.json
+++ b/modules/rules_uv/0.38.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-THhP1n3QZkgY36nr1HlGyAODhfSRaTBTFZKJtqu8QyA=",
     "strip_prefix": "rules_uv-0.38.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.38.0/rules_uv-0.38.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.38.0/rules_uv-0.38.0.tar.gz"
 }

--- a/modules/rules_uv/0.38.0/source.json
+++ b/modules/rules_uv/0.38.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-THhP1n3QZkgY36nr1HlGyAODhfSRaTBTFZKJtqu8QyA=",
     "strip_prefix": "rules_uv-0.38.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.38.0/rules_uv-0.38.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.38.0/rules_uv-0.38.0.tar.gz"
 }

--- a/modules/rules_uv/0.39.0/source.json
+++ b/modules/rules_uv/0.39.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-+iUvcKuYVGvlCWkds5bClh9TXdKikrqJYf5dHwd2/rw=",
     "strip_prefix": "rules_uv-0.39.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.39.0/rules_uv-0.39.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.39.0/rules_uv-0.39.0.tar.gz"
 }

--- a/modules/rules_uv/0.39.0/source.json
+++ b/modules/rules_uv/0.39.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-+iUvcKuYVGvlCWkds5bClh9TXdKikrqJYf5dHwd2/rw=",
     "strip_prefix": "rules_uv-0.39.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.39.0/rules_uv-0.39.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.39.0/rules_uv-0.39.0.tar.gz"
 }

--- a/modules/rules_uv/0.4.0/source.json
+++ b/modules/rules_uv/0.4.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Td8y++vQum8Am/UIhhvTaHQQvazS+gipZ77zF5K2wAs=",
     "strip_prefix": "rules_uv-0.4.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.4.0/rules_uv-0.4.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.4.0/rules_uv-0.4.0.tar.gz"
 }

--- a/modules/rules_uv/0.4.0/source.json
+++ b/modules/rules_uv/0.4.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Td8y++vQum8Am/UIhhvTaHQQvazS+gipZ77zF5K2wAs=",
     "strip_prefix": "rules_uv-0.4.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.4.0/rules_uv-0.4.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.4.0/rules_uv-0.4.0.tar.gz"
 }

--- a/modules/rules_uv/0.40.0/source.json
+++ b/modules/rules_uv/0.40.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-3i4NCLA2SKtDoA2HlZXp9BcIA56TFsYhg+hL7Qdwa7c=",
     "strip_prefix": "rules_uv-0.40.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.40.0/rules_uv-0.40.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.40.0/rules_uv-0.40.0.tar.gz"
 }

--- a/modules/rules_uv/0.40.0/source.json
+++ b/modules/rules_uv/0.40.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-3i4NCLA2SKtDoA2HlZXp9BcIA56TFsYhg+hL7Qdwa7c=",
     "strip_prefix": "rules_uv-0.40.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.40.0/rules_uv-0.40.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.40.0/rules_uv-0.40.0.tar.gz"
 }

--- a/modules/rules_uv/0.41.0/source.json
+++ b/modules/rules_uv/0.41.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-GAS1Vbky1gxtBxe89ua70nCvcEy+fnLdIE9JN//B3sA=",
     "strip_prefix": "rules_uv-0.41.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.41.0/rules_uv-0.41.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.41.0/rules_uv-0.41.0.tar.gz"
 }

--- a/modules/rules_uv/0.41.0/source.json
+++ b/modules/rules_uv/0.41.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-GAS1Vbky1gxtBxe89ua70nCvcEy+fnLdIE9JN//B3sA=",
     "strip_prefix": "rules_uv-0.41.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.41.0/rules_uv-0.41.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.41.0/rules_uv-0.41.0.tar.gz"
 }

--- a/modules/rules_uv/0.42.0/source.json
+++ b/modules/rules_uv/0.42.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-UqSv85vnPZM28/TYSZZTcODpxiTYK90aFM75HqCeiyI=",
     "strip_prefix": "rules_uv-0.42.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.42.0/rules_uv-0.42.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.42.0/rules_uv-0.42.0.tar.gz"
 }

--- a/modules/rules_uv/0.42.0/source.json
+++ b/modules/rules_uv/0.42.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-UqSv85vnPZM28/TYSZZTcODpxiTYK90aFM75HqCeiyI=",
     "strip_prefix": "rules_uv-0.42.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.42.0/rules_uv-0.42.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.42.0/rules_uv-0.42.0.tar.gz"
 }

--- a/modules/rules_uv/0.43.0/source.json
+++ b/modules/rules_uv/0.43.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-SgIOBLj07X5qmH4ucbd3N0AYYgFay3GzFOEKleTo3iE=",
     "strip_prefix": "rules_uv-0.43.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.43.0/rules_uv-0.43.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.43.0/rules_uv-0.43.0.tar.gz"
 }

--- a/modules/rules_uv/0.43.0/source.json
+++ b/modules/rules_uv/0.43.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-SgIOBLj07X5qmH4ucbd3N0AYYgFay3GzFOEKleTo3iE=",
     "strip_prefix": "rules_uv-0.43.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.43.0/rules_uv-0.43.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.43.0/rules_uv-0.43.0.tar.gz"
 }

--- a/modules/rules_uv/0.44.0/source.json
+++ b/modules/rules_uv/0.44.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-RCT8Y8qtbGMBij/NsxZEvVVb8HlDAsL3WaxAexUDvxA=",
     "strip_prefix": "rules_uv-0.44.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.44.0/rules_uv-0.44.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.44.0/rules_uv-0.44.0.tar.gz"
 }

--- a/modules/rules_uv/0.44.0/source.json
+++ b/modules/rules_uv/0.44.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-RCT8Y8qtbGMBij/NsxZEvVVb8HlDAsL3WaxAexUDvxA=",
     "strip_prefix": "rules_uv-0.44.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.44.0/rules_uv-0.44.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.44.0/rules_uv-0.44.0.tar.gz"
 }

--- a/modules/rules_uv/0.45.0/source.json
+++ b/modules/rules_uv/0.45.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-XgNZS42T65U8sCJDjMwbwlkROPZWyMaixtovWvrmaAo=",
     "strip_prefix": "rules_uv-0.45.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.45.0/rules_uv-0.45.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.45.0/rules_uv-0.45.0.tar.gz"
 }

--- a/modules/rules_uv/0.45.0/source.json
+++ b/modules/rules_uv/0.45.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-XgNZS42T65U8sCJDjMwbwlkROPZWyMaixtovWvrmaAo=",
     "strip_prefix": "rules_uv-0.45.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.45.0/rules_uv-0.45.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.45.0/rules_uv-0.45.0.tar.gz"
 }

--- a/modules/rules_uv/0.46.0/source.json
+++ b/modules/rules_uv/0.46.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ulV9WvfLvf9ijUTM3ciPWggGDO/Hhs2Fr5THdRF8wKU=",
     "strip_prefix": "rules_uv-0.46.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.46.0/rules_uv-0.46.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.46.0/rules_uv-0.46.0.tar.gz"
 }

--- a/modules/rules_uv/0.46.0/source.json
+++ b/modules/rules_uv/0.46.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ulV9WvfLvf9ijUTM3ciPWggGDO/Hhs2Fr5THdRF8wKU=",
     "strip_prefix": "rules_uv-0.46.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.46.0/rules_uv-0.46.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.46.0/rules_uv-0.46.0.tar.gz"
 }

--- a/modules/rules_uv/0.47.0/source.json
+++ b/modules/rules_uv/0.47.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-cNnlH+B/F5neoop1ZujIE97BAvt5m75oWpR65AKQN7c=",
     "strip_prefix": "rules_uv-0.47.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.47.0/rules_uv-0.47.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.47.0/rules_uv-0.47.0.tar.gz"
 }

--- a/modules/rules_uv/0.47.0/source.json
+++ b/modules/rules_uv/0.47.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-cNnlH+B/F5neoop1ZujIE97BAvt5m75oWpR65AKQN7c=",
     "strip_prefix": "rules_uv-0.47.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.47.0/rules_uv-0.47.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.47.0/rules_uv-0.47.0.tar.gz"
 }

--- a/modules/rules_uv/0.48.0/source.json
+++ b/modules/rules_uv/0.48.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Sds62xPHP+ZwmdOhpUZer5Vi+UWUahiCPD2+C1Qti5s=",
     "strip_prefix": "rules_uv-0.48.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.48.0/rules_uv-0.48.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.48.0/rules_uv-0.48.0.tar.gz"
 }

--- a/modules/rules_uv/0.48.0/source.json
+++ b/modules/rules_uv/0.48.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Sds62xPHP+ZwmdOhpUZer5Vi+UWUahiCPD2+C1Qti5s=",
     "strip_prefix": "rules_uv-0.48.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.48.0/rules_uv-0.48.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.48.0/rules_uv-0.48.0.tar.gz"
 }

--- a/modules/rules_uv/0.49.0/source.json
+++ b/modules/rules_uv/0.49.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-mt14aQtlqZtbeJBe3cIysbjDQ1BuItrDDINcGvtUMAI=",
     "strip_prefix": "rules_uv-0.49.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.49.0/rules_uv-0.49.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.49.0/rules_uv-0.49.0.tar.gz"
 }

--- a/modules/rules_uv/0.49.0/source.json
+++ b/modules/rules_uv/0.49.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-mt14aQtlqZtbeJBe3cIysbjDQ1BuItrDDINcGvtUMAI=",
     "strip_prefix": "rules_uv-0.49.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.49.0/rules_uv-0.49.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.49.0/rules_uv-0.49.0.tar.gz"
 }

--- a/modules/rules_uv/0.5.0/source.json
+++ b/modules/rules_uv/0.5.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-FSQe5AISXX/RcJsCugM2u7X5vxVZI1KWDcJX+CKRCQY=",
     "strip_prefix": "rules_uv-0.5.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.5.0/rules_uv-0.5.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.5.0/rules_uv-0.5.0.tar.gz"
 }

--- a/modules/rules_uv/0.5.0/source.json
+++ b/modules/rules_uv/0.5.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-FSQe5AISXX/RcJsCugM2u7X5vxVZI1KWDcJX+CKRCQY=",
     "strip_prefix": "rules_uv-0.5.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.5.0/rules_uv-0.5.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.5.0/rules_uv-0.5.0.tar.gz"
 }

--- a/modules/rules_uv/0.51.0/source.json
+++ b/modules/rules_uv/0.51.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-du8tumWkLEpzX63Ebz0XP/7t8gr6Mtz1x5c4v9uJ8RU=",
     "strip_prefix": "rules_uv-0.51.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.51.0/rules_uv-0.51.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.51.0/rules_uv-0.51.0.tar.gz"
 }

--- a/modules/rules_uv/0.51.0/source.json
+++ b/modules/rules_uv/0.51.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-du8tumWkLEpzX63Ebz0XP/7t8gr6Mtz1x5c4v9uJ8RU=",
     "strip_prefix": "rules_uv-0.51.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.51.0/rules_uv-0.51.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.51.0/rules_uv-0.51.0.tar.gz"
 }

--- a/modules/rules_uv/0.52.0/source.json
+++ b/modules/rules_uv/0.52.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-M2nCH/ePmA8kLEnrynlzPLyuYefGgsIAVxA4AD8IORk=",
     "strip_prefix": "rules_uv-0.52.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.52.0/rules_uv-0.52.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.52.0/rules_uv-0.52.0.tar.gz"
 }

--- a/modules/rules_uv/0.52.0/source.json
+++ b/modules/rules_uv/0.52.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-M2nCH/ePmA8kLEnrynlzPLyuYefGgsIAVxA4AD8IORk=",
     "strip_prefix": "rules_uv-0.52.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.52.0/rules_uv-0.52.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.52.0/rules_uv-0.52.0.tar.gz"
 }

--- a/modules/rules_uv/0.53.0/source.json
+++ b/modules/rules_uv/0.53.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-gaeI/PxaDrryoVZSnNcBIxUD/ac43KSpLNw5wInvOxU=",
     "strip_prefix": "rules_uv-0.53.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.53.0/rules_uv-0.53.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.53.0/rules_uv-0.53.0.tar.gz"
 }

--- a/modules/rules_uv/0.53.0/source.json
+++ b/modules/rules_uv/0.53.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-gaeI/PxaDrryoVZSnNcBIxUD/ac43KSpLNw5wInvOxU=",
     "strip_prefix": "rules_uv-0.53.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.53.0/rules_uv-0.53.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.53.0/rules_uv-0.53.0.tar.gz"
 }

--- a/modules/rules_uv/0.55.0/source.json
+++ b/modules/rules_uv/0.55.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-uMlWDzCGzownjLW/9orik8xOz8GG73ftPfyBnU5UryY=",
     "strip_prefix": "rules_uv-0.55.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.55.0/rules_uv-0.55.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.55.0/rules_uv-0.55.0.tar.gz"
 }

--- a/modules/rules_uv/0.55.0/source.json
+++ b/modules/rules_uv/0.55.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-uMlWDzCGzownjLW/9orik8xOz8GG73ftPfyBnU5UryY=",
     "strip_prefix": "rules_uv-0.55.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.55.0/rules_uv-0.55.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.55.0/rules_uv-0.55.0.tar.gz"
 }

--- a/modules/rules_uv/0.56.0/source.json
+++ b/modules/rules_uv/0.56.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-dqwR8SGMaP0aj+248q5pF++mArylwuvV6fqWHhEDozk=",
     "strip_prefix": "rules_uv-0.56.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.56.0/rules_uv-0.56.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.56.0/rules_uv-0.56.0.tar.gz"
 }

--- a/modules/rules_uv/0.56.0/source.json
+++ b/modules/rules_uv/0.56.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-dqwR8SGMaP0aj+248q5pF++mArylwuvV6fqWHhEDozk=",
     "strip_prefix": "rules_uv-0.56.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.56.0/rules_uv-0.56.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.56.0/rules_uv-0.56.0.tar.gz"
 }

--- a/modules/rules_uv/0.59.0/source.json
+++ b/modules/rules_uv/0.59.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-NE4o2lCohoxs8Wt73CXIBajh8g629tEY6lDrVTTJ+N8=",
     "strip_prefix": "rules_uv-0.59.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.59.0/rules_uv-0.59.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.59.0/rules_uv-0.59.0.tar.gz"
 }

--- a/modules/rules_uv/0.59.0/source.json
+++ b/modules/rules_uv/0.59.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-NE4o2lCohoxs8Wt73CXIBajh8g629tEY6lDrVTTJ+N8=",
     "strip_prefix": "rules_uv-0.59.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.59.0/rules_uv-0.59.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.59.0/rules_uv-0.59.0.tar.gz"
 }

--- a/modules/rules_uv/0.6.0/source.json
+++ b/modules/rules_uv/0.6.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-i5dZZAQzCgr4QITFiMQqMkiPaMmYYRpz53YIlmU26F4=",
     "strip_prefix": "rules_uv-0.6.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.6.0/rules_uv-0.6.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.6.0/rules_uv-0.6.0.tar.gz"
 }

--- a/modules/rules_uv/0.6.0/source.json
+++ b/modules/rules_uv/0.6.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-i5dZZAQzCgr4QITFiMQqMkiPaMmYYRpz53YIlmU26F4=",
     "strip_prefix": "rules_uv-0.6.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.6.0/rules_uv-0.6.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.6.0/rules_uv-0.6.0.tar.gz"
 }

--- a/modules/rules_uv/0.6.1/source.json
+++ b/modules/rules_uv/0.6.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-efLfcm7akS2dxIXRGlLef49CAz8z6I5zHM5eMNqKNlY=",
     "strip_prefix": "rules_uv-0.6.1",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.6.1/rules_uv-0.6.1.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.6.1/rules_uv-0.6.1.tar.gz"
 }

--- a/modules/rules_uv/0.6.1/source.json
+++ b/modules/rules_uv/0.6.1/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-efLfcm7akS2dxIXRGlLef49CAz8z6I5zHM5eMNqKNlY=",
     "strip_prefix": "rules_uv-0.6.1",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.6.1/rules_uv-0.6.1.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.6.1/rules_uv-0.6.1.tar.gz"
 }

--- a/modules/rules_uv/0.62.0/source.json
+++ b/modules/rules_uv/0.62.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-I0ZkxYMopBhlRKzralazj+MGiRpkimiZHcczAGfcRrE=",
     "strip_prefix": "rules_uv-0.62.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.62.0/rules_uv-0.62.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.62.0/rules_uv-0.62.0.tar.gz"
 }

--- a/modules/rules_uv/0.62.0/source.json
+++ b/modules/rules_uv/0.62.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-I0ZkxYMopBhlRKzralazj+MGiRpkimiZHcczAGfcRrE=",
     "strip_prefix": "rules_uv-0.62.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.62.0/rules_uv-0.62.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.62.0/rules_uv-0.62.0.tar.gz"
 }

--- a/modules/rules_uv/0.63.0/source.json
+++ b/modules/rules_uv/0.63.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-R6GFg1b3UFec1F5A/H2CSVtKYhBqZb6TEcZ9zjA4vAE=",
     "strip_prefix": "rules_uv-0.63.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.63.0/rules_uv-0.63.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.63.0/rules_uv-0.63.0.tar.gz"
 }

--- a/modules/rules_uv/0.63.0/source.json
+++ b/modules/rules_uv/0.63.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-R6GFg1b3UFec1F5A/H2CSVtKYhBqZb6TEcZ9zjA4vAE=",
     "strip_prefix": "rules_uv-0.63.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.63.0/rules_uv-0.63.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.63.0/rules_uv-0.63.0.tar.gz"
 }

--- a/modules/rules_uv/0.64.0/source.json
+++ b/modules/rules_uv/0.64.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ukOMcIRFwfarTPKfPtn3ASOkaPNa9qwXJYgKCLh5z3I=",
     "strip_prefix": "rules_uv-0.64.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.64.0/rules_uv-0.64.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.64.0/rules_uv-0.64.0.tar.gz"
 }

--- a/modules/rules_uv/0.64.0/source.json
+++ b/modules/rules_uv/0.64.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ukOMcIRFwfarTPKfPtn3ASOkaPNa9qwXJYgKCLh5z3I=",
     "strip_prefix": "rules_uv-0.64.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.64.0/rules_uv-0.64.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.64.0/rules_uv-0.64.0.tar.gz"
 }

--- a/modules/rules_uv/0.65.0/source.json
+++ b/modules/rules_uv/0.65.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-DYIpWBBe/BvjqLpML55i27bN9uKngl8AFz5Dw5FMEkk=",
     "strip_prefix": "rules_uv-0.65.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.65.0/rules_uv-0.65.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.65.0/rules_uv-0.65.0.tar.gz"
 }

--- a/modules/rules_uv/0.65.0/source.json
+++ b/modules/rules_uv/0.65.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-DYIpWBBe/BvjqLpML55i27bN9uKngl8AFz5Dw5FMEkk=",
     "strip_prefix": "rules_uv-0.65.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.65.0/rules_uv-0.65.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.65.0/rules_uv-0.65.0.tar.gz"
 }

--- a/modules/rules_uv/0.68.0/source.json
+++ b/modules/rules_uv/0.68.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-mrqhucTwodDVVM2r3hxbyrJeOnRRmkAiD8EqBI1shSY=",
     "strip_prefix": "rules_uv-0.68.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.68.0/rules_uv-0.68.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.68.0/rules_uv-0.68.0.tar.gz"
 }

--- a/modules/rules_uv/0.68.0/source.json
+++ b/modules/rules_uv/0.68.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-mrqhucTwodDVVM2r3hxbyrJeOnRRmkAiD8EqBI1shSY=",
     "strip_prefix": "rules_uv-0.68.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.68.0/rules_uv-0.68.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.68.0/rules_uv-0.68.0.tar.gz"
 }

--- a/modules/rules_uv/0.69.0/source.json
+++ b/modules/rules_uv/0.69.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-7A4bwfsX/Mdx5siDDxnb/A+0cCD0CJiwIBysbY3GzpE=",
     "strip_prefix": "rules_uv-0.69.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.69.0/rules_uv-0.69.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.69.0/rules_uv-0.69.0.tar.gz"
 }

--- a/modules/rules_uv/0.69.0/source.json
+++ b/modules/rules_uv/0.69.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-7A4bwfsX/Mdx5siDDxnb/A+0cCD0CJiwIBysbY3GzpE=",
     "strip_prefix": "rules_uv-0.69.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.69.0/rules_uv-0.69.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.69.0/rules_uv-0.69.0.tar.gz"
 }

--- a/modules/rules_uv/0.7.0/source.json
+++ b/modules/rules_uv/0.7.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-wWALkOuXK6tM8lWyZEPHH5uqjHYmGUXHaKohOweer4k=",
     "strip_prefix": "rules_uv-0.7.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.7.0/rules_uv-0.7.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.7.0/rules_uv-0.7.0.tar.gz"
 }

--- a/modules/rules_uv/0.7.0/source.json
+++ b/modules/rules_uv/0.7.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-wWALkOuXK6tM8lWyZEPHH5uqjHYmGUXHaKohOweer4k=",
     "strip_prefix": "rules_uv-0.7.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.7.0/rules_uv-0.7.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.7.0/rules_uv-0.7.0.tar.gz"
 }

--- a/modules/rules_uv/0.70.0/source.json
+++ b/modules/rules_uv/0.70.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Kniqk6pWAeZoKebrCU49iMr6dnr2DvBPth9r3BwFiiI=",
     "strip_prefix": "rules_uv-0.70.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.70.0/rules_uv-0.70.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.70.0/rules_uv-0.70.0.tar.gz"
 }

--- a/modules/rules_uv/0.70.0/source.json
+++ b/modules/rules_uv/0.70.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Kniqk6pWAeZoKebrCU49iMr6dnr2DvBPth9r3BwFiiI=",
     "strip_prefix": "rules_uv-0.70.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.70.0/rules_uv-0.70.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.70.0/rules_uv-0.70.0.tar.gz"
 }

--- a/modules/rules_uv/0.71.0/source.json
+++ b/modules/rules_uv/0.71.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-oU0VAXftQLSKarJ300b+1PkpaKVL6EQ7RsTYhO/yv8M=",
     "strip_prefix": "rules_uv-0.71.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.71.0/rules_uv-0.71.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.71.0/rules_uv-0.71.0.tar.gz"
 }

--- a/modules/rules_uv/0.71.0/source.json
+++ b/modules/rules_uv/0.71.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-oU0VAXftQLSKarJ300b+1PkpaKVL6EQ7RsTYhO/yv8M=",
     "strip_prefix": "rules_uv-0.71.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.71.0/rules_uv-0.71.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.71.0/rules_uv-0.71.0.tar.gz"
 }

--- a/modules/rules_uv/0.77.0/source.json
+++ b/modules/rules_uv/0.77.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-X4d/7Wecc4ih6LVFDKNS5g6M53TYoyVr+7DtRR76R5o=",
     "strip_prefix": "rules_uv-0.77.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.77.0/rules_uv-0.77.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.77.0/rules_uv-0.77.0.tar.gz"
 }

--- a/modules/rules_uv/0.77.0/source.json
+++ b/modules/rules_uv/0.77.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-X4d/7Wecc4ih6LVFDKNS5g6M53TYoyVr+7DtRR76R5o=",
     "strip_prefix": "rules_uv-0.77.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.77.0/rules_uv-0.77.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.77.0/rules_uv-0.77.0.tar.gz"
 }

--- a/modules/rules_uv/0.78.0/source.json
+++ b/modules/rules_uv/0.78.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-yVl1GPok9omt/H8+TQXNYB/pE0X1sUAJZ7ZYYckWrWI=",
     "strip_prefix": "rules_uv-0.78.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.78.0/rules_uv-0.78.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.78.0/rules_uv-0.78.0.tar.gz"
 }

--- a/modules/rules_uv/0.78.0/source.json
+++ b/modules/rules_uv/0.78.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-yVl1GPok9omt/H8+TQXNYB/pE0X1sUAJZ7ZYYckWrWI=",
     "strip_prefix": "rules_uv-0.78.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.78.0/rules_uv-0.78.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.78.0/rules_uv-0.78.0.tar.gz"
 }

--- a/modules/rules_uv/0.79.0/source.json
+++ b/modules/rules_uv/0.79.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-JOuOxA/FXjpLl+tZN02YmwnYT1AhBpKWCpGQBAYmn34=",
     "strip_prefix": "rules_uv-0.79.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.79.0/rules_uv-0.79.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.79.0/rules_uv-0.79.0.tar.gz"
 }

--- a/modules/rules_uv/0.79.0/source.json
+++ b/modules/rules_uv/0.79.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-JOuOxA/FXjpLl+tZN02YmwnYT1AhBpKWCpGQBAYmn34=",
     "strip_prefix": "rules_uv-0.79.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.79.0/rules_uv-0.79.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.79.0/rules_uv-0.79.0.tar.gz"
 }

--- a/modules/rules_uv/0.8.0/source.json
+++ b/modules/rules_uv/0.8.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-TTi6xfcxY/p/F9WXfrqsVHFa85ce8kzK2kPMTeWRFx8=",
     "strip_prefix": "rules_uv-0.8.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.8.0/rules_uv-0.8.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.8.0/rules_uv-0.8.0.tar.gz"
 }

--- a/modules/rules_uv/0.8.0/source.json
+++ b/modules/rules_uv/0.8.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-TTi6xfcxY/p/F9WXfrqsVHFa85ce8kzK2kPMTeWRFx8=",
     "strip_prefix": "rules_uv-0.8.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.8.0/rules_uv-0.8.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.8.0/rules_uv-0.8.0.tar.gz"
 }

--- a/modules/rules_uv/0.80.0/source.json
+++ b/modules/rules_uv/0.80.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Rqpt+gYV9IMnCZPAV6Ln3qO+aq2iwMMVKFKU1PKgf5Q=",
     "strip_prefix": "rules_uv-0.80.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.80.0/rules_uv-0.80.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.80.0/rules_uv-0.80.0.tar.gz"
 }

--- a/modules/rules_uv/0.80.0/source.json
+++ b/modules/rules_uv/0.80.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-Rqpt+gYV9IMnCZPAV6Ln3qO+aq2iwMMVKFKU1PKgf5Q=",
     "strip_prefix": "rules_uv-0.80.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.80.0/rules_uv-0.80.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.80.0/rules_uv-0.80.0.tar.gz"
 }

--- a/modules/rules_uv/0.81.0/source.json
+++ b/modules/rules_uv/0.81.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ifefkaB2KGqbMJNSMAvfPWV2a1Gg+l+ZoI3nJ7/lSMQ=",
     "strip_prefix": "rules_uv-0.81.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.81.0/rules_uv-0.81.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.81.0/rules_uv-0.81.0.tar.gz"
 }

--- a/modules/rules_uv/0.81.0/source.json
+++ b/modules/rules_uv/0.81.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-ifefkaB2KGqbMJNSMAvfPWV2a1Gg+l+ZoI3nJ7/lSMQ=",
     "strip_prefix": "rules_uv-0.81.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.81.0/rules_uv-0.81.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.81.0/rules_uv-0.81.0.tar.gz"
 }

--- a/modules/rules_uv/0.82.0/source.json
+++ b/modules/rules_uv/0.82.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-bdQ077dUrZ1EXR43DOmpzRYWTLXRBmNAk44OP9TwV00=",
     "strip_prefix": "rules_uv-0.82.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.82.0/rules_uv-0.82.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.82.0/rules_uv-0.82.0.tar.gz"
 }

--- a/modules/rules_uv/0.82.0/source.json
+++ b/modules/rules_uv/0.82.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-bdQ077dUrZ1EXR43DOmpzRYWTLXRBmNAk44OP9TwV00=",
     "strip_prefix": "rules_uv-0.82.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.82.0/rules_uv-0.82.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.82.0/rules_uv-0.82.0.tar.gz"
 }

--- a/modules/rules_uv/0.83.0/source.json
+++ b/modules/rules_uv/0.83.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-eM5iaGSMrmYQufgV0pFazqAx2AFOOGs/5fCNwExOFcU=",
     "strip_prefix": "rules_uv-0.83.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.83.0/rules_uv-0.83.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.83.0/rules_uv-0.83.0.tar.gz"
 }

--- a/modules/rules_uv/0.83.0/source.json
+++ b/modules/rules_uv/0.83.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-eM5iaGSMrmYQufgV0pFazqAx2AFOOGs/5fCNwExOFcU=",
     "strip_prefix": "rules_uv-0.83.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.83.0/rules_uv-0.83.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.83.0/rules_uv-0.83.0.tar.gz"
 }

--- a/modules/rules_uv/0.84.0/source.json
+++ b/modules/rules_uv/0.84.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-XF1mwgF4HqCZuSGkvyCJ3teW+CTJGhQCX3Vs2rM9wFw=",
     "strip_prefix": "rules_uv-0.84.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.84.0/rules_uv-0.84.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.84.0/rules_uv-0.84.0.tar.gz"
 }

--- a/modules/rules_uv/0.84.0/source.json
+++ b/modules/rules_uv/0.84.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-XF1mwgF4HqCZuSGkvyCJ3teW+CTJGhQCX3Vs2rM9wFw=",
     "strip_prefix": "rules_uv-0.84.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.84.0/rules_uv-0.84.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.84.0/rules_uv-0.84.0.tar.gz"
 }

--- a/modules/rules_uv/0.85.0/source.json
+++ b/modules/rules_uv/0.85.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-mkfPHtTSYW7FbvkLK0FjjXxwAECFKKPkDW8zrZwQjoY=",
     "strip_prefix": "rules_uv-0.85.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.85.0/rules_uv-0.85.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.85.0/rules_uv-0.85.0.tar.gz"
 }

--- a/modules/rules_uv/0.85.0/source.json
+++ b/modules/rules_uv/0.85.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-mkfPHtTSYW7FbvkLK0FjjXxwAECFKKPkDW8zrZwQjoY=",
     "strip_prefix": "rules_uv-0.85.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.85.0/rules_uv-0.85.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.85.0/rules_uv-0.85.0.tar.gz"
 }

--- a/modules/rules_uv/0.86.0/source.json
+++ b/modules/rules_uv/0.86.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-7mMgyUHhE7y285v8iZzt0/4e1wiC3u/4vvoWjMvg/1g=",
     "strip_prefix": "rules_uv-0.86.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.86.0/rules_uv-0.86.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.86.0/rules_uv-0.86.0.tar.gz"
 }

--- a/modules/rules_uv/0.86.0/source.json
+++ b/modules/rules_uv/0.86.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-7mMgyUHhE7y285v8iZzt0/4e1wiC3u/4vvoWjMvg/1g=",
     "strip_prefix": "rules_uv-0.86.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.86.0/rules_uv-0.86.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.86.0/rules_uv-0.86.0.tar.gz"
 }

--- a/modules/rules_uv/0.87.0/source.json
+++ b/modules/rules_uv/0.87.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-481LRtzd04eyfom7L8I3t4IEWgX7nMCfnIeaE4zJSWQ=",
     "strip_prefix": "rules_uv-0.87.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.87.0/rules_uv-0.87.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.87.0/rules_uv-0.87.0.tar.gz"
 }

--- a/modules/rules_uv/0.87.0/source.json
+++ b/modules/rules_uv/0.87.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-481LRtzd04eyfom7L8I3t4IEWgX7nMCfnIeaE4zJSWQ=",
     "strip_prefix": "rules_uv-0.87.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.87.0/rules_uv-0.87.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.87.0/rules_uv-0.87.0.tar.gz"
 }

--- a/modules/rules_uv/0.88.0/source.json
+++ b/modules/rules_uv/0.88.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-1aTlbCo7seHcXZTpTpxnSKB9G9QbL8NG5QTya9gik4E=",
     "strip_prefix": "rules_uv-0.88.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.88.0/rules_uv-0.88.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.88.0/rules_uv-0.88.0.tar.gz"
 }

--- a/modules/rules_uv/0.88.0/source.json
+++ b/modules/rules_uv/0.88.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-1aTlbCo7seHcXZTpTpxnSKB9G9QbL8NG5QTya9gik4E=",
     "strip_prefix": "rules_uv-0.88.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.88.0/rules_uv-0.88.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.88.0/rules_uv-0.88.0.tar.gz"
 }

--- a/modules/rules_uv/0.9.0/source.json
+++ b/modules/rules_uv/0.9.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-9YZtISWNR4Rq45G5GwBWso/NPfY8eLuJFd0F4VSpGHA=",
     "strip_prefix": "rules_uv-0.9.0",
-    "url": "https://github.com/theoremlp/rules_uv/releases/download/v0.9.0/rules_uv-0.9.0.tar.gz"
+    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.9.0/rules_uv-0.9.0.tar.gz"
 }

--- a/modules/rules_uv/0.9.0/source.json
+++ b/modules/rules_uv/0.9.0/source.json
@@ -1,5 +1,5 @@
 {
     "integrity": "sha256-9YZtISWNR4Rq45G5GwBWso/NPfY8eLuJFd0F4VSpGHA=",
     "strip_prefix": "rules_uv-0.9.0",
-    "url": "https://github.com/markelliot/rules_uv/releases/download/v0.9.0/rules_uv-0.9.0.tar.gz"
+    "url": "https://github.com/bazel-contrib/rules_uv/releases/download/v0.9.0/rules_uv-0.9.0.tar.gz"
 }

--- a/modules/rules_uv/metadata.json
+++ b/modules/rules_uv/metadata.json
@@ -1,22 +1,14 @@
 {
-    "homepage": "https://github.com/theoremlp/rules_uv",
+    "homepage": "https://github.com/markelliot/rules_uv",
     "maintainers": [
         {
-            "email": "123787712+mark-thm@users.noreply.github.com",
-            "github": "mark-thm",
+            "email": "685891+markelliot@users.noreply.github.com",
+            "github": "markelliot",
             "name": "Mark Elliot",
-            "github_user_id": 123787712
-        },
-        {
-            "email": "bazel-maintainers@theoremlp.com",
-            "github": "theoremlp",
-            "name": "Theorem Bazel Maintainers",
-            "github_user_id": 84351796
+            "github_user_id": 685891
         }
     ],
-    "repository": [
-        "github:theoremlp/rules_uv"
-    ],
+    "repository": ["github:markelliot/rules_uv"],
     "versions": [
         "0.1.0",
         "0.2.0",

--- a/modules/rules_uv/metadata.json
+++ b/modules/rules_uv/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/markelliot/rules_uv",
+    "homepage": "https://github.com/bazel-contrib/rules_uv",
     "maintainers": [
         {
             "email": "685891+markelliot@users.noreply.github.com",


### PR DESCRIPTION
theoremlp/rules_{multitool,mypy,pydeps,uv} have been contributed to bazel-contrib, update their locales