### PR TITLE
yank: aspect_rules_py@1.8.3

### DIFF
--- a/modules/aspect_rules_py/metadata.json
+++ b/modules/aspect_rules_py/metadata.json
@@ -64,6 +64,7 @@
         "1.8.4"
     ],
     "yanked_versions": {
-        "1.5.0": "Regression in prebuilt artifacts leads to missing rules_rust dep"
+        "1.5.0": "Regression in prebuilt artifacts leads to missing rules_rust dep",
+        "1.8.3": "Points to incorrect URLs for downloading prebuilds (gnu vs musl rename)"
     }
 }


### PR DESCRIPTION
We have some issues with our BCR presubmit testing that didn't catch this error