### PR TITLE
Clear maintainers for Java packages (`rules_jvm_external` now preferred)

### DIFF
--- a/modules/chicory/metadata.json
+++ b/modules/chicory/metadata.json
@@ -2,10 +2,8 @@
     "homepage": "https://chicory.dev/",
     "maintainers": [
         {
-            "email": "john@john-millikin.com",
-            "github": "jmillikin",
-            "name": "John Millikin",
-            "github_user_id": 646128
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
         }
     ],
     "repository": [

--- a/modules/javacc/metadata.json
+++ b/modules/javacc/metadata.json
@@ -2,10 +2,8 @@
     "homepage": "https://javacc.org/",
     "maintainers": [
         {
-            "email": "john@john-millikin.com",
-            "github": "jmillikin",
-            "github_user_id": 646128,
-            "name": "John Millikin"
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
         }
     ],
     "repository": [

--- a/modules/javaparser/metadata.json
+++ b/modules/javaparser/metadata.json
@@ -2,10 +2,8 @@
     "homepage": "https://javaparser.org/",
     "maintainers": [
         {
-            "email": "john@john-millikin.com",
-            "github": "jmillikin",
-            "github_user_id": 646128,
-            "name": "John Millikin"
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
         }
     ],
     "repository": [


### PR DESCRIPTION
See discussion on https://github.com/bazelbuild/bazel-central-registry/pull/6087, specifically:

>> If Bazel projects should use `rules_java_external` instead of `bazel_dep` for Java dependencies, should I consider existing Java BCR packages (e.g. `chicory`, `javacc`, `javaparser`) to be effectively orphaned? If so, I can send a follow-up PR to clear their maintainers lists.
>
> Yeah, I think that makes sense to me.