### PR TITLE
Bump libx11 dep in ogre-next and bump ogre-next to 2.3.3.bcr.2

### DIFF
--- a/modules/ogre-next/2.3.3.bcr.2/MODULE.bazel
+++ b/modules/ogre-next/2.3.3.bcr.2/MODULE.bazel
@@ -1,0 +1,17 @@
+module(
+    name = "ogre-next",
+    version = "2.3.3.bcr.2",
+    compatibility_level = 0,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "egl-registry", version = "0.0.0-20250527")
+bazel_dep(name = "freeimage", version = "3.19.10.bcr.3")
+bazel_dep(name = "freetype", version = "2.13.3")
+bazel_dep(name = "libx11", version = "1.8.12.bcr.3")
+bazel_dep(name = "libxcb", version = "1.17.0.bcr.2")
+bazel_dep(name = "opengl-registry", version = "0.0.0-20250707")
+bazel_dep(name = "rapidjson", version = "1.1.0.bcr.20241007")
+bazel_dep(name = "rules_cc", version = "0.2.0")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/ogre-next/2.3.3.bcr.2/overlay/BUILD.bazel
+++ b/modules/ogre-next/2.3.3.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,421 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_license//rules:license.bzl", "license")
+
+license(
+    name = "license",
+    package_name = "ogre-next",
+)
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+expand_template(
+    name = "OgreBuildSettings",
+    out = "OgreMain/include/OgreBuildSettings.h",
+    substitutions = {
+        "#cmakedefine OGRE_STATIC_LIB": "/* undef OGRE_STATIC_LIB */",
+        "@OGRE_DEBUG_LEVEL_DEBUG@": "3",
+        "@OGRE_DEBUG_LEVEL_RELEASE@": "0",
+        "#cmakedefine OGRE_BUILD_RENDERSYSTEM_D3D11": "/* undef OGRE_BUILD_RENDERSYSTEM_D3D11 */",
+        "#cmakedefine OGRE_BUILD_RENDERSYSTEM_GL3PLUS": "#define OGRE_BUILD_RENDERSYSTEM_GL3PLUS 1",
+        # Order matters for the next two substitutions to avoid malformed directives
+        "#cmakedefine OGRE_BUILD_RENDERSYSTEM_GLES2": "/* undef OGRE_BUILD_RENDERSYSTEM_GLES2 */",
+        "#cmakedefine OGRE_BUILD_RENDERSYSTEM_GLES": "/* undef OGRE_BUILD_RENDERSYSTEM_GLES */",
+        "#cmakedefine OGRE_BUILD_RENDERSYSTEM_METAL": "/* undef OGRE_BUILD_RENDERSYSTEM_METAL */",
+        "#cmakedefine OGRE_BUILD_RENDERSYSTEM_VULKAN": "/* undef OGRE_BUILD_RENDERSYSTEM_VULKAN */",
+        "#cmakedefine OGRE_BUILD_PLUGIN_PFX": "#define OGRE_BUILD_PLUGIN_PFX 1",
+        "#cmakedefine OGRE_BUILD_COMPONENT_HLMS_PBS_MOBILE": "/* undef OGRE_BUILD_COMPONENT_HLMS_PBS_MOBILE */",
+        "#cmakedefine OGRE_BUILD_COMPONENT_HLMS_UNLIT_MOBILE": "/* undef OGRE_BUILD_COMPONENT_HLMS_UNLIT_MOBILE */",
+        "#cmakedefine OGRE_BUILD_COMPONENT_HLMS_PBS": "#define OGRE_BUILD_COMPONENT_HLMS_PBS 1",
+        "#cmakedefine OGRE_BUILD_COMPONENT_HLMS_UNLIT": "#define OGRE_BUILD_COMPONENT_HLMS_UNLIT 1",
+        "#cmakedefine OGRE_BUILD_COMPONENT_PAGING": "/* undef OGRE_BUILD_COMPONENT_PAGING */",
+        "#cmakedefine OGRE_BUILD_COMPONENT_PLANAR_REFLECTIONS": "/* undef OGRE_BUILD_COMPONENT_PLANAR_REFLECTIONS */",
+        "#cmakedefine OGRE_BUILD_COMPONENT_SCENE_FORMAT": "/* undef OGRE_BUILD_COMPONENT_SCENE_FORMAT */",
+        "#cmakedefine OGRE_BUILD_COMPONENT_MESHLODGENERATOR": "#define OGRE_BUILD_COMPONENT_MESHLODGENERATOR 1",
+        "#cmakedefine OGRE_BUILD_COMPONENT_TERRAIN": "/* undef OGRE_BUILD_COMPONENT_TERRAIN */",
+        "#cmakedefine OGRE_BUILD_COMPONENT_VOLUME": "/* undef OGRE_BUILD_COMPONENT_VOLUME */",
+        "#cmakedefine OGRE_BUILD_COMPONENT_PROPERTY": "/* undef OGRE_BUILD_COMPONENT_PROPERTY */",
+        "#cmakedefine OGRE_BUILD_COMPONENT_OVERLAY": "#define OGRE_BUILD_COMPONENT_OVERLAY 1",
+        "#cmakedefine OGRE_BUILD_COMPONENT_RTSHADERSYSTEM": "/* undef OGRE_BUILD_COMPONENT_RTSHADERSYSTEM */",
+        "#cmakedefine OGRE_CONFIG_LITTLE_ENDIAN": "#define OGRE_CONFIG_LITTLE_ENDIAN 1",
+        "#cmakedefine OGRE_CONFIG_BIG_ENDIAN": "/* undef OGRE_CONFIG_BIG_ENDIAN */",
+        "#cmakedefine OGRE_CONFIG_UNIX_NO_X11": "#define OGRE_CONFIG_UNIX_NO_X11 1",
+        "@OGRE_SET_DOUBLE@": "0",
+        "@OGRE_SET_NODE_INHERIT_TRANSFORM@": "0",
+        "@OGRE_SET_ALLOCATOR@": "1",
+        "@OGRE_SET_CONTAINERS_USE_ALLOCATOR@": "1",
+        "@OGRE_SET_STRING_USE_ALLOCATOR@": "0",
+        "@OGRE_SET_MEMTRACK_DEBUG@": "0",
+        "@OGRE_SET_MEMTRACK_RELEASE@": "0",
+        "@OGRE_SET_ASSERT_MODE@": "1",
+        "@OGRE_SET_THREADS@": "0",
+        "@OGRE_SET_THREAD_PROVIDER@": "0",
+        "@OGRE_SET_DISABLE_MESHLOD@": "0",
+        "@OGRE_SET_DISABLE_FREEIMAGE@": "0",
+        "@OGRE_SET_DISABLE_JSON@": "1",
+        "@OGRE_SET_DISABLE_DDS@": "0",
+        "@OGRE_SET_DISABLE_PVRTC@": "1",
+        "@OGRE_SET_DISABLE_ETC@": "0",
+        "@OGRE_SET_DISABLE_STBI@": "1",
+        "@OGRE_SET_DISABLE_ASTC@": "1",
+        "@OGRE_SET_DISABLE_ZIP@": "1",
+        "@OGRE_SET_DISABLE_VIEWPORT_ORIENTATIONMODE@": "1",
+        "@OGRE_SET_DISABLE_GLES2_GLSL_OPTIMISER@": "1",
+        "@OGRE_SET_DISABLE_GLES2_VAO_SUPPORT@": "1",
+        "@OGRE_SET_DISABLE_GL_STATE_CACHE_SUPPORT@": "1",
+        "@OGRE_SET_DISABLE_GLES3_SUPPORT@": "1",
+        "@OGRE_SET_RENDERDOC_INTEGRATION@": "1",
+        "@OGRE_SET_DISABLE_TBB_SCHEDULER@": "0",
+        "@OGRE_SET_USE_BOOST@": "0",
+        "@OGRE_SET_PROFILING@": "0",
+        "@OGRE_SET_PROFILING_EXHAUSTIVE@": "0",
+        "@OGRE_SET_DISABLE_QUAD_BUFFER_STEREO@": "1",
+        "@OGRE_SET_DISABLE_AMD_AGS@": "0",
+        "@OGRE_SET_DISABLE_FINE_LIGHT_MASK_GRANULARITY@": "1",
+        "@OGRE_SET_ENABLE_LIGHT_OBB_RESTRAINT@": "0",
+        "@OGRE_SET_USE_SIMD@": "1",
+        "@OGRE_SET_RESTRICT_ALIASING@": "1",
+        "@OGRE_SET_IDSTRING_ALWAYS_READABLE@": "0",
+        "#cmakedefine RTSHADER_SYSTEM_BUILD_CORE_SHADERS": "/* undef RTSHADER_SYSTEM_BUILD_CORE_SHADERS */",
+        "#cmakedefine RTSHADER_SYSTEM_BUILD_EXT_SHADERS": "/* undef RTSHADER_SYSTEM_BUILD_EXT_SHADERS */",
+    },
+    template = "CMake/Templates/OgreBuildSettings.h.in",
+)
+
+expand_template(
+    name = "OgreGL3PlusBuildSettings",
+    out = "OgreMain/include/OgreGL3PlusBuildSettings.h",
+    substitutions = {
+        "#cmakedefine OGRE_GLSUPPORT_USE_EGL_HEADLESS": "#define OGRE_GLSUPPORT_USE_EGL_HEADLESS=1",
+        "#cmakedefine OGRE_GLSUPPORT_USE_GLX": "/* undef OGRE_GLSUPPORT_USE_GLX */",
+        "#cmakedefine OGRE_GLSUPPORT_USE_WGL": "/* undef OGRE_GLSUPPORT_USE_GLX */",
+        "#cmakedefine OGRE_GLSUPPORT_USE_COCOA": "/* undef OGRE_GLSUPPORT_USE_GLX */",
+    },
+    template = "CMake/Templates/OgreGL3PlusBuildSettings.h.in",
+)
+
+main_srcs = glob(
+    [
+        "OgreMain/src/*.cpp",
+        "OgreMain/src/*.inl",
+        "OgreMain/src/Animation/*.cpp",
+        "OgreMain/src/CommandBuffer/*.cpp",
+        "OgreMain/src/Compositor/**/*.cpp",
+        "OgreMain/src/Compute/*.cpp",
+        "OgreMain/src/Hash/*.cpp",
+        "OgreMain/src/Math/Array/*.cpp",
+        "OgreMain/src/Math/Array/SSE2/Single/*.cpp",
+        "OgreMain/src/Math/Simple/C/*.cpp",
+        "OgreMain/src/Vao/*.cpp",
+    ],
+    exclude = [
+        "OgreMain/src/OgreConfigDialogNoOp.cpp",
+        "OgreMain/src/OgreFileSystemLayerNoOp.cpp",
+        "OgreMain/src/OgrePVRTCCodec.cpp",
+        "OgreMain/src/OgreZip.cpp",
+        "OgreMain/src/OgreSTBICodec.cpp",
+    ],
+) + [
+    "OgreMain/src/GLX/OgreTimer.cpp",
+    "OgreMain/src/GLX/OgreErrorDialog.cpp",
+    "OgreMain/src/GLX/OgreFileSystemLayer.cpp",
+    "OgreMain/src/Threading/OgreDefaultWorkQueueStandard.cpp",
+    "OgreMain/src/Threading/OgreBarrierPThreads.cpp",
+    "OgreMain/src/Threading/OgreLightweightMutexPThreads.cpp",
+    "OgreMain/src/Threading/OgreThreadsPThreads.cpp",
+    "OgreMain/src/Threading/OgreWaitableEvent.cpp",
+]
+
+main_hdrs = glob([
+    "OgreMain/include/*.h",
+    "OgreMain/include/ogrestd/*.h",
+    "OgreMain/include/*.inl",
+    "OgreMain/include/debugbreak/*.h",
+    "OgreMain/include/Hash/*.h",
+    "OgreMain/include/Vao/*.h",
+    "OgreMain/include/Threading/*.h",
+    "OgreMain/include/Animation/*.h",
+    "OgreMain/include/Animation/*.inl",
+    "OgreMain/include/CommandBuffer/*.h",
+    "OgreMain/include/Compositor/**/*.h",
+    "OgreMain/include/Compute/*.h",
+    "OgreMain/include/Math/Array/*.h",
+    "OgreMain/include/Math/Simple/*.h",
+    "OgreMain/include/Math/Simple/C/*.h",
+    "OgreMain/include/Math/Simple/C/*.inl",
+    "OgreMain/include/Math/Array/SSE2/Single/*.h",
+    "OgreMain/include/Math/Array/SSE2/Single/*.inl",
+]) + [
+    "OgreMain/src/OgreImageResampler.h",
+    "OgreMain/src/OgrePixelConversions.h",
+    "OgreMain/src/OgreSIMDHelper.h",
+    "OgreMain/include/OgreBuildSettings.h",
+    "OgreMain/include/OgreGL3PlusBuildSettings.h",
+    "OgreMain/include/GLX/OgreTimerImp.h",
+    "OgreMain/include/GLX/OgreErrorDialogImp.h",
+    "OgreMain/include/Emscripten/OgreConfigDialogImp.h",
+]
+
+alias(
+    name = "ogre-next",
+    actual = ":ogre-main",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ogre-main",
+    srcs = main_srcs,
+    hdrs = main_hdrs,
+    copts = [
+        "-Wno-implicit-fallthrough",
+        "-Wno-deprecated-declarations",
+        "-Wno-array-parameter",
+        "-Wno-int-to-pointer-cast",
+        "-Wno-missing-braces",
+        "-Wno-overloaded-virtual",
+        "-Wno-switch",
+        "-Wno-unused-function",
+        "-Wno-unused-variable",
+        "-Wno-class-memaccess",
+        "-Wno-ignored-attributes",
+        "-Wno-unused-but-set-variable",
+        "-fexceptions",
+    ] + select({
+        "@rules_cc//cc/compiler:clang": [
+            "-Wno-implicit-function-declaration",
+            "-Wno-tautological-overlap-compare",
+            "-Wno-string-conversion",
+            "-Wno-pointer-bool-conversion",
+            "-Wno-pointer-integer-compare",
+            "-Wno-dynamic-class-memaccess",
+            "-Wno-constant-conversion",
+            "-Wno-unknown-warning-option",
+        ],
+        "//conditions:default": [],
+    }),
+    defines = [
+        "OGRE_DEBUG_MODE=0",
+        "OGRE_GCC_VISIBILITY=1",
+    ],
+    includes = [
+        "OgreMain/include",
+        "OgreMain/include/Animation",
+        "OgreMain/include/CommandBuffer",
+        "OgreMain/include/Compositor",
+        "OgreMain/include/Hash",
+        "OgreMain/include/Math",
+        "OgreMain/include/Threading",
+    ],
+    linkopts = [
+        "-ldl",
+        "-pthread",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@egl-registry//:EGL_headers",
+        "@freeimage",
+        "@libx11",
+        "@libxcb",
+        "@opengl-registry//:OpenGL_headers",
+        "@rapidjson",
+    ],
+)
+
+ogre_gl_support_hdrs = glob([
+    "RenderSystems/GL3Plus/include/*.h",
+    "RenderSystems/GL3Plus/include/GL/*.h",
+    "RenderSystems/GL3Plus/include/GLSL/*.h",
+    "RenderSystems/GL3Plus/include/Vao/*.h",
+    "RenderSystems/GL3Plus/include/windowing/*.h",
+    "RenderSystems/GL3Plus/include/windowing/EGL/*.h",
+    "RenderSystems/GL3Plus/include/windowing/EGL/PBuffer/*.h",
+    "RenderSystems/GL3Plus/src/windowing/*.h",
+    "RenderSystems/GL3Plus/src/windowing/EGL/*.h",
+])
+
+ogre_gl_support_srcs = glob([
+    "RenderSystems/GL3Plus/src/windowing/EGL/PBuffer/*.cpp",
+    "RenderSystems/GL3Plus/src/windowing/*.cpp",
+    "RenderSystems/GL3Plus/src/GLSL/*.cpp",
+    "RenderSystems/GL3Plus/src/Vao/*.cpp",
+    "RenderSystems/GL3Plus/src/*.cpp",
+])
+
+cc_binary(
+    name = "RenderSystem_GL3Plus.so",
+    srcs = ogre_gl_support_srcs + ogre_gl_support_hdrs,
+    copts = [
+        "-Wno-implicit-fallthrough",
+        "-Wno-deprecated-declarations",
+        "-Wno-array-parameter",
+        "-Wno-int-to-pointer-cast",
+        "-Wno-missing-braces",
+        "-Wno-overloaded-virtual",
+        "-Wno-switch",
+        "-Wno-unused-function",
+        "-Wno-unused-variable",
+        "-Wno-class-memaccess",
+        "-Wno-ignored-attributes",
+        "-Wno-unused-but-set-variable",
+        "-fexceptions",
+    ] + select({
+        "@rules_cc//cc/compiler:clang": [
+            "-Wno-implicit-function-declaration",
+            "-Wno-tautological-overlap-compare",
+            "-Wno-string-conversion",
+            "-Wno-pointer-bool-conversion",
+            "-Wno-pointer-integer-compare",
+            "-Wno-dynamic-class-memaccess",
+            "-Wno-constant-conversion",
+            "-Wno-unknown-warning-option",
+        ],
+        "//conditions:default": [],
+    }),
+    includes = [
+        "RenderSystems/GL3Plus/include",
+        "RenderSystems/GL3Plus/include/GL",
+        "RenderSystems/GL3Plus/include/GLSL",
+        "RenderSystems/GL3Plus/include/Vao",
+        "RenderSystems/GL3Plus/include/windowing",
+        "RenderSystems/GL3Plus/include/windowing/EGL",
+        "RenderSystems/GL3Plus/src/GLSL/include",
+        "RenderSystems/GL3Plus/src/windowing",
+    ],
+    linkopts = ["-pthread"],
+    linkshared = True,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ogre-main",
+        "@opengl-registry//:OpenGL_headers",
+    ],
+)
+
+cc_library(
+    name = "hlms_common",
+    srcs = glob([
+        "Components/Hlms/Common/src/*.cpp",
+    ]),
+    hdrs = glob([
+        "Components/Hlms/Common/include/*.h",
+        "Components/Hlms/Common/include/*.inl",
+    ]),
+    copts = [
+        "-Wno-overloaded-virtual",
+        "-Wno-switch",
+        "-Wno-unused-variable",
+        "-Wno-class-memaccess",
+        "-fexceptions",
+    ] + select({
+        "@rules_cc//cc/compiler:clang": [
+            "-Wno-private-header",
+            "-Wno-constant-conversion",
+            "-Wno-unknown-warning-option",
+        ],
+        "//conditions:default": [],
+    }),
+    include_prefix = "Hlms/Common",
+    includes = ["Components/Hlms/Common/include"],
+    strip_include_prefix = "Components/Hlms/Common/include",
+    visibility = ["//visibility:public"],
+    deps = [":ogre-main"],
+)
+
+cc_library(
+    name = "hlms_pbs",
+    srcs = glob([
+        "Components/Hlms/Pbs/src/*.cpp",
+        "Components/Hlms/Pbs/src/*.inc",
+        "Components/Hlms/Pbs/src/Cubemaps/*.cpp",
+        "Components/Hlms/Pbs/src/InstantRadiosity/*.cpp",
+        "Components/Hlms/Pbs/src/IrradianceField/*.cpp",
+        "Components/Hlms/Pbs/src/LightProfiles/*.cpp",
+        "Components/Hlms/Pbs/src/Vct/*.cpp",
+    ]),
+    hdrs = glob([
+        "Components/Hlms/Pbs/include/*.h",
+        "Components/Hlms/Pbs/include/**/*.h",
+    ]),
+    copts = [
+        "-Wno-overloaded-virtual",
+        "-Wno-switch",
+        "-Wno-unused-variable",
+        "-Wno-class-memaccess",
+        "-Wno-unused-but-set-variable",
+        "-fexceptions",
+    ] + select({
+        "@rules_cc//cc/compiler:clang": [
+            "-Wno-private-header",
+            "-Wno-constant-conversion",
+            "-Wno-unknown-warning-option",
+        ],
+        "//conditions:default": [],
+    }),
+    include_prefix = "Hlms/Pbs",
+    includes = ["Components/Hlms/Pbs/include"],
+    strip_include_prefix = "Components/Hlms/Pbs/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":hlms_common",
+        ":ogre-main",
+    ],
+)
+
+cc_library(
+    name = "hlms_unlit",
+    srcs = glob([
+        "Components/Hlms/Unlit/src/*.cpp",
+        "Components/Hlms/Unlit/src/*.inc",
+    ]),
+    hdrs = glob(["Components/Hlms/Unlit/include/*.h"]),
+    copts = [
+        "-Wno-overloaded-virtual",
+        "-Wno-switch",
+        "-Wno-unused-variable",
+        "-Wno-class-memaccess",
+        "-fexceptions",
+    ] + select({
+        "@rules_cc//cc/compiler:clang": [
+            "-Wno-private-header",
+            "-Wno-constant-conversion",
+            "-Wno-unknown-warning-option",
+        ],
+        "//conditions:default": [],
+    }),
+    include_prefix = "Hlms/Unlit",
+    includes = ["Components/Hlms/Unlit/include"],
+    strip_include_prefix = "Components/Hlms/Unlit/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":hlms_common",
+        ":ogre-main",
+    ],
+)
+
+cc_library(
+    name = "overlay",
+    srcs = glob(["Components/Overlay/src/*.cpp"]),
+    hdrs = glob(["Components/Overlay/include/*.h"]),
+    copts = [
+        "-Wno-overloaded-virtual",
+        "-Wno-switch",
+        "-Wno-unused-variable",
+        "-fexceptions",
+    ] + select({
+        "@rules_cc//cc/compiler:clang": [
+            "-Wno-private-header",
+            "-Wno-constant-conversion",
+            "-Wno-unknown-warning-option",
+        ],
+        "//conditions:default": [],
+    }),
+    include_prefix = "Overlay",
+    includes = ["Components/Overlay/include"],
+    strip_include_prefix = "Components/Overlay/include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":hlms_unlit",
+        ":ogre-main",
+        "@freetype",
+    ],
+)

