### PR TITLE
Publish toolchains_llvm_bootstrapped@0.4.1

### DIFF
--- a/modules/toolchains_llvm_bootstrapped/0.4.1/MODULE.bazel
+++ b/modules/toolchains_llvm_bootstrapped/0.4.1/MODULE.bazel
@@ -1,0 +1,176 @@
+module(
+    name = "toolchains_llvm_bootstrapped",
+    version = "0.4.1",
+    bazel_compatibility = [">=7.4.0"],
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "bazel_features", version = "1.34.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "with_cfg.bzl", version = "0.12.0")
+bazel_dep(name = "tar.bzl", version = "0.6.0")
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1", dev_dependency = True)
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.6.0", dev_dependency = True)
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+LLVM_VERSION = "21.1.8"
+PREBUILT_LLVM_SUFFIX = "-3"
+
+LLVM_TOOLCHAIN_MINIMAL_SHA256 = {
+    "darwin-arm64": "680ac53e1b0e47b39970a92351f719e2c6608dbe767ab9aaa011cc69f21a2e69",
+    "linux-amd64-musl": "69ace4e9c71ce74d827b4cf182a3c886d8abad48dbf0acceba20397b5d100a26",
+    "linux-arm64-musl": "8cdb101e50585371498b1215eaa76d90d953c6ae27ab17936037ee21f365c533",
+    "windows-amd64": "bdbe6a839f05af341e5f2a82d3248f7b9055d1e6987f766f2b25c1119498390b",
+    "windows-arm64": "f24b0527c1de96877725e90ed4707d39de200641136a982196dc35fe02a1b3b1",
+}
+
+[
+    http_archive(
+        name = "llvm-toolchain-minimal-{llvm_version}-{target}".format(
+            llvm_version = LLVM_VERSION,
+            target = target.replace("-musl", "").replace("-gnu", ""),
+        ),
+        build_file = "//toolchain/llvm:BUILD.llvm_release.tpl" if "windows" not in target else "//toolchain/llvm:BUILD.llvm_release_windows.tpl",
+        sha256 = sha256,
+        urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/llvm-{llvm_version}{prebuilt_llvm_suffix}/llvm-toolchain-minimal-{llvm_version}-{target}.tar.zst".format(
+            llvm_version = LLVM_VERSION,
+            prebuilt_llvm_suffix = PREBUILT_LLVM_SUFFIX,
+            target = target,
+        )],
+    )
+    for (target, sha256) in LLVM_TOOLCHAIN_MINIMAL_SHA256.items()
+]
+
+LLVM_TOOLCHAIN_EXTRAS_SHA256 = {
+    "darwin-arm64": "a50386d09cf70ea6c6a9b30b8d04be48de96d97ca73e5cbe2320dfad93b77efd",
+    "linux-amd64-musl": "034044d9284e3142604d793e8b20dffdd8a46af42db9094d5043b802748902cb",
+    "linux-arm64-musl": "98357273d7bc7e6b4d04648e9a7bdd6220b11e129ad2eca581a7c7b8d980ed1e",
+    "windows-amd64-gnu": "39782cb163129e20faf26a1e52391b4c97999e2d59cfdb7a09873117855143e2",
+    "windows-arm64-gnu": "c5b7188a7c6582292a2c2800089cbdb2b4b240c6ad790b4d0074b3507457f0d9",
+}
+
+VERSION = "20251219"
+
+[
+    http_archive(
+        name = "prebuilts-extras-toolchain-artifacts-{target}".format(target = target.replace("-musl", "").replace("-gnu", "")),
+        build_file = "//prebuilt/extras:BUILD.extras.tpl",
+        sha256 = sha256,
+        urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/prebuilts-extras-{version}/toolchain-extra-prebuilts-{version}-{target}.tar.zst".format(
+            target = target,
+            version = VERSION,
+        )],
+    )
+    for (target, sha256) in LLVM_TOOLCHAIN_EXTRAS_SHA256.items()
+]
+
+LLVM_RELEASE_ASSETS_SHA256 = {
+    "compiler-rt": "dd54ae21aee1780fac59445b51ebff601ad016b31ac3a7de3b21126fd3ccb229",
+    "libcxx": "6422a58a5c29b7f4fda224cfdc07842be8a208a61301bbba7a219116e3351809",
+    "libcxxabi": "709c9a63bde1e36a80d8675becc38073b85f0fa1b4111e34542b885c9e1239da",
+    "libunwind": "03e8adc6c3bdde657dcaedc94886ea70d1f7d551d622fcd8a36a8300e5c36cbc",
+}
+
+[
+    http_archive(
+        name = name,
+        build_file = "//third_party/llvm-project/20.x/{name}:BUILD.tpl".format(name = name),
+        patch_args = ["-p1"],
+        patches = ["//third_party/llvm-project/20.x/libcxx:lgamma_r.patch"] if name == "libcxx" else [],
+        sha256 = sha256,
+        strip_prefix = "{name}-{llvm_version}.src".format(
+            name = name,
+            llvm_version = LLVM_VERSION,
+        ),
+        urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-{llvm_version}/{name}-{llvm_version}.src.tar.xz".format(
+            name = name,
+            llvm_version = LLVM_VERSION,
+        )],
+    )
+    for (name, sha256) in LLVM_RELEASE_ASSETS_SHA256.items()
+]
+
+musl = use_extension("//runtimes/musl/extension:musl.bzl", "musl")
+use_repo(musl, "musl_libc")
+
+mingw = use_extension("//runtimes/mingw/extension:mingw.bzl", "mingw")
+use_repo(mingw, "mingw")
+
+osx = use_extension("//toolchain/extension:osx.bzl", "osx")
+use_repo(osx, "macosx15.4.sdk")
+
+glibc = use_extension("//runtimes/glibc/extension:glibc.bzl", "glibc")
+
+# https://cerisier.github.io/glibc-headers/index.json
+glibc.index(file = "//runtimes/glibc/extension:glibc_headers_index.json")
+use_repo(glibc, "glibc")
+
+kernel_headers = use_extension("//kernel/extension:kernel_headers.bzl", "kernel_headers")
+
+# https://cerisier.github.io/kernel-headers/index.json
+kernel_headers.index(file = "//kernel/extension:kernel_headers_index.json")
+use_repo(kernel_headers, "kernel_headers")
+
+## DEV DEPENDENCIES
+GLIBC_STUBS_GENERATOR_COMMIT = "33276300351d5a3cbedd308f4d21669b8e8ef83d"
+
+bazel_dep(name = "glibc-stubs-generator", version = "2.0.1", dev_dependency = True)
+archive_override(
+    module_name = "glibc-stubs-generator",
+    integrity = "sha256-q7bwGW3nRigiGuXj/2kIZMi/LFCHZpVbMD/kRdllLCg=",
+    strip_prefix = "glibc-stubs-generator-{}".format(GLIBC_STUBS_GENERATOR_COMMIT),
+    urls = ["https://github.com/cerisier/glibc-stubs-generator/archive/{}.tar.gz".format(GLIBC_STUBS_GENERATOR_COMMIT)],
+)
+
+LIBSTDCXX_STUBS_GENERATOR_COMMIT = "ed896a140ef8466140c3bcfd066e710a80a41ebe"
+
+bazel_dep(name = "libstdcxx-stubs-generator", version = "0.0.1", dev_dependency = True)
+archive_override(
+    module_name = "libstdcxx-stubs-generator",
+    integrity = "sha256-OAZfeifniTQmKit60qHpZanOLLIJVyYEiMlpN5Q7Fjw=",
+    strip_prefix = "libstdcxx-stubs-generator-{}".format(LIBSTDCXX_STUBS_GENERATOR_COMMIT),
+    urls = ["https://github.com/cerisier/libstdcxx-stubs-generator/archive/{}.tar.gz".format(LIBSTDCXX_STUBS_GENERATOR_COMMIT)],
+)
+
+llvm_raw = use_extension("//:llvm_raw.bzl", "llvm_raw")
+use_repo(llvm_raw, "llvm-raw", "llvm_zlib", "llvm_zstd")
+
+llvm = use_extension("//:llvm.bzl", "llvm")
+llvm.configure(
+    targets = [
+        "AArch64",
+        "X86",
+        "WebAssembly",
+    ],
+)
+use_repo(llvm, "llvm-project")
+
+## OVERRIDES PORTS FROM DEPENDENCIES
+
+RULES_ZIG_COMMIT = "b9739c615ce62b64ee595ac4bcd9ee7cc06b0422"  # branch=zml
+
+bazel_dep(name = "rules_zig", version = "0.12.2", dev_dependency = True)
+
+zig = use_extension("@rules_zig//zig:extensions.bzl", "zig", dev_dependency = True)
+zig.index(file = "//:zig_index.json")
+zig.toolchain(zig_version = "0.14.0")
+zig.mirrors(urls = [
+    "https://mirror.zml.ai/zig",
+])
+use_repo(zig, "zig_toolchains")
+
+register_toolchains(
+    "@rules_zig//zig/target:all",
+    dev_dependency = True,
+)
+
+register_toolchains(
+    "@zig_toolchains//:all",
+    dev_dependency = True,
+)

