### PR TITLE
libzmq: Disable ALL warnings with `-w`

### DIFF
--- a/modules/libzmq/4.3.5.bcr.4/MODULE.bazel
+++ b/modules/libzmq/4.3.5.bcr.4/MODULE.bazel
@@ -1,0 +1,13 @@
+"""
+The ZeroMQ lightweight messaging kernel is a library which extends the 
+standard socket interfaces with features traditionally provided by 
+specialised messaging middleware products.
+"""
+
+module(
+    name = "libzmq",
+    version = "4.3.5.bcr.4",
+    compatibility_level = 4,
+)
+
+bazel_dep(name = "rules_foreign_cc", version = "0.14.0")

--- a/modules/libzmq/4.3.5.bcr.4/patches/add_build_file.patch
+++ b/modules/libzmq/4.3.5.bcr.4/patches/add_build_file.patch
@@ -1,0 +1,40 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,37 @@
++""" Builds libzmq.
++"""
++load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
++
++filegroup(
++    name = "srcs",
++    srcs = glob(
++        ["**"],
++        exclude = ["bazel-*"],
++    ),
++)
++
++cmake(
++    name = "libzmq",
++    cache_entries = {
++        # Perftools fail to link on some Linux distributions and turning off
++        # shared library build also disables perftools from building.
++        "BUILD_SHARED": "OFF",
++        # Tests fail to link on some Linux distributions.
++        "ZMQ_BUILD_TESTS": "OFF",
++        # Gnu TLS is not available in BCR.
++        "WITH_TLS": "OFF",
++    },
++    copts = ["-w"],
++    env = {"CMAKE_BUILD_TYPE": "Release"},
++    lib_source = ":srcs",
++    out_include_dir = "include",
++    out_static_libs = ["libzmq.a"],
++    visibility = ["//visibility:public"],
++)
++
++cc_library(
++    name = "libzmq_headers_only",
++    hdrs = glob(["include/*.h"]),
++    strip_include_prefix = "include",
++    visibility = ["//visibility:public"],
++)

--- a/modules/libzmq/4.3.5.bcr.4/patches/module_dot_bazel.patch
+++ b/modules/libzmq/4.3.5.bcr.4/patches/module_dot_bazel.patch
@@ -1,0 +1,16 @@
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,13 @@
++"""
++The ZeroMQ lightweight messaging kernel is a library which extends the 
++standard socket interfaces with features traditionally provided by 
++specialised messaging middleware products.
++"""
++
++module(
++    name = "libzmq",
++    version = "4.3.5.bcr.4",
++    compatibility_level = 4,
++)
++
++bazel_dep(name = "rules_foreign_cc", version = "0.14.0")

--- a/modules/libzmq/4.3.5.bcr.4/presubmit.yml
+++ b/modules/libzmq/4.3.5.bcr.4/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  # - macos_arm64
+  # - windows
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@libzmq'

--- a/modules/libzmq/4.3.5.bcr.4/source.json
+++ b/modules/libzmq/4.3.5.bcr.4/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz",
+    "integrity": "sha256-ZlPvWRDxeVSGH+cjMuaLA8puTZxxYOs6jeWlqRO/q0M=",
+    "strip_prefix": "zeromq-4.3.5",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-IqHYkMo4PV3IIaI9f4DzIkkjO1jfvrbBpaQWvvj5u2Y=",
+        "module_dot_bazel.patch": "sha256-NaUxjaDMkr4fnUJ5mPgSYR5JlzFKzHUluL1pYw1LxL0="
+    }
+}

--- a/modules/libzmq/metadata.json
+++ b/modules/libzmq/metadata.json
@@ -1,19 +1,20 @@
 {
-  "homepage": "https://www.zeromq.org/",
-  "maintainers": [
-    {
-      "email": "bcr-maintainers@bazel.build",
-      "name": "No Maintainer Specified"
-    }
-  ],
-  "repository": [
-    "github:zeromq/libzmq"
-  ],
-  "versions": [
-    "4.3.5",
-    "4.3.5.bcr.1",
-    "4.3.5.bcr.2",
-    "4.3.5.bcr.3"
-  ],
-  "yanked_versions": {}
+    "homepage": "https://www.zeromq.org/",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:zeromq/libzmq"
+    ],
+    "versions": [
+        "4.3.5",
+        "4.3.5.bcr.1",
+        "4.3.5.bcr.2",
+        "4.3.5.bcr.3",
+        "4.3.5.bcr.4"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Even with something like this in .bazelrc:
```
common --per_file_copt=^external/@-w
common --host_per_file_copt=^external/@-w
```
it looks like some more recent version of rules_foreign_cc caused warnings to be emitted again.
This is an issue for people who compile with `-Werror` so let's just disable _all_ the warnings using `-w` since this is third-party software anyways.