### PR TITLE
Fix boost.beast@1.88.0.bcr.1

### DIFF
--- a/modules/boost.beast/1.88.0.bcr.1/MODULE.bazel
+++ b/modules/boost.beast/1.88.0.bcr.1/MODULE.bazel
@@ -5,6 +5,7 @@ module(
     compatibility_level = 108800,
 )
 
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "boost.asio", version = "1.88.0.bcr.1")
 bazel_dep(name = "boost.assert", version = "1.88.0.bcr.1")
 bazel_dep(name = "boost.bind", version = "1.88.0.bcr.1")

--- a/modules/boost.beast/1.88.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.beast/1.88.0.bcr.1/overlay/BUILD.bazel
@@ -1,13 +1,25 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+write_file(
+    name = "src",
+    out = "boost.beast.src.cpp",
+    content = ["#include <boost/beast/src.hpp>"],
+    visibility = ["//visibility:private"],
+)
 
 cc_library(
     name = "boost.beast",
+    srcs = [":src"] + ["include/boost/beast/src.hpp"],
     hdrs = glob(
         [
             "include/**/*.hpp",
             "include/**/*.ipp",
         ],
         exclude = [
+            "include/boost/beast/src.hpp",
             "include/boost/beast/_experimental/http/impl/icy_stream.hpp",
             "include/boost/beast/_experimental/test/detail/stream_state.ipp",
             "include/boost/beast/_experimental/test/impl/error.hpp",
@@ -153,7 +165,6 @@ cc_library(
         "include/boost/beast/websocket/ssl.hpp",
         "include/boost/beast/zlib/impl/error.hpp",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "@boost.asio",
         "@boost.assert",

--- a/modules/boost.beast/1.88.0.bcr.1/source.json
+++ b/modules/boost.beast/1.88.0.bcr.1/source.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/boostorg/beast/archive/refs/tags/boost-1.88.0.tar.gz",
     "patch_strip": 0,
     "overlay": {
-        "BUILD.bazel": "sha256-V2tOZh1Gg2gyiVZ2NLjGeRKc+LyeqRPDb9MCzhLXYQE=",
-        "MODULE.bazel": "sha256-tCMHwhAGZj5TXWecEK3LRk0KWcUJ8hw/lJtBzaDfdQo="
+        "BUILD.bazel": "sha256-chDc82+Ukqu3ZtQ64kVH1ltlFmFws0fP2zDAibDn/QE=",
+        "MODULE.bazel": "sha256-Wl+1Jc6zcf16yTPTh24NGlHYBXq6UPVgyH1FbEM+9/M="
     }
 }


### PR DESCRIPTION
WARNING: This PR modifies an already published module

By accident, I copied the wrong `MODULE.bazel` and `BUILD.bazel` file (did take the ones from `1.87.0` and not `1.87.0.bcr.1`).

This PR fixes this. I propose to modify the existing `boost.beast@1.88.0.bcr.1` 

In the current version, you get compiler errors such as:

```
bazel-out/k8-fastbuild/bin/_solib_k8/libokapi_Scli_Slibbenchmark.so: error: undefined reference to 'boost::beast::http::basic_parser<false>::put(boost::asio::const_buffer, boost::system::error_code&)'
bazel-out/k8-fastbuild/bin/_solib_k8/libokapi_Scli_Slibbenchmark.so: error: undefined reference to 'boost::beast::http::to_string(boost::beast::http::verb)'
bazel-out/k8-fastbuild/bin/_solib_k8/libokapi_Scli_Slibbenchmark.so: error: undefined reference to 'boost::beast::iless::operator()(boost::core::basic_string_view<char>, boost::core::basic_string_view<char>) const'
bazel-out/k8-fastbuild/bin/_solib_k8/libokapi_Scli_Slibbenchmark.so: error: undefined reference to 'boost::beast::http::basic_parser<false>::put_eof(boost::system::error_code&)'
bazel-out/k8-fastbuild/bin/_solib_k8/libokapi_Scli_Slibbenchmark.so: error: undefined reference to 'boost::beast::http::detail::trim(boost::core::basic_string_view<char>)'
bazel-out/k8-fastbuild/bin/_solib_k8/libokapi_Scli_Slibbenchmark.so: error: undefined reference to 'boost::beast::iequals(boost::core::basic_string_view<char>, boost::core::basic_string_view<char>)'
bazel-out/k8-fastbuild/bin/_solib_k8/libokapi_Scli_Slibbenchmark.so: error: undefined reference to 'boost::beast::http::to_string(boost::beast::http::field)'
bazel-out/k8-fastbuild/bin/_solib_k8/libokapi_Scli_Slibbenchmark.so: error: undefined reference to 'boost::beast::http::make_error_code(boost::beast::http::error)'
bazel-out/k8-fastbuild/bin/_solib_k8/libokapi_Scli_Slibbenchmark.so: error: undefined reference to 'boost::beast::http::token_list::const_iterator::increment()'
```

Therefore, this will cause less harm than it will be useful.