### PR TITLE
{codspeed_core,codspeed_google_benchmark_compat}@2.1.0

### DIFF
--- a/modules/codspeed_core/2.1.0/MODULE.bazel
+++ b/modules/codspeed_core/2.1.0/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "codspeed_core",
+    version = "2.1.0",
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/codspeed_core/2.1.0/presubmit.yml
+++ b/modules/codspeed_core/2.1.0/presubmit.yml
@@ -1,0 +1,44 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform:
+      - debian10
+      - macos
+      - ubuntu2004
+      - windows
+    bazel:
+      - 7.x
+      - 8.x
+  tasks:
+    verify_instrumentation:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--//:codspeed_mode=instrumentation"
+      build_targets:
+        - "//:codspeed"
+        - "//:instrument_hooks"
+    verify_simulation:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--//:codspeed_mode=simulation"
+      build_targets:
+        - "//:codspeed"
+        - "//:instrument_hooks"
+    verify_walltime:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--//:codspeed_mode=walltime"
+      build_targets:
+        - "//:codspeed"
+        - "//:instrument_hooks"
+    verify_off:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--//:codspeed_mode=off"
+      build_targets:
+        - "//:codspeed"
+        - "//:instrument_hooks"

--- a/modules/codspeed_core/2.1.0/source.json
+++ b/modules/codspeed_core/2.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/CodSpeedHQ/codspeed-cpp/releases/download/v2.1.0/codspeed-cpp-v2.1.0.tar.gz",
+    "integrity": "sha256-njaeAB7hRtHDnxdNwSk4gFIZbdNBmd4WvFqVEnYIB5c=",
+    "strip_prefix": "codspeed-cpp-v2.1.0/core"
+}

--- a/modules/codspeed_core/metadata.json
+++ b/modules/codspeed_core/metadata.json
@@ -2,17 +2,18 @@
     "homepage": "https://codspeed.io",
     "maintainers": [
         {
+            "name": "Arthur Pastel",
             "email": "arthur@codspeed.io",
             "github": "art049",
-            "github_user_id": 15641577,
-            "name": "Arthur Pastel"
+            "github_user_id": 15641577
         }
     ],
     "repository": [
         "github:CodSpeedHQ/codspeed-cpp"
     ],
     "versions": [
-        "2.0.0"
+        "2.0.0",
+        "2.1.0"
     ],
     "yanked_versions": {}
 }

--- a/modules/codspeed_google_benchmark_compat/2.1.0/MODULE.bazel
+++ b/modules/codspeed_google_benchmark_compat/2.1.0/MODULE.bazel
@@ -1,0 +1,42 @@
+module(
+    name = "codspeed_google_benchmark_compat",
+    version = "2.1.0",
+)
+
+bazel_dep(name = "codspeed_core", version = "2.1.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+
+bazel_dep(name = "rules_python", version = "1.0.0", dev_dependency = True)
+bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True, repo_name = "com_google_googletest")
+
+bazel_dep(name = "libpfm", version = "4.11.0.bcr.1")
+
+# Register a toolchain for Python 3.9 to be able to build numpy. Python
+# versions >=3.10 are problematic.
+# A second reason for this is to be able to build Python hermetically instead
+# of relying on the changing default version from rules_python.
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
+python.toolchain(python_version = "3.8")
+python.toolchain(python_version = "3.9")
+python.toolchain(python_version = "3.10")
+python.toolchain(python_version = "3.11")
+python.toolchain(
+    is_default = True,
+    python_version = "3.12",
+)
+python.toolchain(python_version = "3.13")
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)
+pip.parse(
+    hub_name = "tools_pip_deps",
+    python_version = "3.9",
+    requirements_lock = "//tools:requirements.txt",
+)
+use_repo(pip, "tools_pip_deps")
+
+# -- bazel_dep definitions -- #
+
+bazel_dep(name = "nanobind_bazel", version = "2.5.0", dev_dependency = True)

--- a/modules/codspeed_google_benchmark_compat/2.1.0/presubmit.yml
+++ b/modules/codspeed_google_benchmark_compat/2.1.0/presubmit.yml
@@ -1,0 +1,44 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform:
+      - debian10
+      - macos
+      - ubuntu2004
+      - windows
+    bazel:
+      - 7.x
+      - 8.x
+  tasks:
+    verify_instrumentation:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--@codspeed_core//:codspeed_mode=instrumentation"
+      build_targets:
+        - "//:benchmark"
+        - "//:benchmark_main"
+    verify_simulation:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--@codspeed_core//:codspeed_mode=simulation"
+      build_targets:
+        - "//:benchmark"
+        - "//:benchmark_main"
+    verify_walltime:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--@codspeed_core//:codspeed_mode=walltime"
+      build_targets:
+        - "//:benchmark"
+        - "//:benchmark_main"
+    verify_off:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--@codspeed_core//:codspeed_mode=off"
+      build_targets:
+        - "//:benchmark"
+        - "//:benchmark_main"

--- a/modules/codspeed_google_benchmark_compat/2.1.0/source.json
+++ b/modules/codspeed_google_benchmark_compat/2.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/CodSpeedHQ/codspeed-cpp/releases/download/v2.1.0/codspeed-cpp-v2.1.0.tar.gz",
+    "integrity": "sha256-njaeAB7hRtHDnxdNwSk4gFIZbdNBmd4WvFqVEnYIB5c=",
+    "strip_prefix": "codspeed-cpp-v2.1.0/google_benchmark"
+}

--- a/modules/codspeed_google_benchmark_compat/metadata.json
+++ b/modules/codspeed_google_benchmark_compat/metadata.json
@@ -2,17 +2,18 @@
     "homepage": "https://codspeed.io",
     "maintainers": [
         {
+            "name": "Arthur Pastel",
             "email": "arthur@codspeed.io",
             "github": "art049",
-            "github_user_id": 15641577,
-            "name": "Arthur Pastel"
+            "github_user_id": 15641577
         }
     ],
     "repository": [
         "github:CodSpeedHQ/codspeed-cpp"
     ],
     "versions": [
-        "2.0.0"
+        "2.0.0",
+        "2.1.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/CodSpeedHQ/codspeed-cpp/releases/tag/v2.1.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_
