### PR TITLE
Add fmt 11.2.0.bcr.1

### DIFF
--- a/modules/fmt/11.2.0.bcr.1/MODULE.bazel
+++ b/modules/fmt/11.2.0.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "fmt",
+    version = "11.2.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 10,
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/fmt/11.2.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/fmt/11.2.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+)
+
+exports_files([
+    "LICENSE",
+])
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "LICENSE",
+)
+
+cc_library(
+    name = "fmt",
+    srcs = [
+        #"src/fmt.cc", # No C++ module support, yet in Bazel (https://github.com/bazelbuild/bazel/pull/19940)
+        "src/format.cc",
+        "src/os.cc",
+    ],
+    hdrs = glob([
+        "include/fmt/*.h",
+    ]),
+    copts = select({
+        "@rules_cc//cc/compiler:msvc-cl": ["-utf-8"],
+        "//conditions:default": [],
+    }),
+    includes = ["include"],
+    strip_include_prefix = "include",  # workaround: only needed on some macOS systems (see https://github.com/bazelbuild/bazel-central-registry/issues/1537)
+    visibility = ["//visibility:public"],
+)

--- a/modules/fmt/11.2.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/fmt/11.2.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/fmt/11.2.0.bcr.1/patches/f4345467fce7edbc6b36c3fa1cf197a67be617e2.patch
+++ b/modules/fmt/11.2.0.bcr.1/patches/f4345467fce7edbc6b36c3fa1cf197a67be617e2.patch
@@ -1,0 +1,43 @@
+From f4345467fce7edbc6b36c3fa1cf197a67be617e2 Mon Sep 17 00:00:00 2001
+From: Remy Jette <remy@remyjette.com>
+Date: Sat, 21 Jun 2025 07:28:14 -0700
+Subject: [PATCH] Fix compilation on clang-21 / libc++-21 (#4477)
+
+`<cstdlib>` was not being included, so malloc and free were only declared
+via transitive includes. Some includes changed in the latest libc++-21
+build which broke fmt.
+
+Also changed `malloc`/`free` to `std::malloc` and `std::free`, as
+putting those symbols in the global namespace is optional for the
+implementation when including `<cstdlib>`.
+---
+ include/fmt/format.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/include/fmt/format.h b/include/fmt/format.h
+index 721977119c71..8ee403e8c3e6 100644
+--- a/include/fmt/format.h
++++ b/include/fmt/format.h
+@@ -44,6 +44,7 @@
+ #  include <cmath>    // std::signbit
+ #  include <cstddef>  // std::byte
+ #  include <cstdint>  // uint32_t
++#  include <cstdlib>  // std::malloc, std::free
+ #  include <cstring>  // std::memcpy
+ #  include <limits>   // std::numeric_limits
+ #  include <new>      // std::bad_alloc
+@@ -744,12 +745,12 @@ template <typename T> struct allocator : private std::decay<void> {
+ 
+   T* allocate(size_t n) {
+     FMT_ASSERT(n <= max_value<size_t>() / sizeof(T), "");
+-    T* p = static_cast<T*>(malloc(n * sizeof(T)));
++    T* p = static_cast<T*>(std::malloc(n * sizeof(T)));
+     if (!p) FMT_THROW(std::bad_alloc());
+     return p;
+   }
+ 
+-  void deallocate(T* p, size_t) { free(p); }
++  void deallocate(T* p, size_t) { std::free(p); }
+ };
+ 
+ }  // namespace detail

--- a/modules/fmt/11.2.0.bcr.1/presubmit.yml
+++ b/modules/fmt/11.2.0.bcr.1/presubmit.yml
@@ -1,0 +1,28 @@
+matrix:
+  unix_platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2004_arm64
+    - ubuntu2204
+    - ubuntu2404
+  windows_test:
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  unix_test:
+    name: Verify build targets
+    platform: ${{ unix_platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@fmt//:fmt'
+  windows_test:
+    name: Verify build targets
+    platform: ${{ windows_test }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - --cxxopt=/utf-8
+    build_targets:
+      - '@fmt//:fmt'

--- a/modules/fmt/11.2.0.bcr.1/source.json
+++ b/modules/fmt/11.2.0.bcr.1/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://github.com/fmtlib/fmt/releases/download/11.2.0/fmt-11.2.0.zip",
+    "integrity": "sha256-ID606KoNdGxi2PkD31jgQZ43UVkbtT/5cQluqg69TsM=",
+    "strip_prefix": "fmt-11.2.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-+MjDLu/yMtLIecd3q7G4ccJVO3QOiNAMWpQJucAHd8o=",
+        "MODULE.bazel": "sha256-OpDFz8tGUBZr68bayMTrz8v2KfXPo2Jn4gjdZb6Ibuw="
+    },
+    "patches": {
+        "f4345467fce7edbc6b36c3fa1cf197a67be617e2.patch": "sha256-2qRN4MrRNwn5xmtioQvGIsnxhAT/QAKQ+gG0o1rpoiY="
+    },
+    "patch_strip": 1
+}

--- a/modules/fmt/metadata.json
+++ b/modules/fmt/metadata.json
@@ -6,6 +6,10 @@
             "github": "Vertexwahn",
             "github_user_id": 3775001,
             "name": "Julian Amann"
+        },
+        {
+            "github": "mering",
+            "github_user_id": 133344217
         }
     ],
     "repository": [
@@ -29,7 +33,8 @@
         "11.1.2",
         "11.1.3",
         "11.1.4",
-        "11.2.0"
+        "11.2.0",
+        "11.2.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
- Backport fmtlib/fmt@f4345467fce7edbc6b36c3fa1cf197a67be617e2 to fix warning `unterminated-string-initialization` in clang 21
- Add myself as maintainer as suggested by the current maintainer in https://github.com/bazelbuild/bazel-central-registry/pull/5736#issuecomment-3246727819