### PR TITLE
Add proxy-wasm-cpp-sdk@0.0.0-20260123-894dd29

### DIFF
--- a/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/MODULE.bazel
+++ b/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/MODULE.bazel
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "proxy-wasm-cpp-sdk",
+    version = "0.0.0-20260123-894dd29",
+    repo_name = "proxy_wasm_cpp_sdk",
+)
+
+bazel_dep(
+    name = "emsdk",
+    version = "4.0.13",
+)
+bazel_dep(
+    name = "platforms",
+    version = "1.0.0",
+)
+bazel_dep(
+    name = "protobuf",
+    version = "29.3",
+    repo_name = "com_google_protobuf",
+)
+bazel_dep(
+    name = "re2",
+    version = "2024-07-02.bcr.1",
+    repo_name = "com_google_re2",
+)
+bazel_dep(
+    name = "rules_cc",
+    version = "0.2.0",
+)
+bazel_dep(
+    name = "rules_python",
+    version = "1.4.1",
+)

--- a/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/patches/add_load_to_contrib.patch
+++ b/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/patches/add_load_to_contrib.patch
@@ -1,0 +1,8 @@
+--- a/contrib/BUILD
++++ b/contrib/BUILD
+@@ -1,3 +1,5 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
+ licenses(["notice"])  # Apache 2
+ 
+ cc_library(

--- a/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/patches/module_version.patch
+++ b/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/patches/module_version.patch
@@ -1,0 +1,13 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 0000000..1111111 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -14,7 +14,7 @@
+ 
+ module(
+     name = "proxy-wasm-cpp-sdk",
+-    version = "0.0.0",
++    version = "0.0.0-20260123-894dd29",
+     repo_name = "proxy_wasm_cpp_sdk",
+ )
+

--- a/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/patches/proxy-wasm-cpp-sdk.patch
+++ b/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/patches/proxy-wasm-cpp-sdk.patch
@@ -1,0 +1,16 @@
+diff --git a/bazel/defs.bzl b/bazel/defs.bzl
+index 87727c0..ae1b19b 100644
+--- a/bazel/defs.bzl
++++ b/bazel/defs.bzl
+@@ -101,9 +101,9 @@ def proxy_wasm_cc_binary(
+             # Give host code access to Emscripten's _malloc() function
+             "-sEXPORTED_FUNCTIONS=_malloc",
+             # Allow allocating memory past initial heap size
+-            "-sALLOW_MEMORY_GROWTH=1",
++            # "-sALLOW_MEMORY_GROWTH=1",
+             # Initial amount of heap memory. 64KB matches Rust SDK starting heap size.
+-            "-sINITIAL_HEAP=64KB",
++            # "-sINITIAL_HEAP=64KB",
+         ],
+         tags = tags + [
+             "manual",

--- a/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/presubmit.yml
+++ b/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/presubmit.yml
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+matrix:
+  platform: ["debian11", "macos", "ubuntu2204"]
+  bazel: [7.x, 8.x]
+tasks:
+  verify_targets:
+    name: "Build example WebAssembly modules"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@proxy-wasm-cpp-sdk//..."

--- a/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/source.json
+++ b/modules/proxy-wasm-cpp-sdk/0.0.0-20260123-894dd29/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/894dd29ff8333d6cc51b416d334568058d6aef71.tar.gz",
+    "integrity": "sha256-YRvk9G7bePDhTJJhbmUqjVzQdtOIaTVyUwgfLFpUdqc=",
+    "strip_prefix": "proxy-wasm-cpp-sdk-894dd29ff8333d6cc51b416d334568058d6aef71",
+    "patches": {
+        "proxy-wasm-cpp-sdk.patch": "sha256-HX2I0ovtuofK8WmRwhIv2BoyHqTuc7WE+LzJHpKH8JU=",
+        "module_version.patch": "sha256-7YsNSCAHtqbJRu8GM8+ItYrutLxN7BHJvmjnrR0d4Xg=",
+        "add_load_to_contrib.patch": "sha256-RUkvVMX87Ern2GzSKkthSs4osTchzsl4fH+7E31hNi8="
+    },
+    "patch_strip": 1
+}

--- a/modules/proxy-wasm-cpp-sdk/metadata.json
+++ b/modules/proxy-wasm-cpp-sdk/metadata.json
@@ -1,0 +1,38 @@
+{
+    "homepage": "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk",
+    "maintainers": [
+        {
+            "email": "piotrsikora@google.com",
+            "github": "PiotrSikora",
+            "github_user_id": 190297,
+            "name": "Piotr Sikora"
+        },
+        {
+            "email": "martijneken@google.com",
+            "github": "martijneken",
+            "github_user_id": 2081190,
+            "name": "Martijn Eken"
+        },
+        {
+            "email": "mpwarres@google.com",
+            "github": "mpwarres",
+            "github_user_id": 156047,
+            "name": "Michael Warres"
+        },
+        {
+            "github": "leonm1",
+            "github_user_id": 32306579
+        },
+        {
+            "github": "phlax",
+            "github_user_id": 454682
+        }
+    ],
+    "repository": [
+        "github:proxy-wasm/proxy-wasm-cpp-sdk"
+    ],
+    "versions": [
+        "0.0.0-20260123-894dd29"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds proxy-wasm-cpp-sdk module based on commit `894dd29` (2026-01-23), newer than existing PR's `e5256b0` (2025-09-25).

## Module Configuration

- **Version**: `0.0.0-20260123-894dd29` (8-digit date format)
- **Source**: https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/894dd29ff8333d6cc51b416d334568058d6aef71.tar.gz
- **Maintainers**: PiotrSikora, martijneken, mpwarres, leonm1, phlax
- **Dependencies**: emsdk 4.0.13, protobuf 29.3, re2, rules_cc 0.2.0, rules_python 1.4.1
- **CI matrix**: Bazel 7.x, 8.x on debian11, macos, ubuntu2204

## Patches

1. `proxy-wasm-cpp-sdk.patch` - Comments out emscripten `ALLOW_MEMORY_GROWTH` and `INITIAL_HEAP` flags (from envoyproxy/toolshed)
2. `module_version.patch` - Updates MODULE.bazel version string from `0.0.0` to `0.0.0-20260123-894dd29`

## Notes

Upstream removed `rules_proto` dependency between commits e5256b0 and 894dd29.

@bazel-io skip_check unstable_url