### PR TITLE
Update giflib to support Bazel 9

### DIFF
--- a/modules/giflib/5.2.1.bcr.1/MODULE.bazel
+++ b/modules/giflib/5.2.1.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "giflib",
+    version = "5.2.1.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "platforms", version = "1.0.0")

--- a/modules/giflib/5.2.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/giflib/5.2.1.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "giflib",
+    srcs = [
+        "dgif_lib.c",
+        "egif_lib.c",
+        "gif_err.c",
+        "gif_font.c",
+        "gif_hash.c",
+        "gif_hash.h",
+        "gif_lib_private.h",
+        "gifalloc.c",
+        "openbsd-reallocarray.c",
+    ],
+    hdrs = ["gif_lib.h"],
+    defines = select({
+        "@platforms//os:windows": ["_WIN32"],
+        "//conditions:default": [],
+    }),
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/modules/giflib/5.2.1.bcr.1/patches/fix_includes.patch
+++ b/modules/giflib/5.2.1.bcr.1/patches/fix_includes.patch
@@ -1,0 +1,10 @@
+--- gif_hash.h
++++ gif_hash.h
+@@ -9,7 +9,6 @@
+ #ifndef _GIF_HASH_H_
+ #define _GIF_HASH_H_
+ 
+-#include <unistd.h>
+ #include <stdint.h>
+ 
+ #define HT_SIZE			8192	   /* 12bits = 4096 or twice as big! */

--- a/modules/giflib/5.2.1.bcr.1/presubmit.yml
+++ b/modules/giflib/5.2.1.bcr.1/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@giflib//:giflib'

--- a/modules/giflib/5.2.1.bcr.1/source.json
+++ b/modules/giflib/5.2.1.bcr.1/source.json
@@ -1,0 +1,11 @@
+{
+    "integrity": "sha256-tgb9EfSJ7PNDy9PYEPR/mfUXVLLAneSQQlP/sjXj30o=",
+    "strip_prefix": "giflib-5.2.1",
+    "url": "https://github.com/arthenica/giflib/archive/refs/tags/5.2.1.tar.gz",
+    "overlay": {
+        "BUILD.bazel": "sha256-RWJN2VeXs6vZmcEHIDV+WM2S27J9tPIMyLgoSew3mkQ="
+    },
+    "patches": {
+        "fix_includes.patch": "sha256-bZv10WBJG7QlRxSeDhmB5UGxS3OUfcQATPLiuRpVPu8="
+    }
+}

--- a/modules/giflib/metadata.json
+++ b/modules/giflib/metadata.json
@@ -2,15 +2,19 @@
   "homepage": "https://giflib.sourceforge.net/",
   "maintainers": [
     {
-      "email": "bcr-maintainers@bazel.build",
-      "name": "No Maintainer Specified"
+      "email": "eustas@google.com",
+      "github": "eustas",
+      "name": "Evgenii Kliuchnikov",
+      "github_user_id": 203457
     }
   ],
   "repository": [
-    "https://netcologne.dl.sourceforge.net/project/giflib"
+    "https://netcologne.dl.sourceforge.net/project/giflib",
+    "github:arthenica/giflib"
   ],
   "versions": [
-    "5.2.1"
+    "5.2.1",
+    "5.2.1.bcr.1"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
Also use alternative source. Sourceforge is down again.