### PR TITLE
Update cpr to 1.14.1

### DIFF
--- a/modules/cpr/1.14.1/MODULE.bazel
+++ b/modules/cpr/1.14.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "cpr",
+    version = "1.14.1",
+    bazel_compatibility = [">7.2.1"],
+)
+bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "curl", version = "8.11.0.bcr.4")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/cpr/1.14.1/overlay/BUILD.bazel
+++ b/modules/cpr/1.14.1/overlay/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+)
+
+exports_files(["LICENSE"])
+
+license(
+    name = "license",
+    package_name = "cpr",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "LICENSE",
+    package_url = "https://github.com/libcpr/cpr",
+)
+
+genrule(
+    name = "cprver_h",
+    outs = ["include/cpr/cprver.h"],
+    cmd = "echo -e '#pragma once\n#define CPR_VERSION \"{}\"' > $@".format(module_version()),
+)
+
+cc_library(
+    name = "cpr",
+    srcs = glob(["cpr/**/*.cpp"]),
+    hdrs = glob(["include/cpr/**/*.h"]) + [":cprver_h"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = ["@curl"],
+)

--- a/modules/cpr/1.14.1/overlay/MODULE.bazel
+++ b/modules/cpr/1.14.1/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "cpr",
+    version = "1.14.1",
+    bazel_compatibility = [">7.2.1"],
+)
+bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "curl", version = "8.11.0.bcr.4")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/cpr/1.14.1/presubmit.yml
+++ b/modules/cpr/1.14.1/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004_arm64
+    - ubuntu2204
+    - ubuntu2404
+    - fedora40
+    - macos
+    - macos_arm64
+  bazel: [7.x, 8.x, latest]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags: ['--cxxopt=-std=c++17']
+    build_targets: ["@cpr"]

--- a/modules/cpr/1.14.1/source.json
+++ b/modules/cpr/1.14.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/libcpr/cpr/archive/refs/tags/1.14.1.tar.gz",
+    "integrity": "sha256-ITzMfJhoPSymME2XYABe/6EuxR1mS6ur8RRWbLKx4jw=",
+    "strip_prefix": "cpr-1.14.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-CjVPU2BdAq/CTWhceAASVsUk7EqD1c7VgqtlYB7wjKs=",
+        "MODULE.bazel": "sha256-BeYQooaqpoBiS7WWdcT4B8KFDJrERpNe8NBRtnOiDA0="
+    }
+}

--- a/modules/cpr/metadata.json
+++ b/modules/cpr/metadata.json
@@ -12,7 +12,8 @@
         "github:libcpr/cpr"
     ],
     "versions": [
-        "1.12.0"
+        "1.12.0",
+        "1.14.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This PR:
1) Update cpr to 1.14.1
2) Updated rules_cc and curl version to latest
3) Added exporting the license information 