### PR TITLE
dependabot: Group all pip PRs together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: /tools
     schedule:
       interval: weekly
+    groups:
+      all-pip:
+        patterns:
+          - "*"


### PR DESCRIPTION
This would avoid the situation where dependabot sent #6980 for `pydantic-core` and #6983 for `pydantic[email]`, but neither passed checks individually. After running `//tools:requirements.update`, #6980 became an empty PR, while #6983 became the combination of the two (which then passed checks).