### PR TITLE
re.bzl@0.1.0

### DIFF
--- a/modules/re.bzl/0.1.0/MODULE.bazel
+++ b/modules/re.bzl/0.1.0/MODULE.bazel
@@ -1,0 +1,16 @@
+"""
+Bazel module definition for the Starlark regex engine.
+"""
+
+module(
+    name = "re.bzl",
+    compatibility_level = 1,
+    version = "0.1.0",
+)
+
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "package_metadata", version = "0.0.2")
+
+bazel_dep(name = "rules_testing", version = "0.9.0", dev_dependency = True)
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.8.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.1", dev_dependency = True)

--- a/modules/re.bzl/0.1.0/attestations.json
+++ b/modules/re.bzl/0.1.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/jvolkman/re.bzl/releases/download/v0.1.0/source.json.intoto.jsonl",
+            "integrity": "sha256-WQedvOvjb/4t0TXiBU6y/SyqekVAkapo5UTjxXpjZx0="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/jvolkman/re.bzl/releases/download/v0.1.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-LpMAeDoglgvCAjX8jt7mobThBc+l9vk/KKl0NW6IBao="
+        },
+        "re.bzl-v0.1.0.tar.gz": {
+            "url": "https://github.com/jvolkman/re.bzl/releases/download/v0.1.0/re.bzl-v0.1.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-jbmWP1N57rQb2kBDUTdeT91h0USX63XmCtQVqBP+WjU="
+        }
+    }
+}

--- a/modules/re.bzl/0.1.0/patches/module_dot_bazel_version.patch
+++ b/modules/re.bzl/0.1.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -4,8 +4,9 @@
+ 
+ module(
+     name = "re.bzl",
+     compatibility_level = 1,
++    version = "0.1.0",
+ )
+ 
+ bazel_dep(name = "bazel_lib", version = "3.0.0")
+ bazel_dep(name = "package_metadata", version = "0.0.2")

--- a/modules/re.bzl/0.1.0/presubmit.yml
+++ b/modules/re.bzl/0.1.0/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: ["8.x", "7.x"]
+  tasks:
+    run_tests:
+      name: "Run smoke test"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/re.bzl/0.1.0/source.json
+++ b/modules/re.bzl/0.1.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-au8XNiAl0eySd3b3Ilx1QB1bO5+qEHyjFMvtDUUlR6A=",
+    "strip_prefix": "re.bzl-0.1.0",
+    "url": "https://github.com/jvolkman/re.bzl/releases/download/v0.1.0/re.bzl-v0.1.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-xP5OL3vl/4jqYadtfV489cT8BggSWRdwdxx6XPThAhU="
+    },
+    "patch_strip": 1
+}

--- a/modules/re.bzl/metadata.json
+++ b/modules/re.bzl/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/jvolkman/re.bzl",
+    "maintainers": [
+        {
+            "email": "jeremy@jvolkman.com",
+            "github": "jvolkman",
+            "name": "Jeremy Volkman",
+            "github_user_id": 124501
+        }
+    ],
+    "repository": [
+        "github:jvolkman/re.bzl"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/jvolkman/re.bzl/releases/tag/v0.1.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_