### PR TITLE
feat: add `ape@1.1.0`

### DIFF
--- a/modules/ape/1.1.0/MODULE.bazel
+++ b/modules/ape/1.1.0/MODULE.bazel
@@ -1,0 +1,176 @@
+module(
+    name = "ape",
+    version = "1.1.0",
+    bazel_compatibility = [
+        ">=7.4.0",
+    ],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "toolchain_utils", version = "1.0.2")
+bazel_dep(name = "download_utils", version = "1.0.1")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.0.0")
+
+bazel_dep(name = "pre-commit", version = "1.0.9", dev_dependency = True)
+bazel_dep(name = "pre-commit-hooks", version = "1.3.1", dev_dependency = True)
+bazel_dep(name = "hermetic_cc_toolchain", version = "4.0.1", dev_dependency = True)
+single_version_override(
+    module_name = "hermetic_cc_toolchain",
+    patch_strip = 1,
+    patches = ["hermetic_cc_toolchain.patch"],
+)
+
+zig = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains", dev_dependency = True)
+use_repo(zig, "zig_sdk")
+
+register_toolchains(
+    "@zig_sdk//toolchain/...",
+    dev_dependency = True,
+)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
+
+[
+    python.toolchain(
+        configure_coverage_tool = True,
+        # TODO: need hermetic `chmod`/`id`: https://github.com/bazelbuild/rules_python/pull/2024
+        ignore_root_user_error = True,
+        python_version = version,
+    )
+    for version in ("3.10", "3.11", "3.12", "3.13")
+]
+
+download_archive = use_repo_rule("@download_utils//download/archive:defs.bzl", "download_archive")
+
+download_archive(
+    name = "zig-0.11.0-arm64-darwin",
+    srcs = [
+        "entrypoint",
+        "zig",
+    ],
+    integrity = "sha256-xuv5J7sTpwfXQmdHSp9VMnTmSQb9Ib8cdaIL3oyt97I=",
+    links = {
+        "zig-macos-aarch64-0.11.0/zig": "zig",
+        "zig": "entrypoint",
+    },
+    urls = [
+        "https://gitlab.arm.com/api/v4/projects/10212/packages/generic/zig/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
+        "https://ziglang.org/download/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
+    ],
+)
+
+select = use_repo_rule("@toolchain_utils//toolchain/local/select:defs.bzl", "toolchain_local_select")
+
+select(
+    name = "zig",
+    map = {
+        "@zig-0.11.0-arm64-darwin": "arm64-darwin",
+    },
+)
+
+download_file = use_repo_rule("@download_utils//download/file:defs.bzl", "download_file")
+
+download_file(
+    name = "ape-m1.c",
+    executable = False,
+    integrity = "sha256-eK954gq7s/malzVZWbWb1YlJVkBkrbdU8DAuurtL96M=",
+    output = "ape-m1.c",
+    patches = [
+        "//:ape-m1.patch",
+    ],
+    urls = [
+        "https://gitlab.arm.com/api/v4/projects/10212/packages/generic/cosmos.zip/4.0.2/ape-m1.c",
+        "https://raw.githubusercontent.com/jart/cosmopolitan/4.0.2/ape/ape-m1.c",
+    ],
+)
+
+compile = use_repo_rule("//ape/compile:repository.bzl", "compile")
+
+compile(
+    name = "ape-arm64.macho",
+    srcs = ["@ape-m1.c"],
+    args = ["-O"],
+    links = {
+        "entrypoint": "binary",
+    },
+    output = "binary",
+    target = "{cpu}-macos-none",
+    zig = "@zig//:entrypoint",
+)
+
+pe = use_repo_rule("//ape/pe:repository.bzl", "pe")
+
+pe(
+    name = "ape.pe",
+    links = {
+        "entrypoint": "binary",
+    },
+    output = "binary",
+)
+
+select(
+    name = "launcher",
+    map = {
+        "@ape-arm64.elf": "arm64-linux",
+        "@ape-x86_64.elf": "amd64-linux",
+        "@ape-x86_64.macho": "amd64-darwin",
+        "@ape-arm64.macho": "arm64-darwin",
+        "@ape.pe": "windows",
+    },
+)
+
+resolved = use_repo_rule("@toolchain_utils//toolchain/resolved:defs.bzl", "toolchain_resolved")
+
+resolved(
+    name = "resolved-ape",
+    toolchain_type = "//ape/toolchain/ape:type",
+)
+
+register_toolchains("//ape/toolchain/...")
+
+cosmos = use_extension("//ape/cosmos:defs.bzl", "ape_cosmos")
+cosmos.upload(
+    template = "https://gitlab.arm.com/api/v4/projects/10212/packages/generic/cosmos.zip/{version}/{name}",
+)
+cosmos.url(
+    template = "https://gitlab.arm.com/api/v4/projects/10212/packages/generic/cosmos.zip/{version}/{name}",
+)
+cosmos.url(
+    template = "https://cosmo.zip/pub/cosmos/v/{version}/bin/{name}",
+)
+cosmos.download(
+    lock = "//ape/cosmos:4.0.2.json",
+    version = "4.0.2",
+)
+cosmos.download(
+    lock = "//ape/cosmos:3.9.2.json",
+    version = "3.9.2",
+)
+cosmos.download(
+    lock = "//ape/cosmos:3.7.1.json",
+    version = "3.7.1",
+)
+cosmos.download(
+    lock = "//ape/cosmos:3.3.1.json",
+    version = "3.3.1",
+)
+cosmos.download(
+    lock = "//ape/cosmos:3.2.4.json",
+    version = "3.2.4",
+)
+
+# https://github.com/ahgamut/superconfigure/issues/38
+cosmos.override(
+    basename = "pigz",
+    version = "3.2.4",
+)
+cosmos.use(
+    aliases = True,
+    bootstrap = True,
+    metadata = True,
+    upload = True,
+)
+use_repo(cosmos, "aliases", "ape-aarch64.elf", "ape-arm64.elf", "ape-x86_64.elf", "ape-x86_64.macho", "assimilate", "assimilate-aarch64.elf", "assimilate-x86_64.elf", "assimilate-x86_64.macho", "metadata", "upload")

