### PR TITLE
osqp-eigen@0.10.3

### DIFF
--- a/modules/osqp-eigen/0.10.3/MODULE.bazel
+++ b/modules/osqp-eigen/0.10.3/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "osqp-eigen",
+    version = "0.10.3",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+# This dependency can only be used from bazel-central-registry
+bazel_dep(name = "rules_cc", version = "0.1.1")
+
+# These depenencies can be overriden using conda ones
+bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
+bazel_dep(name = "osqp", version = "1.0.0")
+bazel_dep(name = "catch2", version = "3.8.0")

--- a/modules/osqp-eigen/0.10.3/presubmit.yml
+++ b/modules/osqp-eigen/0.10.3/presubmit.yml
@@ -1,0 +1,32 @@
+matrix: &matrix
+  platform:
+    - debian10
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+    - windows
+  bazel: [7.x, 8.x, rolling]
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@osqp-eigen//:osqp-eigen"
+
+bcr_test_module:
+  module_path: tests
+  matrix: *matrix
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - //...
+      test_targets:
+        - //...

--- a/modules/osqp-eigen/0.10.3/source.json
+++ b/modules/osqp-eigen/0.10.3/source.json
@@ -1,0 +1,6 @@
+{
+    "url": "https://github.com/robotology/osqp-eigen/archive/refs/tags/v0.10.3.tar.gz",
+    "integrity": "sha256-HZ/v+bX0NeRZZYSu0bkjxY7gyCDUdWbjXrXvelaSjZU=",
+    "strip_prefix": "osqp-eigen-0.10.3",
+    "patch_strip": 0
+}

--- a/modules/osqp-eigen/metadata.json
+++ b/modules/osqp-eigen/metadata.json
@@ -8,11 +8,7 @@
             "github_user_id": 42202095
         }
     ],
-    "repository": [
-        "github:robotology/osqp-eigen"
-    ],
-    "versions": [
-        "0.10.0"
-    ],
+    "repository": ["github:robotology/osqp-eigen"],
+    "versions": ["0.10.0", "0.10.3"],
     "yanked_versions": {}
 }


### PR DESCRIPTION
@wep21 this integrates tagged v0.10.3 of osqp-eigen.
I worked with the maintainers there to make sure an easy bcr creation is possible as osqp-eigen itself is now bazelised. 
see https://github.com/robotology/osqp-eigen/pull/205