### PR TITLE
go_tree_sitter@0.25.0

### DIFF
--- a/modules/go_tree_sitter/0.25.0/MODULE.bazel
+++ b/modules/go_tree_sitter/0.25.0/MODULE.bazel
@@ -1,0 +1,30 @@
+module(
+    name = "go_tree_sitter",
+    version = "0.25.0",
+    bazel_compatibility = [">=7.7.0"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_go", version = "0.58.2")
+bazel_dep(name = "gazelle", version = "0.45.0")
+
+# Go dependencies for the bindings
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "@go_tree_sitter//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_mattn_go_pointer",
+    "com_github_stretchr_testify",
+    "com_github_tree_sitter_tree_sitter_c",
+    "com_github_tree_sitter_tree_sitter_cpp",
+    "com_github_tree_sitter_tree_sitter_embedded_template",
+    "com_github_tree_sitter_tree_sitter_go",
+    "com_github_tree_sitter_tree_sitter_html",
+    "com_github_tree_sitter_tree_sitter_java",
+    "com_github_tree_sitter_tree_sitter_javascript",
+    "com_github_tree_sitter_tree_sitter_json",
+    "com_github_tree_sitter_tree_sitter_php",
+    "com_github_tree_sitter_tree_sitter_python",
+    "com_github_tree_sitter_tree_sitter_ruby",
+    "com_github_tree_sitter_tree_sitter_rust",
+)

--- a/modules/go_tree_sitter/0.25.0/overlay/BUILD.bazel
+++ b/modules/go_tree_sitter/0.25.0/overlay/BUILD.bazel
@@ -1,0 +1,65 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+# Tree-sitter core C library
+# IMPORTANT: Exclude lib.c - it's a meta-file that includes other C files
+cc_library(
+    name = "tree-sitter-core",
+    srcs = glob(
+        ["src/*.c"],
+        exclude = ["src/lib.c"],
+    ),
+    hdrs = glob([
+        "src/**/*.h",
+        "include/**/*.h",
+    ]),
+    copts = [
+        "-std=c11",
+        "-D_POSIX_C_SOURCE=200112L",
+        "-D_DEFAULT_SOURCE",
+    ],
+    includes = [
+        "include",
+        "src",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Go bindings
+go_library(
+    name = "go_tree_sitter",
+    srcs = [
+        "allocator.c",  # Keep this - it's meant to be compiled with Go
+        "allocator.go",
+        "allocator.h",
+        "dup_unix.go",
+        "dup_windows.go",
+        "edit.go",
+        "language.go",
+        "logger.go",
+        "lookahead_iterator.go",
+        "node.go",
+        "parser.go",
+        "point.go",
+        "query.go",
+        "ranges.go",
+        "tree.go",
+        "tree_cursor.go",
+        # Don't include - only used to build the C library from the C source code
+        # "tree_sitter.go",
+    ],
+    cdeps = [":tree-sitter-core"],  # Link against C library
+    cgo = True,
+    copts = ["-std=c11"],  # Simplified copts - includes come from cdeps
+    importpath = "github.com/tree-sitter/go-tree-sitter",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_mattn_go_pointer//:go-pointer"],
+)
+
+alias(
+    name = "go-tree-sitter",
+    actual = ":go_tree_sitter",
+    visibility = ["//visibility:public"],
+)
+
+# Export all files for reference
+exports_files(glob(["**/*"]))

--- a/modules/go_tree_sitter/0.25.0/overlay/MODULE.bazel
+++ b/modules/go_tree_sitter/0.25.0/overlay/MODULE.bazel
@@ -1,0 +1,1 @@
+../MODULE.bazel

--- a/modules/go_tree_sitter/0.25.0/presubmit.yml
+++ b/modules/go_tree_sitter/0.25.0/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2204
+    - macos
+    - macos_arm64
+  bazel:
+    - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@go_tree_sitter//...'

--- a/modules/go_tree_sitter/0.25.0/source.json
+++ b/modules/go_tree_sitter/0.25.0/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/tree-sitter/go-tree-sitter/archive/56cc6ef292d5d6a755994d3cefadc1624097fbfb.tar.gz",
+    "integrity": "sha256-jzEoZlYDCtzOiKTGLioxCJDMoS+f7MR1xDVBKlZlfYI=",
+    "strip_prefix": "go-tree-sitter-56cc6ef292d5d6a755994d3cefadc1624097fbfb",
+    "overlay": {
+        "MODULE.bazel": "sha256-CCb7GknH36ctqVJ5Z3dMUGodikiuZk8H218gW2GRpbE=",
+        "BUILD.bazel": "sha256-BxkyvvDWBnJLzJemUJAtVaVB4fhHPqye2xCKoaJFrdQ="
+    },
+    "patch_strip": 0
+}

--- a/modules/go_tree_sitter/metadata.json
+++ b/modules/go_tree_sitter/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/tree-sitter/go-tree-sitter",
+    "maintainers": [
+        {
+            "email": "michael.zaccari@gmail.com",
+            "github": "zaccari",
+            "name": "Michael Zaccari",
+            "github_user_id": 646363
+        }
+    ],
+    "repository": [
+        "github:tree-sitter/go-tree-sitter"
+    ],
+    "versions": [
+        "0.25.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
v0.25.0 doesn't have a release yet, so using the archive. This library has been very useful in downstream gazelle plugins for reading various languages.