### PR TITLE
rules_gleam@0.1.11

### DIFF
--- a/modules/rules_gleam/0.1.11/MODULE.bazel
+++ b/modules/rules_gleam/0.1.11/MODULE.bazel
@@ -1,0 +1,45 @@
+module(
+    name = "rules_gleam",
+    version = "0.1.11",
+)
+
+bazel_dep(name = "rules_go", version = "0.57.0")
+bazel_dep(name = "gazelle", version = "0.45.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "rules_erlang", version = "3.16.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_features", version = "1.35.0")
+
+# single_version_override(
+#     module_name = "gazelle",
+#     patches = [
+#         "//:langs.go.diff",
+#     ],
+#     patch_strip = 1,
+#     version = "0.45.0"
+# )
+# Download a suitable Go SDK.
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+
+# go_sdk.download(version = "1.25.1")
+use_repo(go_sdk, "go_host_compatible_sdk_label")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(
+    fail_on_version_conflict = False,
+    go_mod = "//:go.mod",
+)
+use_repo(go_deps, "com_github_bazelbuild_buildtools", "com_github_bmatcuk_doublestar_v4", "com_github_burntsushi_toml", "com_github_google_go_cmp", "com_github_kr_pretty", "com_github_kr_text", "com_github_lithammer_dedent", "com_github_pmezard_go_difflib", "com_github_rogpeppe_go_internal", "org_golang_x_mod", "org_golang_x_sync", "org_golang_x_sys", "org_golang_x_tools_go_vcs")
+
+gleam = use_extension("//:extensions.bzl", "gleam")
+gleam.deps(gleam_toml = "//:gleam/gleeunit/gleam.toml")
+# Registers the default toolchain to be the latest
+# User of rules_gleam, can customize the default tool chains using the same extension tag:
+gleam.toolchain(version = "latest")
+
+register_toolchains("@gleam_toolchains//:all")
+use_repo(gleam, "gleam_hex_repositories_config", "hex_gleam_stdlib", "gleam_toolchains")
+
+# Internal tools
+gleam_tools = use_extension("//internal/tools:extensions.bzl", "tools")
+use_repo(gleam_tools, "rules_gleam_go_repository_cache", "rules_gleam_internal_tools")

--- a/modules/rules_gleam/0.1.11/attestations.json
+++ b/modules/rules_gleam/0.1.11/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/iocat/rules_gleam/releases/download/v0.1.11/source.json.intoto.jsonl",
+            "integrity": "sha256-org/mjA7n1R3O11ss44wMdkX0vq5EpUfyXHzVXFPNlw="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/iocat/rules_gleam/releases/download/v0.1.11/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-9DR9sPe41H4QarTsZp0sWb/glmdVDPQ9yjUP4d4MQ1g="
+        },
+        "rules_gleam-v0.1.11.tar.gz": {
+            "url": "https://github.com/iocat/rules_gleam/releases/download/v0.1.11/rules_gleam-v0.1.11.tar.gz.intoto.jsonl",
+            "integrity": "sha256-5NtlR4Td2ucyS8aqAlH71IAkLOAiEUbUS8tL7yj3TEU="
+        }
+    }
+}

--- a/modules/rules_gleam/0.1.11/patches/module_dot_bazel_version.patch
+++ b/modules/rules_gleam/0.1.11/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_gleam",
+-    version = "0.0.0",
++    version = "0.1.11",
+ )
+ 
+ bazel_dep(name = "rules_go", version = "0.57.0")
+ bazel_dep(name = "gazelle", version = "0.45.0")

--- a/modules/rules_gleam/0.1.11/presubmit.yml
+++ b/modules/rules_gleam/0.1.11/presubmit.yml
@@ -1,0 +1,14 @@
+# We recommend included a bcr test workspace that exercises your ruleset with bzlmod.
+# For an example, see https://github.com/aspect-build/bazel-lib/tree/main/e2e/bzlmod.
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204", "windows"]
+    bazel: [8.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_gleam/0.1.11/source.json
+++ b/modules/rules_gleam/0.1.11/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-Y2RM33jYwuS1buVSbZi83QBXk7o/yV5doVPJ9QLAqzE=",
+    "strip_prefix": "rules_gleam-0.1.11",
+    "url": "https://github.com/iocat/rules_gleam/releases/download/v0.1.11/rules_gleam-v0.1.11.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-29En4kz8YWguBudwH/6JshZKvl7BXMTiE4sYlJkOYuw="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_gleam/metadata.json
+++ b/modules/rules_gleam/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/iocat/rules_gleam",
+    "maintainers": [
+        {
+            "name": "Thanh Ngo",
+            "email": "nokotavi@gmail.com",
+            "github": "iocat",
+            "github_user_id": 11292829
+        }
+    ],
+    "repository": [
+        "github:iocat/rules_gleam"
+    ],
+    "versions": [
+        "0.1.11"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/iocat/rules_gleam/releases/tag/v0.1.11

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_