### PR TITLE
feat: add `rules_patchelf@1.0.1`

### DIFF
--- a/modules/rules_patchelf/1.0.1/MODULE.bazel
+++ b/modules/rules_patchelf/1.0.1/MODULE.bazel
@@ -1,0 +1,28 @@
+module(
+    name = "rules_patchelf",
+    version = "1.0.1",
+    bazel_compatibility = [
+        ">=7.1.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "patchelf", version = "0.18.0")
+bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0", dev_dependency = True)
+bazel_dep(name = "toolchain_utils", version = "1.0.0-beta.18", dev_dependency = True)
+bazel_dep(name = "pre-commit", version = "1.0.9", dev_dependency = True)
+bazel_dep(name = "pre-commit-hooks", version = "1.3.1", dev_dependency = True)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    configure_coverage_tool = True,
+    # TODO: need hermetic `chmod`/`id`: https://github.com/bazelbuild/rules_python/pull/2024
+    ignore_root_user_error = True,
+    python_version = "3.13",
+)
+use_repo(python, python = "python_versions")

--- a/modules/rules_patchelf/1.0.1/presubmit.yml
+++ b/modules/rules_patchelf/1.0.1/presubmit.yml
@@ -1,0 +1,17 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+      - 8.x
+    platform:
+      - debian11
+      - ubuntu2204
+      - fedora39
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/rules_patchelf/1.0.1/source.json
+++ b/modules/rules_patchelf/1.0.1/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/rules_patchelf/-/releases/v1.0.1/downloads/src.tar.gz",
+  "integrity": "sha512-XFqX5C3qxdIcaPUDJcztJrWg2ofepn8+DLDT2H8ChWGdwhwKGrXqg9Lnr+byqUjMfKn3v1hfzFr5zsUFsm/dIw==",
+  "strip_prefix": "rules_patchelf-v1.0.1"
+}

--- a/modules/rules_patchelf/metadata.json
+++ b/modules/rules_patchelf/metadata.json
@@ -1,0 +1,17 @@
+{
+  "homepage": "https://gitlab.arm.com/bazel/rules_patchelf",
+  "repository": [
+    "https://gitlab.arm.com/bazel/rules_patchelf"
+  ],
+  "versions": [
+    "1.0.1"
+  ],
+  "maintainers": [
+    {
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson",
+      "github": "mattyclarkson",
+      "github_user_id": 1081113
+    }
+  ]
+}


### PR DESCRIPTION
> A Bazel ruleset for patching ELF binaries.

Add the following to `MODULE.bazel`:

```py
bazel_dep(name="rules_patchelf", version="...")
```

Use `patchelf_unpack` to unpack the downloaded packages and patch the ELF interpreter path:

```py
patchelf_unpack(
    name = "patched",
    # `rules_distroless#apt` extension is *highly* recommended
    srcs = ["@debian-bookworm-qemu//:packages"],
    filters = [
        "usr/share/doc/**",       # No need to unpack documentation
        "lib64/ld-linux-*.so.?",  # Remove dangling symlink
    ],
)
```

Use `patchelf_launcher` to launch a binary from the unpacked directory:

```py
patchelf_launcher(
    name = "qemu-system-x86_64",
    srcs = [
        ":patched",
        "@rules_patchelf//patchelf/launcher/elf/interpreter/debian",
        "@rules_patchelf//patchelf/launcher/library/path/debian",
    ],
    env = {
        "TMPDIR": "./tmp",
    },
)
```

Run the binary:

```console
$ bazelisk run -- :qemu-system-x86_64 --version
QEMU emulator version 7.2.13 (Debian 1:7.2+dfsg-7+deb12u7)
Copyright (c) 2003-2022 Fabrice Bellard and the QEMU Project developers
```

The project uses `rules_python`. Enable `--@rules_python//python/config_settings:bootstrap_impl=script` to enable hermetic Python execution.

The project uses `patchelf`. Enable a hermetic C/C++ toolchain to build the `patchelf` binary. `hermetic_cc_toolchain` is one option.

Otherwise, the module is entirely hermetic.

[bcr]: https://registry.bazel.build/