### PR TITLE
Add license attributes to ccd and bump version to 2.1.0.bcr.1

### DIFF
--- a/modules/ccd/2.1.0.bcr.1/MODULE.bazel
+++ b/modules/ccd/2.1.0.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "ccd",
+    version = "2.1.0.bcr.1",
+    compatibility_level = 0,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/ccd/2.1.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/ccd/2.1.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,56 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+)
+
+license(
+    name = "license",
+    package_name = "ccd",
+    license_kinds = ["@rules_license//licenses/spdx:BSD-3-Clause"],
+    license_text = ":BSD-LICENSE",
+)
+
+ccd_sources = glob(
+    include = [
+        "src/*.c",
+    ],
+)
+
+ccd_headers = glob(
+    include = [
+        "src/*.h",
+    ],
+)
+
+ccd_public_headers = glob(
+    include = [
+        "src/ccd/*.h",
+    ],
+)
+
+expand_template(
+    name = "config",
+    out = "src/ccd/config.h",
+    substitutions = {"#cmakedefine": "// #undef"},
+    template = "src/ccd/config.h.cmake.in",
+)
+
+cc_library(
+    name = "ccd_single",
+    srcs = ccd_sources + ccd_headers,
+    hdrs = ccd_public_headers + ["src/ccd/config.h"],
+    defines = ["CCD_SINGLE"],
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ccd",
+    srcs = ccd_sources + ccd_headers,
+    hdrs = ccd_public_headers + ["src/ccd/config.h"],
+    defines = ["CCD_DOUBLE"],
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+)

--- a/modules/ccd/2.1.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/ccd/2.1.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/ccd/2.1.0.bcr.1/presubmit.yml
+++ b/modules/ccd/2.1.0.bcr.1/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@ccd//:ccd'
+    - '@ccd//:ccd_single'

--- a/modules/ccd/2.1.0.bcr.1/source.json
+++ b/modules/ccd/2.1.0.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/danfis/libccd/archive/refs/tags/v2.1.tar.gz",
+    "integrity": "sha256-VCtsR/Ui1YH7855R3zLH0SVqwMYm58K0HxBA1LnVDR4=",
+    "strip_prefix": "libccd-2.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-vSXLrvIhZuGcmtmKqYkt3YBBwtGK9swCU++MwKY3cVM=",
+        "MODULE.bazel": "sha256-7nAlW9bfSCdUerZKT7m39b4AfphpuusuN2GD72WgmVM="
+    }
+}

--- a/modules/ccd/metadata.json
+++ b/modules/ccd/metadata.json
@@ -4,15 +4,16 @@
         {
             "email": "iche@intrinsic.ai",
             "github": "iche033",
-            "name": "Ian Chen",
-            "github_user_id": 4000684
+            "github_user_id": 4000684,
+            "name": "Ian Chen"
         }
     ],
     "repository": [
         "github:danfis/libccd"
     ],
     "versions": [
-        "2.1.0"
+        "2.1.0",
+        "2.1.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Updated license rule:
```
license(
    name = "license",
    package_name = "ccd",
    license_kinds = ["@rules_license//licenses/spdx:BSD-3-Clause"],
    license_text = ":BSD-LICENSE",
)
```

Also updated BUILD.bazel and MODULE.bazel files to be applied as overlays for ease-of-maintenance.

Since the `generate_module_diff` github action cannot list the diff between the BUILD.bazel overlay and the `add_build_file` patch, I've generated a manual diff: 
[ccd_2.1.0.bcr.1_BUILD.bazel.diff.txt](https://github.com/user-attachments/files/23195188/ccd_2.1.0.bcr.1_BUILD.bazel.diff.txt)
