### PR TITLE
openssl: Update maintainers

### DIFF
--- a/modules/openssl/metadata.json
+++ b/modules/openssl/metadata.json
@@ -2,16 +2,16 @@
   "homepage": "https://www.openssl.org/",
   "maintainers": [
     {
-      "email": "github@raccoons.build",
-      "github": "raccoons-build",
-      "github_user_id": 166938977,
-      "name": "Raccoons Build"
-    },
-    {
       "email": "dawagner@gmail.com",
       "github": "illicitonion",
       "github_user_id": 1131704,
       "name": "Daniel Wagner-Hall"
+    },
+    {
+      "email": "26427366+UebelAndre@users.noreply.github.com",
+      "github": "UebelAndre",
+      "github_user_id": 26427366,
+      "name": "UebelAndre"
     }
   ],
   "repository": [


### PR DESCRIPTION
raccoons-build is an org not a user, which doesn't get handled amazingly by BCR tooling.

Add UebelAndre who has volunteered to co-maintain.