### PR TITLE
Fix two issues with the Bazel build file for libpfm

### DIFF
--- a/modules/libpfm/4.11.0.bcr.1/patches/add_build_file.patch
+++ b/modules/libpfm/4.11.0.bcr.1/patches/add_build_file.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000..70a84e0
 --- /dev/null
 +++ b/BUILD.bazel
-@@ -0,0 +1,240 @@
+@@ -0,0 +1,238 @@
 +load("@rules_cc//cc:defs.bzl", "cc_library")
 +
 +AARCH32_SRCS_COMMON = [
@@ -191,7 +191,6 @@ index 0000000..70a84e0
 +        "lib/pfmlib_perf_event_pmu.c",
 +        "lib/pfmlib_perf_event_priv.h",
 +        "lib/pfmlib_perf_event_raw.c",
-+        "lib/pfmlib_torrent.c",
 +        "lib/pfmlib_tx2_unc_perf_event.c",
 +        ":cpu_srcs",
 +    ] + select({
@@ -228,7 +227,6 @@ index 0000000..70a84e0
 +        "include",
 +        "lib",
 +    ],
-+    strip_include_prefix = "include",
 +    textual_hdrs = glob([
 +        "lib/**/*.h",
 +    ]),

--- a/modules/libpfm/4.11.0.bcr.1/source.json
+++ b/modules/libpfm/4.11.0.bcr.1/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "libpfm-4.11.0",
     "patches": {
         "module_dot_bazel.patch": "sha256-D7BWrY0WiihCq9XSiVifZWK3sMLbI2chCsgddKJ38kM=",
-        "add_build_file.patch": "sha256-ibpLPyX2v/fbDytUuK4PKeZl/q303bWtSRTU95g5jz0="
+        "add_build_file.patch": "sha256-/BNrpQuKQViQdgNnJepgbUb5p+m64lJELdswU0JLKGM="
     },
     "patch_strip": 1
 }


### PR DESCRIPTION
1) The file `pfmlib_torrent.c` is PowerPC-specific. Its presence in the
   generic source file list leads to build failures on other platforms,
   so remove it. It is already present in the PowerPC-specific source
   list in `POWERPC_SRCS_COMMON` so there is no need to modify it.

2) Stop setting `strip_include_prefix`, which is redundant with the
   existing `includes = [ "include" ]`. `strip_include_prefix` causes
   Bazel to specify the header path to the compiler using a `-I` flag. If
   the consuming project builds with a flag such as `-pedantic-errors`,
   it will encounter build errors such as the one below. Because paths
   specified via `includes` are translated into `-isystem` flags, which
   suppress warnings in headers, this issue is avoided.

```
bazel-out/aarch64-fastbuild/bin/external/libpfm+/_virtual_includes/pfm/perfmon/pfmlib.h:657:16: error: ISO C++ prohibits anonymous structs [-Wpedantic]
  657 |         struct {
      |                ^
```