### PR TITLE
feat: add `download_utils@1.2.1`

### DIFF
--- a/modules/download_utils/1.2.1/MODULE.bazel
+++ b/modules/download_utils/1.2.1/MODULE.bazel
@@ -1,0 +1,47 @@
+module(
+    name = "download_utils",
+    version = "1.2.1",
+    bazel_compatibility = [
+        ">=7.1.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+
+bazel_dep(name = "toolchain_utils", version = "1.0.2", dev_dependency = True)
+bazel_dep(name = "pre-commit", version = "1.0.9", dev_dependency = True)
+bazel_dep(name = "pre-commit-hooks", version = "1.1.0", dev_dependency = True)
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0", dev_dependency = True)
+
+# We have to avoid the `chmod`/`chown`/`id` unhermetic-ness
+# TODO: remove this when `ignore_root_user_error` is hermetic
+dev = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
+dev.toolchain(
+    # TODO: remove this when `ignore_root_user_error` is hermetic
+    # https://github.com/bazelbuild/rules_python/issues/2016
+    ignore_root_user_error = True,
+    python_version = "3.13",
+)
+
+separator = use_repo_rule("//lib:separator.bzl", "separator")
+
+separator(name = "separator")
+
+download = use_extension("//download/template:defs.bzl", "download_template")
+download.substitutions(
+    srcs = [
+        "//download/template:rust.json",
+        "//download/template:triplet.json",
+    ],
+)
+download.substitution(
+    key = "executable.extension",
+    match = "{os}",
+    select = {
+        "windows": ".exe",
+        "//conditions:default": "",
+    },
+)

--- a/modules/download_utils/1.2.1/presubmit.yml
+++ b/modules/download_utils/1.2.1/presubmit.yml
@@ -1,0 +1,20 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+      - 8.x
+    platform:
+      - debian11
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/download_utils/1.2.1/source.json
+++ b/modules/download_utils/1.2.1/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/download_utils/-/releases/v1.2.1/downloads/src.tar.gz",
+  "integrity": "sha512-BGQuCwLISZkzntqmnWLlYAWxCbXVsnoRZo4hxbnM4SVzMbhL/XjeaiFS25DKzs4UDkBqihcutfaFvZJ1DlTBwQ==",
+  "strip_prefix": "download_utils-v1.2.1"
+}

--- a/modules/download_utils/metadata.json
+++ b/modules/download_utils/metadata.json
@@ -9,12 +9,14 @@
     "1.0.0-beta.4",
     "1.0.0-beta.5",
     "1.0.1",
-    "1.2.0"
+    "1.2.0",
+    "1.2.1"
   ],
   "maintainers": [
     {
       "email": "matthew.clarkson@arm.com",
       "name": "Matt Clarkson",
+      "github": "mattyclarkson",
       "github_user_id": 1081113
     }
   ]


### PR DESCRIPTION
Bazel 9 support for `download_{archive,file,deb}@commands`.