### PR TITLE
cargo_env.bzl@0.2.0

### DIFF
--- a/modules/cargo_env.bzl/0.2.0/MODULE.bazel
+++ b/modules/cargo_env.bzl/0.2.0/MODULE.bazel
@@ -1,0 +1,17 @@
+module(name = "cargo_env.bzl",
+    version = "0.2.0",
+)
+
+# keep-sorted start
+bazel_dep(name = "bazel_lib", version = "3.2.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "package_metadata", version = "0.0.7")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_shell", version = "0.6.1")
+# keep-sorted end
+
+# keep-sorted start
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependency = True)
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.9.2", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.47.0", dev_dependency = True)
+# keep-sorted end

--- a/modules/cargo_env.bzl/0.2.0/attestations.json
+++ b/modules/cargo_env.bzl/0.2.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/ZiplineTeam/cargo_env.bzl/releases/download/v0.2.0/source.json.intoto.jsonl",
+            "integrity": "sha256-Fmqs/HqGQziXezC0D8MPgmCI9vZqp1aIsW2Ez1fUabU="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/ZiplineTeam/cargo_env.bzl/releases/download/v0.2.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-5KcoQpCfIwIiJ5TG4/SQkdvVsE+ja4AxR1qlmkJk+Ow="
+        },
+        "cargo_env.bzl-v0.2.0.tar.gz": {
+            "url": "https://github.com/ZiplineTeam/cargo_env.bzl/releases/download/v0.2.0/cargo_env.bzl-v0.2.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-BF4uCSQUP00cNy5lIXyzejEKOPGugd58HMlgFB41GZ8="
+        }
+    }
+}

--- a/modules/cargo_env.bzl/0.2.0/patches/module_dot_bazel_version.patch
+++ b/modules/cargo_env.bzl/0.2.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,5 +1,7 @@
+-module(name = "cargo_env.bzl")
++module(name = "cargo_env.bzl",
++    version = "0.2.0",
++)
+ 
+ # keep-sorted start
+ bazel_dep(name = "bazel_lib", version = "3.2.0")
+ bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/modules/cargo_env.bzl/0.2.0/presubmit.yml
+++ b/modules/cargo_env.bzl/0.2.0/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204", "windows"]
+    bazel: ["8.x", "7.x"]
+  tasks:
+    run_tests:
+      name: "Run tests on examples module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/cargo_env.bzl/0.2.0/source.json
+++ b/modules/cargo_env.bzl/0.2.0/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-TGHRC7GyLwYTRcKp2rcMzlrS+EfNfc/1QFLRgl+Wfbs=",
+    "strip_prefix": "cargo_env.bzl-0.2.0",
+    "docs_url": "https://github.com/ZiplineTeam/cargo_env.bzl/releases/download/v0.2.0/cargo_env.bzl-v0.2.0.docs.tar.gz",
+    "url": "https://github.com/ZiplineTeam/cargo_env.bzl/releases/download/v0.2.0/cargo_env.bzl-v0.2.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-nTAPcb8e4jwo1DDVjq00OhdHNPld2AuFIbhRc6AHT3Q="
+    },
+    "patch_strip": 1
+}

--- a/modules/cargo_env.bzl/metadata.json
+++ b/modules/cargo_env.bzl/metadata.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "https://github.com/ZiplineTeam/cargo_env.bzl",
+    "maintainers": [
+        {
+            "github": "hofbi",
+            "github_user_id": 10724293,
+            "name": "Markus Hofbauer"
+        },
+        {
+            "name": "Lukas Oyen",
+            "github": "lukasoyen",
+            "github_user_id": 6685542
+        },
+        {
+            "name": "Finn Ball",
+            "github": "finn-ball",
+            "github_user_id": 53278189
+        }
+    ],
+    "repository": [
+        "github:ZiplineTeam/cargo_env.bzl"
+    ],
+    "versions": [
+        "0.2.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/ZiplineTeam/cargo_env.bzl/releases/tag/v0.2.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_