### PR TITLE
Update enforce_tooling_sync.yml to remove path filter

### DIFF
--- a/.github/workflows/enforce_tooling_sync.yml
+++ b/.github/workflows/enforce_tooling_sync.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'modules/**'
 
 jobs:
   check-file-sync:


### PR DESCRIPTION
Removed path filter for pull requests in workflow, this check is needed for all PRs

See https://github.com/bazelbuild/bazel-central-registry/pull/6770