### PR TITLE
toolchains_cc@2025.9.18

### DIFF
--- a/modules/toolchains_cc/2025.9.18/MODULE.bazel
+++ b/modules/toolchains_cc/2025.9.18/MODULE.bazel
@@ -1,0 +1,34 @@
+"C/C++ toolchains for Bazel"
+
+module(
+    name = "toolchains_cc",
+    version = "2025.9.18",
+    bazel_compatibility = [">=7.0.0"],
+    compatibility_level = 0,
+)
+
+# ==================
+# || Dependencies ||
+# ==================
+bazel_dep(name = "rules_cc", version = "0.2.8")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# ======================
+# || Dev Dependencies ||
+# ======================
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
+
+# ===========================
+# || Convenience Toolchain ||
+# ===========================
+# For most use cases, this convenience toolchain is expected to be the only needed declaration.
+# While the convenience toolchain is declared by default, it's left up to the user to register it.
+cc_toolchains = use_extension("@toolchains_cc//:extensions.bzl", "cc_toolchains")
+cc_toolchains.declare(name = "toolchains_cc_default_toolchain")
+use_repo(cc_toolchains, "toolchains_cc_default_toolchain")
+
+register_toolchains(
+    "@toolchains_cc",
+    dev_dependency = True,
+)

--- a/modules/toolchains_cc/2025.9.18/presubmit.yml
+++ b/modules/toolchains_cc/2025.9.18/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform: ["ubuntu2004"]
+    bazel: ["7.x", "8.x"]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//tests:all"

--- a/modules/toolchains_cc/2025.9.18/source.json
+++ b/modules/toolchains_cc/2025.9.18/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-NpNmohYnb8SFsyLkIot3XtB6Fd6xm1tBR5BfdADkBZU=",
+    "strip_prefix": "",
+    "url": "https://github.com/reutermj/toolchains_cc/releases/download/2025.9.18/toolchains_cc-2025.9.18.tar.gz"
+}

--- a/modules/toolchains_cc/metadata.json
+++ b/modules/toolchains_cc/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/reutermj/toolchains_cc",
+    "maintainers": [
+        {
+            "name": "Mark Reuter",
+            "email": "13319190+reutermj@users.noreply.github.com",
+            "github": "reutermj",
+            "github_user_id": 13319190
+        }
+    ],
+    "repository": [
+        "github:reutermj/toolchains_cc"
+    ],
+    "versions": [
+        "2025.9.18"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/reutermj/toolchains_cc/releases/tag/2025.9.18

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_