### PR TITLE
cargo_env.bzl@0.1.5

### DIFF
--- a/modules/cargo_env.bzl/0.1.5/MODULE.bazel
+++ b/modules/cargo_env.bzl/0.1.5/MODULE.bazel
@@ -1,0 +1,16 @@
+module(name = "cargo_env.bzl",
+    version = "0.1.5",
+)
+
+# keep-sorted start
+bazel_dep(name = "bazel_lib", version = "3.1.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "package_metadata", version = "0.0.7")
+bazel_dep(name = "platforms", version = "1.0.0")
+# keep-sorted end
+
+# keep-sorted start
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependency = True)
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.8.0", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.47.0", dev_dependency = True)
+# keep-sorted end

--- a/modules/cargo_env.bzl/0.1.5/attestations.json
+++ b/modules/cargo_env.bzl/0.1.5/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/ZiplineTeam/cargo_env.bzl/releases/download/v0.1.5/source.json.intoto.jsonl",
+            "integrity": "sha256-sOgxVICZ/WAqR66tcfLGFCuNmUM3Zgihvbev/LGLJ4E="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/ZiplineTeam/cargo_env.bzl/releases/download/v0.1.5/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-BdGZ7sAQSdSVHheDb7HJfMLsm1oKsmLVk/8s98T9QSY="
+        },
+        "cargo_env.bzl-v0.1.5.tar.gz": {
+            "url": "https://github.com/ZiplineTeam/cargo_env.bzl/releases/download/v0.1.5/cargo_env.bzl-v0.1.5.tar.gz.intoto.jsonl",
+            "integrity": "sha256-2xuQuY9YjOcJ42Hwt+kj8H6QL5n9vaXhreWmT9XaJAI="
+        }
+    }
+}

--- a/modules/cargo_env.bzl/0.1.5/patches/module_dot_bazel_version.patch
+++ b/modules/cargo_env.bzl/0.1.5/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,5 +1,7 @@
+-module(name = "cargo_env.bzl")
++module(name = "cargo_env.bzl",
++    version = "0.1.5",
++)
+ 
+ # keep-sorted start
+ bazel_dep(name = "bazel_lib", version = "3.1.0")
+ bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/modules/cargo_env.bzl/0.1.5/presubmit.yml
+++ b/modules/cargo_env.bzl/0.1.5/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204", "windows"]
+    bazel: ["8.x", "7.x"]
+  tasks:
+    run_tests:
+      name: "Run tests on examples module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/cargo_env.bzl/0.1.5/source.json
+++ b/modules/cargo_env.bzl/0.1.5/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-QeCNcDle/Kt54dJhnoEVaiE+6cLpeYWgjE8zjJdFylU=",
+    "strip_prefix": "cargo_env.bzl-0.1.5",
+    "docs_url": "https://github.com/ZiplineTeam/cargo_env.bzl/releases/download/v0.1.5/cargo_env.bzl-v0.1.5.docs.tar.gz",
+    "url": "https://github.com/ZiplineTeam/cargo_env.bzl/releases/download/v0.1.5/cargo_env.bzl-v0.1.5.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-Ekk5HbAMy2t0V7l7izuy02qXl0ox9HRFqVTtu0igFCU="
+    },
+    "patch_strip": 1
+}

--- a/modules/cargo_env.bzl/metadata.json
+++ b/modules/cargo_env.bzl/metadata.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "https://github.com/ZiplineTeam/cargo_env.bzl",
+    "maintainers": [
+        {
+            "github": "hofbi",
+            "github_user_id": 10724293,
+            "name": "Markus Hofbauer"
+        },
+        {
+            "name": "Lukas Oyen",
+            "github": "lukasoyen",
+            "github_user_id": 6685542
+        },
+        {
+            "name": "Finn Ball",
+            "github": "finn-ball",
+            "github_user_id": 53278189
+        }
+    ],
+    "repository": [
+        "github:ZiplineTeam/cargo_env.bzl"
+    ],
+    "versions": [
+        "0.1.5"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/ZiplineTeam/cargo_env.bzl/releases/tag/v0.1.5

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_