### PR TITLE
toml.bzl@0.1.0

### DIFF
--- a/modules/toml.bzl/0.1.0/MODULE.bazel
+++ b/modules/toml.bzl/0.1.0/MODULE.bazel
@@ -1,0 +1,30 @@
+"""Bazel module for toml.bzl."""
+
+module(
+    name = "toml.bzl",
+    compatibility_level = 1,
+    version = "0.1.0",
+)
+
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "package_metadata", version = "0.0.2")
+bazel_dep(name = "re.bzl", version = "0.1.0")
+
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.8.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.1", dev_dependency = True)
+bazel_dep(name = "rules_testing", version = "0.9.0", dev_dependency = True)
+
+test_suite = use_repo_rule("//toml/tests:test_suite_repo.bzl", "test_suite")
+
+test_suite(
+    name = "toml_test_suite",
+    integrity = "sha256-HqXrCuxACrraSFzbdQreUKfqWaKafbXiJs1Ebzdr9vk",
+    url = "https://github.com/toml-lang/toml-test/archive/229ce2e7bb565d1704eac5f41e939870d4b1bce7.tar.gz",
+)
+
+# TODO: Remove this when re.bzl is released in BCR.
+git_override(
+    module_name = "re.bzl",
+    commit = "bb9d4f96b095fea9acee37c5ce4d4e4d5f88dbf2",
+    remote = "https://github.com/jvolkman/re.bzl",
+)

--- a/modules/toml.bzl/0.1.0/attestations.json
+++ b/modules/toml.bzl/0.1.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/jvolkman/toml.bzl/releases/download/v0.1.0/source.json.intoto.jsonl",
+            "integrity": "sha256-0rZalSJgedTt1TAgzipApJQn2OciDGp1GSBQ8W1PERU="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/jvolkman/toml.bzl/releases/download/v0.1.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-Jix6bIWhHZaPq5CxKGEaJ+NjjRmnX+qKrsGlaFylhtg="
+        },
+        "toml.bzl-v0.1.0.tar.gz": {
+            "url": "https://github.com/jvolkman/toml.bzl/releases/download/v0.1.0/toml.bzl-v0.1.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-pWVV+av2sjrtt1oBc9DrzP40fTLRgMkxxgCbQLBtzaI="
+        }
+    }
+}

--- a/modules/toml.bzl/0.1.0/patches/module_dot_bazel_version.patch
+++ b/modules/toml.bzl/0.1.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -2,8 +2,9 @@
+ 
+ module(
+     name = "toml.bzl",
+     compatibility_level = 1,
++    version = "0.1.0",
+ )
+ 
+ bazel_dep(name = "bazel_lib", version = "3.0.0")
+ bazel_dep(name = "package_metadata", version = "0.0.2")

--- a/modules/toml.bzl/0.1.0/presubmit.yml
+++ b/modules/toml.bzl/0.1.0/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: ["8.x", "7.x"]
+  tasks:
+    run_tests:
+      name: "Run smoke test"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/toml.bzl/0.1.0/source.json
+++ b/modules/toml.bzl/0.1.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-/5tQlOs+eFx5mz4xu6dBcX+kQm576c9gK/4dN85aQ8k=",
+    "strip_prefix": "toml.bzl-0.1.0",
+    "url": "https://github.com/jvolkman/toml.bzl/releases/download/v0.1.0/toml.bzl-v0.1.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-67/Yf87Y5jAYVBUXAntoTILuHYax6bxi5rd7++UbTMY="
+    },
+    "patch_strip": 1
+}

--- a/modules/toml.bzl/metadata.json
+++ b/modules/toml.bzl/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/jvolkman/toml.bzl",
+    "maintainers": [
+        {
+            "email": "jeremy@jvolkman.com",
+            "github": "jvolkman",
+            "name": "Jeremy Volkman",
+            "github_user_id": 124501
+        }
+    ],
+    "repository": [
+        "github:jvolkman/toml.bzl"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/jvolkman/toml.bzl/releases/tag/v0.1.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_