### PR TITLE
gazelle_cc@0.4.0-rc.2

### DIFF
--- a/modules/gazelle_cc/0.4.0-rc.2/MODULE.bazel
+++ b/modules/gazelle_cc/0.4.0-rc.2/MODULE.bazel
@@ -1,0 +1,24 @@
+"""Bazel Gazelle extension for rules_cc"""
+
+module(name = "gazelle_cc",
+    version = "0.4.0-rc.2",
+)
+
+bazel_dep(name = "gazelle", version = "0.46.0")
+bazel_dep(name = "rules_go", version = "0.59.0")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "package_metadata", version = "0.0.5")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.24.0")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bazelbuild_buildtools",
+    "com_github_bmatcuk_doublestar_v4",
+    "com_github_stretchr_testify",
+    "org_golang_google_protobuf",
+)

--- a/modules/gazelle_cc/0.4.0-rc.2/attestations.json
+++ b/modules/gazelle_cc/0.4.0-rc.2/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/EngFlow/gazelle_cc/releases/download/v0.4.0-rc.2/source.json.intoto.jsonl",
+            "integrity": "sha256-5ossSL6LE7e98PhLEqMj6qTwWxelzA4UUOjaN1b70fQ="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/EngFlow/gazelle_cc/releases/download/v0.4.0-rc.2/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-gAHTmiWNiQ+8+IRxFbk+DjdmErOVcnTTXxShdyxeKhw="
+        },
+        "gazelle_cc-v0.4.0-rc.2.tar.gz": {
+            "url": "https://github.com/EngFlow/gazelle_cc/releases/download/v0.4.0-rc.2/gazelle_cc-v0.4.0-rc.2.tar.gz.intoto.jsonl",
+            "integrity": "sha256-mnCTt6uHmjR2LFN+U4UwWpV8UKFYj4nSiFNwI/IK3GU="
+        }
+    }
+}

--- a/modules/gazelle_cc/0.4.0-rc.2/patches/module_dot_bazel_version.patch
+++ b/modules/gazelle_cc/0.4.0-rc.2/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,9 @@
+ """Bazel Gazelle extension for rules_cc"""
+ 
+-module(name = "gazelle_cc")
++module(name = "gazelle_cc",
++    version = "0.4.0-rc.2",
++)
+ 
+ bazel_dep(name = "gazelle", version = "0.46.0")
+ bazel_dep(name = "rules_go", version = "0.59.0")
+ bazel_dep(name = "rules_proto", version = "7.1.0")

--- a/modules/gazelle_cc/0.4.0-rc.2/presubmit.yml
+++ b/modules/gazelle_cc/0.4.0-rc.2/presubmit.yml
@@ -1,0 +1,17 @@
+bcr_test_module:
+  module_path: "example/bzlmod"
+  matrix:
+    platform: ["macos", "ubuntu2004"]
+    bazel: ["7.*", "8.*", "9.*"]
+  tasks:
+    run_tests:
+      name: "Build and test the example module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      shell_commands:
+        # Generate the BUILD files for the test module using Gazelle
+        - bazel run //:gazelle
+      build_targets:
+        - //...
+      test_targets:
+        - //...

--- a/modules/gazelle_cc/0.4.0-rc.2/source.json
+++ b/modules/gazelle_cc/0.4.0-rc.2/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-50dtWtRjZ6+8IUmo3ohliPcW/MusojhzS+w8nt7ydQ0=",
+    "strip_prefix": "gazelle_cc-0.4.0-rc.2",
+    "url": "https://github.com/EngFlow/gazelle_cc/releases/download/v0.4.0-rc.2/gazelle_cc-v0.4.0-rc.2.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-aao3qBQfA+2vX0xysEk8DtNsvRkkbx6MedXNcYSk4aE="
+    },
+    "patch_strip": 1
+}

--- a/modules/gazelle_cc/metadata.json
+++ b/modules/gazelle_cc/metadata.json
@@ -18,7 +18,8 @@
         "github:EngFlow/gazelle_cc"
     ],
     "versions": [
-        "0.1.0"
+        "0.1.0",
+        "0.4.0-rc.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/EngFlow/gazelle_cc/releases/tag/v0.4.0-rc.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_