### PR TITLE
Add paho.mqtt.cpp version 1.3.2

### DIFF
--- a/modules/paho.mqtt.cpp/1.3.2/MODULE.bazel
+++ b/modules/paho.mqtt.cpp/1.3.2/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "paho.mqtt.cpp",
+    version = "1.3.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "paho.mqtt.c", version = "1.3.14")
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/paho.mqtt.cpp/1.3.2/overlay/BUILD.bazel
+++ b/modules/paho.mqtt.cpp/1.3.2/overlay/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "paho.mqtt.cpp",
+    srcs = glob(["src/*.cpp"]),
+    hdrs = glob(["src/mqtt/*.h"]),
+    includes = ["src"],
+    local_defines = [
+        "PAHO_MQTTPP_EXPORTS",
+        "OPENSSL",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["@paho.mqtt.c"],
+)

--- a/modules/paho.mqtt.cpp/1.3.2/overlay/MODULE.bazel
+++ b/modules/paho.mqtt.cpp/1.3.2/overlay/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "paho.mqtt.cpp",
+    version = "1.3.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "paho.mqtt.c", version = "1.3.14")
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/paho.mqtt.cpp/1.3.2/overlay/test/BUILD.bazel
+++ b/modules/paho.mqtt.cpp/1.3.2/overlay/test/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "tests",
+    srcs = glob(
+        [
+            "unit/*.cpp",
+            "unit/*.h",
+        ],
+        exclude = ["unit/test_async_client_v3.cpp"],  # Needs Cppunit
+    ),
+    local_defines = ["TEST_EXTERNAL_SERVER"],
+    tags = ["requires-network"],
+    deps = [
+        "@catch2",
+        "@paho.mqtt.cpp",
+    ],
+)

--- a/modules/paho.mqtt.cpp/1.3.2/overlay/test/MODULE.bazel
+++ b/modules/paho.mqtt.cpp/1.3.2/overlay/test/MODULE.bazel
@@ -1,0 +1,8 @@
+bazel_dep(name = "paho.mqtt.cpp")
+local_path_override(
+    module_name = "paho.mqtt.cpp",
+    path = "..",
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "catch2", version = "3.8.0")

--- a/modules/paho.mqtt.cpp/1.3.2/patches/change_test_urls.patch
+++ b/modules/paho.mqtt.cpp/1.3.2/patches/change_test_urls.patch
@@ -1,0 +1,40 @@
+diff --git i/test/unit/test_async_client.cpp w/test/unit/test_async_client.cpp
+index b7c4b4f..faf0125 100644
+--- i/test/unit/test_async_client.cpp
++++ w/test/unit/test_async_client.cpp
+@@ -36,7 +36,8 @@ using namespace mqtt;
+ // NOTE: This test case requires network access. It uses one of
+ //  	 the public available MQTT brokers
+ #if defined(TEST_EXTERNAL_SERVER)
+-	static const std::string GOOD_SERVER_URI { "tcp://mqtt.eclipse.org:1883" };
++	static const std::string GOOD_SERVER_URI{"tcp://test.mosquitto.org:1883"};
++	static const std::string GOOD_SSL_SERVER_URI{"ssl://test.mosquitto.org:8883"};
+ #else
+ 	static const std::string GOOD_SERVER_URI { "tcp://localhost:1883" };
+ 	static const std::string GOOD_SSL_SERVER_URI { "ssl://localhost:18885" };
+diff --git i/test/unit/test_async_client_v3.cpp w/test/unit/test_async_client_v3.cpp
+index 875e8bb..84461b0 100644
+--- i/test/unit/test_async_client_v3.cpp
++++ w/test/unit/test_async_client_v3.cpp
+@@ -99,7 +99,7 @@ class async_client_v3_test : public CppUnit::TestFixture
+ 	// NOTE: This test case requires network access. It uses one of
+ 	//  	 the public available MQTT brokers
+ 	#if defined(TEST_EXTERNAL_SERVER)
+-		const std::string GOOD_SERVER_URI { "tcp://mqtt.eclipse.org:1883" };
++		const std::string GOOD_SERVER_URI { "tcp://test.mosquitto.org:1883" };
+ 	#else
+ 		const std::string GOOD_SERVER_URI { "tcp://localhost:1883" };
+ 		const std::string GOOD_SSL_SERVER_URI { "ssl://localhost:18885" };
+diff --git i/test/unit/test_client.cpp w/test/unit/test_client.cpp
+index 13cf3e6..e1207f8 100644
+--- i/test/unit/test_client.cpp
++++ w/test/unit/test_client.cpp
+@@ -40,7 +40,7 @@ using namespace mqtt;
+ // NOTE: This test case requires network access. It uses one of
+ //  	 the public available MQTT brokers
+ #if defined(TEST_EXTERNAL_SERVER)
+-	static const std::string GOOD_SERVER_URI { "tcp://mqtt.eclipse.org:1883" };
++	static const std::string GOOD_SERVER_URI { "tcp://test.mosquitto.org:1883" };
+ #else
+ 	static const std::string GOOD_SERVER_URI { "tcp://localhost:1883" };
+ #endif

