### PR TITLE
Fix modules/rules_cc_hdrs_map/0.29.0/MODULE.bazel

### DIFF
--- a/modules/rules_cc_hdrs_map/0.29.0/MODULE.bazel
+++ b/modules/rules_cc_hdrs_map/0.29.0/MODULE.bazel
@@ -64,7 +64,7 @@ register_execution_platforms(
 
 archive_override(
     module_name = "rules_cc",
-    patch_strip = 0,
+    patch_strip = 1,
     patches = ["@rules_cc_hdrs_map//patches/github.com-bazelbuild-rules_cc:0001-patch-cc_shared_library_info_bzl-made-public.patch"],
     sha256 = "458b658277ba51b4730ea7a2020efdf1c6dcadf7d30de72e37f4308277fa8c01",
     strip_prefix = "rules_cc-0.2.16",


### PR DESCRIPTION
`archive_override` has `patch_strip`, not `patch_args` (https://github.com/bazelbuild/bazel/issues/22982).