### PR TITLE
cxxopts@0.0.0-20251212-7f8db1f

### DIFF
--- a/modules/cxxopts/0.0.0-20251212-7f8db1f/MODULE.bazel
+++ b/modules/cxxopts/0.0.0-20251212-7f8db1f/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "cxxopts",
+    version = "0.0.0-20251212-7f8db1f",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/cxxopts/0.0.0-20251212-7f8db1f/patches/module_dot_bazel_version.patch
+++ b/modules/cxxopts/0.0.0-20251212-7f8db1f/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "cxxopts",
+-    version = "3.2.0",
++    version = "0.0.0-20251212-7f8db1f",
+     compatibility_level = 0,
+ )
+ 
+ bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/cxxopts/0.0.0-20251212-7f8db1f/presubmit.yml
+++ b/modules/cxxopts/0.0.0-20251212-7f8db1f/presubmit.yml
@@ -1,0 +1,17 @@
+# BCR presubmit configuration for cxxopts module
+# This file defines the build verification tests
+
+matrix:
+  platform:
+    - ubuntu2004
+    - macos
+    - windows
+  bazel: ["7.x", "8.x"]
+
+tasks:
+  verify_targets:
+    name: Verify cxxopts library builds
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@cxxopts//:cxxopts"

--- a/modules/cxxopts/0.0.0-20251212-7f8db1f/source.json
+++ b/modules/cxxopts/0.0.0-20251212-7f8db1f/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-QNVJejigPVBf3SLEaohpBT01sQYu0RTbbFxzLg5Fib8=",
+    "strip_prefix": "cxxopts-0.0.0-20251212-7f8db1f",
+    "url": "https://github.com/MrAMS/cxxopts/releases/download/v0.0.0-20251212-7f8db1f/cxxopts-0.0.0-20251212-7f8db1f.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-8luexq3jljhxrC08b44Gw6wu4iDPqTSo0Xtf2GyjBqs="
+    },
+    "patch_strip": 1
+}

--- a/modules/cxxopts/metadata.json
+++ b/modules/cxxopts/metadata.json
@@ -1,16 +1,18 @@
 {
-    "homepage": "https://github.com/jarro2783/cxxopts",
+    "homepage": "https://github.com/MrAMS/cxxopts",
     "maintainers": [
         {
-            "github": "hofbi",
-            "github_user_id": 10724293,
-            "name": "Markus Hofbauer"
+            "email": "",
+            "github": "MrAMS",
+            "name": "Qijia Yang",
+            "github_user_id": 25056812
         }
     ],
     "repository": [
-        "github:jarro2783/cxxopts"
+        "github:MrAMS/cxxopts"
     ],
     "versions": [
+        "0.0.0-20251212-7f8db1f",
         "3.0.0",
         "3.3.1"
     ],


### PR DESCRIPTION
Release: https://github.com/MrAMS/cxxopts/releases/tag/v0.0.0-20251212-7f8db1f

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_