### PR TITLE
Support `@bazel-io abandon` to close PRs

### DIFF
--- a/.github/workflows/handle_comment.yml
+++ b/.github/workflows/handle_comment.yml
@@ -1,0 +1,22 @@
+name: Handle Comment Commands
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  handle-comment:
+    # Only run on comments on PRs, and only on commands starting with "@bazel-io ".
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '@bazel-io ')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Handle @bazel-io commands
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@c3b6d8802a72b525c3cd19ad4f556d0314568839
+        with:
+          # This token needs to be updated annually on Feb 05.
+          token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}
+          action-type: 'handle_comment'


### PR DESCRIPTION
If one of the module maintainers post @bazel-io abandon in a BCR PR, the PR will be closed by the @bazel-io bot.

See https://github.com/bazelbuild/continuous-integration/pull/2402