### PR TITLE
yaml-cpp@0.8.0.bcr.1

### DIFF
--- a/modules/yaml-cpp/0.8.0.bcr.1/MODULE.bazel
+++ b/modules/yaml-cpp/0.8.0.bcr.1/MODULE.bazel
@@ -1,0 +1,14 @@
+"""
+yaml-cpp is a YAML parser and emitter in c++ matching the YAML specification.
+"""
+
+module(
+    name = "yaml-cpp",
+    compatibility_level = 1,
+    version = "0.8.0.bcr.1",
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.14")
+
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)

--- a/modules/yaml-cpp/0.8.0.bcr.1/patches/build_dot_bazel.patch
+++ b/modules/yaml-cpp/0.8.0.bcr.1/patches/build_dot_bazel.patch
@@ -1,0 +1,10 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 23e847e..45ae375 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1,3 +1,5 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
+ yaml_cpp_defines = select({
+     # On Windows, ensure static linking is used.
+     "@platforms//os:windows": ["YAML_CPP_STATIC_DEFINE", "YAML_CPP_NO_CONTRIB"],

--- a/modules/yaml-cpp/0.8.0.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/yaml-cpp/0.8.0.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,20 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..7119060
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,14 @@
++"""
++yaml-cpp is a YAML parser and emitter in c++ matching the YAML specification.
++"""
++
++module(
++    name = "yaml-cpp",
++    compatibility_level = 1,
++    version = "0.8.0.bcr.1",
++)
++
++bazel_dep(name = "platforms", version = "1.0.0")
++bazel_dep(name = "rules_cc", version = "0.2.14")
++
++bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)

--- a/modules/yaml-cpp/0.8.0.bcr.1/presubmit.yml
+++ b/modules/yaml-cpp/0.8.0.bcr.1/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    build_targets:
+    - '@yaml-cpp//:yaml-cpp'

--- a/modules/yaml-cpp/0.8.0.bcr.1/source.json
+++ b/modules/yaml-cpp/0.8.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/stonier/yaml-cpp/releases/download/0.8.0/yaml-cpp-0.8.0.tar.gz",
+    "integrity": "sha256-++dLvc7iHWVnFWiHBto8i+z9lG2SzURwXMYJi7I7OhY=",
+    "strip_prefix": "yaml-cpp-0.8.0",
+    "patches": {
+        "module_dot_bazel.patch": "sha256-/ylX49nPNkKBR5G4tRkSfCDP21PpySz5jBz2mIjCp0g=",
+        "build_dot_bazel.patch": "sha256-o+/bmouWKa6H//NnuAfE3yCcjG05+9ZD7YvVqQtL3OI="
+    },
+    "patch_strip": 1
+}

--- a/modules/yaml-cpp/metadata.json
+++ b/modules/yaml-cpp/metadata.json
@@ -10,7 +10,8 @@
     "github:stonier/yaml-cpp"
   ],
   "versions": [
-    "0.8.0"
+    "0.8.0",
+    "0.8.0.bcr.1"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
This updates BUILD.bazel to include the load statement mandatory for Bazel 9. BUILD.bazel and MODULE.bazel have been updated upstream, so once a new upstream release is cut, we won't need the overlay anymore.