### PR TITLE
Publish rules_tensorrt_rtx@0.1.0

### DIFF
--- a/modules/rules_tensorrt_rtx/0.1.0/MODULE.bazel
+++ b/modules/rules_tensorrt_rtx/0.1.0/MODULE.bazel
@@ -1,0 +1,23 @@
+module(
+    name = "rules_tensorrt_rtx",
+    version = "0.1.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_cuda", version = "0.2.5")
+
+tensorrt_rtx = use_extension("@rules_tensorrt_rtx//:extensions.bzl", "tensorrt_rtx")
+tensorrt_rtx.fetch()
+use_repo(
+    tensorrt_rtx,
+    "tensorrt_rtx_linux_x86_64",
+    "tensorrt_rtx_windows_x86_64",
+)
+
+bazel_dep(
+    name = "buildifier_prebuilt",
+    version = "8.2.0.2",
+)

--- a/modules/rules_tensorrt_rtx/0.1.0/attestations.json
+++ b/modules/rules_tensorrt_rtx/0.1.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/wep21/rules_tensorrt_rtx/releases/download/v0.1.0/source.json.intoto.jsonl",
+            "integrity": "sha256-zsGgs12NT5RsosIa2u7y62w/E6CK296IO+D/L/VBjek="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/wep21/rules_tensorrt_rtx/releases/download/v0.1.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-09OW4CHF7K0aM3nXyThP/+EQqiXi8gr2KKQ1tpdS3LI="
+        },
+        "rules_tensorrt_rtx-v0.1.0.tar.gz": {
+            "url": "https://github.com/wep21/rules_tensorrt_rtx/releases/download/v0.1.0/rules_tensorrt_rtx-v0.1.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-K+SE6lZBch/48JwlQF7zq6GtAQhLod9xPrhJNI1ycmk="
+        }
+    }
+}

--- a/modules/rules_tensorrt_rtx/0.1.0/presubmit.yml
+++ b/modules/rules_tensorrt_rtx/0.1.0/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@rules_tensorrt_rtx//..."

--- a/modules/rules_tensorrt_rtx/0.1.0/source.json
+++ b/modules/rules_tensorrt_rtx/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-+BIiZ0MXMYixkm1YddecXFGZNc0l+8LP2yKfvXarXAk=",
+    "strip_prefix": "rules_tensorrt_rtx-0.1.0",
+    "url": "https://github.com/wep21/rules_tensorrt_rtx/releases/download/v0.1.0/rules_tensorrt_rtx-v0.1.0.tar.gz"
+}

--- a/modules/rules_tensorrt_rtx/metadata.json
+++ b/modules/rules_tensorrt_rtx/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/wep21/rules_tensorrt_rtx",
+    "maintainers": [
+        {
+            "email": "daisuke.nishimatsu1021@gmail.com",
+            "github": "wep21",
+            "name": "Daisuke Nishimatsu",
+            "github_user_id": 42202095
+        }
+    ],
+    "repository": [
+        "github:wep21/rules_tensorrt_rtx"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/wep21/rules_tensorrt_rtx/releases/tag/v0.1.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_