### PR TITLE
Use correct URLs for downloading from SourceForge

### DIFF
--- a/modules/giflib/5.2.1/source.json
+++ b/modules/giflib/5.2.1/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://netcologne.dl.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz",
+    "url": "https://downloads.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz",
     "integrity": "sha256-MdpVYvRMXxXWM0Cgmk/WK0jEViDNMC93ptms8Ad4eb0=",
     "strip_prefix": "giflib-5.2.1",
     "patches": {

--- a/modules/giflib/metadata.json
+++ b/modules/giflib/metadata.json
@@ -9,7 +9,7 @@
     }
   ],
   "repository": [
-    "https://netcologne.dl.sourceforge.net/project/giflib",
+    "https://downloads.sourceforge.net/project/giflib",
     "github:arthenica/giflib"
   ],
   "versions": [

--- a/modules/libpfm/4.11.0.bcr.1/source.json
+++ b/modules/libpfm/4.11.0.bcr.1/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://netcologne.dl.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.11.0.tar.gz",
+    "url": "https://downloads.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.11.0.tar.gz",
     "integrity": "sha256-XaX4hyveFLNjTJaI2YD2i9ootRAmhyPMEpc+7bq5/sw=",
     "strip_prefix": "libpfm-4.11.0",
     "patches": {

--- a/modules/libpfm/metadata.json
+++ b/modules/libpfm/metadata.json
@@ -7,7 +7,7 @@
     }
   ],
   "repository": [
-    "https://netcologne.dl.sourceforge.net/project/perfmon2/libpfm4"
+    "https://downloads.sourceforge.net/project/perfmon2/libpfm4"
   ],
   "versions": [
     "4.11.0",

--- a/modules/tinyxml/2.6.2.bcr.1/source.json
+++ b/modules/tinyxml/2.6.2.bcr.1/source.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://netcologne.dl.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz",
+    "url": "https://downloads.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz",
     "integrity": "sha256-Fb39zsWKfaMK3IesKweORBfb5TkvOvtxn5um0GJkVZM=",
     "overlay": {
         "BUILD.bazel": "sha256-4/TJ3JLPA8lIU9RT5VssXDTVNgBH3HnMcDpzhqCKB/0=",

--- a/modules/tinyxml/metadata.json
+++ b/modules/tinyxml/metadata.json
@@ -8,7 +8,7 @@
     ],
     "repository": [
         "http://archive.ubuntu.com/ubuntu/pool/universe/t/tinyxml",
-        "https://netcologne.dl.sourceforge.net/project/tinyxml"
+        "https://downloads.sourceforge.net/project/tinyxml"
     ],
     "versions": [
         "2.6.2",


### PR DESCRIPTION
netcologne.dl.sourceforge.net does not resolve. The correct hostname appears to be downloads.sourceforge.net.