### PR TITLE
update_requirements: use pull_request_target

### DIFF
--- a/.github/workflows/update_requirements.yml
+++ b/.github/workflows/update_requirements.yml
@@ -5,7 +5,7 @@
 name: Run //tools:requirements.update
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'tools/requirements_lock.txt'
 


### PR DESCRIPTION
The last change (https://github.com/bazelbuild/bazel-central-registry/pull/7049) didn't work, as the secret token ended up being invisible to the action (https://github.com/bazelbuild/bazel-central-registry/actions/runs/20727976828/job/59508311518?pr=6980). After perusing the docs and receiving some help from Copilot, it seems that the `pull_request` workflow trigger will hide all secrets from the workflow as it by default runs everything in the PR head branch, which might mean untrusted code execution (makes sense as we literally have a `bazel run` step!).

In comparison, the `pull_request_target` trigger by default runs everything in the PR target branch, and is thus "trusted" and shown secrets. We can still make it check out the PR head branch (which we're already doing) and thereby opening ourselves up to attacks; however, in this particular workflow we should be safe due to the "PR login is dependabot and PR repo is BCR" check. (For even more explanation, I asked Gemini to clear up my confusion after reading the official github docs on `pull_request_target` vs `pull_request`: https://gemini.google.com/share/edb0ea57c4fc)

The saga to test in prod continues.