### PR TITLE
protothreads@0.1.2

### DIFF
--- a/modules/protothreads/0.1.2/MODULE.bazel
+++ b/modules/protothreads/0.1.2/MODULE.bazel
@@ -1,0 +1,4 @@
+""" Module """
+module(name = "protothreads", version = "0.1.2", compatibility_level = 1)
+
+bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)

--- a/modules/protothreads/0.1.2/patches/module_dot_bazel_version.patch
+++ b/modules/protothreads/0.1.2/patches/module_dot_bazel_version.patch
@@ -1,0 +1,9 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,4 +1,4 @@
+ """ Module """
+-module(name = "protothreads", version = "0.0.0", compatibility_level = 1)
++module(name = "protothreads", version = "0.1.2", compatibility_level = 1)
+ 
+ bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)

--- a/modules/protothreads/0.1.2/presubmit.yml
+++ b/modules/protothreads/0.1.2/presubmit.yml
@@ -1,0 +1,24 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2204
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '//example:examples'
+bcr_test_module:
+  matrix:
+    platform:
+    - debian10
+    - ubuntu2204
+    - macos
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      build_targets:
+      - '//test:unit_test'

--- a/modules/protothreads/0.1.2/source.json
+++ b/modules/protothreads/0.1.2/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-isGuozUrrN27oibupPqjHndA7a746gEISJ079Yq95OI=",
+    "strip_prefix": "protothreads-0.1.2",
+    "url": "https://github.com/JalonWong/protothreads/archive/v0.1.2.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-dt19Q+Uu72zxmN0Ifk6jaF8K60bt7GijRtO3vVVBT24="
+    },
+    "patch_strip": 1
+}

--- a/modules/protothreads/metadata.json
+++ b/modules/protothreads/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/JalonWong/protothreads",
+    "maintainers": [
+        {
+            "name": "Jalon Wong",
+            "email": "jalonwong@gmail.com",
+            "github": "jalonwong",
+            "github_user_id": 5309088
+        }
+    ],
+    "repository": [
+        "github:jalonwong/protothreads"
+    ],
+    "versions": [
+        "0.1.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/JalonWong/protothreads/releases/tag/v0.1.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_