### PR TITLE
Introduce opt-out for attestation history check

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -94,6 +94,7 @@ GITHUB_USER_ID_CACHE = {}
 # TODO(fweikert): enforce compliance once attestation feature is more widely used.
 ATTESTATION_HISTORY_CHECK_OPT_OUT = frozenset(["protobuf"])
 
+
 def print_collapsed_group(name):
     print("\n\n--- {0}\n\n".format(name))
 


### PR DESCRIPTION
protobuf accidentally published attestations for protobuf@33.4, which now causes the presubmit to fail since protobuf@34.0-rc1.1 does not have any attestations.

This feature is a workaround that turns the fatal error into a mere warning. It should be used sparingly - eventually we'll be more strict on enforcement.