### PR TITLE
feat: add `ninjatracing`

### DIFF
--- a/modules/ninjatracing/0.0.0-a669e3644cf2/MODULE.bazel
+++ b/modules/ninjatracing/0.0.0-a669e3644cf2/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "ninjatracing",
+    version = "0.0.0-a669e3644cf2",
+    compatibility_level = 0,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_python", version = "1.0.0")

--- a/modules/ninjatracing/0.0.0-a669e3644cf2/overlay/BUILD.bazel
+++ b/modules/ninjatracing/0.0.0-a669e3644cf2/overlay/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+
+py_binary(
+    name = "ninjatracing",
+    srcs = [":ninjatracing.py"],
+    main = "ninjatracing.py",
+    visibility = ["//visibility:public"],
+)

--- a/modules/ninjatracing/0.0.0-a669e3644cf2/overlay/MODULE.bazel
+++ b/modules/ninjatracing/0.0.0-a669e3644cf2/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/ninjatracing/0.0.0-a669e3644cf2/patches/add-file-output.patch
+++ b/modules/ninjatracing/0.0.0-a669e3644cf2/patches/add-file-output.patch
@@ -1,0 +1,22 @@
+diff --git a/ninjatracing b/ninjatracing
+index 458b050..dd3242c 100755
+--- a/ninjatracing
++++ b/ninjatracing
+@@ -173,13 +173,16 @@ def main(argv):
+                         default=False, dest='embed_time_trace',
+                         help='embed clang -ftime-trace json file found '
+                              'adjacent to a target file')
++    parser.add_argument('--output', type=argparse.FileType('w'),
++                        default=sys.stdout, metavar='FILE',
++                        help='Output the trace to file instead.')
+     options = parser.parse_args()
+
+     entries = []
+     for pid, log_file in enumerate(options.logfiles):
+         with open(log_file, 'r') as log:
+             entries += list(log_to_dicts(log, pid, vars(options)))
+-    json.dump(entries, sys.stdout)
++    json.dump(entries, options.output)
+
+
+ if __name__ == '__main__':

--- a/modules/ninjatracing/0.0.0-a669e3644cf2/patches/argparse.patch
+++ b/modules/ninjatracing/0.0.0-a669e3644cf2/patches/argparse.patch
@@ -1,0 +1,90 @@
+From c96b6d39563e24c98721a9fcd41d43a0cdad9315 Mon Sep 17 00:00:00 2001
+From: Daniel Schmitz <40656107+dschmitz89@users.noreply.github.com>
+Date: Thu, 17 Aug 2023 20:52:15 +0200
+Subject: [PATCH 1/2] MAINT: replace `optparse` by `argparse`
+
+---
+ ninjatracing | 34 +++++++++++++++++-----------------
+ 1 file changed, 17 insertions(+), 17 deletions(-)
+
+diff --git a/ninjatracing b/ninjatracing
+index 60e6016..d220d96 100755
+--- a/ninjatracing
++++ b/ninjatracing
+@@ -25,7 +25,7 @@ Usage:
+
+ import json
+ import os
+-import optparse
++import argparse
+ import re
+ import sys
+
+@@ -158,22 +158,22 @@ def log_to_dicts(log, pid, options):
+
+ def main(argv):
+     usage = __doc__
+-    parser = optparse.OptionParser(usage)
+-    parser.add_option('-a', '--showall', action='store_true', dest='showall',
+-                      default=False,
+-                      help='report on last build step for all outputs. Default '
+-                      'is to report just on the last (possibly incremental) '
+-                      'build')
+-    parser.add_option('-g', '--granularity', type='int', default=50000,
+-                      dest='granularity',
+-                      help='minimum length time-trace event to embed in '
+-                      'microseconds. Default: %default')
+-    parser.add_option('-e', '--embed-time-trace', action='store_true',
+-                      default=False, dest='embed_time_trace',
+-                      help='embed clang -ftime-trace json file found adjacent '
+-                      'to a target file')
+-    (options, args) = parser.parse_args()
+-
++    parser = argparse.ArgumentParser(usage)
++    parser.add_argument("logfiles", nargs="*", help=argparse.SUPPRESS)
++    parser.add_argument('-a', '--showall', action='store_true',
++                        dest='showall', default=False,
++                        help='report on last build step for all outputs. '
++                              'Default is to report just on the last '
++                              '(possibly incremental) build')
++    parser.add_argument('-g', '--granularity', type=int, default=50000,
++                        dest='granularity',
++                        help='minimum length time-trace event to embed in '
++                             'microseconds. Default: 50000')
++    parser.add_argument('-e', '--embed-time-trace', action='store_true',
++                        default=False, dest='embed_time_trace',
++                        help='embed clang -ftime-trace json file found '
++                             'adjacent to a target file')
++    options = parser.parse_args()
+     if len(args) == 0:
+       print('Must specify at least one .ninja_log file')
+       parser.print_help()
+
+From 46fa3fa42e7df59f2d3ae01197afce1e97da8818 Mon Sep 17 00:00:00 2001
+From: Daniel Schmitz <40656107+dschmitz89@users.noreply.github.com>
+Date: Thu, 17 Aug 2023 20:53:37 +0200
+Subject: [PATCH 2/2] Fix incomplete update
+
+---
+ ninjatracing | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/ninjatracing b/ninjatracing
+index d220d96..458b050 100755
+--- a/ninjatracing
++++ b/ninjatracing
+@@ -174,13 +174,9 @@ def main(argv):
+                         help='embed clang -ftime-trace json file found '
+                              'adjacent to a target file')
+     options = parser.parse_args()
+-    if len(args) == 0:
+-      print('Must specify at least one .ninja_log file')
+-      parser.print_help()
+-      return 1
+
+     entries = []
+-    for pid, log_file in enumerate(args):
++    for pid, log_file in enumerate(options.logfiles):
+         with open(log_file, 'r') as log:
+             entries += list(log_to_dicts(log, pid, vars(options)))
+     json.dump(entries, sys.stdout)

