### PR TITLE
ruff_prebuilt@0.14.1.3

### DIFF
--- a/modules/ruff_prebuilt/0.14.1.3/MODULE.bazel
+++ b/modules/ruff_prebuilt/0.14.1.3/MODULE.bazel
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+
+module(
+    name = "ruff_prebuilt",
+    version = "0.14.1.3",
+    bazel_compatibility = [">=8.0.1"],
+    compatibility_level = 1,
+)
+
+# Rules dependencies.
+
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# Register the default ruff toolchain.
+
+extension = use_extension("@ruff_prebuilt//:extensions.bzl", "ruff_prebuilt_extension")
+extension.toolchain(name = "ruff_prebuilt_toolchain")
+use_repo(extension, "ruff_prebuilt_toolchain")
+
+register_toolchains("@ruff_prebuilt_toolchain//:all")
+
+# Maintainer dependencies.
+
+# Use via:
+#  bazel run -- @buildifier --mode=fix $(pwd)/*.b*z*l $(pwd)/workflows/*.b*z*l
+bazel_dep(
+    name = "buildifier_prebuilt",
+    version = "8.2.0.2",
+    dev_dependency = True,
+    repo_name = "buildifier",
+)
+bazel_dep(
+    name = "rules_pkg",
+    version = "1.1.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "rules_python",
+    version = "1.6.3",
+    dev_dependency = True,
+)

--- a/modules/ruff_prebuilt/0.14.1.3/presubmit.yml
+++ b/modules/ruff_prebuilt/0.14.1.3/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2404
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@ruff_prebuilt//:ruff'

--- a/modules/ruff_prebuilt/0.14.1.3/source.json
+++ b/modules/ruff_prebuilt/0.14.1.3/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/RobotLocomotion/ruff_prebuilt/releases/download/0.14.1.3/ruff_prebuilt-0.14.1.3.tar.gz",
+    "integrity": "sha256-kcMC2H4YXB4D3z0hWkuCD0J+q1PSskKbVDLJtK07UJ0=",
+    "strip_prefix": "ruff_prebuilt-0.14.1.3"
+}

--- a/modules/ruff_prebuilt/metadata.json
+++ b/modules/ruff_prebuilt/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/RobotLocomotion/ruff_prebuilt",
+    "maintainers": [
+        {
+            "email": "jeremy.nimmer@tri.global",
+            "github": "jwnimmer-tri",
+            "github_user_id": 17596505,
+            "name": "Jeremy Nimmer"
+        }
+    ],
+    "repository": [
+        "github:RobotLocomotion/ruff_prebuilt"
+    ],
+    "versions": [
+        "0.14.1.3"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This is the first BCR version of https://github.com/RobotLocomotion/ruff_prebuilt.

See also https://github.com/astral-sh/ruff/discussions/20672.