### PR TITLE
Update protovalidate maintainers

### DIFF
--- a/modules/protovalidate/metadata.json
+++ b/modules/protovalidate/metadata.json
@@ -6,6 +6,16 @@
             "email": "bcr-github@buf.build",
             "github": "bcr-buf",
             "github_user_id": 196968995
+        },
+        {
+            "name": "Timo Stamm",
+            "email": "tstamm@buf.build",
+            "github": "timostamm"
+        },
+        {
+            "name": "Sri Krishna Paritala",
+            "email": "skrishna@buf.build",
+            "github": "srikrsna-buf"
         }
     ],
     "repository": [


### PR DESCRIPTION
Following the update in the repo: https://github.com/bufbuild/protovalidate/blob/main/.bcr/metadata.template.json