### PR TITLE
hermetic_clang_toolchain@1.0.1

### DIFF
--- a/modules/hermetic_clang_toolchain/1.0.1/MODULE.bazel
+++ b/modules/hermetic_clang_toolchain/1.0.1/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "hermetic_clang_toolchain",
+    version = "1.0.1",
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.2")
+bazel_dep(name = "platforms", version = "1.0.0")

--- a/modules/hermetic_clang_toolchain/1.0.1/presubmit.yml
+++ b/modules/hermetic_clang_toolchain/1.0.1/presubmit.yml
@@ -1,0 +1,12 @@
+---
+matrix:
+  platform: ["ubuntu2004"]
+  bazel: ["7.x", "8.x", "rolling"]
+tasks:
+  verify_targets:
+    name: "Verify toolchain can be registered"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@hermetic_clang_toolchain//clang_toolchain/..."
+      - "@hermetic_clang_toolchain//example:simple_test"

--- a/modules/hermetic_clang_toolchain/1.0.1/source.json
+++ b/modules/hermetic_clang_toolchain/1.0.1/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/FBorowiec/hermetic_clang_toolchain/releases/download/v1.0.1/hermetic_clang_toolchain-1.0.1.tar.gz",
+    "integrity": "sha256-t568oRvru41yjPj4NttrcRl51wwef9CAlt+Vgm2zJ2s=",
+    "strip_prefix": "hermetic_clang_toolchain-1.0.1"
+}

--- a/modules/hermetic_clang_toolchain/metadata.json
+++ b/modules/hermetic_clang_toolchain/metadata.json
@@ -7,11 +7,7 @@
             "github_user_id": 34371791
         }
     ],
-    "repository": [
-        "github:FBorowiec/hermetic_clang_toolchain"
-    ],
-    "versions": [
-        "1.0.0"
-    ],
+    "repository": ["github:FBorowiec/hermetic_clang_toolchain"],
+    "versions": ["1.0.0", "1.0.1"],
     "yanked_versions": {}
 }


### PR DESCRIPTION
The `hermetic_clang_toolchain` now allows for selecting different `clang` versions (17, 18, 19, 20, 21).

```starlark
bazel_dep(name = "hermetic_clang_toolchain", version = "1.0.1")

hermetic_clang = use_extension("@hermetic_clang_toolchain//clang_toolchain:hermetic_clang.bzl", "hermetic_clang_extension")
hermetic_clang.use(version = "21.1.0")
use_repo(hermetic_clang, "hermetic_clang")

register_toolchains("@hermetic_clang_toolchain//clang_toolchain:hermetic_clang_toolchain")
```