### PR TITLE
fix(bcr-validation): default patch_strip to 0

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -580,7 +580,7 @@ class BcrValidator:
                         f"The patch file `{patch_name}` is a symlink to `{patch_file.readlink()}`, "
                         "which is not allowed because https://raw.githubusercontent.com/ will not follow it.",
                     )
-                apply_patch(source_root, source["patch_strip"], str(patch_file.resolve()))
+                apply_patch(source_root, int(source.get("patch_strip", 0)), str(patch_file.resolve()))
         if "overlay" in source:
             overlay_dir = self.registry.get_overlay_dir(module_name, version)
             for overlay_file, expected_integrity in source["overlay"].items():


### PR DESCRIPTION
In the past, it was possible to have patches without a "patch_strip" attribute in a module's source.json. At some point, an addition to the bcr validation script assumed its presence.

This defaults `patch_strip` to `0`, making it consistent with the other accesses in the script.