### PR TITLE
Add gcem version compatible with Bazel 9.

### DIFF
--- a/modules/gcem/1.18.0.bcr.1/MODULE.bazel
+++ b/modules/gcem/1.18.0.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "gcem",
+    version = "1.18.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/modules/gcem/1.18.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/gcem/1.18.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "gcem",
+    hdrs = glob(["include/**/*"]),
+    strip_include_prefix = "/include",
+    visibility = ["//visibility:public"],
+)

--- a/modules/gcem/1.18.0.bcr.1/presubmit.yml
+++ b/modules/gcem/1.18.0.bcr.1/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform:
+  - ubuntu2004
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@gcem//:gcem'

--- a/modules/gcem/1.18.0.bcr.1/source.json
+++ b/modules/gcem/1.18.0.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/kthohr/gcem/archive/refs/tags/v1.18.0.tar.gz",
+    "integrity": "sha256-jnGp9bYpVtpsQJ3aRLSD+YxKmK5yGE86pGWa5bNGLmE=",
+    "strip_prefix": "gcem-1.18.0",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-1a3r/LEnXk+FcdIiKJiDiY4YBl178V7IqQcP5LC6eRI="
+    }
+}

--- a/modules/gcem/metadata.json
+++ b/modules/gcem/metadata.json
@@ -4,15 +4,16 @@
         {
             "email": "caleb.zulawski@gmail.com",
             "github": "calebzulawski",
-            "name": "Caleb Zulawski",
-            "github_user_id": 563826
+            "github_user_id": 563826,
+            "name": "Caleb Zulawski"
         }
     ],
     "repository": [
         "github:kthohr/gcem"
     ],
     "versions": [
-        "1.18.0"
+        "1.18.0",
+        "1.18.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This is my first time contributing to BCR; I wasn't sure whether it's fine to depend on latest version of `rules_cc` or if it's better to default to an older version - I looked at some other modules and it seems to be all over the place.

I also took the liberty to port to the use of overlay files instead of patches.

Use of unstable archive is a no-op compared to the state of the original `1.18.0` version: https://github.com/bazelbuild/bazel-central-registry/pull/1928