### PR TITLE
ruff_prebuilt@0.14.4.2

### DIFF
--- a/modules/ruff_prebuilt/0.14.4.2/MODULE.bazel
+++ b/modules/ruff_prebuilt/0.14.4.2/MODULE.bazel
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+
+module(
+    name = "ruff_prebuilt",
+    version = "0.14.4.2",
+    bazel_compatibility = [">=8.0.1"],
+    compatibility_level = 1,
+)
+
+# Rules dependencies.
+
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# Register the default ruff toolchain.
+
+extension = use_extension("@ruff_prebuilt//:extensions.bzl", "ruff_prebuilt_extension")
+extension.toolchain(name = "ruff_prebuilt_toolchain")
+use_repo(extension, "ruff_prebuilt_toolchain")
+
+register_toolchains("@ruff_prebuilt_toolchain//:all")
+
+# Maintainer dependencies.
+
+# Use via:
+#  bazel run -- @buildifier --mode=fix $(pwd)/*.b*z*l $(pwd)/workflows/*.b*z*l
+bazel_dep(
+    name = "buildifier_prebuilt",
+    version = "8.2.0.2",
+    dev_dependency = True,
+    repo_name = "buildifier",
+)
+bazel_dep(
+    name = "rules_pkg",
+    version = "1.1.0",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "rules_python",
+    version = "1.6.3",
+    dev_dependency = True,
+)

--- a/modules/ruff_prebuilt/0.14.4.2/presubmit.yml
+++ b/modules/ruff_prebuilt/0.14.4.2/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2404
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@ruff_prebuilt//:ruff'

--- a/modules/ruff_prebuilt/0.14.4.2/source.json
+++ b/modules/ruff_prebuilt/0.14.4.2/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/RobotLocomotion/ruff_prebuilt/releases/download/0.14.4.2/ruff_prebuilt-0.14.4.2.tar.gz",
+    "integrity": "sha256-ZXePrCss+wIPnOtrAsmIb50PVieCA+Frq3QqIngezYg=",
+    "strip_prefix": "ruff_prebuilt-0.14.4.2"
+}

--- a/modules/ruff_prebuilt/metadata.json
+++ b/modules/ruff_prebuilt/metadata.json
@@ -12,7 +12,8 @@
         "github:RobotLocomotion/ruff_prebuilt"
     ],
     "versions": [
-        "0.14.1.3"
+        "0.14.1.3",
+        "0.14.4.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/RobotLocomotion/ruff_prebuilt/releases/tag/0.14.4.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_