### PR TITLE
Add ftpmirror.gnu.org to all gnu package mirror_urls

### DIFF
--- a/modules/gawk/5.3.2.bcr.1/source.json
+++ b/modules/gawk/5.3.2.bcr.1/source.json
@@ -1,6 +1,6 @@
 {
     "url": "https://ftp.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz"],
     "strip_prefix": "gawk-5.3.2",
     "integrity": "sha256-+MNIZQnecFGSE4sA7ywAu73Q6Eww1cB9I/xzqdxMycw=",
     "overlay": {

--- a/modules/gawk/5.3.2/source.json
+++ b/modules/gawk/5.3.2/source.json
@@ -1,6 +1,6 @@
 {
     "url": "https://ftp.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz"],
     "strip_prefix": "gawk-5.3.2",
     "integrity": "sha256-+MNIZQnecFGSE4sA7ywAu73Q6Eww1cB9I/xzqdxMycw=",
     "overlay": {

--- a/modules/glpk/5.0.bcr.1/source.json
+++ b/modules/glpk/5.0.bcr.1/source.json
@@ -1,6 +1,6 @@
 {
     "url": "http://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz"],
     "integrity": "sha256-ShAT7rtQ9yj8YBvdgzsLKHAzPDs+WoFu66kh2VvsbxU=",
     "strip_prefix": "glpk-5.0",
     "patches": {

--- a/modules/glpk/5.0.bcr.2/source.json
+++ b/modules/glpk/5.0.bcr.2/source.json
@@ -1,6 +1,6 @@
 {
     "url": "http://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz"],
     "integrity": "sha256-ShAT7rtQ9yj8YBvdgzsLKHAzPDs+WoFu66kh2VvsbxU=",
     "strip_prefix": "glpk-5.0",
     "patches": {

--- a/modules/glpk/5.0.bcr.3/source.json
+++ b/modules/glpk/5.0.bcr.3/source.json
@@ -1,6 +1,6 @@
 {
     "url": "http://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz"],
     "integrity": "sha256-ShAT7rtQ9yj8YBvdgzsLKHAzPDs+WoFu66kh2VvsbxU=",
     "strip_prefix": "glpk-5.0",
     "overlay": {

--- a/modules/glpk/5.0.bcr.4/source.json
+++ b/modules/glpk/5.0.bcr.4/source.json
@@ -1,6 +1,6 @@
 {
     "url": "https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz"],
     "integrity": "sha256-ShAT7rtQ9yj8YBvdgzsLKHAzPDs+WoFu66kh2VvsbxU=",
     "strip_prefix": "glpk-5.0",
     "overlay": {

--- a/modules/glpk/5.0/source.json
+++ b/modules/glpk/5.0/source.json
@@ -1,6 +1,6 @@
 {
     "url": "http://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz"],
     "integrity": "sha256-ShAT7rtQ9yj8YBvdgzsLKHAzPDs+WoFu66kh2VvsbxU=",
     "strip_prefix": "glpk-5.0",
     "patches": {

--- a/modules/gperf/3.1/source.json
+++ b/modules/gperf/3.1/source.json
@@ -1,6 +1,6 @@
 {
     "url": "http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/gperf/gperf-3.1.tar.gz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/gperf/gperf-3.1.tar.gz"],
     "integrity": "sha256-WIVGuUW7pLcLajphboC0q0ZuPzMCSjUvwhmBEs27OuI=",
     "strip_prefix": "gperf-3.1",
     "patches": {

--- a/modules/readline/8.2.bcr.1/source.json
+++ b/modules/readline/8.2.bcr.1/source.json
@@ -1,6 +1,6 @@
 {
     "url": "https://ftp.gnu.org/pub/gnu/readline/readline-8.2.tar.gz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/readline/readline-8.2.tar.gz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/readline/readline-8.2.tar.gz"],
     "strip_prefix": "readline-8.2",
     "integrity": "sha256-P+txcfFqhO6CyhijbXub4QmlLAT0kqBTMx19EJUAfDU=",
     "overlay": {

--- a/modules/readline/8.2.bcr.2/source.json
+++ b/modules/readline/8.2.bcr.2/source.json
@@ -1,6 +1,6 @@
 {
     "url": "https://ftp.gnu.org/pub/gnu/readline/readline-8.2.tar.gz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/readline/readline-8.2.tar.gz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/readline/readline-8.2.tar.gz"],
     "strip_prefix": "readline-8.2",
     "integrity": "sha256-P+txcfFqhO6CyhijbXub4QmlLAT0kqBTMx19EJUAfDU=",
     "overlay": {

--- a/modules/readline/8.2/source.json
+++ b/modules/readline/8.2/source.json
@@ -1,6 +1,6 @@
 {
     "url": "https://ftp.gnu.org/pub/gnu/readline/readline-8.2.tar.gz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/readline/readline-8.2.tar.gz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/readline/readline-8.2.tar.gz"],
     "strip_prefix": "readline-8.2",
     "integrity": "sha256-P+txcfFqhO6CyhijbXub4QmlLAT0kqBTMx19EJUAfDU=",
     "overlay": {

--- a/modules/sed/4.9.bcr.1/source.json
+++ b/modules/sed/4.9.bcr.1/source.json
@@ -1,6 +1,6 @@
 {
     "url": "https://ftp.gnu.org/gnu/sed/sed-4.9.tar.xz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.xz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.xz"],
     "strip_prefix": "sed-4.9",
     "integrity": "sha256-biJrcy4c1zlGStaGK9Ghq6QteYKSLaelNRljHSSXUYE=",
     "overlay": {

--- a/modules/sed/4.9.bcr.2/source.json
+++ b/modules/sed/4.9.bcr.2/source.json
@@ -1,6 +1,6 @@
 {
     "url": "https://ftp.gnu.org/gnu/sed/sed-4.9.tar.xz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.xz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.xz"],
     "strip_prefix": "sed-4.9",
     "integrity": "sha256-biJrcy4c1zlGStaGK9Ghq6QteYKSLaelNRljHSSXUYE=",
     "overlay": {

--- a/modules/sed/4.9/source.json
+++ b/modules/sed/4.9/source.json
@@ -1,6 +1,6 @@
 {
     "url": "https://ftp.gnu.org/gnu/sed/sed-4.9.tar.xz",
-    "mirror_urls": "https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.xz",
+    "mirror_urls": ["https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.xz"],
     "strip_prefix": "sed-4.9",
     "integrity": "sha256-biJrcy4c1zlGStaGK9Ghq6QteYKSLaelNRljHSSXUYE=",
     "overlay": {


### PR DESCRIPTION
ftp.gnu.org has been chronically under a ddos attack for the last few months. I figured the simplest fix was to add mirror_urls: ftpmirror.gnu.org/... to all existing gnu modules. I saw the other PR suggesting a new version. I leave it to the maintainers to decide which is cleaner.