### PR TITLE
grpc_kotlin@1.5.0-rc.2

### DIFF
--- a/modules/grpc_kotlin/1.5.0-rc.2/MODULE.bazel
+++ b/modules/grpc_kotlin/1.5.0-rc.2/MODULE.bazel
@@ -1,0 +1,56 @@
+module(
+    name = "grpc_kotlin",
+    # Note: the Publish-to-BCR app will patch this line to stamp the version being published.
+    version = "1.5.0-rc.2",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "protobuf", version = "31.1")
+bazel_dep(name = "rules_kotlin", version = "2.1.9")
+bazel_dep(name = "rules_java", version = "8.15.1")
+bazel_dep(name = "rules_jvm_external", version = "6.8")
+bazel_dep(name = "grpc-java", version = "1.71.0")
+
+# Formatter.
+bazel_dep(name = "aspect_rules_lint", version = "1.6.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
+bazel_dep(name = "rules_buf", version = "0.5.2", dev_dependency = True)
+bazel_dep(name = "rules_multirun", version = "0.13.0", dev_dependency = True)
+
+http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+
+http_jar(
+    name = "google-java-format",
+    sha256 = "33068bbbdce1099982ec1171f5e202898eb35f2919cf486141e439fc6e3a4203",
+    url = "https://github.com/google/google-java-format/releases/download/v1.17.0/google-java-format-1.17.0-all-deps.jar",
+)
+
+grpc_kotlin_maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+grpc_kotlin_maven.install(
+    name = "grpc_kotlin_maven",
+    # Rerun whenever adding new artifacts.
+    # $ REPIN=1 bazelisk run @grpc_kotlin_maven//:pin
+    artifacts = [
+        "com.google.jimfs:jimfs:1.3.0",
+        "com.google.truth:truth:1.4.4",
+        "com.google.truth.extensions:truth-proto-extension:1.4.4",
+        "com.google.protobuf:protobuf-java:4.30.2",
+        "com.google.protobuf:protobuf-kotlin:4.30.2",
+        "com.google.guava:guava:33.3.1-android",
+        "com.squareup:kotlinpoet:1.14.2",  # Max version without causing compiler errors.
+        "junit:junit:4.13.2",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1",
+    ],
+    fetch_sources = False,
+    generate_compat_repositories = True,
+    lock_file = "//:grpc_kotlin_maven_install.json",
+    strict_visibility = True,
+)
+use_repo(grpc_kotlin_maven, "grpc_kotlin_maven")
+
+install_ktfmt = use_extension("//:extensions.bzl", "install_ktfmt", dev_dependency = True)
+use_repo(install_ktfmt, "ktfmt")
+
+buf = use_extension("@rules_buf//buf:extensions.bzl", "buf", dev_dependency = True)
+use_repo(buf, "rules_buf_toolchains")

--- a/modules/grpc_kotlin/1.5.0-rc.2/patches/module_dot_bazel_version.patch
+++ b/modules/grpc_kotlin/1.5.0-rc.2/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,8 +1,8 @@
+ module(
+     name = "grpc_kotlin",
+     # Note: the Publish-to-BCR app will patch this line to stamp the version being published.
+-    version = "0.0.0",
++    version = "1.5.0-rc.2",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "protobuf", version = "31.1")

--- a/modules/grpc_kotlin/1.5.0-rc.2/presubmit.yml
+++ b/modules/grpc_kotlin/1.5.0-rc.2/presubmit.yml
@@ -1,0 +1,33 @@
+matrix:
+  platform:
+    - ubuntu2204
+    - macos
+  bazel:
+    - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--cxxopt=-std=c++17'
+      - '--host_cxxopt=-std=c++17'
+    build_targets:
+      - '@grpc_kotlin//...'
+bcr_test_module:
+  module_path: bzl-examples/bzlmod
+  matrix:
+    platform:
+      - ubuntu2204
+      - macos
+    bazel:
+      - 8.x
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - java/...
+      test_targets:
+        - javatests/...

--- a/modules/grpc_kotlin/1.5.0-rc.2/source.json
+++ b/modules/grpc_kotlin/1.5.0-rc.2/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-kNW9Vxlv47E+0qquC3WWr5Po7AbsghGuOsvFTzOknfY=",
+    "strip_prefix": "grpc-kotlin-1.5.0-rc.2",
+    "url": "https://github.com/grpc/grpc-kotlin/archive/refs/tags/v1.5.0-rc.2.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-Ix9IzS/Gm9iXAu/sRuOisnqoxAzBXctrB2uUCtSlW9U="
+    },
+    "patch_strip": 1
+}

--- a/modules/grpc_kotlin/metadata.json
+++ b/modules/grpc_kotlin/metadata.json
@@ -3,15 +3,9 @@
     "maintainers": [
         {
             "email": "",
-            "github": "duckladydinh",
-            "github_user_id": 22922064,
-            "name": "Lam Gia Thuan"
-        },
-        {
-            "email": "",
             "github": "bshaffer",
             "github_user_id": 103941,
-            "name": "bshaffer"
+            "name": "Brent Shaffer"
         },
         {
             "email": "",
@@ -24,13 +18,20 @@
             "github": "lowasser",
             "github_user_id": 544569,
             "name": "Louis Wasserman"
+        },
+        {
+            "email": "",
+            "github": "duckladydinh",
+            "github_user_id": 22922064,
+            "name": "Lam Gia Thuan"
         }
     ],
     "repository": [
         "github:grpc/grpc-kotlin"
     ],
     "versions": [
-        "1.5.0-rc.1"
+        "1.5.0-rc.1",
+        "1.5.0-rc.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/grpc/grpc-kotlin/releases/tag/v1.5.0-rc.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_