### PR TITLE
feat(blake3): Add version 1.8.2 with optional oneTBB support

### DIFF
--- a/modules/blake3/1.8.2/MODULE.bazel
+++ b/modules/blake3/1.8.2/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "blake3",
+    version = "1.8.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "onetbb", version = "2022.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")

--- a/modules/blake3/1.8.2/overlay/BUILD.bazel
+++ b/modules/blake3/1.8.2/overlay/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+cc_library(
+    name = "blake3",
+    deps = ["//c:blake3"],
+    includes = ["c"],
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "tbb",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "tbb_enabled",
+    flag_values = {":tbb": "true"},
+    visibility = ["//:__subpackages__"],
+)
+
+platform(
+    name = "internal_ci_only_do_not_use_windows_arm64",
+    constraint_values = [
+        "@@platforms//os:windows",
+        "@@platforms//cpu:arm64",
+    ],
+)

--- a/modules/blake3/1.8.2/overlay/MODULE.bazel
+++ b/modules/blake3/1.8.2/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/blake3/1.8.2/overlay/c/BUILD.bazel
+++ b/modules/blake3/1.8.2/overlay/c/BUILD.bazel
@@ -1,0 +1,175 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:private"])
+
+cc_library(
+    name = "blake3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":blake3_internal_dispatch",
+        ":blake3_internal_headers",
+    ],
+)
+
+cc_library(
+    name = "blake3_internal_headers",
+    hdrs = [
+        "blake3.h",
+        "blake3_impl.h",
+    ],
+)
+
+cc_library(
+    name = "blake3_internal_dispatch_c",
+    srcs = [
+        "blake3.c",
+        "blake3_dispatch.c",
+        "blake3_portable.c",
+    ],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "-std=c99",
+            "-fvisibility=hidden",
+        ],
+    }),
+    deps = [
+        ":blake3_internal_headers",
+    ],
+    linkstatic = True,
+)
+
+cc_library(
+    name = "blake3_internal_dispatch_tbb",
+    srcs = ["blake3_tbb.cpp"],
+    copts = select({
+        "@platforms//os:windows": [
+            "/std:c++20",
+            "/EHs-c-",  # No exceptions
+            "/GR-",     # No RTTI
+        ],
+        "//conditions:default": [
+            "-std=c++20",
+            "-fno-exceptions",
+            "-fno-rtti",
+            "-fvisibility=hidden",
+        ],
+    }),
+    defines = [
+        "BLAKE3_USE_TBB",
+        "TBB_USE_EXCEPTIONS=0",
+    ],
+    deps = [
+        ":blake3_internal_headers",
+        "@onetbb//:tbb",
+    ],
+    linkstatic = True,
+)
+
+cc_library(
+    name = "blake3_internal_dispatch",
+    deps = [
+        ":blake3_internal_dispatch_c",
+    ] + select({
+        "//:tbb_enabled": [":blake3_internal_dispatch_tbb"],
+        "//conditions:default": [],
+    }) + select({
+        "@platforms//cpu:aarch64": [":blake3_internal_neon"],
+        "@platforms//cpu:x86_32": [
+            ":blake3_internal_sse2",
+            ":blake3_internal_sse41",
+            ":blake3_internal_avx2",
+            ":blake3_internal_avx512",
+        ],
+        "@platforms//cpu:x86_64": [
+            ":blake3_internal_sse2_x86-64_asm",
+            ":blake3_internal_sse41_x86-64_asm",
+            ":blake3_internal_avx2_x86-64_asm",
+            ":blake3_internal_avx512_x86-64_asm",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+cc_library(
+    name = "blake3_internal_sse2",
+    srcs = ["blake3_sse2.c"],
+    copts = select({
+        "@platforms//os:windows": ["/arch:SSE2"],
+        "//conditions:default": ["-msse2"],
+    }),
+    deps = [":blake3_internal_headers"],
+)
+
+cc_library(
+    name = "blake3_internal_sse41",
+    srcs = ["blake3_sse41.c"],
+    copts = select({
+        # MSVC has no dedicated sse4.1 flag
+        "@platforms//os:windows": ["/arch:AVX"],
+        "//conditions:default": ["-msse4.1"],
+    }),
+    deps = [":blake3_internal_headers"],
+)
+
+cc_library(
+    name = "blake3_internal_avx2",
+    srcs = ["blake3_avx2.c"],
+    copts = select({
+        "@platforms//os:windows": ["/arch:AVX2"],
+        "//conditions:default": ["-mavx2"],
+    }),
+    deps = [":blake3_internal_headers"],
+)
+
+cc_library(
+    name = "blake3_internal_avx512",
+    srcs = ["blake3_avx512.c"],
+    copts = select({
+        "@platforms//os:windows": ["/arch:AVX512"],
+        "//conditions:default": [
+            "-mavx512f",
+            "-mavx512vl",
+        ],
+    }),
+    deps = [":blake3_internal_headers"],
+)
+
+cc_library(
+    name = "blake3_internal_neon",
+    srcs = ["blake3_neon.c"],
+    defines = ["BLAKE3_USE_NEON=1"],
+    deps = [":blake3_internal_headers"],
+)
+
+cc_library(
+    name = "blake3_internal_sse2_x86-64_asm",
+    srcs = select({
+        "@platforms//os:windows": ["blake3_sse2_x86-64_windows_msvc.asm"],
+        "//conditions:default": ["blake3_sse2_x86-64_unix.S"],
+    }),
+)
+
+cc_library(
+    name = "blake3_internal_sse41_x86-64_asm",
+    srcs = select({
+        "@platforms//os:windows": ["blake3_sse41_x86-64_windows_msvc.asm"],
+        "//conditions:default": ["blake3_sse41_x86-64_unix.S"],
+    }),
+)
+
+cc_library(
+    name = "blake3_internal_avx2_x86-64_asm",
+    srcs = select({
+        "@platforms//os:windows": ["blake3_avx2_x86-64_windows_msvc.asm"],
+        "//conditions:default": ["blake3_avx2_x86-64_unix.S"],
+    }),
+)
+
+cc_library(
+    name = "blake3_internal_avx512_x86-64_asm",
+    srcs = select({
+        "@platforms//os:windows": ["blake3_avx512_x86-64_windows_msvc.asm"],
+        "//conditions:default": ["blake3_avx512_x86-64_unix.S"],
+    }),
+)

--- a/modules/blake3/1.8.2/presubmit.yml
+++ b/modules/blake3/1.8.2/presubmit.yml
@@ -1,0 +1,38 @@
+matrix:
+  platform:
+  - fedora39
+  - ubuntu2404
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@blake3//:blake3'
+  verify_targets_windows_arm:
+    name: Verify build targets for Windows ARM
+    platform: windows
+    setup:
+      - echo bazel_dep(name = "rules_cc", version = "0.0.17") >> MODULE.bazel
+      - echo cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension") >> MODULE.bazel
+      - echo use_repo(cc_configure, "local_config_cc") >> MODULE.bazel
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@blake3//:blake3'
+    build_flags:
+    - '--platforms=@blake3//:internal_ci_only_do_not_use_windows_arm64'
+    - '--extra_toolchains=@local_config_cc//:cc-toolchain-arm64_windows'
+  verify_tbb_targets:
+    name: Verify build targets with TBB
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@blake3//:blake3'
+    build_flags:
+    - '--@blake3//:tbb=true'

--- a/modules/blake3/1.8.2/source.json
+++ b/modules/blake3/1.8.2/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/1.8.2.tar.gz",
+    "integrity": "sha256-a1Gu/lFZaXhdoC6Hvvr8f9x6BlzTRYzxFB8pJndJ6B8=",
+    "strip_prefix": "BLAKE3-1.8.2",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-WMNSGBdxrKmjDJtzbX84+Gjix1Or8mhXU6CzcHmwNNE=",
+        "MODULE.bazel": "sha256-cpGnW7rjJprMXhN7GbAEKSI2MhNcGRjhKFVZW8ql0Bc=",
+        "c/BUILD.bazel": "sha256-RBb2IsLnS9VC5B34u0izaV07FJes2srRvB1XnzCCRVU="
+    }
+}

--- a/modules/blake3/README.md
+++ b/modules/blake3/README.md
@@ -1,0 +1,3 @@
+# BLAKE3
+
+Version 1.8.2 supports the use of oneTBB. It can be enabled with the `--@blake3//:tbb=true` flag.

--- a/modules/blake3/metadata.json
+++ b/modules/blake3/metadata.json
@@ -2,8 +2,10 @@
     "homepage": "https://github.com/BLAKE3-team/BLAKE3",
     "maintainers": [
         {
-            "email": "bcr-maintainers@bazel.build",
-            "name": "No Maintainer Specified"
+            "email": "206078155+daemoninstitute@users.noreply.github.com",
+            "github": "daemoninstitute",
+            "github_user_id": 206078155,
+            "name": "James Wilson"
         }
     ],
     "repository": [
@@ -15,7 +17,8 @@
         "1.5.1",
         "1.5.1.bcr.1",
         "1.5.4",
-        "1.5.4.bcr.1"
+        "1.5.4.bcr.1",
+        "1.8.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
BLAKE3 version 1.8.2

Adds oneTBB Support - This can be enabled with the `--define=blake3:tbb=enabled` flag. I've added a `README.md` that explains this and a new presubmit task.

I have continued the overlay structure that was used in `1.5.4.bcr.1` instead of using patches.

The existing presubmit matrix and the specific CI configuration for Windows ARM64 have been preserved from the previous version as I lack a local Windows environment to validate any changes. I have also kept the `bazel_compatibility` of the prior version.

This is my first contribution to the BCR. I am very open to all feedback and happy to make any necessary changes. I have also added myself as a maintainer in `metadata.json`. Please let me know if this is acceptable or if you'd prefer a different approach.
