### PR TITLE
feat(LZ4): Add version 1.10.0 with optional multithreaded CLI support

### DIFF
--- a/modules/lz4/1.10.0/MODULE.bazel
+++ b/modules/lz4/1.10.0/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "lz4",
+    version = "1.10.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")

--- a/modules/lz4/1.10.0/overlay/BUILD.bazel
+++ b/modules/lz4/1.10.0/overlay/BUILD.bazel
@@ -1,0 +1,68 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:private"])
+
+cc_library(
+    name = "lz4",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":lz4_core",
+        ":lz4_frame",
+        ":lz4_hc",
+        ":lz4_file",
+    ],
+)
+
+cc_library(
+    name = "lz4_core",
+    srcs = ["lib/lz4.c"],
+    hdrs = ["lib/lz4.h"],
+    strip_include_prefix = "lib",
+)
+
+cc_library(
+    name = "lz4_hc",
+    srcs = ["lib/lz4hc.c"],
+    hdrs = ["lib/lz4hc.h"],
+    strip_include_prefix = "lib",
+    deps = [
+        ":lz4_core",
+        ":lz4_internal",
+    ],
+)
+
+cc_library(
+    name = "lz4_file",
+    srcs = ["lib/lz4file.c"],
+    hdrs = ["lib/lz4file.h"],
+    strip_include_prefix = "lib",
+    deps = [":lz4_frame"],
+)
+
+cc_library(
+    name = "lz4_frame",
+    srcs = ["lib/lz4frame.c"],
+    hdrs = [
+        "lib/lz4frame.h",
+        "lib/lz4frame_static.h",
+    ],
+    strip_include_prefix = "lib",
+    deps = [
+        ":lz4_hc",
+        ":xxhash",
+    ],
+)
+
+cc_library(
+    name = "lz4_internal",
+    hdrs = ["lib/lz4.c"],
+    strip_include_prefix = "lib",
+)
+
+cc_library(
+    name = "xxhash",
+    srcs = ["lib/xxhash.c"],
+    hdrs = ["lib/xxhash.h"],
+    defines = ["XXH_NAMESPACE=LZ4_"],
+    strip_include_prefix = "lib",
+)

--- a/modules/lz4/1.10.0/overlay/MODULE.bazel
+++ b/modules/lz4/1.10.0/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/lz4/1.10.0/overlay/programs/BUILD.bazel
+++ b/modules/lz4/1.10.0/overlay/programs/BUILD.bazel
@@ -1,0 +1,57 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+package(default_visibility = ["//visibility:private"])
+
+bool_flag(
+    name = "multithreading",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "multithreading_on_windows",
+    flag_values = {":multithreading": "true"},
+    constraint_values = ["@platforms//os:windows"],
+)
+
+config_setting(
+    name = "multithreading_enabled",
+    flag_values = {":multithreading": "true"},
+)
+
+cc_binary(
+    name = "lz4",
+    srcs = [
+        "bench.c",
+        "bench.h",
+        "lorem.c",
+        "lorem.h",
+        "lz4cli.c",
+        "lz4conf.h",
+        "lz4io.c",
+        "lz4io.h",
+        "platform.h",
+        "threadpool.c",
+        "threadpool.h",
+        "timefn.c",
+        "timefn.h",
+        "util.c",
+        "util.h",
+    ],
+    visibility = ["//visibility:public"],
+    copts = select({
+        ":multithreading_on_windows": ["-DLZ4IO_MULTITHREAD=1"],
+        ":multithreading_enabled": [
+            "-DLZ4IO_MULTITHREAD=1",
+            "-pthread",
+        ],
+        "//conditions:default": ["-DLZ4IO_MULTITHREAD=0"],
+    }),
+    linkopts = select({
+        ":multithreading_on_windows": [],
+        ":multithreading_enabled": ["-pthread"],
+        "//conditions:default": [],
+    }),
+    deps = ["//:lz4"],
+)

--- a/modules/lz4/1.10.0/presubmit.yml
+++ b/modules/lz4/1.10.0/presubmit.yml
@@ -1,0 +1,25 @@
+matrix:
+  platform:
+    - debian11
+    - fedora40
+    - macos
+    - macos_arm64
+    - windows
+  bazel: [7.x, 8.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@lz4//:lz4"
+      - "@lz4//programs:lz4"
+  verify_multithreading_targets:
+    name: Verify build targets with multithreading
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@lz4//:lz4"
+      - "@lz4//programs:lz4"
+    build_flags:
+      - "--@lz4//programs:multithreading=true"

--- a/modules/lz4/1.10.0/source.json
+++ b/modules/lz4/1.10.0/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/lz4/lz4/releases/download/v1.10.0/lz4-1.10.0.tar.gz",
+    "integrity": "sha256-U3USkEdEs14jKRIFXM+Oxm12hjn/Or5XiNkNeS7F9Is=",
+    "strip_prefix": "lz4-1.10.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-1ZU9fi+y7BC7Z5B4NY5s/acZLWHe7twm1o/CZYingyQ=",
+        "MODULE.bazel": "sha256-3DEYXtnxjNBPpqkK5XhcOZPndj03ysUH8vgNcjfrznU=",
+        "programs/BUILD.bazel": "sha256-G//+Ysw/cPNGPqPuaiZM2GBnFofHb+vlZrsRT8XaQ+4="
+    },
+    "patch_strip": 0
+}

--- a/modules/lz4/README.md
+++ b/modules/lz4/README.md
@@ -1,0 +1,10 @@
+# LZ4
+
+## Features
+
+### Multithreading for the CLI Tool
+
+This module provides an option to build the `lz4` CLI tool with multithreading
+support. This feature is disabled by default on all platforms.
+
+It can be enabled with the `--@lz4//programs:multithreading=true` flag

--- a/modules/lz4/metadata.json
+++ b/modules/lz4/metadata.json
@@ -2,8 +2,10 @@
     "homepage": "https://github.com/lz4/lz4",
     "maintainers": [
         {
-            "email": "bcr-maintainers@bazel.build",
-            "name": "No Maintainer Specified"
+            "email": "206078155+daemoninstitute@users.noreply.github.com",
+            "github": "daemoninstitute",
+            "github_user_id": 206078155,
+            "name": "James Wilson"
         }
     ],
     "repository": [
@@ -12,7 +14,8 @@
     "versions": [
         "1.9.4",
         "1.9.4.bcr.1",
-        "1.9.4.bcr.2"
+        "1.9.4.bcr.2",
+        "1.10.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds multithreaded support for the CLI tool via the bool flag `--@lz4//programs:multithreading=true`. The multithreading feature is now disabled by default on all platforms, including Windows. This provides consistent behaviour but diverges slightly from the upstream build, which enables it by default on Windows. I have added a README to document this.

I have switched to overlay from patches, and the CI has been updated to more modern and varied runners. I have also included a multithreaded CI target.

As this module has no maintainer, I have added myself in `metadata.json`.