### PR TITLE
Add colorama for Windows

### DIFF
--- a/tools/requirements.in
+++ b/tools/requirements.in
@@ -1,6 +1,7 @@
 pyyaml
 validators
 click
+colorama
 networkx
 numpy
 scipy

--- a/tools/requirements_lock.txt
+++ b/tools/requirements_lock.txt
@@ -259,6 +259,12 @@ click==8.3.1 \
     #   -r tools/requirements.in
     #   typer
     #   uvicorn
+colorama==0.4.6 \
+    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63fc6d6ed5c201be6e44 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+    # via
+    #   -r tools/requirements.in
+    #   click
 cloudpickle==3.1.2 \
     --hash=sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414 \
     --hash=sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a


### PR DESCRIPTION
`bazel run //tools:update_integrity -- ...` leads to issues on Windows - a missing dependency to `colorama` is reported. This PR fixes the issue