### PR TITLE
libcap@2.29.bcr.1

### DIFF
--- a/modules/libcap/2.27.bcr.1/MODULE.bazel
+++ b/modules/libcap/2.27.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "libcap",
+    version = "2.27.bcr.1",
+    compatibility_level = 0,
+    bazel_compatibility = ['>=7.2.1'],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "sed", version = "4.9.bcr.3")

--- a/modules/libcap/2.27.bcr.1/overlay/BUILD.bazel
+++ b/modules/libcap/2.27.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,95 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
+
+genrule(
+    name = "cap_names_list_h",
+    srcs = ["libcap/include/uapi/linux/capability.h"],
+    outs = ["cap_names.list.h"],
+    # Use the same logic as libcap/Makefile
+    cmd = """
+        $(location @sed) -ne '/^#define[ \\t]CAP[_A-Z]\\+[ \\t]\\+[0-9]\\+/{s/^#define \\([^ \\t]*\\)[ \\t]*\\([^ \\t]*\\)/\\{"\\1",\\2\\},/p;}' $< | \\
+        $(location @sed) 'y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/' > $@
+    """,
+    tools = ["@sed"],
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "makenames_textual_hdrs",
+    textual_hdrs = [
+        ":cap_names.list.h",
+        "libcap/include/uapi/linux/capability.h",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+cc_binary(
+    name = "makenames",
+    srcs = [
+        "libcap/_makenames.c",
+        "libcap/include/sys/capability.h",
+    ],
+    includes = [
+        "libcap/..",
+        "libcap/include",
+        "libcap/include/uapi",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [":makenames_textual_hdrs"],
+)
+
+genrule(
+    name = "cap_names_h",
+    outs = ["libcap/cap_names.h"],
+    cmd = "mkdir -p libcap && $(location makenames) > $@ || { rm -f $@; false; }",
+    tools = [":makenames"],
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "cap",
+    srcs = [
+        "libcap/cap_alloc.c",
+        "libcap/cap_extint.c",
+        "libcap/cap_file.c",
+        "libcap/cap_flag.c",
+        "libcap/cap_proc.c",
+        "libcap/cap_text.c",
+    ],
+    copts = [
+        "-Wno-tautological-compare",
+        "-Wno-unused-result",
+        # Work around sys/xattr.h not declaring this
+        "-DXATTR_NAME_CAPS=\"\\\"security.capability\\\"\"",
+    ],
+    includes = [
+        "libcap",
+        "libcap/include",
+        "libcap/include/uapi",
+    ],
+    textual_hdrs = [
+        "libcap/include/sys/capability.h",
+        "libcap/include/uapi/linux/capability.h",
+        "libcap/libcap.h",
+        "libcap/cap_names.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+   name = "libcap",
+   actual = ":cap",
+   visibility = ["//visibility:public"],
+)

--- a/modules/libcap/2.27.bcr.1/overlay/MODULE.bazel
+++ b/modules/libcap/2.27.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "libcap",
+    version = "2.27.bcr.1",
+    compatibility_level = 0,
+    bazel_compatibility = ['>=7.2.1'],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "sed", version = "4.9.bcr.3")

--- a/modules/libcap/2.27.bcr.1/presubmit.yml
+++ b/modules/libcap/2.27.bcr.1/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  bazel:
+  - 8.x
+  - 7.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@libcap'

--- a/modules/libcap/2.27.bcr.1/source.json
+++ b/modules/libcap/2.27.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.27.tar.gz",
+    "integrity": "sha256-JgtUnBVLB8PNwWuczJPARjPDn0+2pKO40fpbipw/X+g=",
+    "strip_prefix": "libcap-2.27",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-t0rIdsYn1pc33QEhu8EJdYprH38Tv86ZrsaI4DHPb/I=",
+        "MODULE.bazel": "sha256-fANNek2SsikylJNDd/XRy8iBGXEKEQefqBQhIPbwh2g="
+    }
+}

--- a/modules/libcap/metadata.json
+++ b/modules/libcap/metadata.json
@@ -12,7 +12,8 @@
         "https://www.kernel.org/pub/linux/libs/security/linux-privs"
     ],
     "versions": [
-        "2.27"
+        "2.27",
+        "2.27.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
* Compatible with Bazel 9.x.
* Uses hermetic sed.
* Update output to be called libcap instead of liblibcap.

Fixes #7201 and #7275