### PR TITLE
Attestations: allow multiple repository entries.

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -869,7 +869,7 @@ class BcrValidator:
                     f"but got {', '.join(gh_source_uris)}."
                 ),
             )
-            return 
+            return
 
         success = True
         tmp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
Instead of expecting a single value, we now calculate the expected source URI based on attestation URLs, then check that this value is part of the repository list.

Fixes presubmit for https://github.com/bazelbuild/bazel-central-registry/pull/6668.