### PR TITLE
icestorm@0.0.0-20251212-59e4c98

### DIFF
--- a/modules/icestorm/0.0.0-20251212-59e4c98/MODULE.bazel
+++ b/modules/icestorm/0.0.0-20251212-59e4c98/MODULE.bazel
@@ -1,0 +1,13 @@
+module(
+    name = "icestorm",
+    version = "0.0.0-20251212-59e4c98"
+)
+
+bazel_dep(name = "rules_python", version = "1.4.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "abseil-cpp", version = "20250127.1")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    python_version = "3.13",
+)

--- a/modules/icestorm/0.0.0-20251212-59e4c98/patches/module_dot_bazel_version.patch
+++ b/modules/icestorm/0.0.0-20251212-59e4c98/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "icestorm",
+-    version = "0.0.0"
++    version = "0.0.0-20251212-59e4c98"
+ )
+ 
+ bazel_dep(name = "rules_python", version = "1.4.0")
+ bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/icestorm/0.0.0-20251212-59e4c98/presubmit.yml
+++ b/modules/icestorm/0.0.0-20251212-59e4c98/presubmit.yml
@@ -1,0 +1,21 @@
+# BCR presubmit configuration for icestorm module
+# This file defines the build verification tests
+
+# Simple smoke test matrix
+matrix:
+  platform:
+    - ubuntu2004
+  bazel: ["7.x", "8.x"]
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@icestorm//:icebram"
+      - "@icestorm//:icepack"
+      - "@icestorm//:icepll"
+      - "@icestorm//:icemulti"
+      - "@icestorm//icetime:icetime"
+      - "@icestorm//:chipdb_1k_txt"

--- a/modules/icestorm/0.0.0-20251212-59e4c98/source.json
+++ b/modules/icestorm/0.0.0-20251212-59e4c98/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-6axZ4ZGiOPXYSvze1QJ5V69iwMCjHzX2aTPl/V76tAQ=",
+    "strip_prefix": "icestorm-0.0.0-20251212-59e4c98",
+    "url": "https://github.com/MrAMS/icestorm/releases/download/v0.0.0-20251212-59e4c98/icestorm-0.0.0-20251212-59e4c98.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-ekZQkS/jZ/9yKOoIuzBm/VZQyh5SSYgs/bA3mRHxSCY="
+    },
+    "patch_strip": 1
+}

--- a/modules/icestorm/metadata.json
+++ b/modules/icestorm/metadata.json
@@ -1,17 +1,18 @@
 {
-    "homepage": "https://prjicestorm.readthedocs.io/en/latest/",
+    "homepage": "https://github.com/MrAMS/icestorm",
     "maintainers": [
         {
-            "email": "26427366+UebelAndre@users.noreply.github.com",
-            "github": "UebelAndre",
-            "github_user_id": 26427366,
-            "name": "UebelAndre"
+            "email": "",
+            "github": "MrAMS",
+            "name": "Qijia Yang",
+            "github_user_id": 25056812
         }
     ],
     "repository": [
-        "github:YosysHQ/icestorm"
+        "github:MrAMS/icestorm"
     ],
     "versions": [
+        "0.0.0-20251212-59e4c98",
         "1.1"
     ],
     "yanked_versions": {}


### PR DESCRIPTION
Release: https://github.com/MrAMS/icestorm/releases/tag/v0.0.0-20251212-59e4c98

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_