### PR TITLE
Simple upgrades to Bzlmod migration tool

### DIFF
--- a/tools/migrate_to_bzlmod.py
+++ b/tools/migrate_to_bzlmod.py
@@ -537,9 +537,11 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
         python_version = match.group(1)
     else:
         important(
-            (f'{python_version} is used as a default python version.\n'
-             '\t\tIf you need a different version, please change it manually and then rerun the migration tool.\n'
-             '\t\tIf you\'re using `python_register_multi_toolchains`, add `python.toolchain` for each python version.')
+            (
+                f"{python_version} is used as a default python version.\n"
+                "\t\tIf you need a different version, please change it manually and then rerun the migration tool.\n"
+                "\t\tIf you're using `python_register_multi_toolchains`, add `python.toolchain` for each python version."
+            )
         )
 
     py_ext = f"""


### PR DESCRIPTION
* Fix regex so module name is the same as the workspace name
* Add note to users to add `python.toolchain()` call for each version in `python_register_multi_toolchains`. This is hard to select from the migration tool itself due to being visible only for "python_3_x_toolchains" targets in `resolved_deps` (these targets are not used directly in most of the cases).