### PR TITLE
toolchains_buildbuddy@0.0.2

### DIFF
--- a/modules/toolchains_buildbuddy/0.0.2/MODULE.bazel
+++ b/modules/toolchains_buildbuddy/0.0.2/MODULE.bazel
@@ -1,0 +1,35 @@
+module(
+    name = "toolchains_buildbuddy",
+    version = "0.0.2",
+    repo_name = "io_buildbuddy_buildbuddy_toolchain",
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_java", version = "8.16.1")
+bazel_dep(name = "platforms", version = "0.0.10")
+
+bazel_dep(
+    name = "rules_bazel_integration_test",
+    version = "0.34.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "buildifier_prebuilt",
+    version = "8.2.0.2",
+    dev_dependency = True,
+)
+
+buildbuddy = use_extension("//:extensions.bzl", "buildbuddy")
+use_repo(buildbuddy, "buildbuddy_toolchain")
+
+register_toolchains(
+    "//toolchains/cc:all",
+)
+
+bazel_binaries = use_extension(
+    "@rules_bazel_integration_test//:extensions.bzl",
+    "bazel_binaries",
+    dev_dependency = True,
+)
+bazel_binaries.download(version_file = "//:.bazelversion")
+use_repo(bazel_binaries, "bazel_binaries", "bazel_binaries_bazelisk", "build_bazel_bazel_.bazelversion")

--- a/modules/toolchains_buildbuddy/0.0.2/patches/module_dot_bazel_version.patch
+++ b/modules/toolchains_buildbuddy/0.0.2/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "toolchains_buildbuddy",
+-    version = "0.0.1",
++    version = "0.0.2",
+     repo_name = "io_buildbuddy_buildbuddy_toolchain",
+ )
+ 
+ bazel_dep(name = "rules_cc", version = "0.0.17")

--- a/modules/toolchains_buildbuddy/0.0.2/presubmit.yml
+++ b/modules/toolchains_buildbuddy/0.0.2/presubmit.yml
@@ -1,0 +1,14 @@
+# We recommend included a bcr test workspace that exercises your ruleset with bzlmod.
+# For an example, see https://github.com/aspect-build/bazel-lib/tree/main/e2e/bzlmod.
+bcr_test_module:
+  module_path: "examples/bzlmod"
+  matrix:
+    platform: ["ubuntu2004"]
+    bazel: [7.x]
+  tasks:
+    build_module:
+      name: "build module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."

--- a/modules/toolchains_buildbuddy/0.0.2/source.json
+++ b/modules/toolchains_buildbuddy/0.0.2/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-8a6zG52+4MM07qUI9oD6tcBreNUh8dvn1Cljwc3v6fM=",
+    "strip_prefix": "buildbuddy-toolchain-v0.0.2",
+    "url": "https://github.com/buildbuddy-io/buildbuddy-toolchain/releases/download/v0.0.2/buildbuddy-toolchain-v0.0.2.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-zRZXLPwPJep17DU44iOvdOU3oH/3+DxRqmEzdecT6WU="
+    },
+    "patch_strip": 1
+}

--- a/modules/toolchains_buildbuddy/metadata.json
+++ b/modules/toolchains_buildbuddy/metadata.json
@@ -18,7 +18,8 @@
         "github:buildbuddy-io/buildbuddy-toolchain"
     ],
     "versions": [
-        "0.0.1"
+        "0.0.1",
+        "0.0.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/buildbuddy-io/buildbuddy-toolchain/releases/tag/v0.0.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_
