### PR TITLE
picotool, pico-sdk: Update maintainers

### DIFF
--- a/modules/pico-sdk/metadata.json
+++ b/modules/pico-sdk/metadata.json
@@ -7,6 +7,11 @@
             "github_user_id": 21975658
         },
         {
+            "github": "davexroth",
+            "name": "Dave Roth",
+            "github_user_id": 49175007
+        },
+        {
             "github": "kilograham",
             "name": "Graham Sanderson",
             "github_user_id": 575810

--- a/modules/picotool/metadata.json
+++ b/modules/picotool/metadata.json
@@ -12,6 +12,15 @@
             "github": "armandomontanez",
             "name": "Armando Montanez",
             "github_user_id": 21975658
+        },
+        {
+            "github": "davexroth",
+            "name": "Dave Roth",
+            "github_user_id": 49175007
+        },
+        {
+            "email": "pigweed-team@googlegroups.com",
+            "name": "The Pigweed Team"
         }
     ],
     "repository": [


### PR DESCRIPTION
Add Dave Roth to Pico SDK and Picotool maintainers, and ensure the contact email address for the Pigweed team is in both lists.