### PR TITLE
Yank LZ4 1.10.0

### DIFF
--- a/modules/lz4/metadata.json
+++ b/modules/lz4/metadata.json
@@ -18,5 +18,7 @@
         "1.10.0",
         "1.10.0.bcr.1"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "1.10.0": "Contains an unintentional breaking change to build targets. Fixed in 1.10.0.bcr.1"
+    }
 }


### PR DESCRIPTION
Following on from Issue #5899 and PR #5922, this yanks `1.10.0` which can cause dependency build failures due to breaking changes in its refactored build targets