### PR TITLE
rules_formatjs@0.4.4

### DIFF
--- a/modules/rules_formatjs/0.4.4/MODULE.bazel
+++ b/modules/rules_formatjs/0.4.4/MODULE.bazel
@@ -1,0 +1,60 @@
+"""rules_formatjs - Bazel rules for FormatJS internationalization"""
+
+module(
+    name = "rules_formatjs",
+
+    # NOTE:
+    version = "0.4.4",
+    #
+    # Always leave version unset or set to "" (the default). The default value
+    # can prevent issues when the module is used via non-registry overrides
+    # (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).
+    #
+    # The publish.yaml GitHub Action sets the version in the registry to the
+    # release version by patching this MODULE.bazel file in the pull request to
+    # the BCR.
+    #
+    # For more info, see this Slack thread:
+    # https://bazelbuild.slack.com/archives/CA31HN1T3/p1750406404452179
+
+    # NOTE:
+    compatibility_level = 0,
+    #
+    # Bumping compatibility_level too frequently is discouraged because it's
+    # very disruptive: as soon as a module is requested at two different
+    # compatibility levels in the dependency tree, users will see an error.
+    #
+    # As such, the compatibility_level (1) should be bumped *only* when the
+    # breaking change affects most use cases and isn't easy to migrate and/or
+    # work-around, and (2) *in the same commit* that introduces an incompatible
+    # (breaking) change.
+)
+
+# Core dependencies required by rules_formatjs
+bazel_dep(name = "jq.bzl", version = "0.4.0")  # JSON manipulation in aggregation aspect
+bazel_dep(name = "package_metadata", version = "0.0.6")  # Package metadata for BCR
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# Development dependencies
+bazel_dep(name = "bazel_lib", version = "3.0.0", dev_dependency = True)
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.8.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.47.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_shell", version = "0.3.0", dev_dependency = True)
+
+# FormatJS CLI toolchain
+formatjs_cli = use_extension("//formatjs_cli:extensions.bzl", "formatjs_cli")
+formatjs_cli.toolchain(version = "0.1.11")
+use_repo(
+    formatjs_cli,
+    "formatjs_cli_toolchains",
+    "formatjs_cli_toolchains_darwin_arm64",
+    "formatjs_cli_toolchains_darwin_x86_64",
+    "formatjs_cli_toolchains_linux_aarch64",
+    "formatjs_cli_toolchains_linux_x64",
+    "formatjs_cli_toolchains_windows_x86_64",
+)
+
+# Register all toolchains - Bazel will automatically select the appropriate one
+# based on exec_compatible_with constraints
+register_toolchains("@formatjs_cli_toolchains//:all")

--- a/modules/rules_formatjs/0.4.4/attestations.json
+++ b/modules/rules_formatjs/0.4.4/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/formatjs/rules_formatjs/releases/download/v0.4.4/source.json.intoto.jsonl",
+            "integrity": "sha256-OXLeu/uxsWn0USFqiJT8ZpPCplmiFEcEVnrUz9IsZ2A="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/formatjs/rules_formatjs/releases/download/v0.4.4/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-wRZTI/oftG6iJxsdAucsEzfBb3k3Ttb5FYA3mojgD0g="
+        },
+        "rules_formatjs-v0.4.4.tar.gz": {
+            "url": "https://github.com/formatjs/rules_formatjs/releases/download/v0.4.4/rules_formatjs-v0.4.4.tar.gz.intoto.jsonl",
+            "integrity": "sha256-5Ab5a7ppchvV6KeGyr6vLH5PUjikK3eaH+yfq2xsA+w="
+        }
+    }
+}

--- a/modules/rules_formatjs/0.4.4/patches/module_dot_bazel_version.patch
+++ b/modules/rules_formatjs/0.4.4/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -3,9 +3,9 @@
+ module(
+     name = "rules_formatjs",
+ 
+     # NOTE:
+-    version = "",
++    version = "0.4.4",
+     #
+     # Always leave version unset or set to "" (the default). The default value
+     # can prevent issues when the module is used via non-registry overrides
+     # (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).

--- a/modules/rules_formatjs/0.4.4/presubmit.yml
+++ b/modules/rules_formatjs/0.4.4/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform: ["macos_arm64", "ubuntu2204"]
+    bazel: ["8.5.0"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_formatjs/0.4.4/source.json
+++ b/modules/rules_formatjs/0.4.4/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-KXZF0yT6g5hA+ZeQ7xUCSGbqF9ybsQed7iWF/AyL+jw=",
+    "strip_prefix": "rules_formatjs-0.4.4",
+    "docs_url": "https://github.com/formatjs/rules_formatjs/releases/download/v0.4.4/rules_formatjs-v0.4.4.docs.tar.gz",
+    "url": "https://github.com/formatjs/rules_formatjs/releases/download/v0.4.4/rules_formatjs-v0.4.4.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-V0+RisaZ2zOLGJijSCdn0aGOZxOUPN/87HnGXJZE+SU="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_formatjs/metadata.json
+++ b/modules/rules_formatjs/metadata.json
@@ -12,7 +12,8 @@
         "github:formatjs/rules_formatjs"
     ],
     "versions": [
-        "0.4.3"
+        "0.4.3",
+        "0.4.4"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/formatjs/rules_formatjs/releases/tag/v0.4.4

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_