--- a/modules/ape/1.1.0/presubmit.yml
+++ b/modules/ape/1.1.0/presubmit.yml
@@ -1,0 +1,20 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel:
+      - 7.x
+      - 8.x
+    platform:
+      - debian11
+      - ubuntu2204
+      - fedora39
+      - macos
+      - macos_arm64
+      - windows
+  tasks:
+    e2e_tests:
+      name: Run end-to-end Tests
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/modules/ape/1.1.0/source.json
+++ b/modules/ape/1.1.0/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://gitlab.arm.com/bazel/ape/-/releases/v1.1.0/downloads/src.tar.gz",
+  "integrity": "sha512-inCnlhP+NgllGyiOcVDMTHaX0i2y1Uxq5TXuePvyG4BOBelXc9Bk/VAZE+IakmTzgjZDE1w+pd/8TwSq7dCbXQ==",
+  "strip_prefix": "ape-v1.1.0"
+}

--- a/modules/ape/metadata.json
+++ b/modules/ape/metadata.json
@@ -1,33 +1,34 @@
 {
-    "homepage": "https://gitlab.arm.com/bazel/ape",
-    "maintainers": [
-        {
-            "email": "matthew.clarkson@arm.com",
-            "name": "Matt Clarkson",
-            "github": "mattyclarkson",
-            "github_user_id": 1081113
-        }
-    ],
-    "repository": [
-        "https://gitlab.arm.com/bazel/ape"
-    ],
-    "versions": [
-        "1.0.0-alpha.1",
-        "1.0.0-alpha.2",
-        "1.0.0-alpha.3",
-        "1.0.0-alpha.5",
-        "1.0.0-beta.2",
-        "1.0.0-beta.3",
-        "1.0.0-beta.4",
-        "1.0.0-beta.6",
-        "1.0.0-beta.7",
-        "1.0.0-beta.11",
-        "1.0.0-beta.12",
-        "1.0.0-beta.13",
-        "1.0.0-beta.14",
-        "1.0.0-beta.15",
-        "1.0.0-beta.16",
-        "1.0.0-beta.17",
-        "1.0.1"
-    ]
+  "homepage": "https://gitlab.arm.com/bazel/ape",
+  "maintainers": [
+    {
+      "email": "matthew.clarkson@arm.com",
+      "name": "Matt Clarkson",
+      "github": "mattyclarkson",
+      "github_user_id": 1081113
+    }
+  ],
+  "repository": [
+    "https://gitlab.arm.com/bazel/ape"
+  ],
+  "versions": [
+    "1.0.0-alpha.1",
+    "1.0.0-alpha.2",
+    "1.0.0-alpha.3",
+    "1.0.0-alpha.5",
+    "1.0.0-beta.2",
+    "1.0.0-beta.3",
+    "1.0.0-beta.4",
+    "1.0.0-beta.6",
+    "1.0.0-beta.7",
+    "1.0.0-beta.11",
+    "1.0.0-beta.12",
+    "1.0.0-beta.13",
+    "1.0.0-beta.14",
+    "1.0.0-beta.15",
+    "1.0.0-beta.16",
+    "1.0.0-beta.17",
+    "1.0.1",
+    "1.1.0"
+  ]
 }


### PR DESCRIPTION
- Bazel 9 support
- Enable `gitlab.arm.com` mirrors as first URL to reduce load on upstream bandwidth
- Optimise the Apple Silicon launcher
- Upgrade to stable dependency versions