### PR TITLE
feat: add matrix json fields to add_module script

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -189,6 +189,8 @@ class Module:
         self.test_module_path = None
         self.test_module_build_targets = []
         self.test_module_test_targets = []
+        self.matrix_bazel_versions = []
+        self.matrix_platforms = []
 
     def add_dep(self, module_name, version):
         self.deps.append((module_name, version))
@@ -431,12 +433,14 @@ module(
         if module.presubmit_yml:
             shutil.copy(module.presubmit_yml, presubmit_yml)
         else:
-            PLATFORMS = ["debian11", "ubuntu2204", "macos", "macos_arm64", "windows"]
-            BAZEL_VERSIONS = ["8.x", "7.x", "6.x"]
+            DEFAULT_PLATFORMS = ["debian11", "ubuntu2204", "macos", "macos_arm64", "windows"]
+            DEFAULT_BAZEL_VERSIONS = ["8.x", "7.x", "6.x"]
+            platforms = module.matrix_platforms or DEFAULT_PLATFORMS
+            bazel_versions = module.matrix_bazel_versions or DEFAULT_BAZEL_VERSIONS
             presubmit = {
                 "matrix": {
-                    "platform": PLATFORMS.copy(),
-                    "bazel": BAZEL_VERSIONS.copy(),
+                    "platform": platforms.copy(),
+                    "bazel": bazel_versions.copy(),
                 },
                 "tasks": {
                     "verify_targets": {
@@ -461,8 +465,8 @@ module(
                 presubmit["bcr_test_module"] = {
                     "module_path": module.test_module_path,
                     "matrix": {
-                        "platform": PLATFORMS.copy(),
-                        "bazel": BAZEL_VERSIONS.copy(),
+                        "platform": platforms.copy(),
+                        "bazel": bazel_versions.copy(),
                     },
                     "tasks": {"run_test_module": task},
                 }


### PR DESCRIPTION
When adding a module with the `//tools:add_module` script, this allows specifying matrix parameters in the JSON descriptor without specifying a full `presubmit.yml` file.

For example, this is useful when one wants to add a new version of a module that:
- doesn't support bazel 6.x
- doesn't support a given platform