### PR TITLE
feat: add GitHub Actions workflow to automatically run `//tools:requirements.update` for Dependabot PRs.

### DIFF
--- a/.github/workflows/update_requirements.yml
+++ b/.github/workflows/update_requirements.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   update-requirements:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'bazelbuild/bazel-central-registry'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Dependabot often sends PRs that change `requirements_lock.txt`, but fail to properly run `//tools:requirements.update`, causing the PR checks to fail. This workflow runs `//tools:requirements.update` and commits the changes.

Vibe-coded using Antigravity, so very unsure whether it actually works...