### PR TITLE
Update maintainers for protovalidate

### DIFF
--- a/modules/protovalidate/metadata.json
+++ b/modules/protovalidate/metadata.json
@@ -6,12 +6,6 @@
             "email": "bcr-github@buf.build",
             "github": "bcr-buf",
             "github_user_id": 196968995
-        },
-        {
-            "name": "John Chadwick",
-            "email": "jchadwick@buf.build",
-            "github": "jchadwick-buf",
-            "github_user_id": 116005195
         }
     ],
     "repository": [


### PR DESCRIPTION
The removed user account is no longer active on GitHub.