### PR TITLE
cereal@1.3.2.bcr.1: add support for vendored rapidjson dependency

### DIFF
--- a/modules/cereal/1.3.2.bcr.1/MODULE.bazel
+++ b/modules/cereal/1.3.2.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "cereal",
+    version = "1.3.2.bcr.1",
+    compatibility_level = 1,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.13")

--- a/modules/cereal/1.3.2.bcr.1/overlay/BUILD
+++ b/modules/cereal/1.3.2.bcr.1/overlay/BUILD
@@ -1,0 +1,11 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "cereal",
+    hdrs = glob([
+      "include/cereal/**/*.hpp",
+      "include/cereal/**/*.h",
+    ]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/modules/cereal/1.3.2.bcr.1/overlay/MODULE.bazel
+++ b/modules/cereal/1.3.2.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "cereal",
+    version = "1.3.2.bcr.1",
+    compatibility_level = 1,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.13")

--- a/modules/cereal/1.3.2.bcr.1/presubmit.yml
+++ b/modules/cereal/1.3.2.bcr.1/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@cereal//:cereal'

--- a/modules/cereal/1.3.2.bcr.1/source.json
+++ b/modules/cereal/1.3.2.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/USCiLab/cereal/archive/refs/tags/v1.3.2.tar.gz",
+    "integrity": "sha256-FqetmzG6WIDaxV1itdbyQ8PryNRqNRQUnla15+qB+F8=",
+    "strip_prefix": "cereal-1.3.2",
+    "overlay": {
+        "BUILD": "sha256-nK4zjp13v1KAO9g72wUC+HVeWbiEjwnCQZZfISN0mdw=",
+        "MODULE.bazel": "sha256-sYL2HOjWooYr1s7t3BEJx58KpYnDdqBgnbY2ge1gdik="
+    }
+}

--- a/modules/cereal/metadata.json
+++ b/modules/cereal/metadata.json
@@ -6,7 +6,12 @@
             "name": "No Maintainer Specified"
         }
     ],
-    "repository": ["github:USCiLab/cereal"],
-    "versions": ["1.3.2"],
+    "repository": [
+        "github:USCiLab/cereal"
+    ],
+    "versions": [
+        "1.3.2",
+        "1.3.2.bcr.1"
+    ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This PR adds support for cereal to use its vendored rapidjson dependency.

That was omitted from the current overlay because the header files required use the `.h` extension, and only `.hpp` files were included.

@bazel-io skip_check unstable_url