### PR TITLE
rules_formatjs@0.3.0

### DIFF
--- a/modules/rules_formatjs/0.3.0/MODULE.bazel
+++ b/modules/rules_formatjs/0.3.0/MODULE.bazel
@@ -1,0 +1,61 @@
+"""rules_formatjs - Bazel rules for FormatJS internationalization"""
+
+module(
+    name = "rules_formatjs",
+
+    # NOTE:
+    version = "0.3.0",
+    #
+    # Always leave version unset or set to "" (the default). The default value
+    # can prevent issues when the module is used via non-registry overrides
+    # (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).
+    #
+    # The publish.yaml GitHub Action sets the version in the registry to the
+    # release version by patching this MODULE.bazel file in the pull request to
+    # the BCR.
+    #
+    # For more info, see this Slack thread:
+    # https://bazelbuild.slack.com/archives/CA31HN1T3/p1750406404452179
+
+    # NOTE:
+    compatibility_level = 0,
+    #
+    # Bumping compatibility_level too frequently is discouraged because it's
+    # very disruptive: as soon as a module is requested at two different
+    # compatibility levels in the dependency tree, users will see an error.
+    #
+    # As such, the compatibility_level (1) should be bumped *only* when the
+    # breaking change affects most use cases and isn't easy to migrate and/or
+    # work-around, and (2) *in the same commit* that introduces an incompatible
+    # (breaking) change.
+)
+
+# Core dependencies required by rules_formatjs
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "jq.bzl", version = "0.4.0")  # JSON manipulation in aggregation aspect
+bazel_dep(name = "package_metadata", version = "0.0.6")  # Package metadata for BCR
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# Development dependencies
+bazel_dep(name = "bazel_lib", version = "3.0.0", dev_dependency = True)
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.8.0", dev_dependency = True)
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.2", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.47.0", dev_dependency = True, repo_name = "bazel_gazelle")
+
+# FormatJS CLI toolchain
+formatjs_cli = use_extension("//formatjs_cli:extensions.bzl", "formatjs_cli")
+formatjs_cli.toolchain(version = "0.1.2")
+use_repo(
+    formatjs_cli,
+    "formatjs_cli_toolchains",
+    "formatjs_cli_toolchains_darwin_arm64",
+    "formatjs_cli_toolchains_darwin_x86_64",
+    "formatjs_cli_toolchains_linux_aarch64",
+    "formatjs_cli_toolchains_linux_x64",
+    "formatjs_cli_toolchains_windows_x86_64",
+)
+
+# Register all toolchains - Bazel will automatically select the appropriate one
+# based on exec_compatible_with constraints
+register_toolchains("@formatjs_cli_toolchains//:all")

--- a/modules/rules_formatjs/0.3.0/attestations.json
+++ b/modules/rules_formatjs/0.3.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/formatjs/rules_formatjs/releases/download/v0.3.0/source.json.intoto.jsonl",
+            "integrity": "sha256-nO9S/B5HeBL4s9wBK4lGPTx0wS2nK9OjZEPm1PptfOU="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/formatjs/rules_formatjs/releases/download/v0.3.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-QjwVWpTNcG1Z35ZZ3F4bjKbZFSY8b4aIkNmfoxUtqEw="
+        },
+        "rules_formatjs-v0.3.0.tar.gz": {
+            "url": "https://github.com/formatjs/rules_formatjs/releases/download/v0.3.0/rules_formatjs-v0.3.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-DcB+Gkw821knsUdsfJxibD3N5sszhtGDW1vvAWd4VZs="
+        }
+    }
+}

--- a/modules/rules_formatjs/0.3.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_formatjs/0.3.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -3,9 +3,9 @@
+ module(
+     name = "rules_formatjs",
+ 
+     # NOTE:
+-    version = "",
++    version = "0.3.0",
+     #
+     # Always leave version unset or set to "" (the default). The default value
+     # can prevent issues when the module is used via non-registry overrides
+     # (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).

--- a/modules/rules_formatjs/0.3.0/presubmit.yml
+++ b/modules/rules_formatjs/0.3.0/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004"]
+    bazel: ["8.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_formatjs/0.3.0/source.json
+++ b/modules/rules_formatjs/0.3.0/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-hZ8ZdTYo1kFVkA6QvDaHmxDG3E9DChiCzn96J0QUDls=",
+    "strip_prefix": "rules_formatjs-0.3.0",
+    "docs_url": "https://github.com/formatjs/rules_formatjs/releases/download/v0.3.0/rules_formatjs-v0.3.0.docs.tar.gz",
+    "url": "https://github.com/formatjs/rules_formatjs/releases/download/v0.3.0/rules_formatjs-v0.3.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-fcmuIOxZ62gDC/oqHtQfB3vM1Kw/CTgcSe9uHeezi6M="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_formatjs/metadata.json
+++ b/modules/rules_formatjs/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/formatjs/rules_formatjs",
+    "maintainers": [
+        {
+            "email": "holevietlong@gmail.com",
+            "github": "longlho",
+            "name": "Long Ho",
+            "github_user_id": 198255
+        }
+    ],
+    "repository": [
+        "github:formatjs/rules_formatjs"
+    ],
+    "versions": [
+        "0.3.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/formatjs/rules_formatjs/releases/tag/v0.3.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_