### PR TITLE
Fix bcr_validation for modules without MODULE.bazel files in the source archive

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -618,10 +618,10 @@ class BcrValidator:
                 overlay_dst.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(overlay_src, overlay_dst)
 
+        bcr_module_dot_bazel = self.registry.get_module_dot_bazel_path(module_name, version)
         source_module_dot_bazel = source_root.joinpath("MODULE.bazel")
         if source_module_dot_bazel.exists():
             source_module_dot_bazel_content = open(source_module_dot_bazel, "r").readlines()
-            bcr_module_dot_bazel = self.registry.get_module_dot_bazel_path(module_name, version)
             bcr_module_dot_bazel_content = open(bcr_module_dot_bazel, "r").readlines()
             source_module_dot_bazel_content = fix_line_endings(source_module_dot_bazel_content)
             bcr_module_dot_bazel_content = fix_line_endings(bcr_module_dot_bazel_content)


### PR DESCRIPTION
See this presubmit failure for details: https://buildkite.com/bazel/bcr-presubmit/builds/25640#019b99df-3f02-459f-a5c1-8acfc1f6c2fe

The previous change (https://github.com/bazelbuild/bazel-central-registry/commit/35454ac6ffc180815675aeaa12086ed85cbfaacb) accidentally made the `bcr_module_dot_bazel` variable uninitialized when the source archive doesn't contain a MODULE.bazel file.