### PR TITLE
postgres@16.2.bcr.3: Fix missing header when building a program that uses libpq

### DIFF
--- a/modules/postgres/16.2.bcr.3/MODULE.bazel
+++ b/modules/postgres/16.2.bcr.3/MODULE.bazel
@@ -1,0 +1,13 @@
+"""https://www.postgresql.org/"""
+
+module(
+    name = "postgres",
+    version = "16.2.bcr.3",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "boringssl", version = "0.20241024.0")
+bazel_dep(name = "openssl", version = "3.3.1.bcr.6")

--- a/modules/postgres/16.2.bcr.3/overlay/BUILD.bazel
+++ b/modules/postgres/16.2.bcr.3/overlay/BUILD.bazel
@@ -1,0 +1,1278 @@
+"""PostgreSQL BUILD file."""
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+PG_VERSION_NUM = "160002"
+
+PG_MAJORVERSION_NUM = "16"
+
+PG_MINORVERSION_NUM = "2"
+
+write_file(
+    name = "pg_config_ext",
+    out = "src/include/pg_config_ext.h",
+    content = """\
+/* src/include/pg_config_ext.h.  Generated from Bazel.  */
+
+/* Define to the name of a signed 64-bit integer type. */
+#define PG_INT64_TYPE long int
+""".splitlines(),
+    newline = "unix",
+)
+
+write_file(
+    name = "pg_config_paths",
+    out = "src/include/pg_config_paths.h",
+    content = """\
+#define PGBINDIR "/usr/local/pgsql/bin"
+#define PGSHAREDIR "/usr/local/pgsql/share"
+#define SYSCONFDIR "/usr/local/pgsql/etc"
+#define INCLUDEDIR "/usr/local/pgsql/include"
+#define PKGINCLUDEDIR "/usr/local/pgsql/include"
+#define INCLUDEDIRSERVER "/usr/local/pgsql/include/server"
+#define LIBDIR "/usr/local/pgsql/lib"
+#define PKGLIBDIR "/usr/local/pgsql/lib"
+#define LOCALEDIR "/usr/local/pgsql/share/locale"
+#define DOCDIR "/usr/local/pgsql/share/doc/"
+#define HTMLDIR "/usr/local/pgsql/share/doc/"
+#define MANDIR "/usr/local/pgsql/share/man"
+""".splitlines(),
+    newline = "unix",
+)
+
+bool_flag(
+    name = "use_boringssl",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "use_boringssl_setting",
+    flag_values = {":use_boringssl": "True"},
+)
+
+write_file(
+    name = "pg_config",
+    out = "src/include/pg_config.h",
+    content = ["""\
+/* src/include/pg_config.h.  Generated from pg_config.h.in by configure.  */
+/* src/include/pg_config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+/* #undef AC_APPLE_UNIVERSAL_BUILD */
+
+/* The normal alignment of `double', in bytes. */
+#define ALIGNOF_DOUBLE 8
+
+/* The normal alignment of `int', in bytes. */
+#define ALIGNOF_INT 4
+
+/* The normal alignment of `long', in bytes. */
+#define ALIGNOF_LONG 8
+
+/* The normal alignment of `long long int', in bytes. */
+/* #undef ALIGNOF_LONG_LONG_INT */
+
+/* The normal alignment of `PG_INT128_TYPE', in bytes. */
+#define ALIGNOF_PG_INT128_TYPE 16
+
+/* The normal alignment of `short', in bytes. */
+#define ALIGNOF_SHORT 2
+
+/* Size of a disk block --- this also limits the size of a tuple. You can set
+   it bigger if you need bigger tuples (although TOAST should reduce the need
+   to have large tuples, since fields can be spread across multiple tuples).
+   BLCKSZ must be a power of 2. The maximum possible value of BLCKSZ is
+   currently 2^15 (32768). This is determined by the 15-bit widths of the
+   lp_off and lp_len fields in ItemIdData (see include/storage/itemid.h).
+   Changing BLCKSZ requires an initdb. */
+#define BLCKSZ 8192
+
+/* Saved arguments from configure */
+#define CONFIGURE_ARGS " '--without-icu' '--without-readline' '--without-zlib'"
+
+/* Define to the default TCP port number on which the server listens and to
+   which clients will try to connect. This can be overridden at run-time, but
+   it's convenient if your clients have the right default compiled in.
+   (--with-pgport=PORTNUM) */
+#define DEF_PGPORT 5432
+
+/* Define to the default TCP port number as a string constant. */
+#define DEF_PGPORT_STR "5432"
+
+/* Define to the file name extension of dynamically-loadable modules. */
+"""] + select({
+        "@platforms//os:macos": ["#define DLSUFFIX \".dylib\""],
+        "@platforms//os:windows": ["#define DLSUFFIX \".dll\""],
+        "//conditions:default": ["#define DLSUFFIX \".so\""],
+    }) + ["""
+
+/* Define to build with GSSAPI support. (--with-gssapi) */
+/* #undef ENABLE_GSS */
+
+/* Define to 1 if you want National Language Support. (--enable-nls) */
+/* #undef ENABLE_NLS */
+
+/* Define to 1 to build client libraries as thread-safe code.
+   (--enable-thread-safety) */
+#define ENABLE_THREAD_SAFETY 1
+
+/* Define to 1 if you have the `append_history' function. */
+/* #undef HAVE_APPEND_HISTORY */
+
+/* Define to 1 if you have the `ASN1_STRING_get0_data' function. */
+/* #undef HAVE_ASN1_STRING_GET0_DATA */
+
+/* Define to 1 if you want to use atomics if available. */
+#define HAVE_ATOMICS 1
+
+/* Define to 1 if you have the <atomic.h> header file. */
+/* #undef HAVE_ATOMIC_H */
+
+/* Define to 1 if you have the `backtrace_symbols' function. */
+#define HAVE_BACKTRACE_SYMBOLS 1
+
+/* Define to 1 if you have the `BIO_meth_new' function. */
+/* #undef HAVE_BIO_METH_NEW */
+
+/* Define to 1 if your compiler handles computed gotos. */
+#define HAVE_COMPUTED_GOTO 1
+
+/* Define to 1 if you have the `copyfile' function. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_COPYFILE 1"],
+        "//conditions:default": ["/* #undef HAVE_COPYFILE */"],
+    }) + ["""
+
+/* Define to 1 if you have the <copyfile.h> header file. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_COPYFILE_H 1"],
+        "//conditions:default": ["/* #undef HAVE_COPYFILE_H */"],
+    }) + ["""
+
+/* Define to 1 if you have the <crtdefs.h> header file. */
+/* #undef HAVE_CRTDEFS_H */
+
+/* Define to 1 if you have the `CRYPTO_lock' function. */
+/* #undef HAVE_CRYPTO_LOCK */
+
+/* Define to 1 if you have the declaration of `fdatasync', and to 0 if you
+   don't. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_DECL_FDATASYNC 0"],
+        "//conditions:default": ["#define HAVE_DECL_FDATASYNC 1"],
+    }) + ["""
+
+/* Define to 1 if you have the declaration of `F_FULLFSYNC', and to 0 if you
+   don't. */
+   """] + select({
+        "@platforms//os:macos": ["#define HAVE_DECL_F_FULLFSYNC 1"],
+        "//conditions:default": ["#define HAVE_DECL_F_FULLFSYNC 0"],
+    }) + ["""
+
+/* Define to 1 if you have the declaration of
+   `LLVMCreateGDBRegistrationListener', and to 0 if you don't. */
+/* #undef HAVE_DECL_LLVMCREATEGDBREGISTRATIONLISTENER */
+
+/* Define to 1 if you have the declaration of
+   `LLVMCreatePerfJITEventListener', and to 0 if you don't. */
+/* #undef HAVE_DECL_LLVMCREATEPERFJITEVENTLISTENER */
+
+/* Define to 1 if you have the declaration of `LLVMGetHostCPUFeatures', and to
+   0 if you don't. */
+/* #undef HAVE_DECL_LLVMGETHOSTCPUFEATURES */
+
+/* Define to 1 if you have the declaration of `LLVMGetHostCPUName', and to 0
+   if you don't. */
+/* #undef HAVE_DECL_LLVMGETHOSTCPUNAME */
+
+/* Define to 1 if you have the declaration of `LLVMOrcGetSymbolAddressIn', and
+   to 0 if you don't. */
+/* #undef HAVE_DECL_LLVMORCGETSYMBOLADDRESSIN */
+
+/* Define to 1 if you have the declaration of `posix_fadvise', and to 0 if you
+   don't. */
+   """] + select({
+        "@platforms//os:macos": ["#define HAVE_DECL_POSIX_FADVISE 1"],
+        "//conditions:default": ["#define HAVE_DECL_POSIX_FADVISE 0"],
+    }) + ["""
+
+/* Define to 1 if you have the declaration of `preadv', and to 0 if you don't.
+   */
+#define HAVE_DECL_PREADV 1
+
+/* Define to 1 if you have the declaration of `pwritev', and to 0 if you
+   don't. */
+#define HAVE_DECL_PWRITEV 1
+
+/* Define to 1 if you have the declaration of `strlcat', and to 0 if you
+   don't. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_DECL_STRLCAT 1"],
+        "//conditions:default": ["#define HAVE_DECL_STRLCAT 0"],
+    }) + ["""
+
+/* Define to 1 if you have the declaration of `strlcpy', and to 0 if you
+   don't. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_DECL_STRLCPY 1"],
+        "//conditions:default": ["#define HAVE_DECL_STRLCPY 0"],
+    }) + ["""
+
+/* Define to 1 if you have the declaration of `strnlen', and to 0 if you
+   don't. */
+#define HAVE_DECL_STRNLEN 1
+
+/* Define to 1 if you have the <editline/history.h> header file. */
+/* #undef HAVE_EDITLINE_HISTORY_H */
+
+/* Define to 1 if you have the <editline/readline.h> header file. */
+/* #undef HAVE_EDITLINE_READLINE_H */
+
+/* Define to 1 if you have the <execinfo.h> header file. */
+#define HAVE_EXECINFO_H 1
+
+/* Define to 1 if you have the `explicit_bzero' function. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_EXPLICIT_BZERO */"],
+        "//conditions:default": ["#define HAVE_EXPLICIT_BZERO 1"],
+    }) + ["""
+
+/* Define to 1 if fseeko (and presumably ftello) exists and is declared. */
+#define HAVE_FSEEKO 1
+
+/* Define to 1 if you have __atomic_compare_exchange_n(int *, int *, int). */
+#define HAVE_GCC__ATOMIC_INT32_CAS 1
+
+/* Define to 1 if you have __atomic_compare_exchange_n(int64 *, int64 *,
+   int64). */
+#define HAVE_GCC__ATOMIC_INT64_CAS 1
+
+/* Define to 1 if you have __sync_lock_test_and_set(char *) and friends. */
+#define HAVE_GCC__SYNC_CHAR_TAS 1
+
+/* Define to 1 if you have __sync_val_compare_and_swap(int *, int, int). */
+#define HAVE_GCC__SYNC_INT32_CAS 1
+
+/* Define to 1 if you have __sync_lock_test_and_set(int *) and friends. */
+#define HAVE_GCC__SYNC_INT32_TAS 1
+
+/* Define to 1 if you have __sync_val_compare_and_swap(int64 *, int64, int64).
+   */
+#define HAVE_GCC__SYNC_INT64_CAS 1
+
+/* Define to 1 if you have the `getifaddrs' function. */
+#define HAVE_GETIFADDRS 1
+
+/* Define to 1 if you have the `getopt' function. */
+#define HAVE_GETOPT 1
+
+/* Define to 1 if you have the <getopt.h> header file. */
+#define HAVE_GETOPT_H 1
+
+/* Define to 1 if you have the `getopt_long' function. */
+#define HAVE_GETOPT_LONG 1
+
+/* Define to 1 if you have the `getpeereid' function. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_GETPEEREID 1"],
+        "//conditions:default": ["/* #undef HAVE_GETPEEREID */"],
+    }) + ["""
+
+/* Define to 1 if you have the `getpeerucred' function. */
+/* #undef HAVE_GETPEERUCRED */
+
+/* Define to 1 if you have the <gssapi_ext.h> header file. */
+/* #undef HAVE_GSSAPI_EXT_H */
+
+/* Define to 1 if you have the <gssapi/gssapi_ext.h> header file. */
+/* #undef HAVE_GSSAPI_GSSAPI_EXT_H */
+
+/* Define to 1 if you have the <gssapi/gssapi.h> header file. */
+/* #undef HAVE_GSSAPI_GSSAPI_H */
+
+/* Define to 1 if you have the <gssapi.h> header file. */
+/* #undef HAVE_GSSAPI_H */
+
+/* Define to 1 if you have the <history.h> header file. */
+/* #undef HAVE_HISTORY_H */
+
+/* Define to 1 if you have the `history_truncate_file' function. */
+/* #undef HAVE_HISTORY_TRUNCATE_FILE */
+
+/* Define to 1 if you have the `HMAC_CTX_free' function. */
+/* #undef HAVE_HMAC_CTX_FREE */
+
+/* Define to 1 if you have the `HMAC_CTX_new' function. */
+/* #undef HAVE_HMAC_CTX_NEW */
+
+/* Define to 1 if you have the <ifaddrs.h> header file. */
+#define HAVE_IFADDRS_H 1
+
+/* Define to 1 if you have the `inet_aton' function. */
+#define HAVE_INET_ATON 1
+
+/* Define to 1 if you have the `inet_pton' function. */
+#define HAVE_INET_PTON 1
+
+/* Define to 1 if the system has the type `int64'. */
+/* #undef HAVE_INT64 */
+
+/* Define to 1 if the system has the type `int8'. */
+/* #undef HAVE_INT8 */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the global variable 'int opterr'. */
+#define HAVE_INT_OPTERR 1
+
+/* Define to 1 if you have the global variable 'int optreset'. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_INT_OPTRESET 1"],
+        "//conditions:default": ["/* #undef HAVE_INT_OPTRESET */"],
+    }) + ["""
+
+/* Define to 1 if you have the global variable 'int timezone'. */
+#define HAVE_INT_TIMEZONE 1
+
+/* Define to 1 if __builtin_constant_p(x) implies "i"(x) acceptance. */
+/* #undef HAVE_I_CONSTRAINT__BUILTIN_CONSTANT_P */
+
+/* Define to 1 if you have the `kqueue' function. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_KQUEUE 1"],
+        "//conditions:default": ["/* #undef HAVE_KQUEUE */"],
+    }) + ["""
+
+/* Define to 1 if you have the <langinfo.h> header file. */
+#define HAVE_LANGINFO_H 1
+
+/* Define to 1 if you have the `ldap_initialize' function. */
+/* #undef HAVE_LDAP_INITIALIZE */
+
+/* Define to 1 if you have the `crypto' library (-lcrypto). */
+/* #undef HAVE_LIBCRYPTO */
+
+/* Define to 1 if you have the `ldap' library (-lldap). */
+/* #undef HAVE_LIBLDAP */
+
+/* Define to 1 if you have the `lz4' library (-llz4). */
+/* #undef HAVE_LIBLZ4 */
+
+/* Define to 1 if you have the `m' library (-lm). */
+#define HAVE_LIBM 1
+
+/* Define to 1 if you have the `pam' library (-lpam). */
+/* #undef HAVE_LIBPAM */
+
+/* Define if you have a function readline library */
+/* #undef HAVE_LIBREADLINE */
+
+/* Define to 1 if you have the `selinux' library (-lselinux). */
+/* #undef HAVE_LIBSELINUX */
+
+/* Define to 1 if you have the `ssl' library (-lssl). */
+/* #undef HAVE_LIBSSL */
+
+/* Define to 1 if you have the `wldap32' library (-lwldap32). */
+/* #undef HAVE_LIBWLDAP32 */
+
+/* Define to 1 if you have the `xml2' library (-lxml2). */
+/* #undef HAVE_LIBXML2 */
+
+/* Define to 1 if you have the `xslt' library (-lxslt). */
+/* #undef HAVE_LIBXSLT */
+
+/* Define to 1 if you have the `z' library (-lz). */
+/* #undef HAVE_LIBZ */
+
+/* Define to 1 if you have the `zstd' library (-lzstd). */
+/* #undef HAVE_LIBZSTD */
+
+/* Define to 1 if the system has the type `locale_t'. */
+#define HAVE_LOCALE_T 1
+
+/* Define to 1 if `long int' works and is 64 bits. */
+#define HAVE_LONG_INT_64 1
+
+/* Define to 1 if `long long int' works and is 64 bits. */
+/* #undef HAVE_LONG_LONG_INT_64 */
+
+/* Define to 1 if you have the <mbarrier.h> header file. */
+/* #undef HAVE_MBARRIER_H */
+
+/* Define to 1 if you have the `mbstowcs_l' function. */
+/* #undef HAVE_MBSTOWCS_L */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `memset_s' function. */
+/* #undef HAVE_MEMSET_S */
+
+/* Define to 1 if you have the `mkdtemp' function. */
+#define HAVE_MKDTEMP 1
+
+/* Define to 1 if you have the `OPENSSL_init_ssl' function. */
+/* #undef HAVE_OPENSSL_INIT_SSL */
+
+/* Define to 1 if you have the <ossp/uuid.h> header file. */
+/* #undef HAVE_OSSP_UUID_H */
+
+/* Define to 1 if you have the <pam/pam_appl.h> header file. */
+/* #undef HAVE_PAM_PAM_APPL_H */
+
+/* Define to 1 if you have the `posix_fadvise' function. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_POSIX_FADVISE */"],
+        "//conditions:default": ["#define HAVE_POSIX_FADVISE 1"],
+    }) + ["""
+
+/* Define to 1 if you have the `posix_fallocate' function. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_POSIX_FALLOCATE */"],
+        "//conditions:default": ["#define HAVE_POSIX_FALLOCATE 1"],
+    }) + ["""
+
+/* Define to 1 if you have the `ppoll' function. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_PPOLL */"],
+        "//conditions:default": ["#define HAVE_PPOLL 1"],
+    }) + ["""
+
+/* Define if you have POSIX threads libraries and header files. */
+#define HAVE_PTHREAD 1
+
+/* Define to 1 if you have the `pthread_barrier_wait' function. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_PTHREAD_BARRIER_WAIT */"],
+        "//conditions:default": ["#define HAVE_PTHREAD_BARRIER_WAIT 1"],
+    }) + ["""
+
+/* Define to 1 if you have the `pthread_is_threaded_np' function. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_PTHREAD_IS_THREADED_NP 1"],
+        "//conditions:default": ["/* #undef HAVE_PTHREAD_IS_THREADED_NP */"],
+    }) + ["""
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#define HAVE_PTHREAD_PRIO_INHERIT 1
+
+/* Define to 1 if you have the <readline.h> header file. */
+/* #undef HAVE_READLINE_H */
+
+/* Define to 1 if you have the <readline/history.h> header file. */
+/* #undef HAVE_READLINE_HISTORY_H */
+
+/* Define to 1 if you have the <readline/readline.h> header file. */
+/* #undef HAVE_READLINE_READLINE_H */
+
+/* Define to 1 if you have the `rl_completion_matches' function. */
+/* #undef HAVE_RL_COMPLETION_MATCHES */
+
+/* Define to 1 if you have the global variable 'rl_completion_suppress_quote'.
+   */
+/* #undef HAVE_RL_COMPLETION_SUPPRESS_QUOTE */
+
+/* Define to 1 if you have the `rl_filename_completion_function' function. */
+/* #undef HAVE_RL_FILENAME_COMPLETION_FUNCTION */
+
+/* Define to 1 if you have the global variable 'rl_filename_quote_characters'.
+   */
+/* #undef HAVE_RL_FILENAME_QUOTE_CHARACTERS */
+
+/* Define to 1 if you have the global variable 'rl_filename_quoting_function'.
+   */
+/* #undef HAVE_RL_FILENAME_QUOTING_FUNCTION */
+
+/* Define to 1 if you have the `rl_reset_screen_size' function. */
+/* #undef HAVE_RL_RESET_SCREEN_SIZE */
+
+/* Define to 1 if you have the `rl_variable_bind' function. */
+/* #undef HAVE_RL_VARIABLE_BIND */
+
+/* Define to 1 if you have the <security/pam_appl.h> header file. */
+/* #undef HAVE_SECURITY_PAM_APPL_H */
+
+/* Define to 1 if you have the `setproctitle' function. */
+/* #undef HAVE_SETPROCTITLE */
+
+/* Define to 1 if you have the `setproctitle_fast' function. */
+/* #undef HAVE_SETPROCTITLE_FAST */
+
+/* Define to 1 if the system has the type `socklen_t'. */
+#define HAVE_SOCKLEN_T 1
+
+/* Define to 1 if you have spinlocks. */
+#define HAVE_SPINLOCKS 1
+
+/* Define to 1 if you have the `SSL_CTX_set_cert_cb' function. */
+/* #undef HAVE_SSL_CTX_SET_CERT_CB */
+
+/* Define to 1 if stdbool.h conforms to C99. */
+#define HAVE_STDBOOL_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `strchrnul' function. */
+#define HAVE_STRCHRNUL 1
+
+/* Define to 1 if you have the `strerror_r' function. */
+#define HAVE_STRERROR_R 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strlcat' function. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_STRLCAT 1"],
+        "//conditions:default": ["/* #undef HAVE_STRLCAT */"],
+    }) + ["""
+
+/* Define to 1 if you have the `strlcpy' function. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_STRLCPY 1"],
+        "//conditions:default": ["/* #undef HAVE_STRLCPY */"],
+    }) + ["""
+
+/* Define to 1 if you have the `strnlen' function. */
+#define HAVE_STRNLEN 1
+
+/* Define to 1 if you have the `strsignal' function. */
+#define HAVE_STRSIGNAL 1
+
+/* Define to 1 if the system has the type `struct option'. */
+#define HAVE_STRUCT_OPTION 1
+
+/* Define to 1 if `sa_len' is a member of `struct sockaddr'. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_STRUCT_SOCKADDR_SA_LEN 1"],
+        "//conditions:default": ["/* #undef HAVE_STRUCT_SOCKADDR_SA_LEN */"],
+    }) + ["""
+
+/* Define to 1 if `tm_zone' is a member of `struct tm'. */
+#define HAVE_STRUCT_TM_TM_ZONE 1
+
+/* Define to 1 if you have the `syncfs' function. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_SYNCFS */"],
+        "//conditions:default": ["#define HAVE_SYNCFS 1"],
+    }) + ["""
+
+/* Define to 1 if you have the `sync_file_range' function. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_SYNC_FILE_RANGE */"],
+        "//conditions:default": ["#define HAVE_SYNC_FILE_RANGE 1"],
+    }) + ["""
+
+/* Define to 1 if you have the syslog interface. */
+#define HAVE_SYSLOG 1
+
+/* Define to 1 if you have the <sys/epoll.h> header file. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_SYS_EPOLL_H */"],
+        "//conditions:default": ["#define HAVE_SYS_EPOLL_H 1"],
+    }) + ["""
+
+/* Define to 1 if you have the <sys/event.h> header file. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_SYS_EVENT_H 1"],
+        "//conditions:default": ["/* #undef HAVE_SYS_EVENT_H */"],
+    }) + ["""
+
+/* Define to 1 if you have the <sys/personality.h> header file. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_SYS_PERSONALITY_H */"],
+        "//conditions:default": ["#define HAVE_SYS_PERSONALITY_H 1"],
+    }) + ["""
+
+/* Define to 1 if you have the <sys/prctl.h> header file. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_SYS_PRCTL_H */"],
+        "//conditions:default": ["#define HAVE_SYS_PRCTL_H 1"],
+    }) + ["""
+
+/* Define to 1 if you have the <sys/procctl.h> header file. */
+/* #undef HAVE_SYS_PROCCTL_H */
+
+/* Define to 1 if you have the <sys/signalfd.h> header file. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_SYS_SIGNALFD_H */"],
+        "//conditions:default": ["#define HAVE_SYS_SIGNALFD_H 1"],
+    }) + ["""
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <sys/ucred.h> header file. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_SYS_UCRED_H 1"],
+        "//conditions:default": ["/* #undef HAVE_SYS_UCRED_H */"],
+    }) + ["""
+
+/* Define to 1 if you have the <termios.h> header file. */
+#define HAVE_TERMIOS_H 1
+
+/* Define to 1 if your compiler understands `typeof' or something similar. */
+#define HAVE_TYPEOF 1
+
+/* Define to 1 if you have the <ucred.h> header file. */
+/* #undef HAVE_UCRED_H */
+
+/* Define to 1 if the system has the type `uint64'. */
+/* #undef HAVE_UINT64 */
+
+/* Define to 1 if the system has the type `uint8'. */
+/* #undef HAVE_UINT8 */
+
+/* Define to 1 if the system has the type `union semun'. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_UNION_SEMUN 1"],
+        "//conditions:default": ["/* #undef HAVE_UNION_SEMUN */"],
+    }) + ["""
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the `uselocale' function. */
+#define HAVE_USELOCALE 1
+
+/* Define to 1 if you have BSD UUID support. */
+/* #undef HAVE_UUID_BSD */
+
+/* Define to 1 if you have E2FS UUID support. */
+/* #undef HAVE_UUID_E2FS */
+
+/* Define to 1 if you have the <uuid.h> header file. */
+/* #undef HAVE_UUID_H */
+
+/* Define to 1 if you have OSSP UUID support. */
+/* #undef HAVE_UUID_OSSP */
+
+/* Define to 1 if you have the <uuid/uuid.h> header file. */
+/* #undef HAVE_UUID_UUID_H */
+
+/* Define to 1 if your compiler knows the visibility("hidden") attribute. */
+#define HAVE_VISIBILITY_ATTRIBUTE 1
+
+/* Define to 1 if you have the `wcstombs_l' function. */
+"""] + select({
+        "@platforms//os:macos": ["#define HAVE_WCSTOMBS_L 1"],
+        "//conditions:default": ["/* #undef HAVE_WCSTOMBS_L */"],
+    }) + ["""
+
+/* Define to 1 if you have the `X509_get_signature_info' function. */
+/* #undef HAVE_X509_GET_SIGNATURE_INFO */
+
+/* Define to 1 if you have the `X509_get_signature_nid' function. */
+/* #undef HAVE_X509_GET_SIGNATURE_NID */
+
+/* Define to 1 if the assembler supports X86_64's POPCNTQ instruction. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE_X86_64_POPCNTQ */"],
+        "//conditions:default": ["#define HAVE_X86_64_POPCNTQ 1"],
+    }) + ["""
+
+/* Define to 1 if the system has the type `_Bool'. */
+#define HAVE__BOOL 1
+
+/* Define to 1 if your compiler understands __builtin_bswap16. */
+#define HAVE__BUILTIN_BSWAP16 1
+
+/* Define to 1 if your compiler understands __builtin_bswap32. */
+#define HAVE__BUILTIN_BSWAP32 1
+
+/* Define to 1 if your compiler understands __builtin_bswap64. */
+#define HAVE__BUILTIN_BSWAP64 1
+
+/* Define to 1 if your compiler understands __builtin_clz. */
+#define HAVE__BUILTIN_CLZ 1
+
+/* Define to 1 if your compiler understands __builtin_constant_p. */
+#define HAVE__BUILTIN_CONSTANT_P 1
+
+/* Define to 1 if your compiler understands __builtin_ctz. */
+#define HAVE__BUILTIN_CTZ 1
+
+/* Define to 1 if your compiler understands __builtin_frame_address. */
+#define HAVE__BUILTIN_FRAME_ADDRESS 1
+
+/* Define to 1 if your compiler understands __builtin_$op_overflow. */
+#define HAVE__BUILTIN_OP_OVERFLOW 1
+
+/* Define to 1 if your compiler understands __builtin_popcount. */
+#define HAVE__BUILTIN_POPCOUNT 1
+
+/* Define to 1 if your compiler understands __builtin_types_compatible_p. */
+#define HAVE__BUILTIN_TYPES_COMPATIBLE_P 1
+
+/* Define to 1 if your compiler understands __builtin_unreachable. */
+#define HAVE__BUILTIN_UNREACHABLE 1
+
+/* Define to 1 if you have the `_configthreadlocale' function. */
+/* #undef HAVE__CONFIGTHREADLOCALE */
+
+/* Define to 1 if you have __cpuid. */
+/* #undef HAVE__CPUID */
+
+/* Define to 1 if you have __get_cpuid. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef HAVE__GET_CPUID */"],
+        "//conditions:default": ["#define HAVE__GET_CPUID 1"],
+    }) + ["""
+
+/* Define to 1 if your compiler understands _Static_assert. */
+#define HAVE__STATIC_ASSERT 1
+
+/* Define to the appropriate printf length modifier for 64-bit ints. */
+#define INT64_MODIFIER "l"
+
+/* Define to 1 if `locale_t' requires <xlocale.h>. */
+"""] + select({
+        "@platforms//os:macos": ["#define LOCALE_T_IN_XLOCALE 1"],
+        "//conditions:default": ["/* #undef LOCALE_T_IN_XLOCALE */"],
+    }) + ["""
+
+/* Define as the maximum alignment requirement of any C data type. */
+#define MAXIMUM_ALIGNOF 8
+
+/* Define bytes to use libc memset(). */
+#define MEMSET_LOOP_LIMIT 1024
+
+/* Define to the OpenSSL API version in use. This avoids deprecation warnings
+   from newer OpenSSL versions. */
+/* #undef OPENSSL_API_COMPAT */
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "pgsql-bugs@lists.postgresql.org"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "PostgreSQL"
+
+/* Define to the full name and version of this package. */
+"""] + [
+        "#define PACKAGE_STRING \"PostgreSQL {major}.{minor}\"".format(
+            major = PG_MAJORVERSION_NUM,
+            minor = PG_MINORVERSION_NUM,
+        ),
+    ] + ["""
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "postgresql"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "https://www.postgresql.org/"
+
+/* Define to the version of this package. */
+"""] + [
+        "#define PACKAGE_VERSION \"{major}.{minor}\"".format(
+            major = PG_MAJORVERSION_NUM,
+            minor = PG_MINORVERSION_NUM,
+        ),
+    ] + ["""
+
+/* Define to the name of a signed 128-bit integer type. */
+#define PG_INT128_TYPE __int128
+
+/* Define to the name of a signed 64-bit integer type. */
+#define PG_INT64_TYPE long int
+
+/* Define to the name of the default PostgreSQL service principal in Kerberos
+   (GSSAPI). (--with-krb-srvnam=NAME) */
+#define PG_KRB_SRVNAM "postgres"
+
+/* PostgreSQL major version as a string */
+"""] + [
+        "#define PG_MAJORVERSION_NUM \"{}\"".format(PG_MAJORVERSION_NUM),
+    ] + ["""
+
+/* PostgreSQL major version number */
+"""] + [
+        "#define PG_MAJORVERSION_NUM {}".format(PG_MAJORVERSION_NUM),
+    ] + ["""
+
+/* PostgreSQL minor version number */
+"""] + [
+        "#define PG_MINORVERSION_NUM {}".format(PG_MINORVERSION_NUM),
+    ] + ["""
+
+/* Define to best printf format archetype, usually gnu_printf if available. */
+"""] + select({
+        "@platforms//os:macos": ["#define PG_PRINTF_ATTRIBUTE printf"],
+        "//conditions:default": ["#define PG_PRINTF_ATTRIBUTE gnu_printf"],
+    }) + ["""
+
+/* Define to 1 to use <stdbool.h> to define type bool. */
+#define PG_USE_STDBOOL 1
+
+/* PostgreSQL version as a string */
+"""] + [
+        "#define PG_VERSION \"{major}.{minor}\"".format(
+            major = PG_MAJORVERSION_NUM,
+            minor = PG_MINORVERSION_NUM,
+        ),
+    ] + ["""
+
+/* PostgreSQL version as a number */
+"""] + [
+        "#define PG_VERSION_NUM {}".format(PG_VERSION_NUM),
+    ] + ["""
+
+/* A string containing the version number, platform, and C compiler */
+"""] + select({
+        "@platforms//os:macos": ["#define PG_VERSION_STR \"PostgreSQL {major}.{minor} on aarch64-apple-darwin24.3.0, compiled by Bazel\"".format(
+            major = PG_MAJORVERSION_NUM,
+            minor = PG_MINORVERSION_NUM,
+        )],
+        "//conditions:default": ["#define PG_VERSION_STR \"PostgreSQL {major}.{minor} on x86_64-pc-linux-gnu, compiled by Bazel\"".format(
+            major = PG_MAJORVERSION_NUM,
+            minor = PG_MINORVERSION_NUM,
+        )],
+    }) + ["""
+
+/* Define to 1 to allow profiling output to be saved separately for each
+   process. */
+/* #undef PROFILE_PID_DIR */
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* RELSEG_SIZE is the maximum number of blocks allowed in one disk file. Thus,
+   the maximum size of a single file is RELSEG_SIZE * BLCKSZ; relations bigger
+   than that are divided into multiple files. RELSEG_SIZE * BLCKSZ must be
+   less than your OS' limit on file size. This is often 2 GB or 4GB in a
+   32-bit operating system, unless you have large file support enabled. By
+   default, we make the limit 1 GB to avoid any possible integer-overflow
+   problems within the OS. A limit smaller than necessary only means we divide
+   a large relation into more chunks than necessary, so it seems best to err
+   in the direction of a small limit. A power-of-2 value is recommended to
+   save a few cycles in md.c, but is not absolutely required. Changing
+   RELSEG_SIZE requires an initdb. */
+#define RELSEG_SIZE 131072
+
+/* The size of `bool', as computed by sizeof. */
+#define SIZEOF_BOOL 1
+
+/* The size of `long', as computed by sizeof. */
+#define SIZEOF_LONG 8
+
+/* The size of `off_t', as computed by sizeof. */
+#define SIZEOF_OFF_T 8
+
+/* The size of `size_t', as computed by sizeof. */
+#define SIZEOF_SIZE_T 8
+
+/* The size of `void *', as computed by sizeof. */
+#define SIZEOF_VOID_P 8
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to 1 if strerror_r() returns int. */
+"""] + select({
+        "@platforms//os:macos": ["#define STRERROR_R_INT 1"],
+        "//conditions:default": ["/* #undef STRERROR_R_INT */"],
+    }) + ["""
+
+/* Define to 1 to use ARMv8 CRC Extension. */
+"""] + select({
+        "@platforms//os:macos": ["#define USE_ARMV8_CRC32C 1"],
+        "//conditions:default": ["/* #undef USE_ARMV8_CRC32C */"],
+    }) + ["""
+
+/* Define to 1 to use ARMv8 CRC Extension with a runtime check. */
+/* #undef USE_ARMV8_CRC32C_WITH_RUNTIME_CHECK */
+
+/* Define to 1 to build with assertion checks. (--enable-cassert) */
+/* #undef USE_ASSERT_CHECKING */
+
+/* Define to 1 to build with Bonjour support. (--with-bonjour) */
+/* #undef USE_BONJOUR */
+
+/* Define to 1 to build with BSD Authentication support. (--with-bsd-auth) */
+/* #undef USE_BSD_AUTH */
+
+/* Define to build with ICU support. (--with-icu) */
+/* #undef USE_ICU */
+
+/* Define to 1 to build with LDAP support. (--with-ldap) */
+/* #undef USE_LDAP */
+
+/* Define to 1 to build with XML support. (--with-libxml) */
+/* #undef USE_LIBXML */
+
+/* Define to 1 to use XSLT support when building contrib/xml2.
+   (--with-libxslt) */
+/* #undef USE_LIBXSLT */
+
+/* Define to 1 to build with LLVM based JIT support. (--with-llvm) */
+/* #undef USE_LLVM */
+
+/* Define to 1 to build with LZ4 support. (--with-lz4) */
+/* #undef USE_LZ4 */
+
+/* Define to select named POSIX semaphores. */
+/* #undef USE_NAMED_POSIX_SEMAPHORES */
+
+/* Define to 1 to build with OpenSSL support. (--with-ssl=openssl) */
+/* #undef USE_OPENSSL */
+
+/* Define to 1 to build with PAM support. (--with-pam) */
+/* #undef USE_PAM */
+
+/* Define to 1 to use software CRC-32C implementation (slicing-by-8). */
+/* #undef USE_SLICING_BY_8_CRC32C */
+
+/* Define to 1 use Intel SSE 4.2 CRC instructions. */
+/* #undef USE_SSE42_CRC32C */
+
+/* Define to 1 to use Intel SSE 4.2 CRC instructions with a runtime check. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK */"],
+        "//conditions:default": ["#define USE_SSE42_CRC32C_WITH_RUNTIME_CHECK 1"],
+    }) + ["""
+
+/* Define to build with systemd support. (--with-systemd) */
+/* #undef USE_SYSTEMD */
+
+/* Define to select SysV-style semaphores. */
+"""] + select({
+        "@platforms//os:macos": ["#define USE_SYSV_SEMAPHORES 1"],
+        "//conditions:default": ["/* #undef USE_SYSV_SEMAPHORES */"],
+    }) + ["""
+
+/* Define to select SysV-style shared memory. */
+#define USE_SYSV_SHARED_MEMORY 1
+
+/* Define to select unnamed POSIX semaphores. */
+"""] + select({
+        "@platforms//os:macos": ["/* #undef USE_UNNAMED_POSIX_SEMAPHORES */"],
+        "//conditions:default": ["#define USE_UNNAMED_POSIX_SEMAPHORES 1"],
+    }) + ["""
+
+
+/* Define to select Win32-style semaphores. */
+/* #undef USE_WIN32_SEMAPHORES */
+
+/* Define to select Win32-style shared memory. */
+/* #undef USE_WIN32_SHARED_MEMORY */
+
+/* Define to 1 to build with ZSTD support. (--with-zstd) */
+/* #undef USE_ZSTD */
+
+/* Define to 1 if `wcstombs_l' requires <xlocale.h>. */
+"""] + select({
+        "@platforms//os:macos": ["#define WCSTOMBS_L_IN_XLOCALE 1"],
+        "//conditions:default": ["/* #undef WCSTOMBS_L_IN_XLOCALE */"],
+    }) + ["""
+
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+/* #  undef WORDS_BIGENDIAN */
+# endif
+#endif
+
+/* Size of a WAL file block. This need have no particular relation to BLCKSZ.
+   XLOG_BLCKSZ must be a power of 2, and if your system supports O_DIRECT I/O,
+   XLOG_BLCKSZ must be a multiple of the alignment requirement for direct-I/O
+   buffers, else direct I/O may fail. Changing XLOG_BLCKSZ requires an initdb.
+   */
+#define XLOG_BLCKSZ 8192
+
+
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* Define to 1 to make fseeko visible on some hosts (e.g. glibc 2.2). */
+/* #undef _LARGEFILE_SOURCE */
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+/* #undef inline */
+#endif
+
+/* Define to keyword to use for C99 restrict support, or to nothing if not
+   supported */
+#define pg_restrict __restrict
+
+/* Define to the equivalent of the C99 'restrict' keyword, or to
+   nothing if this is not supported.  Do not define if restrict is
+   supported directly.  */
+#define restrict __restrict
+/* Work around a bug in Sun C++: it does not support _Restrict or
+   __restrict__, even though the corresponding Sun C compiler ends up with
+   "#define restrict _Restrict" or "#define restrict __restrict__" in the
+   previous line.  Perhaps some future version of Sun C++ will work with
+   restrict; if so, hopefully it defines __RESTRICT like Sun C does.  */
+#if defined __SUNPRO_CC && !defined __RESTRICT
+# define _Restrict
+# define __restrict__
+#endif
+
+/* Define to how the compiler spells `typeof'. */
+/* #undef typeof */
+"""],
+    newline = "unix",
+)
+
+copy_file(
+    name = "pg_config_os",
+    src = select({
+        "@platforms//os:linux": "src/include/port/linux.h",
+        "@platforms//os:macos": "src/include/port/darwin.h",
+        "@platforms//os:windows": "src/include/port/win32.h",
+    }),
+    out = "src/include/pg_config_os.h",
+)
+
+cc_library(
+    name = "include",
+    hdrs = [
+        ":src/include/pg_config.h",
+        ":src/include/pg_config_ext.h",
+        ":src/include/pg_config_os.h",
+        ":src/include/pg_config_paths.h",
+    ] + glob(["src/**/*.h"]),
+    includes = [
+        "src/common",
+        "src/include",
+    ],
+)
+
+LIBPORTS_BASE = [
+    "src/port/bsearch_arg.c",
+    "src/port/chklocale.c",
+    "src/port/inet_net_ntop.c",
+    "src/port/noblock.c",
+    "src/port/pg_bitutils.c",
+    "src/port/pg_crc32c_sb8.c",
+    "src/port/pg_strong_random.c",
+    "src/port/pgcheckdir.c",
+    "src/port/pgmkdirp.c",
+    "src/port/pgsleep.c",
+    "src/port/pgstrcasecmp.c",
+    "src/port/pgstrsignal.c",
+    "src/port/pqsignal.c",
+    "src/port/qsort.c",
+    "src/port/quotes.c",
+    "src/port/snprintf.c",
+    "src/port/strerror.c",
+    "src/port/strlcat.c",
+    "src/port/strlcpy.c",
+    "src/port/tar.c",
+]
+
+LIBPORTS_LINUX = [
+    "src/port/getpeereid.c",
+    "src/port/thread.c",
+]
+
+LIBPORTS_MACOS = [
+    "src/port/explicit_bzero.c",
+    "src/port/thread.c",
+]
+
+LIBPORTS_WINDOWS = [
+    "src/port/getpeereid.c",
+    "src/port/explicit_bzero.c",
+    "src/port/win32common.c",
+    "src/port/win32dlopen.c",
+    "src/port/win32env.c",
+    "src/port/win32error.c",
+    "src/port/win32fdatasync.c",
+    "src/port/win32fseek.c",
+    "src/port/win32getrusage.c",
+    "src/port/win32gettimeofday.c",
+    "src/port/win32link.c",
+    "src/port/win32ntdll.c",
+    "src/port/win32pread.c",
+    "src/port/win32pwrite.c",
+    "src/port/win32security.c",
+    "src/port/win32setlocale.c",
+    "src/port/win32stat.c",
+    "src/port/open.c",
+    "src/port/dirmod.c",
+]
+
+LIBPQ_PUBLIC_HDRS = [
+    "src/include/pg_config.h",
+    "src/include/pg_config_ext.h",
+    "src/include/pg_config_manual.h",
+    "src/include/postgres_ext.h",
+    "src/interfaces/libpq/fe-auth-sasl.h",
+    "src/include/postgres_fe.h",
+    "src/include/port.h",
+    "src/include/c.h",
+    "src/include/libpq/libpq-fs.h",
+    "src/include/libpq/pqcomm.h",
+    "src/interfaces/libpq/libpq-fe.h",
+    "src/interfaces/libpq/pqexpbuffer.h",
+    "src/interfaces/libpq/libpq-int.h",
+    "src/interfaces/libpq/libpq-events.h",
+]
+
+LIBCOMMON_BASE = [
+    "src/common/base64.c",
+    "src/common/encnames.c",
+    "src/common/fe_memutils.c",
+    "src/common/file_perm.c",
+    "src/common/ip.c",
+    "src/common/jsonapi.c",
+    "src/common/kwlookup.c",
+    "src/common/link-canary.c",
+    "src/common/logging.c",
+    "src/common/md5_common.c",
+    "src/common/md5.c",
+    "src/common/percentrepl.c",
+    "src/common/pg_get_line.c",
+    "src/common/pg_lzcompress.c",
+    "src/common/pg_prng.c",
+    "src/common/pgfnames.c",
+    "src/common/psprintf.c",
+    "src/common/restricted_token.c",
+    "src/common/rmtree.c",
+    "src/common/saslprep.c",
+    "src/common/scram-common.c",
+    "src/common/sha1.c",
+    "src/common/sha2.c",
+    "src/common/sprompt.c",
+    "src/common/string.c",
+    "src/common/stringinfo.c",
+    "src/common/unicode_norm.c",
+    "src/common/username.c",
+    "src/common/wait_error.c",
+    "src/common/wchar.c",
+]
+
+LIBCOMMON_NOT_WINDOWS = [
+    "src/common/cryptohash.c",
+    "src/common/hmac.c",
+]
+
+LIBCOMMON_WINDOWS = [
+    "src/common/cryptohash.c",
+    "src/common/hmac.c",
+]
+
+LIBPQ_BASE = [
+    "src/interfaces/libpq/fe-auth-scram.c",
+    "src/interfaces/libpq/fe-auth.c",
+    "src/interfaces/libpq/fe-connect.c",
+    "src/interfaces/libpq/fe-exec.c",
+    "src/interfaces/libpq/fe-lobj.c",
+    "src/interfaces/libpq/fe-misc.c",
+    "src/interfaces/libpq/fe-print.c",
+    "src/interfaces/libpq/fe-protocol3.c",
+    "src/interfaces/libpq/fe-secure.c",
+    "src/interfaces/libpq/fe-trace.c",
+    "src/interfaces/libpq/legacy-pqsignal.c",
+    "src/interfaces/libpq/libpq-events.c",
+    "src/interfaces/libpq/pqexpbuffer.c",
+]
+
+LIBPQ_NOT_WINDOWS = [
+    "src/interfaces/libpq/fe-secure-common.c",
+]
+
+LIBPQ_WINDOWS = [
+    "src/interfaces/libpq/pthread-win32.c",
+    "src/interfaces/libpq/win32.c",
+]
+
+cc_library(
+    name = "pq_ssl_lib",
+    defines = select({
+        ":use_boringssl_setting": [
+            "BAZEL_PQ_USE_BORINGSSL=1",
+        ],
+        "//conditions:default": [],
+    }),
+    tags = ["manual"],
+    deps = select({
+        ":use_boringssl_setting": [
+            "@boringssl//:crypto",
+            "@boringssl//:ssl",
+        ],
+        "//conditions:default": [
+            "@openssl//:crypto",
+            "@openssl//:ssl",
+        ],
+    }),
+)
+
+cc_library(
+    name = "pq",
+    srcs = select({
+        "@platforms//os:linux": LIBPQ_BASE + LIBPQ_NOT_WINDOWS + LIBCOMMON_BASE + LIBCOMMON_NOT_WINDOWS + LIBPORTS_BASE + LIBPORTS_LINUX,
+        "@platforms//os:macos": LIBPQ_BASE + LIBPQ_NOT_WINDOWS + LIBCOMMON_BASE + LIBCOMMON_NOT_WINDOWS + LIBPORTS_BASE + LIBPORTS_MACOS,
+        "@platforms//os:windows": LIBPQ_BASE + LIBPQ_WINDOWS + LIBCOMMON_BASE + LIBCOMMON_WINDOWS + LIBPORTS_BASE + LIBPORTS_WINDOWS,
+    }),
+    hdrs = LIBPQ_PUBLIC_HDRS,
+    implementation_deps = [
+        ":include",
+    ],
+    includes = [
+        "src/include",
+        "src/interfaces",
+    ],
+    linkopts = select({
+        "@platforms//os:windows": [
+            "Secur32",
+            "Shell32",
+        ],
+        "//conditions:default": [],
+    }),
+    linkstatic = True,
+    local_defines = [
+        "FRONTEND",
+    ] + select({
+        "@platforms//os:linux": [
+            "_GNU_SOURCE",
+        ],
+        "@platforms//os:macos": [
+            "_FORTIFY_SOURCE=0",
+        ],
+        "@platforms//os:windows": [
+            "WIN32",
+            "_WINDOWS",
+            "__WIN32__",
+            "__WINDOWS__",
+            "HAVE_SOCKLEN_T=1",
+        ],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":pq_ssl_lib"],
+)
+
+alias(
+    name = "libpq",
+    actual = ":pq",
+    visibility = ["//visibility:public"],
+)

--- a/modules/postgres/16.2.bcr.3/overlay/MODULE.bazel
+++ b/modules/postgres/16.2.bcr.3/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/postgres/16.2.bcr.3/overlay/example/BUILD.bazel
+++ b/modules/postgres/16.2.bcr.3/overlay/example/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
+cc_binary(
+    name = "example",
+    srcs = ["example.c"],
+    deps = [
+        "//:pq",
+    ],
+)

--- a/modules/postgres/16.2.bcr.3/overlay/example/example.c
+++ b/modules/postgres/16.2.bcr.3/overlay/example/example.c
@@ -1,0 +1,6 @@
+#include <libpq/libpq-fe.h>
+
+int main()
+{
+    return 0;
+}

--- a/modules/postgres/16.2.bcr.3/patches/boringssl.patch
+++ b/modules/postgres/16.2.bcr.3/patches/boringssl.patch
@@ -1,0 +1,36 @@
+diff --git a/src/include/common/openssl.h b/src/include/common/openssl.h
+index fcc5b50..688dc21 100644
+--- a/src/include/common/openssl.h
++++ b/src/include/common/openssl.h
+@@ -39,7 +39,7 @@
+ #endif
+ 
+ /* src/common/protocol_openssl.c */
+-#ifndef SSL_CTX_set_min_proto_version
++#if !defined(SSL_CTX_set_min_proto_version) && !defined(BAZEL_PQ_USE_BORINGSSL)
+ extern int	SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version);
+ extern int	SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version);
+ #endif
+diff --git a/src/interfaces/libpq/fe-secure-openssl.c b/src/interfaces/libpq/fe-secure-openssl.c
+index 5f34049..dcf2f18 100644
+--- a/src/interfaces/libpq/fe-secure-openssl.c
++++ b/src/interfaces/libpq/fe-secure-openssl.c
+@@ -1389,12 +1389,18 @@ open_client_SSL(PGconn *conn)
+ 							 * codes listed here, but a hint about protocol
+ 							 * versions seems like it's appropriate for all.
+ 							 */
++#ifndef BAZEL_PQ_USE_BORINGSSL
+ 						case SSL_R_NO_PROTOCOLS_AVAILABLE:
++#endif
+ 						case SSL_R_UNSUPPORTED_PROTOCOL:
++#ifndef BAZEL_PQ_USE_BORINGSSL
+ 						case SSL_R_BAD_PROTOCOL_VERSION_NUMBER:
++#endif
+ 						case SSL_R_UNKNOWN_PROTOCOL:
+ 						case SSL_R_UNKNOWN_SSL_VERSION:
++#ifndef BAZEL_PQ_USE_BORINGSSL
+ 						case SSL_R_UNSUPPORTED_SSL_VERSION:
++#endif
+ 						case SSL_R_WRONG_SSL_VERSION:
+ 						case SSL_R_WRONG_VERSION_NUMBER:
+ 						case SSL_R_TLSV1_ALERT_PROTOCOL_VERSION:

--- a/modules/postgres/16.2.bcr.3/presubmit.yml
+++ b/modules/postgres/16.2.bcr.3/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform: ["macos_arm64", "ubuntu2004"]
+    bazel: ["7.x", "8.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - //...

--- a/modules/postgres/16.2.bcr.3/source.json
+++ b/modules/postgres/16.2.bcr.3/source.json
@@ -1,0 +1,15 @@
+{
+    "url": "https://ftp.postgresql.org/pub/source/v16.2/postgresql-16.2.tar.gz",
+    "integrity": "sha256-K4IBBH7IGs0brSnbonjXiOeJG5w+gjLtoWuyneyBMcc=",
+    "strip_prefix": "postgresql-16.2",
+    "overlay": {
+        "BUILD.bazel": "sha256-TYOj00bOyV29UKqVfuzTjIaTfBQMgGKkGcKJITlj2ZA=",
+        "MODULE.bazel": "sha256-MzLpfrAL1/fZewIwj6ltohoONFnh4seiFzsrKggRoD0=",
+        "example/BUILD.bazel": "sha256-QnUAVrpmgbi0hiMwbXKYQzB3MarB/U+bjgFt6u/Wh5s=",
+        "example/example.c": "sha256-nVX03pLy0bRyhdAG6PAj9mcjAKj7bcbc3PjHbf9dBVU="
+    },
+    "patch_strip": 1,
+    "patches": {
+        "boringssl.patch": "sha256-/rKMvAxeZ6jM7YODyvkgr1CdjP6vCTu8pwKL6rZ29ME="
+    }
+}

--- a/modules/postgres/metadata.json
+++ b/modules/postgres/metadata.json
@@ -8,10 +8,7 @@
             "name": "UebelAndre"
         }
     ],
-    "repository": [
-        "https://ftp.postgresql.org/",
-        "github:postgres/postgres"
-    ],
+    "repository": ["https://ftp.postgresql.org/", "github:postgres/postgres"],
     "versions": [
         "14.18",
         "14.18.bcr.1",
@@ -21,7 +18,8 @@
         "14.18.bcr.5",
         "16.2",
         "16.2.bcr.1",
-        "16.2.bcr.2"
+        "16.2.bcr.2",
+        "16.2.bcr.3"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
When I attempt to use `bazel_dep(name = "postgres", version = "16.2.bcr.2")`, I get an error like this:

```
% bazel build --sandbox_debug --verbose_failures //example:example
INFO: Analyzed target //example:example (0 packages loaded, 0 targets configured).
ERROR: /Users/jhemphill/oss/bazel-central-registry/temp_test_repos/postgres/16.2.bcr.2/test_module/output/postgresql-16.2/example/BUILD.bazel:3:10: Compiling example/example.c failed: (Exit 1): sandbox-exec failed: error executing CppCompile command 
  (cd /private/var/tmp/_bazel_jhemphill/613e429a891d16ab2bacf2417ddcce71/sandbox/darwin-sandbox/1125/execroot/_main && \
  exec env - \
    PATH=<redacted> \
    PWD=/proc/self/cwd \
    TMPDIR=/var/folders/wr/v3z5smnj5kj1bmkbxh7fr1xr0000gn/T/ \
  /usr/bin/sandbox-exec -f /private/var/tmp/_bazel_jhemphill/613e429a891d16ab2bacf2417ddcce71/sandbox/darwin-sandbox/1125/sandbox.sb /var/tmp/_bazel_jhemphill/install/96e26d97222159f904e14600d7490eb0/process-wrapper '--timeout=0' '--kill_delay=15' '--stats=/private/var/tmp/_bazel_jhemphill/613e429a891d16ab2bacf2417ddcce71/sandbox/darwin-sandbox/1125/stats.out' external/rules_cc~~cc_configure_extension~local_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer '-frandom-seed=bazel-out/darwin_arm64-fastbuild/bin/example/_objs/example/example.o' '-mmacosx-version-min=10.11' -MD -MF bazel-out/darwin_arm64-fastbuild/bin/example/_objs/example/example.d -iquote . -iquote bazel-out/darwin_arm64-fastbuild/bin -iquote external/openssl~ -iquote bazel-out/darwin_arm64-fastbuild/bin/external/openssl~ -iquote external/rules_cc~ -iquote bazel-out/darwin_arm64-fastbuild/bin/external/rules_cc~ -iquote external/bazel_tools -iquote bazel-out/darwin_arm64-fastbuild/bin/external/bazel_tools -isystem src/include -isystem bazel-out/darwin_arm64-fastbuild/bin/src/include -isystem src/interfaces -isystem bazel-out/darwin_arm64-fastbuild/bin/src/interfaces -isystem external/openssl~/include -isystem bazel-out/darwin_arm64-fastbuild/bin/external/openssl~/include -c example/example.c -o bazel-out/darwin_arm64-fastbuild/bin/example/_objs/example/example.o -no-canonical-prefixes -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"')
In file included from example/example.c:1:
In file included from src/interfaces/libpq/libpq-fe.h:29:
src/include/postgres_ext.h:26:10: fatal error: 'pg_config_ext.h' file not found
   26 | #include "pg_config_ext.h"
      |          ^~~~~~~~~~~~~~~~~
1 error generated.
Target //example:example failed to build
INFO: Elapsed time: 0.261s, Critical Path: 0.15s
INFO: 3 processes: 3 internal.
ERROR: Build did NOT complete successfully
```

Since `pg_config_ext.h` is transitively included by the public header `libpq-fe.h`, it must be a public header as well.

I've added a minimal example to the `overlays` directory and `source.json`, so that this example will be built on presubmit. The minimal example fails to build when `pg_config_ext.h` is not in `LIBPQ_PUBLIC_HDRS` and succeeds when `pg_config_ext.h` is in `LIBPQ_PUBLIC_HDRS`.