### PR TITLE
gcc_toolchain: Add 0.9.0.bcr.1 for Bazel 9 compat

### DIFF
--- a/modules/gcc_toolchain/0.9.0.bcr.1/MODULE.bazel
+++ b/modules/gcc_toolchain/0.9.0.bcr.1/MODULE.bazel
@@ -1,0 +1,68 @@
+module(
+    name = "gcc_toolchain",
+    version = "0.9.0.bcr.1",
+)
+
+# Dependencies
+# ============
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.40.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.0")
+
+# Local Toolchains
+# ================
+gcc_toolchains = use_extension("//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
+
+[
+    [
+        gcc_toolchains.toolchain(
+            name = "gcc_toolchain_{}".format(arch),
+            target_arch = arch,
+        ),
+        use_repo(gcc_toolchains, "gcc_toolchain_{}".format(arch)),
+        register_toolchains(
+            "@gcc_toolchain_{}//:cc_toolchain".format(arch),
+            "@gcc_toolchain_{}//:fortran_toolchain".format(arch),
+            # Register toolchains as dev dependencies so that we don't pollute the toolchain resolution of consumers.
+            dev_dependency = True,
+        ),
+    ]
+    # Unfortunately, we can't load `ARCHS` directly here.
+    # But the attributes in `gcc_toolchains.toolchain` are gated to only contain values from ARCHS.
+    for arch in [
+        "aarch64",
+        "armv7",
+        "x86_64",
+    ]
+]
+
+# Dev Dependencies (for examples/)
+# ===============================
+bazel_dep(name = "rules_proto", version = "7.1.0", dev_dependency = True)
+bazel_dep(name = "rules_foreign_cc", version = "0.15.0", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.5.6", dev_dependency = True, repo_name = "io_bazel_stardoc")
+
+# We pin stardoc because a dependency requests a newer version (0.7.2), but the non-workspace flow doesn't work with it.
+single_version_override(
+    module_name = "stardoc",
+    version = "0.5.6",
+)
+
+bazel_dep(name = "protobuf", version = "29.3", dev_dependency = True, repo_name = "com_google_protobuf")
+single_version_override(
+    module_name = "protobuf",
+    patch_strip = 1,
+    patches = [
+        "//third_party/patches:com_google_protobuf.bzlmod.patch",
+    ],
+    version = "29.3",
+)
+
+non_bazel_dependencies = use_extension("//:internal.bzl", "non_bazel_dependencies")
+use_repo(
+    non_bazel_dependencies,
+    "avl",
+    "lapack",
+    "openssl",
+)

--- a/modules/gcc_toolchain/0.9.0.bcr.1/patches/bazel_9_compatibility.patch
+++ b/modules/gcc_toolchain/0.9.0.bcr.1/patches/bazel_9_compatibility.patch
@@ -1,0 +1,22 @@
+===================================================================
+--- a/toolchain/cc_toolchain_config.bzl
++++ b/toolchain/cc_toolchain_config.bzl
+@@ -19,6 +19,7 @@
+ """
+ 
+ load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
++load("@rules_cc//cc:defs.bzl", "CcToolchainConfigInfo", "cc_common")
+ load(
+     "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+     "action_config",
+===================================================================
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -250,6 +250,7 @@
+ 
+ _TOOLCHAIN_BUILD_FILE_CONTENT = """\
+ load("@rules_cc//cc:defs.bzl", "cc_toolchain")
++load("@rules_cc//cc:defs.bzl", "cc_library")
+ load("@{gcc_toolchain_workspace_name}//toolchain:cc_toolchain_config.bzl", "cc_toolchain_config")
+ load("@{gcc_toolchain_workspace_name}//toolchain/fortran:defs.bzl", "fortran_toolchain")
+ load("//:tool_paths.bzl", "tool_paths")

--- a/modules/gcc_toolchain/0.9.0.bcr.1/patches/module_dot_bazel_version.patch
+++ b/modules/gcc_toolchain/0.9.0.bcr.1/patches/module_dot_bazel_version.patch
@@ -1,0 +1,19 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,4 +1,7 @@
+-module(name = "gcc_toolchain")
++module(
++    name = "gcc_toolchain",
++    version = "0.9.0.bcr.1",
++)
+ 
+ # Dependencies
+ # ============
+@@ -39,6 +42,7 @@
+ bazel_dep(name = "rules_proto", version = "7.1.0", dev_dependency = True)
+ bazel_dep(name = "rules_foreign_cc", version = "0.15.0", dev_dependency = True)
+ bazel_dep(name = "stardoc", version = "0.5.6", dev_dependency = True, repo_name = "io_bazel_stardoc")
++
+ # We pin stardoc because a dependency requests a newer version (0.7.2), but the non-workspace flow doesn't work with it.
+ single_version_override(
+     module_name = "stardoc",

--- a/modules/gcc_toolchain/0.9.0.bcr.1/presubmit.yml
+++ b/modules/gcc_toolchain/0.9.0.bcr.1/presubmit.yml
@@ -1,0 +1,14 @@
+bcr_test_module:
+  module_path: examples/bzlmod
+  matrix:
+    platform: ["ubuntu2204"]
+    bazel: [7.x, 8.x, 9.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--enable_bzlmod"
+      test_targets:
+        - "//..."

--- a/modules/gcc_toolchain/0.9.0.bcr.1/source.json
+++ b/modules/gcc_toolchain/0.9.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-5qAKn5mbKbpO7gv3P3Sr7uwcuFdAyMGXqL+omnPnIrA=",
+    "strip_prefix": "gcc-toolchain-0.9.0",
+    "url": "https://github.com/f0rmiga/gcc-toolchain/releases/download/0.9.0/gcc-toolchain-0.9.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-vNw4/zXc6AgEg7ckKFxVhL17lDOKnV+ZqdUo1Y9hNoc=",
+        "bazel_9_compatibility.patch": "sha256-ZbiuGSS9djmlyVdeWz5cUIti4sSBJpLR++UFO5glNvs="
+    },
+    "patch_strip": 1
+}

--- a/modules/gcc_toolchain/metadata.json
+++ b/modules/gcc_toolchain/metadata.json
@@ -18,7 +18,8 @@
         "github:f0rmiga/gcc-toolchain"
     ],
     "versions": [
-        "0.9.0"
+        "0.9.0",
+        "0.9.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Introduce a new version of gcc_toolchain, 0.9.0.bcr.1, to fix compatibility issues with Bazel 9.

Changes included in this version:
1.  **Load CcToolchainConfigInfo from rules_cc**: Bazel 9 removed `CcToolchainConfigInfo` from the built-in global scope and from `@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl`. This patch updates `toolchain/cc_toolchain_config.bzl` to load it from `@rules_cc//cc:defs.bzl` instead.
2.  **Load cc_common from rules_cc**: The `create_cc_toolchain_config_info` method was removed from the built-in `cc_common` module. The patch loads `cc_common` from `@rules_cc//cc:defs.bzl`, which provide the necessary method.
3.  **Explicitly load cc_library**: Bazel 9 removed the native `cc_library` rule. The generated `BUILD.bazel` file (created via `toolchain/defs.bzl`) used `cc_library` without loading it. The patch updates `toolchain/defs.bzl` to inject `load("@rules_cc//cc:defs.bzl", "cc_library")` into the generated build file template.

These changes ensure that gcc_toolchain can be built and used with Bazel 9.