--- a/modules/paho.mqtt.cpp/1.3.2/presubmit.yml
+++ b/modules/paho.mqtt.cpp/1.3.2/presubmit.yml
@@ -1,0 +1,24 @@
+matrix:
+  platform: [debian11, ubuntu2404, macos, macos_arm64]
+  bazel: &bazels [7.x, 8.x]
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags: [--cxxopt=-std=c++17]
+    build_targets: ["@paho.mqtt.cpp//...", -@paho.mqtt.cpp//test/...]
+
+bcr_test_module:
+  matrix:
+    platform: [debian11, ubuntu2404]
+    bazel: *bazels
+  module_path: test
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags: [--cxxopt=-std=c++17]
+      test_targets: [//...]

--- a/modules/paho.mqtt.cpp/1.3.2/source.json
+++ b/modules/paho.mqtt.cpp/1.3.2/source.json
@@ -1,0 +1,15 @@
+{
+    "url": "https://github.com/eclipse-paho/paho.mqtt.cpp/archive/refs/tags/v1.3.2.tar.gz",
+    "strip_prefix": "paho.mqtt.cpp-1.3.2",
+    "integrity": "sha256-wnHVISh/QXECtEez0ejRe+Dg9qOwtlMzTrzSzNINHkY=",
+    "patch_strip": 1,
+    "overlay": {
+        "BUILD.bazel": "sha256-BnwAKY9nKFiCpGUYkxbFPgNBhC/1ktcCNLL0bvuh2n8=",
+        "MODULE.bazel": "sha256-x2jRzNhvObcsh5xCWERBP8IjsYGpDQG1/uaG2EFjm4M=",
+        "test/BUILD.bazel": "sha256-+ux35W3iyzSEdYE0XpMLFzaL7Ts2JCMmGcfAy1w3lbk=",
+        "test/MODULE.bazel": "sha256-qJIKKbbWIUso3jl7FKwoKo6NTNyRWsl7pAjZhviNUc8="
+    },
+    "patches": {
+        "change_test_urls.patch": "sha256-erGiOsQsneCyt9Ms9Fd6TZPd/Jgk52Anija0Rb8RZGQ="
+    }
+}

--- a/modules/paho.mqtt.cpp/metadata.json
+++ b/modules/paho.mqtt.cpp/metadata.json
@@ -12,6 +12,7 @@
         "github:eclipse-paho/paho.mqtt.cpp"
     ],
     "versions": [
+        "1.3.2",
         "1.5.2"
     ],
     "yanked_versions": {}


### PR DESCRIPTION
Based the build rules on the existing ones for 1.5.2. Hade to change the test urls though since mqtt.eclipseprojects.io is no longer maintained (https://github.com/eclipse-mosquitto/mosquitto/issues/3303)