### PR TITLE
hermetic_clang_toolchain@1.0.0

### DIFF
--- a/modules/hermetic_clang_toolchain/1.0.0/MODULE.bazel
+++ b/modules/hermetic_clang_toolchain/1.0.0/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "hermetic_clang_toolchain",
+    version = "1.0.0",
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+hermetic_clang = use_extension("//clang_toolchain:hermetic_clang.bzl", "hermetic_clang_extension")
+use_repo(hermetic_clang, "hermetic_clang_18_1_8")
+
+register_toolchains("//clang_toolchain:hermetic_clang_toolchain")

--- a/modules/hermetic_clang_toolchain/1.0.0/presubmit.yml
+++ b/modules/hermetic_clang_toolchain/1.0.0/presubmit.yml
@@ -1,0 +1,12 @@
+---
+matrix:
+  platform: ["ubuntu2004"]
+  bazel: ["7.x", "8.x", "rolling"]
+tasks:
+  verify_targets:
+    name: "Verify toolchain can be registered"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@hermetic_clang_toolchain//clang_toolchain/..."
+      - "@hermetic_clang_toolchain//example:simple_test"

--- a/modules/hermetic_clang_toolchain/1.0.0/source.json
+++ b/modules/hermetic_clang_toolchain/1.0.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/FBorowiec/hermetic_clang_toolchain/releases/download/v1.0.0/hermetic_clang_toolchain-1.0.0.tar.gz",
+    "integrity": "sha256-3NhWjOmLZeRkdDQObH3WmklmsoZHT8czqP+RmHs7zfI=",
+    "strip_prefix": "hermetic_clang_toolchain-1.0.0"
+}

--- a/modules/hermetic_clang_toolchain/metadata.json
+++ b/modules/hermetic_clang_toolchain/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/FBorowiec/hermetic_clang_toolchain",
+    "maintainers": [
+        {
+            "github": "FBorowiec",
+            "name": "FBorowiec",
+            "github_user_id": 34371791
+        }
+    ],
+    "repository": [
+        "github:FBorowiec/hermetic_clang_toolchain"
+    ],
+    "versions": [
+        "1.0.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
# Hermetic clang toolchain for `bazel`

A lightweight, hermetic Clang toolchain for `bazel` that downloads pre-built
LLVM binaries and bundles necessary system dependencies.

## Features

- fully hermetic
- lightweight - downloads pre-built binaries instead of building from source
- cross-platform - works on all linux x86_64 systems
- `clang18` - pre-built compiler binaries
- `ubuntu` lib - bundled `libtinfo5` for compatibility

## Usage

Add this to your `MODULE.bazel`:

```python
bazel_dep(name = "hermetic_clang_toolchain", version = "1.0.0")
```

