### PR TITLE
update_requirements: Use bazel-io as the author

### DIFF
--- a/.github/workflows/update_requirements.yml
+++ b/.github/workflows/update_requirements.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.16.0
@@ -32,8 +33,8 @@ jobs:
 
       - name: Commit and push changes
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "bazel.build machine account"
+          git config --global user.email "ci.bazel@gmail.com"
           git add tools/requirements_lock.txt
           if git diff --staged --quiet; then
             echo "No changes to commit"


### PR DESCRIPTION
So the workflow kinda works! It appended a commit with the correct changes to https://github.com/bazelbuild/bazel-central-registry/pull/6980, but the CLA check failed because Google's CLA doesn't like the github actions bot (boo!). Let's try using the bazel-io account instead. (Again, vibe coded with Antigravity. But the track record is good so far.)