### PR TITLE
vnu@26.2.6

### DIFF
--- a/modules/vnu/26.2.6/MODULE.bazel
+++ b/modules/vnu/26.2.6/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "vnu",
+    version = "26.2.6",
+    compatibility_level = 26,
+    bazel_compatibility = [">=9.0.0"],
+)

--- a/modules/vnu/26.2.6/overlay/BUILD.bazel
+++ b/modules/vnu/26.2.6/overlay/BUILD.bazel
@@ -1,0 +1,3 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["build/dist/vnu.jar"])

--- a/modules/vnu/26.2.6/overlay/MODULE.bazel
+++ b/modules/vnu/26.2.6/overlay/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "vnu",
+    version = "26.2.6",
+    compatibility_level = 26,
+    bazel_compatibility = [">=9.0.0"],
+)

--- a/modules/vnu/26.2.6/presubmit.yml
+++ b/modules/vnu/26.2.6/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify:
+    name: Verify vnu jar
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@vnu//:build/dist/vnu.jar'

--- a/modules/vnu/26.2.6/source.json
+++ b/modules/vnu/26.2.6/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-26.2.6.tgz",
+    "integrity": "sha256-oo4QfwDR0tzrWmhX6Q2zbJK044fQSA3scLrly8RtFus=",
+    "strip_prefix": "package",
+    "overlay": {
+        "BUILD.bazel": "sha256-rn+RUKWkbItNvgMSLTso+iNitX3Un7d2Qz7rrqvp9W0=",
+        "MODULE.bazel": "sha256-5nmF1JH7SHpzs1kZ9N0rQnLy+AiYeNPmhAKWTLV1Xck="
+    }
+}

--- a/modules/vnu/metadata.json
+++ b/modules/vnu/metadata.json
@@ -1,0 +1,19 @@
+{
+    "homepage": "https://validator.github.io/validator/",
+    "maintainers": [
+        {
+            "email": "robert@vantle.org",
+            "github": "robbie-vanderzee",
+            "github_user_id": 26888565,
+            "name": "Robbie VanDerzee"
+        }
+    ],
+    "repository": [
+        "github:validator/validator",
+        "https://registry.npmjs.org/vnu-jar/"
+    ],
+    "versions": [
+        "26.2.6"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Initial submission of the [Nu HTML Checker](https://validator.github.io/validator/) (`vnu.jar`) to the Bazel Central Registry.

**Source**: npm tarball [`vnu-jar@26.2.6`](https://www.npmjs.com/package/vnu-jar/v/26.2.6)
**Repository**: [validator/validator](https://github.com/validator/validator)

Future versions will be automated via [publish-to-bcr](https://github.com/bazel-contrib/publish-to-bcr).