### PR TITLE
iverilog@0.0.0-20251212-8833caf

### DIFF
--- a/modules/iverilog/0.0.0-20251212-8833caf/MODULE.bazel
+++ b/modules/iverilog/0.0.0-20251212-8833caf/MODULE.bazel
@@ -1,0 +1,15 @@
+module(
+    name = "iverilog",
+    version = "0.0.0-20251212-8833caf",
+)
+
+bazel_dep(name = "gperf", version = "3.1")
+bazel_dep(name = "bzip2", version = "1.0.8.bcr.2")
+bazel_dep(name = "rules_flex", version = "0.4")
+bazel_dep(name = "rules_bison", version = "0.4")
+bazel_dep(name = "sed", version = "4.9.bcr.1")
+bazel_dep(name = "rules_m4", version = "0.3")
+bazel_dep(name = "readline", version = "8.2.bcr.1")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/modules/iverilog/0.0.0-20251212-8833caf/patches/module_dot_bazel_version.patch
+++ b/modules/iverilog/0.0.0-20251212-8833caf/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "iverilog",
+-    version = "0.0.0",
++    version = "0.0.0-20251212-8833caf",
+ )
+ 
+ bazel_dep(name = "gperf", version = "3.1")
+ bazel_dep(name = "bzip2", version = "1.0.8.bcr.2")

--- a/modules/iverilog/0.0.0-20251212-8833caf/presubmit.yml
+++ b/modules/iverilog/0.0.0-20251212-8833caf/presubmit.yml
@@ -1,0 +1,18 @@
+# BCR presubmit configuration for iverilog module
+# This file defines the build verification tests
+
+# Simple smoke test matrix
+matrix:
+  platform:
+    - ubuntu2004
+  bazel: ["7.x", "8.x"]
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@iverilog//:ivl"
+      - "@iverilog//:ivlpp"
+      - "@iverilog//:iverilog-bin"

--- a/modules/iverilog/0.0.0-20251212-8833caf/source.json
+++ b/modules/iverilog/0.0.0-20251212-8833caf/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-qmMT3Dshww7UC67j3aFTbDE9AmxYEAXSaa1n/7DXJX4=",
+    "strip_prefix": "iverilog-0.0.0-20251212-8833caf",
+    "url": "https://github.com/MrAMS/iverilog/releases/download/v0.0.0-20251212-8833caf/iverilog-0.0.0-20251212-8833caf.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-fivSBh386MH4wFeHM26gEkHv4EZaP9mkA8dWqxv+mYw="
+    },
+    "patch_strip": 1
+}

--- a/modules/iverilog/metadata.json
+++ b/modules/iverilog/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/MrAMS/iverilog",
+    "maintainers": [
+        {
+            "email": "",
+            "github": "MrAMS",
+            "name": "Qijia Yang",
+            "github_user_id": 25056812
+        }
+    ],
+    "repository": [
+        "github:MrAMS/iverilog"
+    ],
+    "versions": [
+        "0.0.0-20251212-8833caf"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/MrAMS/iverilog/releases/tag/v0.0.0-20251212-8833caf

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_