### PR TITLE
rules_gleam@0.1.13

### DIFF
--- a/modules/rules_gleam/0.1.13/MODULE.bazel
+++ b/modules/rules_gleam/0.1.13/MODULE.bazel
@@ -1,0 +1,40 @@
+module(
+    name = "rules_gleam",
+    version = "0.1.13",
+)
+
+bazel_dep(name = "rules_go", version = "0.57.0")
+bazel_dep(name = "gazelle", version = "0.45.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "rules_erlang", version = "3.16.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_features", version = "1.35.0")
+
+# Download a suitable Go SDK.
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.25.1")
+use_repo(go_sdk, "go_host_compatible_sdk_label")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(
+    fail_on_version_conflict = False,
+    go_mod = "//:go.mod",
+)
+use_repo(go_deps, "com_github_bazelbuild_buildtools", "com_github_bmatcuk_doublestar_v4", "com_github_burntsushi_toml", "com_github_google_go_cmp", "com_github_kr_pretty", "com_github_kr_text", "com_github_lithammer_dedent", "com_github_pmezard_go_difflib", "com_github_rogpeppe_go_internal", "org_golang_x_mod", "org_golang_x_sync", "org_golang_x_sys", "org_golang_x_tools_go_vcs")
+
+gleam = use_extension("//:extensions.bzl", "gleam")
+gleam.deps(gleam_toml = "//:gleam/gleeunit/gleam.toml")
+gleam.erlang(version = "latest")
+
+# Registers the default toolchain to be the latest
+# User of rules_gleam, can customize the default tool chains using the same extension tag:
+gleam.toolchain(version = "latest")
+
+register_toolchains("@gleam_toolchains//:all")
+register_toolchains("@gleam_erlang_toolchains//:all")
+
+use_repo(gleam, "gleam_compiler_aarch64_apple_darwin", "gleam_compiler_aarch64_pc_windows_msvc", "gleam_compiler_aarch64_unknown_linux_musl", "gleam_compiler_x86_64_apple_darwin", "gleam_compiler_x86_64_pc_windows_msvc", "gleam_compiler_x86_64_unknown_linux_musl", "gleam_erlang_toolchains", "gleam_hex_repositories_config", "gleam_toolchains", "hex_gleam_stdlib")
+
+# Internal tools
+gleam_tools = use_extension("//internal/tools:extensions.bzl", "tools")
+use_repo(gleam_tools, "rules_gleam_go_repository_cache", "rules_gleam_internal_tools")

--- a/modules/rules_gleam/0.1.13/attestations.json
+++ b/modules/rules_gleam/0.1.13/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/iocat/rules_gleam/releases/download/v0.1.13/source.json.intoto.jsonl",
+            "integrity": "sha256-6yPjupX/ha9/XK/AFxnOGUyrcPT4IgLmCj2Pr2ZbaxA="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/iocat/rules_gleam/releases/download/v0.1.13/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-e2AwPTmqxwyvSp1sw7ayHdI94R6Srw4p/6hOyCD3PTI="
+        },
+        "rules_gleam-v0.1.13.tar.gz": {
+            "url": "https://github.com/iocat/rules_gleam/releases/download/v0.1.13/rules_gleam-v0.1.13.tar.gz.intoto.jsonl",
+            "integrity": "sha256-EI0wvwyBqxgUYxpMKsKg7/bG5kWz1GQ+BWi7NE7Xl/4="
+        }
+    }
+}

--- a/modules/rules_gleam/0.1.13/patches/module_dot_bazel_version.patch
+++ b/modules/rules_gleam/0.1.13/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_gleam",
+-    version = "0.0.0",
++    version = "0.1.13",
+ )
+ 
+ bazel_dep(name = "rules_go", version = "0.57.0")
+ bazel_dep(name = "gazelle", version = "0.45.0")

--- a/modules/rules_gleam/0.1.13/presubmit.yml
+++ b/modules/rules_gleam/0.1.13/presubmit.yml
@@ -1,0 +1,13 @@
+bcr_test_module:
+  module_path: "examples/basic"
+  matrix:
+    bazel: [8.x]
+  tasks:
+    ubuntu2204:
+      name: "Build/test module on Ubuntu"
+      platform: ubuntu2204
+      bazel: ${{ bazel }}
+      build_targets:
+      - "..."
+      test_targets:
+      - "..."

--- a/modules/rules_gleam/0.1.13/source.json
+++ b/modules/rules_gleam/0.1.13/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-ZfZAPUAQsWw+ZwraCq4MlGcaVBzGojepH/AbqDx0jkg=",
+    "strip_prefix": "rules_gleam-0.1.13",
+    "url": "https://github.com/iocat/rules_gleam/releases/download/v0.1.13/rules_gleam-v0.1.13.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-3qWjWJdByd3Bi9YqRY0m8humBlgyW6v/muG8TqyLygc="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_gleam/metadata.json
+++ b/modules/rules_gleam/metadata.json
@@ -12,7 +12,8 @@
         "github:iocat/rules_gleam"
     ],
     "versions": [
-        "0.1.12"
+        "0.1.12",
+        "0.1.13"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/iocat/rules_gleam/releases/tag/v0.1.13

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_