### PR TITLE
Publish gcc_toolchain@0.9.0

### DIFF
--- a/modules/gcc_toolchain/0.9.0/MODULE.bazel
+++ b/modules/gcc_toolchain/0.9.0/MODULE.bazel
@@ -1,0 +1,66 @@
+module(name = "gcc_toolchain",
+    version = "0.9.0",
+)
+
+# Dependencies
+# ============
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.40.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.0")
+
+# Local Toolchains
+# ================
+gcc_toolchains = use_extension("//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
+
+[
+    [
+        gcc_toolchains.toolchain(
+            name = "gcc_toolchain_{}".format(arch),
+            target_arch = arch,
+        ),
+        use_repo(gcc_toolchains, "gcc_toolchain_{}".format(arch)),
+        register_toolchains(
+            "@gcc_toolchain_{}//:cc_toolchain".format(arch),
+            "@gcc_toolchain_{}//:fortran_toolchain".format(arch),
+            # Register toolchains as dev dependencies so that we don't pollute the toolchain resolution of consumers.
+            dev_dependency = True,
+        ),
+    ]
+    # Unfortunately, we can't load `ARCHS` directly here.
+    # But the attributes in `gcc_toolchains.toolchain` are gated to only contain values from ARCHS.
+    for arch in [
+        "aarch64",
+        "armv7",
+        "x86_64",
+    ]
+]
+
+# Dev Dependencies (for examples/)
+# ===============================
+bazel_dep(name = "rules_proto", version = "7.1.0", dev_dependency = True)
+bazel_dep(name = "rules_foreign_cc", version = "0.15.0", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.5.6", dev_dependency = True, repo_name = "io_bazel_stardoc")
+# We pin stardoc because a dependency requests a newer version (0.7.2), but the non-workspace flow doesn't work with it.
+single_version_override(
+    module_name = "stardoc",
+    version = "0.5.6",
+)
+
+bazel_dep(name = "protobuf", version = "29.3", dev_dependency = True, repo_name = "com_google_protobuf")
+single_version_override(
+    module_name = "protobuf",
+    patch_strip = 1,
+    patches = [
+        "//third_party/patches:com_google_protobuf.bzlmod.patch",
+    ],
+    version = "29.3",
+)
+
+non_bazel_dependencies = use_extension("//:internal.bzl", "non_bazel_dependencies")
+use_repo(
+    non_bazel_dependencies,
+    "avl",
+    "lapack",
+    "openssl",
+)

--- a/modules/gcc_toolchain/0.9.0/attestations.json
+++ b/modules/gcc_toolchain/0.9.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/f0rmiga/gcc-toolchain/releases/download/0.9.0/source.json.intoto.jsonl",
+            "integrity": "sha256-rM3CS7Y6IaleFXqtoFcV7/oph2yNJthRQDw1Ce0U0WM="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/f0rmiga/gcc-toolchain/releases/download/0.9.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-B+m80fgk5Xk3ZkyhXLo8a6C27o4hmRZd4h7+QC7kAMA="
+        },
+        "gcc-toolchain-0.9.0.tar.gz": {
+            "url": "https://github.com/f0rmiga/gcc-toolchain/releases/download/0.9.0/gcc-toolchain-0.9.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-oxC78vANXaUc21D8XegZiiLsSDpTk6pXgmA9s1vmrsU="
+        }
+    }
+}

--- a/modules/gcc_toolchain/0.9.0/patches/module_dot_bazel_version.patch
+++ b/modules/gcc_toolchain/0.9.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,5 +1,7 @@
+-module(name = "gcc_toolchain")
++module(name = "gcc_toolchain",
++    version = "0.9.0",
++)
+ 
+ # Dependencies
+ # ============
+ bazel_dep(name = "bazel_skylib", version = "1.8.1")

--- a/modules/gcc_toolchain/0.9.0/presubmit.yml
+++ b/modules/gcc_toolchain/0.9.0/presubmit.yml
@@ -1,0 +1,14 @@
+bcr_test_module:
+  module_path: examples/bzlmod
+  matrix:
+    platform: ["ubuntu2204"]
+    bazel: [7.x, 8.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--enable_bzlmod"
+      test_targets:
+        - "//..."

--- a/modules/gcc_toolchain/0.9.0/source.json
+++ b/modules/gcc_toolchain/0.9.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-5qAKn5mbKbpO7gv3P3Sr7uwcuFdAyMGXqL+omnPnIrA=",
+    "strip_prefix": "gcc-toolchain-0.9.0",
+    "url": "https://github.com/f0rmiga/gcc-toolchain/releases/download/0.9.0/gcc-toolchain-0.9.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-YI0RfCICLBAgR3yr4RKEmy19vKhdh5c3udmn/Rw9DSw="
+    },
+    "patch_strip": 1
+}

--- a/modules/gcc_toolchain/metadata.json
+++ b/modules/gcc_toolchain/metadata.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://github.com/f0rmiga/gcc-toolchain",
+    "maintainers": [
+        {
+            "name": "Thulio Feraz Assis",
+            "email": "3149049+f0rmiga@users.noreply.github.com",
+            "github": "f0rmiga",
+            "github_user_id": 3149049
+        },
+        {
+            "name": "Borja Lorente",
+            "email": "borja@bytebard.software",
+            "github": "blorente",
+            "github_user_id": 5861182
+        }
+    ],
+    "repository": [
+        "github:f0rmiga/gcc-toolchain"
+    ],
+    "versions": [
+        "0.9.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/f0rmiga/gcc-toolchain/releases/tag/0.9.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_