### PR TITLE
bazel_lib@3.0.0

### DIFF
--- a/modules/bazel_lib/3.0.0/MODULE.bazel
+++ b/modules/bazel_lib/3.0.0/MODULE.bazel
@@ -1,0 +1,84 @@
+module(
+    name = "bazel_lib",
+    bazel_compatibility = [">=6.0.0"],
+    compatibility_level = 1,
+    version = "3.0.0",
+)
+
+# Lower-bounds (minimum) versions for direct runtime dependencies
+bazel_dep(name = "bazel_features", version = "1.9.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "stardoc", version = "0.7.1")
+bazel_dep(name = "rules_shell", version = "0.4.1")
+
+bazel_lib_toolchains = use_extension("@bazel_lib//lib:extensions.bzl", "toolchains")
+bazel_lib_toolchains.copy_directory()
+bazel_lib_toolchains.copy_to_directory()
+bazel_lib_toolchains.coreutils()
+bazel_lib_toolchains.zstd()
+bazel_lib_toolchains.expand_template()
+bazel_lib_toolchains.bats()
+use_repo(bazel_lib_toolchains, "bats_toolchains", "copy_directory_toolchains", "copy_to_directory_toolchains", "coreutils_toolchains", "expand_template_toolchains", "zstd_toolchains")
+
+register_toolchains(
+    "@copy_directory_toolchains//:all",
+    "@copy_to_directory_toolchains//:all",
+    "@coreutils_toolchains//:all",
+    "@expand_template_toolchains//:all",
+    "@bats_toolchains//:all",
+    "@zstd_toolchains//:all",
+)
+
+####### Dev dependencies ########
+
+# To allow /tools to be built from source
+# NOTE: when publishing to BCR, we patch this to be dev_dependency, as we publish pre-built binaries
+# along with our releases.
+
+bazel_dep(
+    name = "gazelle",
+    version = "0.40.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "rules_go",
+    version = "0.55.0",
+    repo_name = "io_bazel_rules_go",
+    dev_dependency = True,
+)
+
+go_sdk = use_extension(
+    "@io_bazel_rules_go//go:extensions.bzl",
+    "go_sdk",
+    dev_dependency = True,
+)
+go_sdk.from_file(go_mod = "//:go.mod")
+
+go_deps = use_extension(
+    "@gazelle//:extensions.bzl",
+    "go_deps",
+    dev_dependency = True,
+)
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bmatcuk_doublestar_v4",
+    "org_golang_x_exp",
+    "org_golang_x_sys",
+)
+
+host = use_extension("@bazel_lib//lib:extensions.bzl", "host", dev_dependency = True)
+host.host()
+use_repo(host, "bazel_lib_host")
+
+host_platform = use_extension("@platforms//host:extension.bzl", "host_platform")
+use_repo(host_platform, "host_platform")
+
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.2", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
+bazel_dep(name = "external_test_repo", version = "0.0.0", dev_dependency = True)
+local_path_override(
+    module_name = "external_test_repo",
+    path = "./lib/tests/external_test_repo",
+)

--- a/modules/bazel_lib/3.0.0/attestations.json
+++ b/modules/bazel_lib/3.0.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0/source.json.intoto.jsonl",
+            "integrity": "sha256-7VXgY7CjE9mE1H/idRcKBVvx2FlWd21eHF1j/okPYEQ="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-LhBm9EyOSZy/HSPdGvEs5IcOQKeklclvMbLlPJJtWEg="
+        },
+        "bazel-lib-v3.0.0.tar.gz": {
+            "url": "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0/bazel-lib-v3.0.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-BzcRje7BLQc8Az43G7zDmAOT0om0WR4GCsSiiaXE0RU="
+        }
+    }
+}

--- a/modules/bazel_lib/3.0.0/patches/go_dev_dep.patch
+++ b/modules/bazel_lib/3.0.0/patches/go_dev_dep.patch
@@ -1,0 +1,35 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index eec026a..4854935 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -41,26 +41,26 @@ register_toolchains(
+ bazel_dep(
+     name = "gazelle",
+     version = "0.40.0",
+-    # In released versions: dev_dependency = True
++    dev_dependency = True,
+ )
+ bazel_dep(
+     name = "rules_go",
+     version = "0.55.0",
+     repo_name = "io_bazel_rules_go",
+-    # In released versions: dev_dependency = True
++    dev_dependency = True,
+ )
+
+ go_sdk = use_extension(
+     "@io_bazel_rules_go//go:extensions.bzl",
+     "go_sdk",
+-    # In released versions: dev_dependency = True
++    dev_dependency = True,
+ )
+ go_sdk.from_file(go_mod = "//:go.mod")
+
+ go_deps = use_extension(
+     "@gazelle//:extensions.bzl",
+     "go_deps",
+-    # In released versions: dev_dependency = True
++    dev_dependency = True,
+ )
+ go_deps.from_file(go_mod = "//:go.mod")
+ use_repo(

--- a/modules/bazel_lib/3.0.0/patches/module_dot_bazel_version.patch
+++ b/modules/bazel_lib/3.0.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,8 +1,9 @@
+ module(
+     name = "bazel_lib",
+     bazel_compatibility = [">=6.0.0"],
+     compatibility_level = 1,
++    version = "3.0.0",
+ )
+ 
+ # Lower-bounds (minimum) versions for direct runtime dependencies
+ bazel_dep(name = "bazel_features", version = "1.9.0")

--- a/modules/bazel_lib/3.0.0/presubmit.yml
+++ b/modules/bazel_lib/3.0.0/presubmit.yml
@@ -1,0 +1,15 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel:
+      - 6.x
+      - 7.x
+      - 8.x
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/bazel_lib/3.0.0/source.json
+++ b/modules/bazel_lib/3.0.0/source.json
@@ -1,0 +1,11 @@
+{
+    "integrity": "sha256-ZZXq7fo8inFCbkUO7VjOseq4wMYhXLud9grX3C5i0Eo=",
+    "strip_prefix": "bazel-lib-3.0.0",
+    "docs_url": "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0/bazel-lib-v3.0.0.docs.tar.gz",
+    "url": "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0/bazel-lib-v3.0.0.tar.gz",
+    "patches": {
+        "go_dev_dep.patch": "sha256-vfOhL71sEmANcXQEs5EkBuR/GuurhpE8KH5AexvJu/4=",
+        "module_dot_bazel_version.patch": "sha256-cKOg+XV7+4n7KPJQoSGzS6qZFqdyQ933FMI0SkCcWVw="
+    },
+    "patch_strip": 1
+}

--- a/modules/bazel_lib/metadata.json
+++ b/modules/bazel_lib/metadata.json
@@ -14,17 +14,18 @@
             "github_user_id": 4948761
         },
         {
-            "name": "Jason Bedard",
-            "email": "jason@aspect.build",
-            "github": "jbedard",
-            "github_user_id": 89246
+            "email": "fabian@buildbuddy.io",
+            "github": "fmeum",
+            "name": "Fabian Meumertzheim",
+            "github_user_id": 4312191
         }
     ],
     "repository": [
         "github:bazel-contrib/bazel-lib"
     ],
     "versions": [
-        "3.0.0-beta.1"
+        "3.0.0-beta.1",
+        "3.0.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/bazel-contrib/bazel-lib/releases/tag/v3.0.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_