### PR TITLE
Add maintainers as code owners for everything but `/modules/`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Set code owners for everything except the "modules" directory, which has a bot that manages review requests.
+*          @bazelbuild/bcr-maintainers
+/modules/


### PR DESCRIPTION
This ensures that maintainers are notified of all infra changes even if they don't watch all activity.