### PR TITLE
feat: add `hiredis@1.3.0`

### DIFF
--- a/modules/hiredis/1.3.0/MODULE.bazel
+++ b/modules/hiredis/1.3.0/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "hiredis",
+    version = "1.3.0",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "libevent", version = "2.1.12-stable.bcr.0")
+bazel_dep(name = "libuv", version = "1.48.0")
+bazel_dep(name = "glib", version = "2.82.2.bcr.5")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.0")
+bazel_dep(name = "boringssl", version = "0.20250818.0")

--- a/modules/hiredis/1.3.0/overlay/BUILD.bazel
+++ b/modules/hiredis/1.3.0/overlay/BUILD.bazel
@@ -1,0 +1,62 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "hiredis",
+    srcs = [
+        "alloc.c",
+        "async.c",
+        "async_private.h",
+        "dict.h",
+        "fmacros.h",
+        "hiredis.c",
+        "net.c",
+        "net.h",
+        "read.c",
+        "sds.c",
+        "sdsalloc.h",
+        "sockcompat.c",
+        "win32.h",
+    ],
+    hdrs = [
+        "alloc.h",
+        "async.h",
+        "hiredis.h",
+        "read.h",
+        "sds.h",
+        "sockcompat.h",
+    ],
+    include_prefix = "hiredis",
+    local_defines = [
+        "_CRT_SECURE_NO_WARNINGS",
+        "WIN32_LEAN_AND_MEAN",
+    ],
+    textual_hdrs = [
+        "dict.c",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "hiredis_ssl",
+    srcs = [
+        "async_private.h",
+        "ssl.c",
+        "win32.h",
+    ],
+    hdrs = ["hiredis_ssl.h"],
+    include_prefix = "hiredis",
+    local_defines = [
+        "_CRT_SECURE_NO_WARNINGS",
+        "WIN32_LEAN_AND_MEAN",
+    ],
+    deps = [
+        ":hiredis",
+        "@boringssl//:ssl",
+    ],
+)
+
+alias(
+    name = "ssl",
+    actual = "hiredis_ssl",
+    visibility = ["//visibility:public"],
+)

--- a/modules/hiredis/1.3.0/overlay/MODULE.bazel
+++ b/modules/hiredis/1.3.0/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/hiredis/1.3.0/overlay/adapters/BUILD.bazel
+++ b/modules/hiredis/1.3.0/overlay/adapters/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "glib",
+    hdrs = ["glib.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:hiredis",
+        "@glib//glib",
+    ],
+)
+
+cc_library(
+    name = "libevent",
+    hdrs = ["libevent.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:hiredis",
+        "@libevent//:event",
+    ],
+)
+
+cc_library(
+    name = "libuv",
+    hdrs = ["libuv.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:hiredis",
+        "@libuv",
+    ],
+)
+
+cc_library(
+    name = "macosx",
+    hdrs = ["macosx.h"],
+    target_compatible_with = ["@platforms//os:macos"],
+    visibility = ["//visibility:public"],
+    deps = ["//:hiredis"],
+)
+
+cc_library(
+    name = "poll",
+    hdrs = ["poll.h"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = ["//:hiredis"],
+)

--- a/modules/hiredis/1.3.0/presubmit.yml
+++ b/modules/hiredis/1.3.0/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2404
+  - macos
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  validate:
+    name: Validate targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+      - '@hiredis'
+      - '@hiredis//:ssl'
+      - '@hiredis//adapters:all'

--- a/modules/hiredis/1.3.0/source.json
+++ b/modules/hiredis/1.3.0/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/redis/hiredis/archive/refs/tags/v1.3.0.tar.gz",
+    "integrity": "sha256-Jc7kUA81nPXK07Ue1iBZqt/Ak5sFFQwfGcfigpEjYxw=",
+    "strip_prefix": "hiredis-1.3.0",
+    "patch_strip": 0,
+    "overlay": {
+        "adapters/BUILD.bazel": "sha256-DV35jl5mgCP8tzDh3DvnjyeuaFD7XgEj4qjytmVtA18=",
+        "BUILD.bazel": "sha256-U6iyAUCk0xglymFhCvDELhHigRiBX95/qbiRYO9n5+4=",
+        "MODULE.bazel": "sha256-El9PN5OrkwpafgSsI2uPwEqIDlIk32kCQZDyS8qoXho="
+    }
+}

--- a/modules/hiredis/metadata.json
+++ b/modules/hiredis/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/redis/hiredis",
+    "maintainers": [
+        {
+            "github": "mattyclarkson",
+            "name": "Matt Clarkson",
+            "github_user_id": 1081113
+        }
+    ],
+    "repository": [
+        "github:redis/hiredis"
+    ],
+    "versions": [
+        "1.3.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
> Hiredis is a minimalistic C client library for the [Redis](https://redis.io/) database.
>
> It is minimalistic because it just adds minimal support for the protocol, but
> at the same time it uses a high level printf-alike API in order to make it
> much higher level than otherwise suggested by its minimal code base and the
> lack of explicit bindings for every Redis command.
>
> Apart from supporting sending commands and receiving replies, it comes with
> a reply parser that is decoupled from the I/O layer. It
> is a stream parser designed for easy reusability, which can for instance be used
> in higher level language bindings for efficient reply parsing.
>
> Hiredis only supports the binary-safe Redis protocol, so you can use it with any
> Redis version >= 1.2.0.
>
> The library comes with multiple APIs. There is the
> *synchronous API*, the *asynchronous API* and the *reply parsing API*.

As of `1.3.0` there is no stable release URL, just the GitHub release archive.