### PR TITLE
Replace symlink

### DIFF
--- a/modules/boost.filesystem/1.89.0/overlay/MODULE.bazel
+++ b/modules/boost.filesystem/1.89.0/overlay/MODULE.bazel
@@ -1,1 +1,23 @@
-../MODULE.bazel
+module(
+    name = "boost.filesystem",
+    version = "1.89.0",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = 108800,
+)
+
+bazel_dep(name = "boost.assert", version = "1.89.0")
+bazel_dep(name = "boost.atomic", version = "1.89.0")
+bazel_dep(name = "boost.config", version = "1.89.0")
+bazel_dep(name = "boost.container_hash", version = "1.89.0")
+bazel_dep(name = "boost.core", version = "1.89.0")
+bazel_dep(name = "boost.detail", version = "1.89.0")
+bazel_dep(name = "boost.io", version = "1.89.0")
+bazel_dep(name = "boost.iterator", version = "1.89.0")
+bazel_dep(name = "boost.predef", version = "1.89.0")
+bazel_dep(name = "boost.scope", version = "1.89.0")
+bazel_dep(name = "boost.smart_ptr", version = "1.89.0")
+bazel_dep(name = "boost.system", version = "1.89.0")
+bazel_dep(name = "boost.type_traits", version = "1.89.0")
+bazel_dep(name = "boost.winapi", version = "1.89.0")
+bazel_dep(name = "boost.pin_version", version = "1.89.0")
+bazel_dep(name = "rules_cc", version = "0.1.3")


### PR DESCRIPTION
By accident I approved https://github.com/bazelbuild/bazel-central-registry/pull/6437 which introduces a symlink - this lets other PRs fail -> e.g. https://github.com/bazelbuild/bazel-central-registry/pull/6461. This PR replaces the MODULE.bazel symlink by a "hard" copy of the MODULE.bazel file.

@fmeum @meteorcloudy 