--- a/modules/ogre-next/2.3.3.bcr.2/overlay/MODULE.bazel
+++ b/modules/ogre-next/2.3.3.bcr.2/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/ogre-next/2.3.3.bcr.2/patches/fix_char_traits.patch
+++ b/modules/ogre-next/2.3.3.bcr.2/patches/fix_char_traits.patch
@@ -1,0 +1,15 @@
+--- a/OgreMain/include/OgreUTFString.h
++++ b/OgreMain/include/OgreUTFString.h
+@@ -189,10 +189,10 @@
+         static const size_type npos = static_cast<size_type>(~0);
+
+         //! a single 32-bit Unicode character
+-        typedef uint32 unicode_char;
++        typedef char32_t unicode_char;
+
+         //! a single UTF-16 code point
+-        typedef uint16 code_point;
++        typedef char16_t code_point;
+
+         //! value type typedef for use in iterators
+         typedef code_point value_type;

--- a/modules/ogre-next/2.3.3.bcr.2/patches/fix_cpp20.patch
+++ b/modules/ogre-next/2.3.3.bcr.2/patches/fix_cpp20.patch
@@ -1,0 +1,63 @@
+--- a/OgreMain/include/OgreGpuProgramParams.h
++++ b/OgreMain/include/OgreGpuProgramParams.h
+@@ -1524,7 +1524,7 @@ namespace Ogre {
+
+     public:
+         GpuProgramParameters();
+-        ~GpuProgramParameters() {}
++        ~GpuProgramParameters();
+
+         /// Copy constructor
+         GpuProgramParameters(const GpuProgramParameters& oth);
+@@ -1922,7 +1922,7 @@ namespace Ogre {
+         // const bool* getBoolPointer(size_t pos) const { return &mBoolConstants[pos]; }
+
+         /// Get a reference to the list of auto constant bindings
+-        const AutoConstantList& getAutoConstantList() const { return mAutoConstants; }
++        const AutoConstantList& getAutoConstantList() const;
+
+         /** Sets up a constant which will automatically be updated by the system.
+             @remarks
+@@ -1983,7 +1983,7 @@ namespace Ogre {
+         /** Gets an iterator over the automatic constant bindings currently in place. */
+         AutoConstantIterator getAutoConstantIterator(void) const;
+         /// Gets the number of int constants that have been set
+-        size_t getAutoConstantCount(void) const { return mAutoConstants.size(); }
++        size_t getAutoConstantCount(void) const;
+         /** Gets a specific Auto Constant entry if index is in valid range
+             otherwise returns a NULL
+             @param index which entry is to be retrieved
+@@ -1991,7 +1991,7 @@ namespace Ogre {
+         GpuProgramParameters_AutoConstantEntry *getAutoConstantEntry(
+             const size_t index );
+         /** Returns true if this instance has any automatic constants. */
+-        bool hasAutoConstants( void ) const { return !( mAutoConstants.empty() ); }
++        bool hasAutoConstants( void ) const;
+         /** Finds an auto constant that's affecting a given logical parameter
+             index for floating-point values.
+             @note Only applicable for low-level programs.
+
+--- a/OgreMain/src/OgreGpuProgramParams.cpp
++++ b/OgreMain/src/OgreGpuProgramParams.cpp
+@@ -940,6 +940,8 @@ namespace Ogre
+     {
+     }
+     //-----------------------------------------------------------------------------
++    GpuProgramParameters::~GpuProgramParameters() {}
++    //-----------------------------------------------------------------------------
+
+     GpuProgramParameters::GpuProgramParameters(const GpuProgramParameters& oth)
+     {
+@@ -2235,6 +2237,12 @@ namespace Ogre
+         }
+     }
+     //-----------------------------------------------------------------------------
++    bool GpuProgramParameters::hasAutoConstants( void ) const { return !( mAutoConstants.empty() ); }
++    //-----------------------------------------------------------------------------
++    size_t GpuProgramParameters::getAutoConstantCount(void) const { return mAutoConstants.size(); }
++    //-----------------------------------------------------------------------------
++    const GpuProgramParameters::AutoConstantList& GpuProgramParameters::getAutoConstantList() const { return mAutoConstants; }
++    //-----------------------------------------------------------------------------
+     void GpuProgramParameters::setAutoConstant(size_t index, AutoConstantType acType, size_t extraInfo)
+     {
+         // Get auto constant definition for sizing

--- a/modules/ogre-next/2.3.3.bcr.2/patches/fix_tr1.patch
+++ b/modules/ogre-next/2.3.3.bcr.2/patches/fix_tr1.patch
@@ -1,0 +1,43 @@
+--- a/Components/Hlms/Pbs/src/InstantRadiosity/OgreInstantRadiosity.cpp
++++ b/Components/Hlms/Pbs/src/InstantRadiosity/OgreInstantRadiosity.cpp
+@@ -58,7 +58,7 @@ THE SOFTWARE.
+     OGRE_PLATFORM == OGRE_PLATFORM_FREEBSD)
+     #include <random>
+ #else
+-    #include <tr1/random>
++    #include <random>
+ #endif
+
+ namespace Ogre
+@@ -72,7 +72,7 @@ namespace Ogre
+     OGRE_PLATFORM == OGRE_PLATFORM_FREEBSD
+         std::mt19937        mRng;
+ #else
+-        std::tr1::mt19937   mRng;
++        std::mt19937   mRng;
+ #endif
+
+     public:
+
+--- a/OgreMain/include/OgreString.h
++++ b/OgreMain/include/OgreString.h
+@@ -212,16 +212,16 @@ namespace Ogre {
+ #   elif OGRE_COMP_VER < 430
+     typedef ::__gnu_cxx::hash< _StringBase > _StringHash;
+ #   else
+-    typedef ::std::tr1::hash< _StringBase > _StringHash;
++    typedef ::std::hash< _StringBase > _StringHash;
+ #   endif
+ #elif OGRE_COMPILER == OGRE_COMPILER_CLANG
+ #   if defined(_LIBCPP_VERSION) || __cplusplus >= 201103L
+     typedef ::std::hash< _StringBase > _StringHash;
+ #   else
+-    typedef ::std::tr1::hash< _StringBase > _StringHash;
++    typedef ::std::hash< _StringBase > _StringHash;
+ #   endif
+ #elif OGRE_COMPILER == OGRE_COMPILER_MSVC && OGRE_COMP_VER >= 1600 && OGRE_COMP_VER < 1910 && !defined(STLPORT) // VC++ 10.0
+-    typedef ::std::tr1::hash< _StringBase > _StringHash;
++    typedef ::std::hash< _StringBase > _StringHash;
+ #elif !defined( _STLP_HASH_FUN_H )
+     typedef stdext::hash_compare< _StringBase, std::less< _StringBase > > _StringHash;
+ #else

--- a/modules/ogre-next/2.3.3.bcr.2/presubmit.yml
+++ b/modules/ogre-next/2.3.3.bcr.2/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - ubuntu2204
+  - ubuntu2404
+  bazel:
+  - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@ogre-next//:ogre-main'
+    - '@ogre-next//:RenderSystem_GL3Plus.so'
+    - '@ogre-next//:hlms_common'
+    - '@ogre-next//:hlms_pbs'
+    - '@ogre-next//:hlms_unlit'
+    - '@ogre-next//:overlay'

--- a/modules/ogre-next/2.3.3.bcr.2/source.json
+++ b/modules/ogre-next/2.3.3.bcr.2/source.json
@@ -1,0 +1,15 @@
+{
+    "url": "https://github.com/OGRECave/ogre-next/archive/refs/tags/v2.3.3.tar.gz",
+    "integrity": "sha256-ks53ZdiS1kJN89jUpWqPwLL0+RwhaxsdWyMcqpq6qjg=",
+    "strip_prefix": "ogre-next-2.3.3",
+    "overlay": {
+        "BUILD.bazel": "sha256-TjwWYTqzSpB2aSjjZ975OkCH2IeGVUGf1NEVuGoVyBM=",
+        "MODULE.bazel": "sha256-IvCCzQRPDmZJ5NEHyH8rxDvDnu18n5ebkDl5V3VKgS0="
+    },
+    "patches": {
+        "fix_char_traits.patch": "sha256-PJJ2I/oa/jo9oauPmblx6KrtKcb9mHEPEVgULuN7DgM=",
+        "fix_cpp20.patch": "sha256-0ip0A4+NE7nC1+a1rZ5rTiBb55s5sU/eqSTt2NOVZ0w=",
+        "fix_tr1.patch": "sha256-b8Z7G3rmP9N3sS7FMTUdFRu60XnWfIvxj3i8xSf8CQk="
+    },
+    "patch_strip": 1
+}

--- a/modules/ogre-next/metadata.json
+++ b/modules/ogre-next/metadata.json
@@ -19,7 +19,8 @@
     ],
     "versions": [
         "2.3.3",
-        "2.3.3.bcr.1"
+        "2.3.3.bcr.1",
+        "2.3.3.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Pulls in a fix for `libxtrans` transitively on Ubuntu 24.04: https://github.com/bazelbuild/bazel-central-registry/pull/6235