### PR TITLE
toml.bzl@0.1.1

### DIFF
--- a/modules/toml.bzl/0.1.1/MODULE.bazel
+++ b/modules/toml.bzl/0.1.1/MODULE.bazel
@@ -1,0 +1,24 @@
+"""Bazel module for toml.bzl."""
+
+module(
+    name = "toml.bzl",
+    compatibility_level = 1,
+    version = "0.1.1",
+)
+
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "package_metadata", version = "0.0.2")
+bazel_dep(name = "re.bzl", version = "0.1.0")
+
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.8.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.1", dev_dependency = True)
+bazel_dep(name = "rules_testing", version = "0.9.0", dev_dependency = True)
+
+test_suite = use_repo_rule("//toml/tests:test_suite_repo.bzl", "test_suite")
+
+test_suite(
+    name = "toml_test_suite",
+    dev_dependency = True,
+    integrity = "sha256-HqXrCuxACrraSFzbdQreUKfqWaKafbXiJs1Ebzdr9vk",
+    url = "https://github.com/toml-lang/toml-test/archive/229ce2e7bb565d1704eac5f41e939870d4b1bce7.tar.gz",
+)

--- a/modules/toml.bzl/0.1.1/attestations.json
+++ b/modules/toml.bzl/0.1.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/jvolkman/toml.bzl/releases/download/v0.1.1/source.json.intoto.jsonl",
+            "integrity": "sha256-BBesUkn8mTC/ZJhdaYQjtrlTTWtzkTgb4lOxK2Pgg4I="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/jvolkman/toml.bzl/releases/download/v0.1.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-P/Yu9ieCbUYS1n6DzkNBsHd4TQcT1TwU7jQ8PX21brk="
+        },
+        "toml.bzl-v0.1.1.tar.gz": {
+            "url": "https://github.com/jvolkman/toml.bzl/releases/download/v0.1.1/toml.bzl-v0.1.1.tar.gz.intoto.jsonl",
+            "integrity": "sha256-ragLFaZVXyCP6LvZaR0T4sT/HF4Ml64N9InOyTZjs+o="
+        }
+    }
+}

--- a/modules/toml.bzl/0.1.1/patches/module_dot_bazel_version.patch
+++ b/modules/toml.bzl/0.1.1/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -2,8 +2,9 @@
+ 
+ module(
+     name = "toml.bzl",
+     compatibility_level = 1,
++    version = "0.1.1",
+ )
+ 
+ bazel_dep(name = "bazel_lib", version = "3.0.0")
+ bazel_dep(name = "package_metadata", version = "0.0.2")

--- a/modules/toml.bzl/0.1.1/presubmit.yml
+++ b/modules/toml.bzl/0.1.1/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: ["8.x", "7.x"]
+  tasks:
+    run_tests:
+      name: "Run smoke test"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/toml.bzl/0.1.1/source.json
+++ b/modules/toml.bzl/0.1.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-OkQYIOW7o6zu9bwXbLo8BVd4VJ+raLJAS2SDPeEjbWU=",
+    "strip_prefix": "toml.bzl-0.1.1",
+    "url": "https://github.com/jvolkman/toml.bzl/releases/download/v0.1.1/toml.bzl-v0.1.1.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-TJYTbWhiUM70ZnQwdyaBer5w0bGDbqtHnxxlR/emCGY="
+    },
+    "patch_strip": 1
+}

--- a/modules/toml.bzl/metadata.json
+++ b/modules/toml.bzl/metadata.json
@@ -12,7 +12,8 @@
         "github:jvolkman/toml.bzl"
     ],
     "versions": [
-        "0.1.0"
+        "0.1.0",
+        "0.1.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/jvolkman/toml.bzl/releases/tag/v0.1.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_