### PR TITLE
protothreads@0.1.6

### DIFF
--- a/modules/protothreads/0.1.6/MODULE.bazel
+++ b/modules/protothreads/0.1.6/MODULE.bazel
@@ -1,0 +1,2 @@
+module(name = "protothreads", version = "0.1.6", compatibility_level = 1)
+

--- a/modules/protothreads/0.1.6/attestations.json
+++ b/modules/protothreads/0.1.6/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/JalonWong/protothreads/releases/download/v0.1.6/source.json.intoto.jsonl",
+            "integrity": "sha256-LFOZqfVA4a1/rmKb5mTyqSt8NcBvdXOV023RnKEFElA="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/JalonWong/protothreads/releases/download/v0.1.6/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-LQ7JB/Di+41RaazyzXXYYW0iFjE3GQHvk+bGBA1A3FU="
+        },
+        "protothreads-v0.1.6.tar.gz": {
+            "url": "https://github.com/JalonWong/protothreads/releases/download/v0.1.6/protothreads-v0.1.6.tar.gz.intoto.jsonl",
+            "integrity": "sha256-JJjIO2HMOfL4ktuu8pPl/D7Zxs4DblH3D3gQFpIQp9k="
+        }
+    }
+}

--- a/modules/protothreads/0.1.6/presubmit.yml
+++ b/modules/protothreads/0.1.6/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel: [8.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@protothreads//:pt"

--- a/modules/protothreads/0.1.6/source.json
+++ b/modules/protothreads/0.1.6/source.json
@@ -1,0 +1,4 @@
+{
+    "integrity": "sha256-1rMMlPqArmHHD0nMaW2VJ7/ZDzhcI9FrbReT/ISWhF8=",
+    "url": "https://github.com/JalonWong/protothreads/releases/download/v0.1.6/protothreads-v0.1.6.tar.gz"
+}

--- a/modules/protothreads/metadata.json
+++ b/modules/protothreads/metadata.json
@@ -12,7 +12,8 @@
         "github:JalonWong/protothreads"
     ],
     "versions": [
-        "0.1.5"
+        "0.1.5",
+        "0.1.6"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/JalonWong/protothreads/releases/tag/v0.1.6

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_
