### PR TITLE
Add aom 3.12.1.bcr.1

### DIFF
--- a/modules/aom/3.12.1.bcr.1/MODULE.bazel
+++ b/modules/aom/3.12.1.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "aom",
+    version = "3.12.1.bcr.1",
+    bazel_compatibility = ['>=7.2.1'],
+)
+bazel_dep(name = "rules_foreign_cc", version = "0.15.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "nasm", version = "2.16.03.bcr.1")

--- a/modules/aom/3.12.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/aom/3.12.1.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@rules_license//rules:license.bzl", "license")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(["LICENSE"])
+
+license(
+    name = "license",
+    package_name = "aom",
+    license_kinds = [
+        "@rules_license//licenses/spdx:BSD-3-Clause",
+    ],
+    license_text = "LICENSE",
+    package_url = "https://aomedia.googlesource.com/aom",
+)
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+cmake(
+    name = "aom",
+    build_data = [
+        "@nasm",
+    ],
+    cache_entries = {
+        "BUILD_SHARED_LIBS": "OFF",
+        "ENABLE_DOCS": "OFF",
+        "ENABLE_EXAMPLES": "OFF",
+        "ENABLE_TESTS": "OFF",
+        "ENABLE_TOOLS": "OFF",
+    },
+    env = {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_BUILD_PARALLEL_LEVEL": "4",
+        "PATH": "$$PATH:$$(dirname $(execpath @nasm))",
+    },
+    lib_source = ":all_srcs",
+    out_static_libs = ["libaom.a"],
+)

--- a/modules/aom/3.12.1.bcr.1/overlay/MODULE.bazel
+++ b/modules/aom/3.12.1.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/aom/3.12.1.bcr.1/patches/af548f4167a174f64f09d149458dd950219972ac.patch
+++ b/modules/aom/3.12.1.bcr.1/patches/af548f4167a174f64f09d149458dd950219972ac.patch
@@ -1,0 +1,32 @@
+From af548f4167a174f64f09d149458dd950219972ac Mon Sep 17 00:00:00 2001
+From: Jerome Jiang <jianj@google.com>
+Date: Tue, 6 May 2025 10:58:05 -0400
+Subject: [PATCH] Fix length of kFileMagic
+
+Compiler warning from clang:
+
+warning: initializer-string for character array is too long
+array size is 8 but initializer has size 9
+(including the null terminating character);
+
+Change-Id: I571c73343a1f3e9594acedd8cf8365411e9cd054
+---
+ aom_dsp/grain_table.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/aom_dsp/grain_table.c b/aom_dsp/grain_table.c
+index 3ca875658b..6c525d9953 100644
+--- a/aom_dsp/grain_table.c
++++ b/aom_dsp/grain_table.c
+@@ -36,7 +36,7 @@
+ #include "aom_dsp/grain_table.h"
+ #include "aom_mem/aom_mem.h"
+ 
+-static const char kFileMagic[8] = "filmgrn1";
++static const char kFileMagic[8] = { 'f', 'i', 'l', 'm', 'g', 'r', 'n', '1' };
+ 
+ static void grain_table_entry_read(FILE *file,
+                                    struct aom_internal_error_info *error_info,
+-- 
+2.51.0.338.gd7d06c2dae-goog
+

--- a/modules/aom/3.12.1.bcr.1/presubmit.yml
+++ b/modules/aom/3.12.1.bcr.1/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@aom'

--- a/modules/aom/3.12.1.bcr.1/source.json
+++ b/modules/aom/3.12.1.bcr.1/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://storage.googleapis.com/aom-releases/libaom-3.12.1.tar.gz",
+    "integrity": "sha256-npd1GA3sff1hp54AvaOAnUOJGu5rLjMf9/JphiB+oi4=",
+    "strip_prefix": "libaom-3.12.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-YIIYGRlUkgAgud4Y3o2YLoKsjRE2zMcyvCdSHj6pHyM=",
+        "MODULE.bazel": "sha256-xTc63dyxRkoVAwKmxqI3ynaet+SmVeDJ0tYWLlOc6hM="
+    },
+    "patches": {
+        "af548f4167a174f64f09d149458dd950219972ac.patch": "sha256-etgrVpWK925Zq0LdDuqtbQPT5Tp8g1gZUgchTRb1+oI="
+    },
+    "patch_strip": 1
+}

--- a/modules/aom/metadata.json
+++ b/modules/aom/metadata.json
@@ -6,6 +6,10 @@
             "github": "faximan",
             "github_user_id": 207300,
             "name": "Alex Faxa"
+        },
+        {
+            "github": "mering",
+            "github_user_id": 133344217
         }
     ],
     "repository": [
@@ -13,7 +17,8 @@
         "https://storage.googleapis.com/aom-releases"
     ],
     "versions": [
-        "3.12.1"
+        "3.12.1",
+        "3.12.1.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
- Convert from patches to overlay
- Backport [`af548f4167a174f64f09d149458dd950219972ac`](https://aomedia.googlesource.com/aom/+/af548f4167a174f64f09d149458dd950219972ac) to fix warning `unterminated-string-initialization` in clang 21
- Add myself as maintainer