### PR TITLE
fix(validation): don't allow patch to fuzz

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -96,7 +96,7 @@ def parse_module_versions(registry, check_all, inputs):
 def apply_patch(work_dir, patch_strip, patch_file):
     # Requires patch to be installed
     subprocess.run(
-        ["patch", "-p%d" % patch_strip, "-f", "-l", "-i", patch_file],
+        ["patch", "--strip", patch_strip, "--force", "--fuzz", "0", "--ignore-whitespace", "--input", patch_file],
         shell=False,
         check=True,
         env=os.environ,


### PR DESCRIPTION
Docs:

> With context diffs, and to a lesser extent with normal diffs, patch can detect when the line
     numbers mentioned in the patch are incorrect, and will attempt to find the correct place to
     apply each hunk of the patch.  As a first guess, it takes the line number mentioned for the
     hunk, plus or minus any offset used in applying the previous hunk.  If that is not the correct
     place, patch will scan both forwards and backwards for a set of lines matching the context
     given in the hunk.  First patch looks for a place where all lines of the context match.  If no
     such place is found, and it is a context diff, and the maximum fuzz factor is set to 1 or more,
     then another scan takes place ignoring the first and last line of context.  If that fails, and
     the maximum fuzz factor is set to 2 or more, the first two and last two lines of context are
     ignored, and another scan is made.  (The default maximum fuzz factor is 2).

In the case of BCR patches, line offsets should be exact.