### PR TITLE
mcap@2.0.2

### DIFF
--- a/modules/mcap/2.0.2/MODULE.bazel
+++ b/modules/mcap/2.0.2/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "mcap",
+    version = "2.0.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "lz4", version = "1.9.4")
+bazel_dep(name = "zstd", version = "1.5.6")

--- a/modules/mcap/2.0.2/overlay/BUILD.bazel
+++ b/modules/mcap/2.0.2/overlay/BUILD.bazel
@@ -1,0 +1,34 @@
+""" Builds mcap.
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "mcap",
+    hdrs = glob(
+        [
+            "include/**/*.inl",
+            "include/**/*.hpp",
+        ],
+        exclude = [
+            "include/mcap/reader.inl",
+            "include/mcap/types.inl",
+            "include/mcap/writer.inl",
+        ],
+    ),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    features = [
+        "parse_headers",
+    ],
+    textual_hdrs = [
+        "include/mcap/reader.inl",
+        "include/mcap/types.inl",
+        "include/mcap/writer.inl",
+    ],
+    copts = ["-std=c++17"],  # only needed for parse_headers
+    deps = [
+        "@lz4//:lz4_frame",
+        "@zstd//:zstd"
+    ],
+)

--- a/modules/mcap/2.0.2/overlay/MODULE.bazel
+++ b/modules/mcap/2.0.2/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/mcap/2.0.2/presubmit.yml
+++ b/modules/mcap/2.0.2/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - windows
+  bazel: [7.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@mcap'

--- a/modules/mcap/2.0.2/source.json
+++ b/modules/mcap/2.0.2/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/foxglove/mcap/archive/refs/tags/releases/cpp/v2.0.2.tar.gz",
+    "integrity": "sha256-r0T5K2L0O9S0SgByh4D5PfWWAVN9muu8hixMubWtdD4=",
+    "strip_prefix": "mcap-releases-cpp-v2.0.2/cpp/mcap",
+    "overlay": {
+        "BUILD.bazel": "sha256-UsMrgmIRqu9ZG/VJQ6hD6/B88NdEXBcHrJmdeEH7fvA=",
+        "MODULE.bazel": "sha256-UJ43r9hSXb6xmznmhtSw83Q8PtjueaRw5jzD0oroyEA="
+    },
+    "patch_strip": 0
+}

--- a/modules/mcap/metadata.json
+++ b/modules/mcap/metadata.json
@@ -1,18 +1,19 @@
 {
-  "homepage": "https://github.com/foxglove/mcap",
-  "maintainers": [
-    {
-      "email": "bcr-maintainers@bazel.build",
-      "name": "No Maintainer Specified"
-    }
-  ],
-  "repository": [
-    "github:foxglove/mcap"
-  ],
-  "versions": [
-    "0.8.0",
-    "1.2.1",
-    "1.4.0"
-  ],
-  "yanked_versions": {}
+    "homepage": "https://github.com/foxglove/mcap",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:foxglove/mcap"
+    ],
+    "versions": [
+        "0.8.0",
+        "1.2.1",
+        "1.4.0",
+        "2.0.2"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Add mcap 2.0.2. Followed mostly https://github.com/bazelbuild/bazel-central-registry/pull/2665.

PR needs  @bazel-io skip_check unstable_url because the release has no stable url available.