### PR TITLE
rules_docs@0.1.0

### DIFF
--- a/modules/rules_docs/0.1.0/MODULE.bazel
+++ b/modules/rules_docs/0.1.0/MODULE.bazel
@@ -1,0 +1,56 @@
+"Bazel dependencies"
+
+module(
+    name = "rules_docs",
+    version = "0.1.0",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "package_metadata", version = "0.0.6")
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "jq.bzl", version = "0.4.0")
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.6.0")
+bazel_dep(name = "rules_python", version = "1.7.0")
+
+bazel_dep(name = "gazelle", version = "0.47.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.2", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "default_pypi",
+    python_version = "3.11",
+    requirements_lock = "//:requirements.txt",
+)
+use_repo(pip, "default_pypi")
+
+docgen = use_extension("//docgen:extensions.bzl", "docgen")
+docgen.mkdocs(
+    name = "mkdocs",
+    # These must be defined in the requirements.txt
+    plugins = [
+        "mkdocs-material",
+        "mkdocs-glightbox",
+        "mkdocs-table-reader-plugin",
+    ],
+    pypi_hub = "@default_pypi",
+)
+use_repo(docgen, "mkdocs")
+
+E2E_FOLDERS = [
+    "git_last_updated",
+    "smoke",
+]
+
+[
+    [
+        bazel_dep(name = "rules_docs_e2e_%s" % folder, version = "0.0.0", dev_dependency = True),
+        local_path_override(
+            module_name = "rules_docs_e2e_%s" % folder,
+            path = "e2e/%s" % folder,
+        ),
+    ]
+    for folder in E2E_FOLDERS
+]

--- a/modules/rules_docs/0.1.0/attestations.json
+++ b/modules/rules_docs/0.1.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/jacobshirley/rules_docs/releases/download/v0.1.0/source.json.intoto.jsonl",
+            "integrity": "sha256-xkXaFk0KOdOTXUTGd3hoDHX2zLE6UYB9V/BpUdX8qsk="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/jacobshirley/rules_docs/releases/download/v0.1.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-/63TElvSxq8VPLgZmyFBOM3TwQV7hp3V+U/PzCQDJiA="
+        },
+        "rules_docs-v0.1.0.tar.gz": {
+            "url": "https://github.com/jacobshirley/rules_docs/releases/download/v0.1.0/rules_docs-v0.1.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-/lhjJdCYygoAWo+L4bZ9QneU4C0ctRqvkHBurUB5xK8="
+        }
+    }
+}

--- a/modules/rules_docs/0.1.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_docs/0.1.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,9 +1,9 @@
+ "Bazel dependencies"
+ 
+ module(
+     name = "rules_docs",
+-    version = "",
++    version = "0.1.0",
+ )
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.8.2")
+ bazel_dep(name = "platforms", version = "1.0.0")

--- a/modules/rules_docs/0.1.0/presubmit.yml
+++ b/modules/rules_docs/0.1.0/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: ["8.x", "7.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_docs/0.1.0/source.json
+++ b/modules/rules_docs/0.1.0/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-lPobeHzONLnRMNidreus5LZ09/ZdsuCkD5aRg+M5gm4=",
+    "strip_prefix": "rules_docs-0.1.0",
+    "docs_url": "https://github.com/jacobshirley/rules_docs/releases/download/v0.1.0/rules_docs-v0.1.0.docs.tar.gz",
+    "url": "https://github.com/jacobshirley/rules_docs/releases/download/v0.1.0/rules_docs-v0.1.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-s46J5PLmcFdB7PjPk5w9Q90H0a+8sCYRxa2D6i7Rwo4="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_docs/metadata.json
+++ b/modules/rules_docs/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/jacobshirley/rules_docs",
+    "maintainers": [
+        {
+            "email": "jakeshirley2@gmail.com",
+            "github": "jacobshirley",
+            "name": "Jacob Shirley",
+            "github_user_id": 543204
+        }
+    ],
+    "repository": [
+        "github:jacobshirley/rules_docs"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/jacobshirley/rules_docs/releases/tag/v0.1.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_

Was previously https://github.com/bazelbuild/bazel-central-registry/pull/6821