### PR TITLE
Release bazeldnf@v0.99.2-rc0

### DIFF
--- a/modules/bazeldnf/metadata.json
+++ b/modules/bazeldnf/metadata.json
@@ -24,7 +24,8 @@
         "github:rmohr/bazeldnf"
     ],
     "versions": [
-        "v0.7.0-alpha2"
+        "v0.7.0-alpha2",
+        "v0.99.2-rc0"
     ],
     "yanked_versions": {}
 }

--- a/modules/bazeldnf/v0.99.2-rc0/MODULE.bazel
+++ b/modules/bazeldnf/v0.99.2-rc0/MODULE.bazel
@@ -1,0 +1,22 @@
+"bazelndf dependencies"
+
+module(
+    name = "bazeldnf",
+    version = "v0.99.2-rc0",
+    bazel_compatibility = [">=7.0.0"],
+    compatibility_level = 0,
+)
+
+bazeldnf_toolchain = use_extension("//bazeldnf:extensions.bzl", "bazeldnf_toolchain")
+bazeldnf_toolchain.register()
+use_repo(
+    bazeldnf_toolchain,
+    "bazeldnf_toolchains",
+)
+
+register_toolchains("@bazeldnf_toolchains//:all")
+
+# bazeldnf starlark dependenies
+bazel_dep(name = "bazel_skylib", version = "1.8.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_features", version = "1.38.0")

--- a/modules/bazeldnf/v0.99.2-rc0/MODULE.bazel.orig
+++ b/modules/bazeldnf/v0.99.2-rc0/MODULE.bazel.orig
@@ -1,0 +1,51 @@
+"bazelndf dependencies"
+
+module(
+    name = "bazeldnf",
+    version = "v0.99.2-rc0",
+    bazel_compatibility = [">=7.0.0"],
+    compatibility_level = 0,
+)
+
+bazeldnf_toolchain = use_extension("//bazeldnf:extensions.bzl", "bazeldnf_toolchain")
+bazeldnf_toolchain.register()
+use_repo(
+    bazeldnf_toolchain,
+    "bazeldnf_toolchains",
+)
+
+register_toolchains("@bazeldnf_toolchains//:all")
+
+# bazeldnf starlark dependenies
+bazel_dep(name = "bazel_skylib", version = "1.8.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_features", version = "1.38.0")
+
+# if someone wants to build the bazeldnf toolchain from sources needs this set of dependencies
+bazel_dep(name = "gazelle", version = "0.47.0")
+bazel_dep(name = "rules_go", version = "0.59.0")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
+go_sdk.download(version = "1.24.1")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_adrg_xdg",
+    "com_github_bazelbuild_buildtools",
+    "com_github_crillab_gophersat",
+    "com_github_hashicorp_go_retryablehttp",
+    "com_github_jdx_go_netrc",
+    "com_github_klauspost_compress",
+    "com_github_onsi_gomega",
+    "com_github_sassoftware_go_rpmutils",
+    "com_github_sirupsen_logrus",
+    "com_github_spf13_cobra",
+    "com_github_ulikunitz_xz",
+    "com_github_zyedidia_generic",
+    "io_k8s_sigs_yaml",
+    "org_golang_x_crypto",
+    "org_golang_x_exp",
+)
+

--- a/modules/bazeldnf/v0.99.2-rc0/patches/MODULE.bazel.patch
+++ b/modules/bazeldnf/v0.99.2-rc0/patches/MODULE.bazel.patch
@@ -1,0 +1,35 @@
+--- MODULE.bazel.orig	2026-01-19 23:08:47.000000000 +0100
++++ MODULE.bazel	2026-01-19 23:42:25.521082167 +0100
+@@ -20,32 +20,3 @@
+ bazel_dep(name = "bazel_skylib", version = "1.8.0")
+ bazel_dep(name = "platforms", version = "1.0.0")
+ bazel_dep(name = "bazel_features", version = "1.38.0")
+-
+-# if someone wants to build the bazeldnf toolchain from sources needs this set of dependencies
+-bazel_dep(name = "gazelle", version = "0.47.0")
+-bazel_dep(name = "rules_go", version = "0.59.0")
+-
+-go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
+-go_sdk.download(version = "1.24.1")
+-
+-go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+-go_deps.from_file(go_mod = "//:go.mod")
+-use_repo(
+-    go_deps,
+-    "com_github_adrg_xdg",
+-    "com_github_bazelbuild_buildtools",
+-    "com_github_crillab_gophersat",
+-    "com_github_hashicorp_go_retryablehttp",
+-    "com_github_jdx_go_netrc",
+-    "com_github_klauspost_compress",
+-    "com_github_onsi_gomega",
+-    "com_github_sassoftware_go_rpmutils",
+-    "com_github_sirupsen_logrus",
+-    "com_github_spf13_cobra",
+-    "com_github_ulikunitz_xz",
+-    "com_github_zyedidia_generic",
+-    "io_k8s_sigs_yaml",
+-    "org_golang_x_crypto",
+-    "org_golang_x_exp",
+-)
+-

--- a/modules/bazeldnf/v0.99.2-rc0/presubmit.yml
+++ b/modules/bazeldnf/v0.99.2-rc0/presubmit.yml
@@ -1,0 +1,14 @@
+# We recommend included a bcr test workspace that exercises your ruleset with bzlmod.
+# For an example, see https://github.com/aspect-build/bazel-lib/tree/main/e2e/bzlmod.
+bcr_test_module:
+  module_path: "e2e/bazel-bzlmod"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004"]
+    bazel: [7.x, 8.x]
+  tasks:
+    build_tests:
+      name: "Build test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."

--- a/modules/bazeldnf/v0.99.2-rc0/source.json
+++ b/modules/bazeldnf/v0.99.2-rc0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-+0hlwRdTCnWlXkUYV6hFgdQkfRXUuegGtKLeoy/y0jY=",
+    "strip_prefix": "bazeldnf-v0.99.2-rc0",
+    "url": "https://github.com/rmohr/bazeldnf/releases/download/v0.99.2-rc0/bazeldnf-v0.99.2-rc0.tar.gz",
+    "patches": {
+        "MODULE.bazel.patch": "sha256-0LOmBK32eVhIkcTKBoPeqeuCiBYVkhwEutryCg6B3O8="
+    },
+    "patch_strip": 0
+}


### PR DESCRIPTION
Adding release of bazeldnf@v0.99.2-rc0, did most of it by hand based on the previous release, there doesn't seem to be a tool to automate doing a new release on an existing module

Release:
https://github.com/rmohr/bazeldnf/releases/download/v0.99.2-rc0/bazeldnf-v0.99.2-rc0.tar.gz