### PR TITLE
awk.bzl published its stardocs, update source.json

### DIFF
--- a/modules/awk.bzl/0.2.2/source.json
+++ b/modules/awk.bzl/0.2.2/source.json
@@ -2,6 +2,7 @@
     "integrity": "sha256-/ZxlKmbsvsx0BT0eTJnBtBhlWNbuSg1wmqbWUvAhC4w=",
     "strip_prefix": "awk.bzl-0.2.2",
     "url": "https://github.com/alexeagle/awk.bzl/releases/download/v0.2.2/awk.bzl-v0.2.2.tar.gz",
+    "docs_url": "https://github.com/alexeagle/awk.bzl/releases/download/v0.2.2/awk.bzl-v0.2.2.docs.tar.gz",
     "patches": {
         "module_dot_bazel_version.patch": "sha256-+qr+30bK5pY1OdC8wjgZFYlLEquVQcFLxjrQwVsC5To="
     },


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel-central-registry/issues/5593

In theory this lets the BCR UI present the API docs