### PR TITLE
.gemini/styleguide.md: Fix typo in structure

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -38,7 +38,7 @@ modules/
       presubmit.yml
       # optional:
       patches/*.patch
-      overlays/**/*
+      overlay/**/*
       README.md (e.g., document BUILD overlays)
 ```
 


### PR DESCRIPTION
Change overlays/ to overlay/.

"overlay/" is used in the MODULE.bazel section as well as the bazel docs.

https://github.com/bazelbuild/bazel-central-registry/blob/7c5b74bffa03b0611e08bfdf98a8d816989c085b/.gemini/styleguide.md?plain=1#L68

https://bazel.build/external/registry#source-json

This appears to be the source of incorrect gemini-code-assist suggestions:

https://github.com/bazelbuild/bazel-central-registry/pull/7182#discussion_r2701236362

> The BCR style guide specifies that overlay files should be placed in
> an overlays directory (plural), but this file is in an overlay directory
> (singular).