### PR TITLE
Added version 25.11.bcr.2

### DIFF
--- a/modules/openusd/25.11.bcr.2/MODULE.bazel
+++ b/modules/openusd/25.11.bcr.2/MODULE.bazel
@@ -1,0 +1,13 @@
+module(
+    name = "openusd",
+    version = "25.11.bcr.2",
+    # Required to be able to use the 'overlay' files feature of BCR
+    bazel_compatibility = ['>=7.2.1'],
+)
+bazel_dep(name = "onetbb", version = "2022.1.0")
+
+bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
+bazel_dep(name = "rules_cc", version = "0.2.14")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_lib", version = "3.0.0")

--- a/modules/openusd/25.11.bcr.2/overlay/BUILD
+++ b/modules/openusd/25.11.bcr.2/overlay/BUILD
@@ -1,0 +1,129 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_license//rules:license.bzl", "license")
+load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(["LICENSE.txt"])
+
+# Note: OpenUSD uses a derivative of the Apache 2.0 license called the
+# Tomorrow Open Source Technology License 1.0.
+license(
+    name = "license",
+    package_name = "openusd",
+    license_kinds = [
+    ],
+    license_text = ":LICENSE.txt",
+)
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob([
+    	"CMakeLists.txt",
+    	"pxr/**",
+    	"cmake/**",
+    	"extras/**",
+    	"docs/**",
+    	"third_party/**"
+    ], exclude=[
+    	"bazel*/**",
+    	"BUILD",
+    	"BUILD.bazel",
+    	"MODULE.bazel"
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+# Build OpenUSD as a monolithic static library. This is the simplest option for linking
+# but note it does not allow USD plugins or Python modules. This is because it  would result in duplicate
+# symbol definitions for libusd symbols (statically linked into the main exec and also linked into the dynamic libs).
+#
+# Also note: We must specify the alwayslink=True so that dependents link in all symbols from the archive. This is
+# a stated requirement in BUILDING.md. If not specified, OpenUSD will not initialize properly and you will encounter
+# segfaults when using certain objects.
+#
+# See BUILDING.md in the OpenUSD repo for details.
+#
+cmake(
+    name = "openusd",
+    cache_entries = {
+        "BUILD_SHARED_LIBS": "OFF",
+        "PXR_BUILD_MONOLITHIC": "ON",
+        "PXR_PREFER_SAFETY_OVER_SPEED": "ON",
+        "PXR_FIND_TBB_IN_CONFIG": "OFF",
+        "TBB_USE_DEBUG_BUILD": "OFF",
+        "PXR_ENABLE_PYTHON_SUPPORT": "OFF",
+        "PXR_ENABLE_GL_SUPPORT": "OFF",
+        "PXR_ENABLE_METAL_SUPPORT": "OFF",
+        "PXR_BUILD_DOCUMENTATION": "OFF",
+        "PXR_BUILD_HTML_DOCUMENTATION": "OFF",
+        "PXR_BUILD_PYTHON_DOCUMENTATION": "OFF",
+        "PXR_BUILD_TESTS": "OFF",
+        "PXR_BUILD_EXAMPLES": "OFF",
+        "PXR_BUILD_TUTORIALS": "OFF",
+        "PXR_BUILD_USD_TOOLS": "OFF",
+        "PXR_BUILD_USD_VALIDATION": "OFF",
+        "PXR_BUILD_IMAGING": "OFF",
+        "PXR_BUILD_USD_IMAGING": "OFF",
+        "PXR_BUILD_USDVIEW": "OFF",
+        "PXR_BUILD_ALEMBIC_PLUGIN": "OFF",
+        "PXR_BUILD_DRACO_PLUGIN": "OFF",
+        "PXR_ENABLE_MATERIALX_SUPPORT": "OFF",
+        "PXR_BUILD_MAYAPY_TESTS": "OFF",
+        "PXR_BUILD_ANIMX_TESTS": "OFF",
+        "Boost_NO_SYSTEM_PATHS": "ON",
+    },
+    env = {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_BUILD_PARALLEL_LEVEL": "4",
+    },
+    # OpenUSD generates many compiler warnings. It will fail
+    # to compile if these warnings are treated as errors.
+    copts = [
+        "-Wno-error",
+    ],
+    alwayslink = True,
+    out_static_libs = [
+        # This is name of the monolithic static lib.
+	    "libusd_m.a",
+    ],
+    out_data_dirs = [
+	    "lib/usd"
+    ],
+    lib_source = ":all_srcs",
+    deps = [
+        "@onetbb//:tbb",
+    ],
+)
+
+# As part of the cmake build, OpenUSD installs a directory of plugin file resources (many plugInfo.json files)
+# to openusd/lib/usd. On program startup, OpenUSD expects these plugin files to be in a usd/ dir directly next
+# to the executable or .so library. It will throw an exception and crash if they are not found.
+# We use the 'copy_to_directory' helper to copy them out of 'openusd/lib/usd' to just 'usd' so that they
+# are at the right path.
+copy_to_directory(
+    name = "plugin_files",
+    srcs = [":openusd"],
+    out = "usd",
+    replace_prefixes = {
+        "openusd/lib/usd": "",
+    }
+)
+
+cc_test(
+    name = "test_main",
+    srcs = ["test_main.cpp"],
+    deps = [
+      ":openusd",
+      "@bazel_tools//tools/cpp/runfiles",
+    ],
+    data = [
+	    ":plugin_files",
+    ]
+)
+

--- a/modules/openusd/25.11.bcr.2/overlay/MODULE.bazel
+++ b/modules/openusd/25.11.bcr.2/overlay/MODULE.bazel
@@ -1,0 +1,13 @@
+module(
+    name = "openusd",
+    version = "25.11.bcr.2",
+    # Required to be able to use the 'overlay' files feature of BCR
+    bazel_compatibility = ['>=7.2.1'],
+)
+bazel_dep(name = "onetbb", version = "2022.1.0")
+
+bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
+bazel_dep(name = "rules_cc", version = "0.2.14")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_lib", version = "3.0.0")

--- a/modules/openusd/25.11.bcr.2/overlay/test_main.cpp
+++ b/modules/openusd/25.11.bcr.2/overlay/test_main.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+
+#include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usdGeom/sphere.h>
+#include <pxr/base/tf/token.h>
+#include <pxr/base/plug/registry.h>
+
+#include "tools/cpp/runfiles/runfiles.h"
+
+using bazel::tools::cpp::runfiles::Runfiles;
+
+int main(int argc, char** argv) {
+    std::cout << "--- USD Initialization Test ---\n";
+
+    // Use the bazel runfiles lib to get the path to the openusd plugins that this
+    // executable depends on. Use Create() for regular binaries and CreateForTest()
+    // for tests.
+    std::string error;
+    //std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0], &error));
+    std::unique_ptr<Runfiles> runfiles(Runfiles::CreateForTest(&error));
+    if (runfiles == nullptr) {
+      std::cout << "NO RUNFILES FOUND" << std::endl;
+      return 1;
+    }
+
+    // Register our custom plugins path with the plugin registry.
+    // If we do not do this, OpenUSD will throw when creating a stage.
+    std::string pluginsPath = runfiles->Rlocation("usd");
+    std::cout << "PATH to openusd/usd => " << pluginsPath << std::endl;
+    pxr::PlugRegistry::GetInstance().RegisterPlugins(pluginsPath);
+
+    // Create a USD Stage (the core container for a scene)
+    auto stage = pxr::UsdStage::CreateNew(std::string("HelloWorld.usda"));
+    if (stage) {
+        // Create a primary root primitive (like a scene root)
+        pxr::SdfPath primPath("/World/MyFirstPrim");
+        pxr::UsdGeomSphere sphere = 
+            pxr::UsdGeomSphere::Define(stage, primPath);
+        std::cout << "Successfully created a primitive at path: " 
+                  << sphere.GetPath().GetString() << "\n";
+
+		    // Print a tftoken
+        pxr::TfToken myToken("Success!");
+        std::cout << "TfToken status: " << myToken.GetString() << "\n";
+    } else {
+        std::cerr << "ERROR: Failed to create an in-memory USD stage!\n";
+        return 1;
+    }
+    
+    std::cout << "--- USD Test Complete ---\n";
+    return 0;
+}

--- a/modules/openusd/25.11.bcr.2/presubmit.yml
+++ b/modules/openusd/25.11.bcr.2/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - ubuntu2204
+  bazel:
+  - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@openusd//:openusd'
+  run_test_module:
+      name: Run tests
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "@openusd//:test_main"  

--- a/modules/openusd/25.11.bcr.2/source.json
+++ b/modules/openusd/25.11.bcr.2/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/PixarAnimationStudios/OpenUSD/archive/refs/tags/v25.11.tar.gz",
+    "integrity": "sha256-w3xjO1A3pFUvYVdGcOzKiDYim3gya9YmIvNCJnEYhmc=",
+    "strip_prefix": "OpenUSD-25.11",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD": "sha256-FeefW8KA9aupY4EJBEGthYgI8UM0Sq6Ezfhj03ak93o=",
+        "MODULE.bazel": "sha256-cYbvLDvhrhxhLgnRbAn0I8OWsxrRM++GIxPCJ/DdZZg=",
+        "test_main.cpp": "sha256-5hfksFp7KzvT01pbtvmOz432CBbb2fBOd3bhsy3oiSw="
+    }
+}

--- a/modules/openusd/metadata.json
+++ b/modules/openusd/metadata.json
@@ -19,7 +19,8 @@
     ],
     "versions": [
         "25.11",
-        "25.11.bcr.1"
+        "25.11.bcr.1",
+        "25.11.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds version 25.11.bcr.2. This version silences all compiler warnings using -Wno-error. OpenUSD generates many warnings during compiling, so that is necessary for those who typically compile with "-Wall" and "-Werror". 