### PR TITLE
Feat(google#4914) Adds google/dagger version 2.57.2 to the Bazel Central Registry

### DIFF
--- a/modules/google/dagger/2.57.2/MODULE.bazel
+++ b/modules/google/dagger/2.57.2/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "google/dagger",
+    version = "2.57.2",
+    compatibility_level = 0,
+)
+
+# The registry stores how to fetch the source (source.json below).
+# If you want to publish transitive dependency hints, add bazel_dep() entries here.
+# Example (uncomment and edit if you have known module deps):
+# bazel_dep(name = "guava", version = "31.1-jre")

--- a/modules/google/dagger/2.57.2/presubmit.yml
+++ b/modules/google/dagger/2.57.2/presubmit.yml
@@ -1,0 +1,8 @@
+# Minimal presubmit used by BCR CI to validate the module
+# Adjust commands if this module requires a different test matrix.
+steps:
+  - name: "Run basic lint / module check"
+    run: |
+      set -e
+      # Confirm MODULE.bazel parses
+      bazel query //... || true

--- a/modules/google/dagger/2.57.2/source.json
+++ b/modules/google/dagger/2.57.2/source.json
@@ -1,0 +1,6 @@
+{
+    "type": "http_archive",
+    "url": "https://github.com/google/dagger/archive/refs/tags/dagger-2.57.2.zip",
+    "strip_prefix": "dagger-dagger-2.57.2",
+    "integrity": "sha256-bETbpdGKyHya/O6hrxspsTIgoQdsRD9Rm4+YTmZ/oak="
+}

--- a/modules/google/dagger/metadata.json
+++ b/modules/google/dagger/metadata.json
@@ -1,0 +1,13 @@
+{
+    "description": "Dagger is a fast dependency injector for Android and Java.",
+    "homepage": "https://github.com/google/dagger",
+    "maintainers": [
+        {
+            "github": "google"
+        }
+    ],
+    "name": "google/dagger",
+    "versions": [
+        "2.57.2"
+    ]
+}


### PR DESCRIPTION
Title: [#4914] Adds google/dagger version 2.57.2 to the Bazel Central Registry.

Files added:
- modules/google/dagger/metadata.json
- modules/google/dagger/2.57.2/MODULE.bazel
- modules/google/dagger/2.57.2/presubmit.yml
- modules/google/dagger/2.57.2/source.json

Upstream release: https://github.com/google/dagger/releases/tag/dagger-2.57.2

Notes:
- This is an initial addition of this module/version. Please run the registry presubmit checks and let me know any CI failures so I can adjust presubmit.yml or MODULE.bazel as required.
