### PR TITLE
Add rules_verilator 0.1.0

### DIFF
--- a/modules/rules_verilator/0.1.0/MODULE.bazel
+++ b/modules/rules_verilator/0.1.0/MODULE.bazel
@@ -1,0 +1,19 @@
+module(
+    name = "rules_verilator",
+    version = "0.1.0",
+    bazel_compatibility = [">=7.5.0"],
+    repo_name = "rules_hdl",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+
+bazel_dep(name = "verilator", version = "5.036.bcr.3")
+bazel_dep(name = "systemc", version = "3.0.2")
+bazel_dep(name = "googletest", version = "1.16.0.bcr.1", dev_dependency = True)
+
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "rules_license", version = "1.0.0")
+
+register_toolchains(
+    "//verilator:verilator_toolchain",
+)

--- a/modules/rules_verilator/0.1.0/presubmit.yml
+++ b/modules/rules_verilator/0.1.0/presubmit.yml
@@ -1,0 +1,22 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform:
+      - debian10
+      - ubuntu2004
+    bazel: [7.x, 8.x]
+  tasks:
+    run_tests:
+      name: "Run tests"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//verilator/tests:adder_verilator"
+        - "//verilator/tests:load_and_count_verilator"
+        - "//verilator/tests:nested_module_verilator"
+        - "//verilator/tests:adder_trace_verilator"
+      test_targets:
+        - "//verilator/tests:adder_test"
+        - "//verilator/tests:load_and_count_test"
+        - "//verilator/tests:nested_module_test"
+        - "//verilator/tests:adder_trace_test"

--- a/modules/rules_verilator/0.1.0/source.json
+++ b/modules/rules_verilator/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "sha256-aYV9vEAHbgB5IWhJeKIr1skix++5ao1zlVaS8cIZ4ss=",
+  "strip_prefix": "bazel_rules_verilator-0.1.0",
+  "url": "https://github.com/MrAMS/bazel_rules_verilator/releases/download/v0.1.0/bazel_rules_verilator-0.1.0.tar.gz"
+}

--- a/modules/rules_verilator/metadata.json
+++ b/modules/rules_verilator/metadata.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://github.com/MrAMS/bazel_rules_verilator",
+    "maintainers": [
+        {
+            "github": "MrAMS",
+            "github_user_id": 25056812
+        }
+    ],
+    "repository": [
+        "github:MrAMS/bazel_rules_verilator"
+    ],
+    "versions": [
+        "0.1.0"
+    ]
+}


### PR DESCRIPTION
### New Module: rules_verilator

This PR introduces the initial version (`0.1.0`) of `rules_verilator`.

**Description:**
`rules_verilator` provides Bazel rules for Verilator-based SystemVerilog simulation. It is a modern, Bzlmod-native fork of the Verilator rules originally found in [bazel_rules_hdl](https://github.com/hdl/bazel_rules_hdl).

**Key Features & Differences:**
- **BCR Integration**: Unlike the original implementation, this module does not bundle Verilator binaries. Instead, it leverages the official `verilator` module from the BCR.
- **Modular Design**: SystemC support is completely optional. Users can register the SystemC-enabled toolchain only when needed by adding the `systemc` dependency from BCR.
- **Bzlmod Native**: Designed specifically for Bazel 7.5.0+ with full Bzlmod support.

**Homepage:** https://github.com/MrAMS/bazel_rules_verilator