### PR TITLE
Add libcpr

### DIFF
--- a/modules/cpr/1.12.0/MODULE.bazel
+++ b/modules/cpr/1.12.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "cpr",
+    version = "1.12.0",
+    bazel_compatibility = [">7.2.1"],
+)
+bazel_dep(name = "rules_cc", version = "0.2.8")
+bazel_dep(name = "curl", version = "8.8.0.bcr.3")

--- a/modules/cpr/1.12.0/overlay/BUILD.bazel
+++ b/modules/cpr/1.12.0/overlay/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+genrule(
+    name = "cprver_h",
+    outs = ["include/cpr/cprver.h"],
+    cmd = "echo -e '#pragma once\n#define CPR_VERSION \"{}\"' > $@".format(module_version()),
+)
+
+cc_library(
+    name = "cpr",
+    srcs = glob(["cpr/**/*.cpp"]),
+    hdrs = glob(["include/cpr/**/*.h"]) + [":cprver_h"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = ["@curl"],
+)

--- a/modules/cpr/1.12.0/overlay/MODULE.bazel
+++ b/modules/cpr/1.12.0/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/cpr/1.12.0/presubmit.yml
+++ b/modules/cpr/1.12.0/presubmit.yml
@@ -12,4 +12,5 @@ tasks:
   verify_targets:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
+    build_flags: ['--cxxopt=-std=c++17']
     build_targets: ["@cpr"]

--- a/modules/cpr/1.12.0/presubmit.yml
+++ b/modules/cpr/1.12.0/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004_arm64
+    - ubuntu2204
+    - ubuntu2404
+    - fedora40
+    - macos
+    - macos_arm64
+  bazel: [7.x, 8.x, latest]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets: ["@cpr"]

--- a/modules/cpr/1.12.0/source.json
+++ b/modules/cpr/1.12.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/libcpr/cpr/archive/refs/tags/1.12.0.tar.gz",
+    "integrity": "sha256-9ktQHeZuFj1qJ4+7apXzle6HO3pmyQXdeF6uEHJmpwk=",
+    "strip_prefix": "cpr-1.12.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-f7YhCNRSKG85v65sADKXuoinZHCUL+I/WePSrX664zc=",
+        "MODULE.bazel": "sha256-QFQGOqsE5sTBJDPySdza0qjFVsWmhSdd81q1nEeR4SU="
+    }
+}

--- a/modules/cpr/metadata.json
+++ b/modules/cpr/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/libcpr/cpr",
+    "maintainers": [
+        {
+            "email": "bcr@laure.nz",
+            "github": "lalten",
+            "github_user_id": 11611719,
+            "name": "lalten"
+        }
+    ],
+    "repository": [
+        "github:libcpr/cpr"
+    ],
+    "versions": [
+        "1.12.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add https://github.com/libcpr/cpr/releases/tag/1.12.0

Closes https://github.com/bazelbuild/bazel-central-registry/issues/599

There are some upstream efforts to add Bazel integration like https://github.com/libcpr/cpr/issues/1167, but this isn't landed or part of any release.
There is also https://github.com/hedronvision/bazel-make-cc-https-easy but that is Workspace only and unmaintained.

As far as I can see the existing work to Bazelize libcpr was mostly focused on getting curl to build or to use the host curl. This BCR module completely avoids that by just depending on the curl BCR module that exists now (it didn't when some of the previous work was done)