### PR TITLE
protothreads@0.1.3

### DIFF
--- a/modules/protothreads/0.1.3/MODULE.bazel
+++ b/modules/protothreads/0.1.3/MODULE.bazel
@@ -1,0 +1,4 @@
+""" Module """
+module(name = "protothreads", version = "0.1.3", compatibility_level = 1)
+
+bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)

--- a/modules/protothreads/0.1.3/presubmit.yml
+++ b/modules/protothreads/0.1.3/presubmit.yml
@@ -1,0 +1,26 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2204
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: [8.x]
+    build_targets:
+    - '//example:examples'
+bcr_test_module:
+  matrix:
+    platform:
+    - debian10
+    - ubuntu2204
+    - macos
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: [8.x]
+      build_targets:
+      - '//test:unit_test'

--- a/modules/protothreads/0.1.3/source.json
+++ b/modules/protothreads/0.1.3/source.json
@@ -1,0 +1,4 @@
+{
+    "integrity": "sha256-EwVTNc6CNSR931Ad9Lu5VUTrUTpCnIvggZStytzb2KY=",
+    "url": "https://github.com/JalonWong/protothreads/releases/download/v0.1.3/protothreads.tar.gz"
+}

--- a/modules/protothreads/metadata.json
+++ b/modules/protothreads/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/JalonWong/protothreads",
+    "maintainers": [
+        {
+            "name": "Jalon Wong",
+            "email": "jalonwong@gmail.com",
+            "github": "jalonwong",
+            "github_user_id": 5309088
+        }
+    ],
+    "repository": [
+        "github:jalonwong/protothreads"
+    ],
+    "versions": [
+        "0.1.3"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/JalonWong/protothreads/releases/tag/v0.1.3

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_