--- a/modules/ninjatracing/0.0.0-a669e3644cf2/presubmit.yml
+++ b/modules/ninjatracing/0.0.0-a669e3644cf2/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform:
+  - debian11
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@ninjatracing'

--- a/modules/ninjatracing/0.0.0-a669e3644cf2/source.json
+++ b/modules/ninjatracing/0.0.0-a669e3644cf2/source.json
@@ -1,0 +1,14 @@
+{
+    "url": "https://github.com/nico/ninjatracing/archive/a669e3644cf22b29cbece31dbed2cfbf34e5f48e.tar.gz",
+    "integrity": "sha256-uEUDjwTNX4cvu54aUKFJTuiQOIBZ6G62wx7Di9BaPW8=",
+    "strip_prefix": "ninjatracing-a669e3644cf22b29cbece31dbed2cfbf34e5f48e",
+    "patch_strip": 1,
+    "patches": {
+        "argparse.patch": "sha256-bzJhzKkuCE5Vobf//f3tYLWICUWmrurG58SsFABnlD0=",
+        "add-file-output.patch": "sha256-ohXoyd4LsCbWtscMlVDFtAsroKytpl9g84j0yryLxwc="
+    },
+    "overlay": {
+        "BUILD.bazel": "sha256-raRi4ck7WSkg6JRizdiqpZNa1XFDCI91WBuwfoVTbTQ=",
+        "MODULE.bazel": "sha256-0uNedCqcWqY6EVt8o4FVt7doMA5vcPxi9zVS+ndJmSw="
+    }
+}

--- a/modules/ninjatracing/metadata.json
+++ b/modules/ninjatracing/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/nico/ninjatracing",
+    "maintainers": [
+        {
+            "email": "matthew.clarkson@arm.com",
+            "name": "Matt Clarkson",
+            "github": "mattyclarkson",
+            "github_user_id": 1081113
+        }
+    ],
+    "repository": [
+        "github:nico/ninjatracing"
+    ],
+    "versions": [
+        "0.0.0-a669e3644cf2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
No release tag, yet. Using latest SHA.

Needs a patch from the upstream PRs to update to `argparse`.

Adds a new `--output` argument to allow `ninjatracing` to be easily used with `ctx.actions.run`.