### PR TITLE
Add boost.assign 1.83.0.bcr.1

### DIFF
--- a/modules/boost.assign/1.83.0.bcr.1/MODULE.bazel
+++ b/modules/boost.assign/1.83.0.bcr.1/MODULE.bazel
@@ -1,0 +1,21 @@
+module(
+    name = "boost.assign",
+    version = "1.83.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 108300,
+)
+
+bazel_dep(name = "boost.array", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.config", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.core", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.move", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.multi_index", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.preprocessor", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.ptr_container", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.range", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.static_assert", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.test", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.throw_exception", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.tuple", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.type_traits", version = "1.83.0.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.0.14")

--- a/modules/boost.assign/1.83.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.assign/1.83.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "boost.assign",
+    hdrs = glob(
+        [
+            "include/**/*.hpp",
+        ],
+        exclude = [
+            "include/boost/assign.hpp",
+        ],
+    ),
+    features = [
+        "parse_headers",
+    ],
+    includes = ["include"],
+    textual_hdrs = ["include/boost/assign.hpp"],
+    deps = [
+        "@boost.array",
+        "@boost.config",
+        "@boost.core",
+        "@boost.move",
+        "@boost.preprocessor",
+        "@boost.ptr_container",
+        "@boost.range",
+        "@boost.static_assert",
+        "@boost.throw_exception",
+        "@boost.tuple",
+        "@boost.type_traits",
+    ],
+)

--- a/modules/boost.assign/1.83.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/boost.assign/1.83.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,21 @@
+module(
+    name = "boost.assign",
+    version = "1.83.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 108300,
+)
+
+bazel_dep(name = "boost.array", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.config", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.core", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.move", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.multi_index", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.preprocessor", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.ptr_container", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.range", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.static_assert", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.test", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.throw_exception", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.tuple", version = "1.83.0.bcr.1")
+bazel_dep(name = "boost.type_traits", version = "1.83.0.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.0.14")

--- a/modules/boost.assign/1.83.0.bcr.1/presubmit.yml
+++ b/modules/boost.assign/1.83.0.bcr.1/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel: [7.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.assign//:boost.assign'

--- a/modules/boost.assign/1.83.0.bcr.1/source.json
+++ b/modules/boost.assign/1.83.0.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-HHZKV4rwNH+NGldsGo7YQ7goD0oDXPIH48y+N3I58CI=",
+    "strip_prefix": "assign-boost-1.83.0",
+    "url": "https://github.com/boostorg/assign/archive/refs/tags/boost-1.83.0.tar.gz",
+    "overlay": {
+        "BUILD.bazel": "sha256-7EmzmzMy3eS0hq5YlE7RFxhZr4phb+Ou66ThsDIQNoQ=",
+        "MODULE.bazel": "sha256-sWIF6LDbOXXxPbS7dIMXa9IFOQo8j5vTTXUWOkImMiw="
+    }
+}

--- a/modules/boost.assign/metadata.json
+++ b/modules/boost.assign/metadata.json
@@ -18,6 +18,7 @@
         "github:boostorg/assign"
     ],
     "versions": [
+        "1.83.0.bcr.1",
         "1.87.0",
         "1.88.0.bcr.1",
         "1.88.0.bcr.2",


### PR DESCRIPTION
Following structure added in https://github.com/bazelbuild/bazel-central-registry/commit/82895adb2603fb91e179275ccb60b6dd42e9b147 without using symlink for MODULE.bazel (https://github.com/bazelbuild/bazel-central-registry/pull/6440).

Adjusted according to other boost.* 1.83.0.bcr.1 targets:

- presubmit.yml matrix.platform list and matrix.bazel
- Dependencies:
  - rules_cc using version 0.0.14

Adding @bazel-io skip_check unstable_url as it doesn't have a stable url.

Ran and applied modifications produced by:
```
bazel run //tools:update_integrity -- boost.assign --version 1.83.0.bcr.1
bazel run //tools:update_integrity -- boost.assign
```