### PR TITLE
Add soplex 7.1.4.bcr.2

### DIFF
--- a/modules/soplex/7.1.4.bcr.2/MODULE.bazel
+++ b/modules/soplex/7.1.4.bcr.2/MODULE.bazel
@@ -1,0 +1,31 @@
+module(
+    name = "soplex",
+    version = "7.1.4.bcr.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.11",
+)
+bazel_dep(
+    name = "fmt",
+    version = "11.1.3",
+)
+bazel_dep(
+    name = "boost.multiprecision",
+    version = "1.89.0.bcr.1",
+)
+bazel_dep(
+    name = "boost.serialization",
+    version = "1.89.0.bcr.1",
+)
+bazel_dep(
+    name = "zlib",
+    version = "1.3.1.bcr.5",
+)
+bazel_dep(
+    name = "zstr",
+    version = "1.0.7",
+)

--- a/modules/soplex/7.1.4.bcr.2/overlay/BUILD.bazel
+++ b/modules/soplex/7.1.4.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,46 @@
+# Description:
+# Soplex is a LP solver, a common tool in Operations Research.
+
+cc_library(
+    name = "soplex",
+    srcs = glob(
+        ["src/soplex/*.cpp"],
+        exclude = ["src/git_hash.cpp"],
+    ),
+    hdrs = glob(
+        [
+            "src/soplex/*.h",
+            "src/soplex/*.hpp",
+        ],
+    ) + [
+        "src/soplex.h",
+        "src/soplex.hpp",
+        "src/soplex/git_hash.cpp",
+    ],
+    copts = select({
+        "@platforms//os:windows": ["/utf-8"],
+        "//conditions:default": [],
+    }),
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boost.multiprecision",
+        "@boost.serialization",
+        "@fmt",
+        "@zstr",
+    ],
+)
+
+cc_binary(
+    name = "soplex_interactive",
+    srcs = ["src/soplexmain.cpp"],
+    copts = select({
+        "@platforms//os:windows": ["/utf-8"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":soplex",
+        "@boost.multiprecision",
+        "@zlib",
+    ],
+)

--- a/modules/soplex/7.1.4.bcr.2/overlay/MODULE.bazel
+++ b/modules/soplex/7.1.4.bcr.2/overlay/MODULE.bazel
@@ -1,0 +1,31 @@
+module(
+    name = "soplex",
+    version = "7.1.4.bcr.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "0.0.11",
+)
+bazel_dep(
+    name = "fmt",
+    version = "11.1.3",
+)
+bazel_dep(
+    name = "boost.multiprecision",
+    version = "1.89.0.bcr.1",
+)
+bazel_dep(
+    name = "boost.serialization",
+    version = "1.89.0.bcr.1",
+)
+bazel_dep(
+    name = "zlib",
+    version = "1.3.1.bcr.5",
+)
+bazel_dep(
+    name = "zstr",
+    version = "1.0.7",
+)

--- a/modules/soplex/7.1.4.bcr.2/patches/add_config_dot_h.patch
+++ b/modules/soplex/7.1.4.bcr.2/patches/add_config_dot_h.patch
@@ -1,0 +1,24 @@
+diff --git a/src/soplex/config.h b/src/soplex/config.h
+new file mode 100644
+index 00000000..e465106c
+--- /dev/null
++++ b/src/soplex/config.h
+@@ -0,0 +1,18 @@
++#ifndef __SPXCONFIG_H__
++#define __SPXCONFIG_H__
++
++#define CMAKE_BUILD_TYPE "Release"
++
++#define SOPLEX_VERSION_MAJOR 7
++#define SOPLEX_VERSION_MINOR 1
++#define SOPLEX_VERSION_PATCH 4
++#define SOPLEX_VERSION_SUB 0
++#define SOPLEX_WITH_BOOST
++#define SOPLEX_WITH_CPPMPF
++/* #undef SOPLEX_WITH_FLOAT128 */
++/* #undef SOPLEX_WITH_GMP */
++/* #undef SOPLEX_WITH_MPFR */
++/* #undef SOPLEX_WITH_PAPILO */
++#define SOPLEX_WITH_ZLIB
++
++#endif

--- a/modules/soplex/7.1.4.bcr.2/patches/add_git_hash_dot_cpp.patch
+++ b/modules/soplex/7.1.4.bcr.2/patches/add_git_hash_dot_cpp.patch
@@ -1,0 +1,7 @@
+diff --git a/src/soplex/git_hash.cpp b/src/soplex/git_hash.cpp
+new file mode 100644
+index 00000000..bc2d689d
+--- /dev/null
++++ b/src/soplex/git_hash.cpp
+@@ -0,0 +1 @@
++#define SPX_GITHASH "60fd96f"

--- a/modules/soplex/7.1.4.bcr.2/patches/fmt_dot_hpp.patch
+++ b/modules/soplex/7.1.4.bcr.2/patches/fmt_dot_hpp.patch
@@ -1,0 +1,15 @@
+diff --git a/src/soplex/fmt.hpp b/src/soplex/fmt.hpp
+index 934cb085..c3a31bb8 100644
+--- a/src/soplex/fmt.hpp
++++ b/src/soplex/fmt.hpp
+@@ -49,8 +49,8 @@
+ 
+ /* to provide backwards compatibility use fmt of PaPILO <= 2.3 due to breaking changes in fmt 7 */
+ #if !defined(SOPLEX_WITH_PAPILO) || PAPILO_VERSION_MAJOR > 2 || (PAPILO_VERSION_MAJOR == 2 && PAPILO_VERSION_MINOR > 3)
+-#include "soplex/external/fmt/format.h"
+-#include "soplex/external/fmt/ostream.h"
++#include "fmt/format.h"
++#include "fmt/ostream.h"
+ #else
+ #include "papilo/external/fmt/format.h"
+ #include "papilo/external/fmt/ostream.h"

--- a/modules/soplex/7.1.4.bcr.2/patches/macos_debug.patch
+++ b/modules/soplex/7.1.4.bcr.2/patches/macos_debug.patch
@@ -1,0 +1,246 @@
+commit 7fc0c9a600de9949e157faeb54546b6912581f76
+Author: Jeremy Kun <j2kun@users.noreply.github.com>
+Date:   Tue Jun 3 12:41:12 2025 -0700
+
+    rename verobsity enums to avoid DEBUG conflict on MacOS
+
+diff --git a/src/soplex.hpp b/src/soplex.hpp
+index 0721a8c6..72cd340a 100644
+--- a/src/soplex.hpp
++++ b/src/soplex.hpp
+@@ -5998,27 +5998,27 @@ bool SoPlexBase<R>::setIntParam(const IntParam param, const int value, const boo
+       switch(value)
+       {
+       case 0:
+-         spxout.setVerbosity(SPxOut::ERROR);
++         spxout.setVerbosity(SPxOut::VERB_ERROR);
+          break;
+ 
+       case 1:
+-         spxout.setVerbosity(SPxOut::WARNING);
++         spxout.setVerbosity(SPxOut::VERB_WARNING);
+          break;
+ 
+       case 2:
+-         spxout.setVerbosity(SPxOut::DEBUG);
++         spxout.setVerbosity(SPxOut::VERB_DEBUG);
+          break;
+ 
+       case 3:
+-         spxout.setVerbosity(SPxOut::INFO1);
++         spxout.setVerbosity(SPxOut::VERB_INFO1);
+          break;
+ 
+       case 4:
+-         spxout.setVerbosity(SPxOut::INFO2);
++         spxout.setVerbosity(SPxOut::VERB_INFO2);
+          break;
+ 
+       case 5:
+-         spxout.setVerbosity(SPxOut::INFO3);
++         spxout.setVerbosity(SPxOut::VERB_INFO3);
+          break;
+       }
+ 
+@@ -10095,7 +10095,7 @@ typename SPxSolverBase<R>::Status SoPlexBase<R>::optimize(volatile bool* interru
+    }
+ 
+    SPX_MSG_INFO1(spxout, spxout << "\n";
+-                 printShortStatistics(spxout.getStream(SPxOut::INFO1));
++                 printShortStatistics(spxout.getStream(SPxOut::VERB_INFO1));
+                  spxout << "\n");
+ 
+ 
+diff --git a/src/soplex/spxdefines.h b/src/soplex/spxdefines.h
+index cbcee568..9491a670 100644
+--- a/src/soplex/spxdefines.h
++++ b/src/soplex/spxdefines.h
+@@ -26,12 +26,12 @@
+  * @brief Debugging, floating point type and parameter definitions.
+  *
+  * In optimized code with \c NDEBUG defined, only
+- * \ref soplex::SPxOut::INFO1 "INFO1",
+- * \ref soplex::SPxOut::INFO2 "INFO2", and
+- * \ref soplex::SPxOut::INFO3 "INFO3" are set.
++ * \ref soplex::SPxOut::VERB_INFO1 "INFO1",
++ * \ref soplex::SPxOut::VERB_INFO2 "INFO2", and
++ * \ref soplex::SPxOut::VERB_INFO3 "INFO3" are set.
+  * If \c NDEBUG is not defined, the code within \#TRACE is used.
+  * If \c SOPLEX_DEBUG is defined, the code within
+- * \ref soplex::SPxOut::DEBUG "DEBUG" is also used.
++ * \ref soplex::SPxOut::VERB_DEBUG "DEBUG" is also used.
+  *
+  * If \c WITH_LONG_DOUBLE is defined, all Real numbers are of type
+  * long double instead of just double.
+@@ -159,16 +159,16 @@ bool EQ(int a, int b);
+ #define SOPLEX_DO_WITH_ERR_VERBOSITY( do_something ) { do_something; }
+ #endif
+ 
+-/// Prints out message \p x if the verbosity level is at least SPxOut::ERROR.
++/// Prints out message \p x if the verbosity level is at least SPxOut::VERB_ERROR.
+ #define SPX_MSG_ERROR(x)            { SOPLEX_DO_WITH_ERR_VERBOSITY( x ) }
+-/// Prints out message \p x if the verbosity level is at least SPxOut::WARNING.
+-#define SPX_MSG_WARNING(spxout, x)  { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::WARNING, spxout, x ) }
+-/// Prints out message \p x if the verbosity level is at least SPxOut::INFO1.
+-#define SPX_MSG_INFO1(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::INFO1, spxout, x ) }
+-/// Prints out message \p x if the verbosity level is at least SPxOut::INFO2.
+-#define SPX_MSG_INFO2(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::INFO2, spxout, x ) }
+-/// Prints out message \p x if the verbosity level is at least SPxOut::INFO3.
+-#define SPX_MSG_INFO3(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::INFO3, spxout, x ) }
++/// Prints out message \p x if the verbosity level is at least SPxOut::VERB_WARNING.
++#define SPX_MSG_WARNING(spxout, x)  { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::VERB_WARNING, spxout, x ) }
++/// Prints out message \p x if the verbosity level is at least SPxOut::VERB_INFO1.
++#define SPX_MSG_INFO1(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::VERB_INFO1, spxout, x ) }
++/// Prints out message \p x if the verbosity level is at least SPxOut::VERB_INFO2.
++#define SPX_MSG_INFO2(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::VERB_INFO2, spxout, x ) }
++/// Prints out message \p x if the verbosity level is at least SPxOut::VERB_INFO3.
++#define SPX_MSG_INFO3(spxout, x)    { SOPLEX_DO_WITH_TMP_VERBOSITY( SPxOut::VERB_INFO3, spxout, x ) }
+ 
+ extern bool msginconsistent(const char* name, const char* file, int line);
+ 
+diff --git a/src/soplex/spxout.cpp b/src/soplex/spxout.cpp
+index 6a2cffdd..15070b62 100644
+--- a/src/soplex/spxout.cpp
++++ b/src/soplex/spxout.cpp
+@@ -30,14 +30,14 @@ namespace soplex
+ {
+ /// constructor
+ SPxOut::SPxOut()
+-   : m_verbosity(ERROR)
++   : m_verbosity(VERB_ERROR)
+    , m_streams(nullptr)
+ {
+-   spx_alloc(m_streams, INFO3 + 1);
+-   m_streams = new(m_streams) std::ostream*[INFO3 + 1];
+-   m_streams[ ERROR ] = m_streams[ WARNING ] = &std::cerr;
++   spx_alloc(m_streams, VERB_INFO3 + 1);
++   m_streams = new(m_streams) std::ostream*[VERB_INFO3 + 1];
++   m_streams[ VERB_ERROR ] = m_streams[ VERB_WARNING ] = &std::cerr;
+ 
+-   for(int i = DEBUG; i <= INFO3; ++i)
++   for(int i = VERB_DEBUG; i <= VERB_INFO3; ++i)
+       m_streams[ i ] = &std::cout;
+ }
+ 
+@@ -54,7 +54,7 @@ SPxOut& SPxOut::operator=(const SPxOut& base)
+    if(this != &base)
+       m_verbosity = base.m_verbosity;
+ 
+-   for(int i = DEBUG; i <= INFO3; ++i)
++   for(int i = VERB_DEBUG; i <= VERB_INFO3; ++i)
+       m_streams[ i ] = base.m_streams[ i ];
+ 
+    return *this;
+@@ -64,11 +64,11 @@ SPxOut::SPxOut(const SPxOut& rhs)
+ {
+    m_verbosity = rhs.m_verbosity;
+    m_streams = nullptr;
+-   spx_alloc(m_streams, INFO3 + 1);
+-   m_streams = new(m_streams) std::ostream*[INFO3 + 1];
+-   m_streams[ ERROR ] = m_streams[ WARNING ] = rhs.m_streams[ERROR];
++   spx_alloc(m_streams, VERB_INFO3 + 1);
++   m_streams = new(m_streams) std::ostream*[VERB_INFO3 + 1];
++   m_streams[ VERB_ERROR ] = m_streams[ VERB_WARNING ] = rhs.m_streams[VERB_ERROR];
+ 
+-   for(int i = DEBUG; i <= INFO3; ++i)
++   for(int i = VERB_DEBUG; i <= VERB_INFO3; ++i)
+       m_streams[ i ] = rhs.m_streams[ i ];
+ }
+ 
+diff --git a/src/soplex/spxout.h b/src/soplex/spxout.h
+index d03d1ffb..f9561a9a 100644
+--- a/src/soplex/spxout.h
++++ b/src/soplex/spxout.h
+@@ -61,16 +61,16 @@ struct EnableDebugOutput
+    level. In particular, this means that the first element in an output stream
+    should always be the verbosity. For instance, use
+    @code
+-      spxout << verb( SPxOut::WARNING ) << std::setw( 15 ) << 42 << std::endl;
++      spxout << verb( SPxOut::VERB_WARNING ) << std::setw( 15 ) << 42 << std::endl;
+    @endcode
+    or
+    @code
+-      spxout.setVerbosity( SPxOut::WARNING );
++      spxout.setVerbosity( SPxOut::VERB_WARNING );
+       spxout << std::setw( 15 ) << 42 << std::endl;
+    @endcode
+    instead of
+    @code
+-      spxout << std::setw( 15 ) << verb( SPxOut::WARNING ) << 42 << std::endl;
++      spxout << std::setw( 15 ) << verb( SPxOut::VERB_WARNING ) << 42 << std::endl;
+    @endcode
+    in order to make sure that @c std::setw( 15 ) is applied to the warning stream.
+ */
+@@ -85,15 +85,15 @@ public:
+    /// Verbosity level
+    typedef enum
+    {
+-      // Note: the implementation uses the fact that ERROR == 0
+-      // and that the verbosity levels are subsequent numbers.
+-      // If you change this, change the implementation as well.
+-      ERROR    = 0,
+-      WARNING  = 1,
+-      DEBUG    = 2,
+-      INFO1    = 3,
+-      INFO2    = 4,
+-      INFO3    = 5
++      // Note: the implementation uses the fact that VERB_ERROR == 0 and that
++      // the verbosity levels are subsequent numbers. If you change this,
++      // change the implementation as well.
++      VERB_ERROR    = 0,
++      VERB_WARNING  = 1,
++      VERB_DEBUG    = 2,
++      VERB_INFO1    = 3,
++      VERB_INFO2    = 4,
++      VERB_INFO3    = 5
+    } Verbosity;
+ 
+    /// helper struct for the output operator
+@@ -240,7 +240,7 @@ private:
+     Calling
+     @code
+          SPxOut spxout;
+-         spxout << verb( SPxOut::ERROR ) << "This is an error!" << std::endl;
++         spxout << verb( SPxOut::VERB_ERROR ) << "This is an error!" << std::endl;
+     @endcode
+     passes such a struct to the output operator defined below, which
+     extracts the verbosity level from the struct and passes it to the
+diff --git a/src/soplex/validation.hpp b/src/soplex/validation.hpp
+index a186cf5c..7e586ebc 100644
+--- a/src/soplex/validation.hpp
++++ b/src/soplex/validation.hpp
+@@ -91,7 +91,7 @@ void Validation<R>::validateSolveReal(SoPlexBase<R>& soplex)
+    R sumDualViolation = 0.0;
+    R sol;
+ 
+-   std::ostream& os = soplex.spxout.getStream(SPxOut::INFO1);
++   std::ostream& os = soplex.spxout.getStream(SPxOut::VERB_INFO1);
+ 
+    if(validatesolution == "+infinity")
+    {
+diff --git a/src/soplexmain.cpp b/src/soplexmain.cpp
+index 5379ca36..4d2b1407 100644
+--- a/src/soplexmain.cpp
++++ b/src/soplexmain.cpp
+@@ -1380,7 +1380,7 @@ int runSoPlex(int argc, char* argv[])
+       if(displayStatistics)
+       {
+          SPX_MSG_INFO1(soplex->spxout, soplex->spxout << "Statistics\n==========\n\n");
+-         soplex->printStatistics(soplex->spxout.getStream(SPxOut::INFO1));
++         soplex->printStatistics(soplex->spxout.getStream(SPxOut::VERB_INFO1));
+       }
+ 
+       if(validation->validate)
+diff --git a/tests/exercise_LP_changes.cpp b/tests/exercise_LP_changes.cpp
+index 94eb2da4..38f303f0 100644
+--- a/tests/exercise_LP_changes.cpp
++++ b/tests/exercise_LP_changes.cpp
+@@ -82,7 +82,7 @@ public:
+    static const Real epsilon;
+    static const Real epsilon_factor;
+    static const Real epsilon_update;
+-   static const int verbose = SPxOut::ERROR;
++   static const int verbose = SPxOut::VERB_ERROR;
+    static const int precision = 12;
+    ///@}
+ 

--- a/modules/soplex/7.1.4.bcr.2/patches/spxfileio_dot_h.patch
+++ b/modules/soplex/7.1.4.bcr.2/patches/spxfileio_dot_h.patch
@@ -1,0 +1,13 @@
+diff --git a/src/soplex/spxfileio.h b/src/soplex/spxfileio.h
+index 035b30e0..4bff223c 100644
+--- a/src/soplex/spxfileio.h
++++ b/src/soplex/spxfileio.h
+@@ -41,7 +41,7 @@
+  *-----------------------------------------------------------------------------
+  */
+ #ifdef SOPLEX_WITH_ZLIB
+-#include "soplex/external/zstr/zstr.hpp"
++#include "zstr.hpp"
+ #endif // WITH_GSZSTREAM
+ 
+ namespace soplex

--- a/modules/soplex/7.1.4.bcr.2/presubmit.yml
+++ b/modules/soplex/7.1.4.bcr.2/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  build_flags:
+  - ['--compilation_mode=fastbuild']
+  - ['--compilation_mode=opt']
+  - ['--compilation_mode=dbg']
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@soplex//...'

--- a/modules/soplex/7.1.4.bcr.2/source.json
+++ b/modules/soplex/7.1.4.bcr.2/source.json
@@ -1,0 +1,17 @@
+{
+    "url": "https://github.com/scipopt/soplex/archive/refs/tags/release-714.tar.gz",
+    "integrity": "sha256-NYE7p/S8WYxScUOTGNIBfst+eLTvnElv5AmnHnhL66A=",
+    "strip_prefix": "soplex-release-714",
+    "patches": {
+        "add_config_dot_h.patch": "sha256-1F+E1HR69Mx5fBqHg0LFWVMi2I0lV1+LBJoQNojJTsg=",
+        "add_git_hash_dot_cpp.patch": "sha256-yWQXKL/i9dHi8ibsk6Yi2fwaxri0yWIYo5cxexjftQg=",
+        "fmt_dot_hpp.patch": "sha256-l3uQmHQOXJhsyGfBArkMIUI0n3t1BsvGD2r3d0CtVrc=",
+        "spxfileio_dot_h.patch": "sha256-g3qdN7pcA2Ef64Kx3vb2xjyNJrKRjLIPJCI6dLkj/N8=",
+        "macos_debug.patch": "sha256-43VLg3zyQtjDllvBEi4qnMuVKAqneCCEMMf+gs7rlEQ="
+    },
+    "patch_strip": 1,
+    "overlay": {
+        "BUILD.bazel": "sha256-xFOmYj3tIpHXZOeEhuPEMYrKo8AEOZvgv0lYcKchBY0=",
+        "MODULE.bazel": "sha256-TVl8q2KC7FbYPTLCUsuSLsleVqrzrdkpVYqH+nOt/Gs="
+    }
+}

--- a/modules/soplex/metadata.json
+++ b/modules/soplex/metadata.json
@@ -6,9 +6,9 @@
             "name": "Laurent Perron"
         },
         {
+            "email": "jkun@google.com",
             "github": "j2kun",
             "github_user_id": 2467754,
-            "email": "jkun@google.com",
             "name": "Jeremy Kun"
         }
     ],
@@ -20,7 +20,8 @@
         "7.1.2.bcr.1",
         "7.1.3",
         "7.1.4",
-        "7.1.4.bcr.1"
+        "7.1.4.bcr.1",
+        "7.1.4.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This makes soplex compatible with Boost 1.89.

Updated dependencies per conversation on https://github.com/bazelbuild/bazel-central-registry/pull/6441#issuecomment-3502498793