### PR TITLE
Remove MODULE.bazel matching check in BCR validation

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -133,8 +133,6 @@ def run_git(*args):
     )
 
 
-
-
 def extract_reference(repo_path, path):
     """
     Extracts the reference from a path matching the pattern /<repo_path>/archive/<ref>.zip or /<repo_path>/archive/<ref>.tar.gz
@@ -482,7 +480,6 @@ class BcrValidator:
                     BcrValidationResult.GOOD,
                     "The presubmit.yml file matches the previous version.",
                 )
-
 
     def _download_source_archive(self, source, output_dir):
         source_url = source["url"]


### PR DESCRIPTION
The latest releases of Bazel 7 and 8 don't require the checked in file anymore

Fixes https://github.com/bazelbuild/bazel-central-registry/issues/6622