### PR TITLE
Upgrade versions of deps in MODULE.bazel to support rolling

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,10 +4,11 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_rules_js", version = "2.6.2")
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.0")
+bazel_dep(name = "aspect_rules_js", version = "2.8.3")
 bazel_dep(name = "buildozer", version = "8.2.1")
-bazel_dep(name = "rules_nodejs", version = "6.5.2")
-bazel_dep(name = "rules_python", version = "1.6.3")
+bazel_dep(name = "rules_nodejs", version = "6.6.2")
+bazel_dep(name = "rules_python", version = "1.7.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")


### PR DESCRIPTION
Right now CI fails to run tests for rolling because aspect_bazel_lib is too old. For example:
https://github.com/bazelbuild/bazel-central-registry/pull/6530