### PR TITLE
cereal@1.3.2.bcr.2: add a filegroup for bundling headers

### DIFF
--- a/modules/cereal/1.3.2.bcr.2/MODULE.bazel
+++ b/modules/cereal/1.3.2.bcr.2/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "cereal",
+    version = "1.3.2.bcr.2",
+    compatibility_level = 1,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.13")

--- a/modules/cereal/1.3.2.bcr.2/overlay/BUILD
+++ b/modules/cereal/1.3.2.bcr.2/overlay/BUILD
@@ -1,0 +1,19 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+filegroup(
+    name = "headers",
+    srcs = glob([
+        "include/**/*.h",
+        "include/**/*.hpp",
+    ]),
+)
+
+cc_library(
+    name = "cereal",
+    hdrs = glob([
+      "include/cereal/**/*.hpp",
+      "include/cereal/**/*.h",
+    ]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/modules/cereal/1.3.2.bcr.2/overlay/MODULE.bazel
+++ b/modules/cereal/1.3.2.bcr.2/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "cereal",
+    version = "1.3.2.bcr.2",
+    compatibility_level = 1,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.13")

--- a/modules/cereal/1.3.2.bcr.2/presubmit.yml
+++ b/modules/cereal/1.3.2.bcr.2/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@cereal//:cereal'

--- a/modules/cereal/1.3.2.bcr.2/source.json
+++ b/modules/cereal/1.3.2.bcr.2/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/USCiLab/cereal/archive/refs/tags/v1.3.2.tar.gz",
+    "integrity": "sha256-FqetmzG6WIDaxV1itdbyQ8PryNRqNRQUnla15+qB+F8=",
+    "strip_prefix": "cereal-1.3.2",
+    "overlay": {
+        "BUILD": "sha256-xehdPNOHV9lf8Oxll0JxMS/jodelGxlI4EM08EuODPg=",
+        "MODULE.bazel": "sha256-eVeJmQ2jNQ0+Ct29Nj2Q0VmWlzurmF2CDqjrpcT6xzE="
+    }
+}

--- a/modules/cereal/metadata.json
+++ b/modules/cereal/metadata.json
@@ -11,7 +11,8 @@
     ],
     "versions": [
         "1.3.2",
-        "1.3.2.bcr.1"
+        "1.3.2.bcr.1",
+        "1.3.2.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
We have some use cases where we want to bundle the headers, but the BCR build file doesn't have the filegroup that we have in our custom BUILD for cereal (pre-bazelmod).

I wonder if there's a better way to do this than adding this upstream BUILD rule. Does it make sense to have a local override of the BUILD file for this one rule? Is it sensible to declare a build rule in my project that globs files in an external repository? These are questions for which, it seems the fastest way to get an answer is to create this pull request with the possibly wrong solution :)

Please and thank you!