### PR TITLE
Update trigger_bcr_frontend_rebuild.yml

### DIFF
--- a/.github/workflows/trigger_bcr_frontend_rebuild.yml
+++ b/.github/workflows/trigger_bcr_frontend_rebuild.yml
@@ -1,7 +1,9 @@
+name: Trigger BCR Frontend Rebuild
 on:
   push:
     branches:
       - main
+      
 jobs:
   trigger_build:
     runs-on: ubuntu-latest
@@ -13,7 +15,7 @@ jobs:
           # Fine-grained PAT (https://github.com/settings/personal-access-tokens/new), which needs
           # to be exchanged once a year.
           # Scoped to the `bazel-contrib/bcr-frontend` repository.
-          # Requires "Read and write" permissions for "Contents" to be able to do the workflow dispatch.
+          # Requires "Read and write" permissions for "Contents" and "Workflows" to be able to do the workflow dispatch.
           token: ${{ secrets.BCR_FRONTEND_REPO_ACCESS_TOKEN }}
           event-type: on-bcr-trigger
           client-payload: '{"bcrCommitHash": "${{ github.sha }}"}'


### PR DESCRIPTION
- Give it a name
- Update the comment about token permissions; apparently we need RW permissions for both "Contents" and "Workflows"

cc @alexeagle 