--- a/modules/toolchains_llvm_bootstrapped/0.4.1/attestations.json
+++ b/modules/toolchains_llvm_bootstrapped/0.4.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.4.1/source.json.intoto.jsonl",
+            "integrity": "sha256-hANljy3MCm8OMkzhxMkSTunkkhSBByDK26gNBviw9SI="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.4.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-oQBhsTHojw5TspywJGPfr8R8MWeLpPNWr6bp6wlvWYM="
+        },
+        "toolchains_llvm_bootstrapped-0.4.1.tar.gz": {
+            "url": "https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.4.1/toolchains_llvm_bootstrapped-0.4.1.tar.gz.intoto.jsonl",
+            "integrity": "sha256-+y2ESj6Y96daX+m0i7fOpdl8Lz9tk7LCMhfp4VmXOlc="
+        }
+    }
+}

--- a/modules/toolchains_llvm_bootstrapped/0.4.1/presubmit.yml
+++ b/modules/toolchains_llvm_bootstrapped/0.4.1/presubmit.yml
@@ -1,0 +1,13 @@
+bcr_test_module:
+  module_path: .
+  matrix:
+    bazel: [8.x, 9.*]
+    # Add macos_arm64 back when we support sdk discovery
+    platform: [debian11, ubuntu2004]
+  tasks:
+    run_test_module:
+      name: Run test module
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      build_targets:
+        - //:all

--- a/modules/toolchains_llvm_bootstrapped/0.4.1/source.json
+++ b/modules/toolchains_llvm_bootstrapped/0.4.1/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-BFwsXnqm+ddbJXxTjYFtj3wCGUk6ighzx7di92gT6Ac=",
+    "strip_prefix": "toolchains_llvm_bootstrapped-0.4.1",
+    "url": "https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.4.1/toolchains_llvm_bootstrapped-0.4.1.tar.gz"
+}

--- a/modules/toolchains_llvm_bootstrapped/metadata.json
+++ b/modules/toolchains_llvm_bootstrapped/metadata.json
@@ -6,6 +6,12 @@
             "email": "corentin.kerisit@gmail.com",
             "github": "cerisier",
             "github_user_id": 1126594
+        },
+        {
+            "name": "David Zbarsky",
+            "email": "dzbarsky@gmail.com",
+            "github": "dzbarsky",
+            "github_user_id": 1565842
         }
     ],
     "repository": [
@@ -18,7 +24,8 @@
         "0.2.3",
         "0.2.4",
         "0.2.5",
-        "0.3.1"
+        "0.3.1",
+        "0.4.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/tag/0.4.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_