### PR TITLE
simdjson: add module with versions 3.12.2 to 4.2.4

### DIFF
--- a/modules/simdjson/3.12.2/MODULE.bazel
+++ b/modules/simdjson/3.12.2/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "3.12.2",
+    compatibility_level = 3,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/3.12.2/patches/add_build_file.patch
+++ b/modules/simdjson/3.12.2/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/3.12.2/presubmit.yml
+++ b/modules/simdjson/3.12.2/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/3.12.2/source.json
+++ b/modules/simdjson/3.12.2/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v3.12.2/singleheader.zip",
+    "integrity": "sha256-wj27tDzp0cq3vmDx3857ocyY+UQ1IoFNYKpHlijm1eY=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/3.12.3/MODULE.bazel
+++ b/modules/simdjson/3.12.3/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "3.12.3",
+    compatibility_level = 3,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/3.12.3/patches/add_build_file.patch
+++ b/modules/simdjson/3.12.3/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/3.12.3/presubmit.yml
+++ b/modules/simdjson/3.12.3/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/3.12.3/source.json
+++ b/modules/simdjson/3.12.3/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v3.12.3/singleheader.zip",
+    "integrity": "sha256-3vpZMY8dlGvIGTzLgksT+1ewMICeM9FSYQdCWLtuZnI=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/3.13.0/MODULE.bazel
+++ b/modules/simdjson/3.13.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "3.13.0",
+    compatibility_level = 3,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/3.13.0/patches/add_build_file.patch
+++ b/modules/simdjson/3.13.0/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/3.13.0/presubmit.yml
+++ b/modules/simdjson/3.13.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/3.13.0/source.json
+++ b/modules/simdjson/3.13.0/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v3.13.0/singleheader.zip",
+    "integrity": "sha256-38Ayt/PdhpkaZ7kg63e2WYfhHgH6Llp7qp2ThDJr0Sg=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.0.0/MODULE.bazel
+++ b/modules/simdjson/4.0.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.0.0",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.0.0/patches/add_build_file.patch
+++ b/modules/simdjson/4.0.0/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.0.0/presubmit.yml
+++ b/modules/simdjson/4.0.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.0.0/source.json
+++ b/modules/simdjson/4.0.0/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.0.0/singleheader.zip",
+    "integrity": "sha256-OI4Yh9nsVaPTIPIaTtTSPJJ4uKxEo0meQRyp9Xzkj6M=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.0.1/MODULE.bazel
+++ b/modules/simdjson/4.0.1/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.0.1",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.0.1/patches/add_build_file.patch
+++ b/modules/simdjson/4.0.1/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.0.1/presubmit.yml
+++ b/modules/simdjson/4.0.1/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.0.1/source.json
+++ b/modules/simdjson/4.0.1/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.0.1/singleheader.zip",
+    "integrity": "sha256-0swtgKr9EJ3Id08YYJYrNSmNGc1rwqoYd2GLzVKKYeU=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.0.2/MODULE.bazel
+++ b/modules/simdjson/4.0.2/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.0.2",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.0.2/patches/add_build_file.patch
+++ b/modules/simdjson/4.0.2/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.0.2/presubmit.yml
+++ b/modules/simdjson/4.0.2/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.0.2/source.json
+++ b/modules/simdjson/4.0.2/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.0.2/singleheader.zip",
+    "integrity": "sha256-C74aa1qnuJR9D9V2vrRGEf2juLrtFA6zynGBtrLVRZY=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.0.3/MODULE.bazel
+++ b/modules/simdjson/4.0.3/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.0.3",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.0.3/patches/add_build_file.patch
+++ b/modules/simdjson/4.0.3/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.0.3/presubmit.yml
+++ b/modules/simdjson/4.0.3/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.0.3/source.json
+++ b/modules/simdjson/4.0.3/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.0.3/singleheader.zip",
+    "integrity": "sha256-qPob3fA9OoCG0X2EeKL3XsK+dbYjTGIGzYGJlT2yHl0=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.0.4/MODULE.bazel
+++ b/modules/simdjson/4.0.4/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.0.4",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.0.4/patches/add_build_file.patch
+++ b/modules/simdjson/4.0.4/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.0.4/presubmit.yml
+++ b/modules/simdjson/4.0.4/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.0.4/source.json
+++ b/modules/simdjson/4.0.4/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.0.4/singleheader.zip",
+    "integrity": "sha256-yexbaaFNMKEm96keZUJeqn5DgaKODaLowfG9K70+Zpw=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.0.5/MODULE.bazel
+++ b/modules/simdjson/4.0.5/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.0.5",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.0.5/patches/add_build_file.patch
+++ b/modules/simdjson/4.0.5/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.0.5/presubmit.yml
+++ b/modules/simdjson/4.0.5/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.0.5/source.json
+++ b/modules/simdjson/4.0.5/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.0.5/singleheader.zip",
+    "integrity": "sha256-gSI75oljVNIZdttzaGXLZFuseX/Bf04IdLE2Y91WkK4=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.0.6/MODULE.bazel
+++ b/modules/simdjson/4.0.6/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.0.6",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.0.6/patches/add_build_file.patch
+++ b/modules/simdjson/4.0.6/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.0.6/presubmit.yml
+++ b/modules/simdjson/4.0.6/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.0.6/source.json
+++ b/modules/simdjson/4.0.6/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.0.6/singleheader.zip",
+    "integrity": "sha256-5rnM7lExewRy27eS53NLdxKGgnDlXebdtJWijQ7kczU=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.0.7/MODULE.bazel
+++ b/modules/simdjson/4.0.7/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.0.7",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.0.7/patches/add_build_file.patch
+++ b/modules/simdjson/4.0.7/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.0.7/presubmit.yml
+++ b/modules/simdjson/4.0.7/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.0.7/source.json
+++ b/modules/simdjson/4.0.7/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.0.7/singleheader.zip",
+    "integrity": "sha256-B27jv3FVVTV1gdhsh6fdTdWKan+ZVfJWofDRO03mLE4=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.1.0/MODULE.bazel
+++ b/modules/simdjson/4.1.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.1.0",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.1.0/patches/add_build_file.patch
+++ b/modules/simdjson/4.1.0/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.1.0/presubmit.yml
+++ b/modules/simdjson/4.1.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.1.0/source.json
+++ b/modules/simdjson/4.1.0/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.1.0/singleheader.zip",
+    "integrity": "sha256-TOGuTdrPDacOMViH1XI9DP91n5PpZBOoEPVk9wGRE38=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.2.0/MODULE.bazel
+++ b/modules/simdjson/4.2.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.2.0",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.2.0/patches/add_build_file.patch
+++ b/modules/simdjson/4.2.0/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.2.0/presubmit.yml
+++ b/modules/simdjson/4.2.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.2.0/source.json
+++ b/modules/simdjson/4.2.0/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.2.0/singleheader.zip",
+    "integrity": "sha256-yMwhfQicuVdW13lY/3OloCAgmL2s0hdvRDl4hLDfeU8=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.2.1/MODULE.bazel
+++ b/modules/simdjson/4.2.1/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.2.1",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.2.1/patches/add_build_file.patch
+++ b/modules/simdjson/4.2.1/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.2.1/presubmit.yml
+++ b/modules/simdjson/4.2.1/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.2.1/source.json
+++ b/modules/simdjson/4.2.1/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.2.1/singleheader.zip",
+    "integrity": "sha256-t8sXW04OQBNVeUAsWNB8xY4uD/yo1mHq2HX1T6p4Zn0=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.2.2/MODULE.bazel
+++ b/modules/simdjson/4.2.2/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.2.2",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.2.2/patches/add_build_file.patch
+++ b/modules/simdjson/4.2.2/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.2.2/presubmit.yml
+++ b/modules/simdjson/4.2.2/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.2.2/source.json
+++ b/modules/simdjson/4.2.2/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.2.2/singleheader.zip",
+    "integrity": "sha256-w3sICz4iLlNjMdPNzOIhKpI7iMyNm+3vLpJ/+/U1888=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.2.3/MODULE.bazel
+++ b/modules/simdjson/4.2.3/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.2.3",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.2.3/patches/add_build_file.patch
+++ b/modules/simdjson/4.2.3/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.2.3/presubmit.yml
+++ b/modules/simdjson/4.2.3/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.2.3/source.json
+++ b/modules/simdjson/4.2.3/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.2.3/singleheader.zip",
+    "integrity": "sha256-wo1njBmgVRrsGTVQt81spfgCEBtdJzAbOH+eshFN6FE=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/4.2.4/MODULE.bazel
+++ b/modules/simdjson/4.2.4/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdjson",
+    version = "4.2.4",
+    compatibility_level = 4,
+)
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/modules/simdjson/4.2.4/patches/add_build_file.patch
+++ b/modules/simdjson/4.2.4/patches/add_build_file.patch
@@ -1,0 +1,18 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,15 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "simdjson",
++    srcs = ["simdjson.cpp"],
++    hdrs = ["simdjson.h"],
++    includes = ["."],
++    defines = ["SIMDJSON_THREADS_ENABLED=1"],
++    linkopts = select({
++        "@platforms//os:windows": [],
++        "//conditions:default": ["-pthread"],
++    }),
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/simdjson/4.2.4/presubmit.yml
+++ b/modules/simdjson/4.2.4/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@simdjson//:simdjson'

--- a/modules/simdjson/4.2.4/source.json
+++ b/modules/simdjson/4.2.4/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/simdjson/simdjson/releases/download/v4.2.4/singleheader.zip",
+    "integrity": "sha256-tP1St+YOiBBQiTYTNnUWwOvfSqUPGKvhpQgZrf51DZo=",
+    "patches": {
+        "add_build_file.patch": "sha256-VZlqXyP+7Z2sDwdur1+1eGKWXNhgb10EC10sLHaFNZc="
+    },
+    "patch_strip": 0
+}

--- a/modules/simdjson/metadata.json
+++ b/modules/simdjson/metadata.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "https://simdjson.org/",
+    "maintainers": [
+        {
+            "email": "yangzhgg@gmail.com",
+            "github": "yangzhg",
+            "name": "Zhengguo Yang",
+            "github_user_id": 9098473
+        }
+    ],
+    "repository": [
+        "github:simdjson/simdjson"
+    ],
+    "versions": [
+        "3.12.2",
+        "3.12.3",
+        "3.13.0",
+        "4.0.0",
+        "4.0.1",
+        "4.0.2",
+        "4.0.3",
+        "4.0.4",
+        "4.0.5",
+        "4.0.6",
+        "4.0.7",
+        "4.1.0",
+        "4.2.0",
+        "4.2.1",
+        "4.2.2",
+        "4.2.3",
+        "4.2.4"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This commit adds the `simdjson` module to the Bazel Central Registry. It includes the following versions:
- v3.12.x: 3.12.2, 3.12.3
- v3.13.x: 3.13.0
- v4.0.x: 4.0.0 - 4.0.7
- v4.1.x: 4.1.0
- v4.2.x: 4.2.0 - 4.2.4

The module uses the official `singleheader.zip` release assets. A patch file (`add_build_file.patch`) is applied to inject the `BUILD.bazel` file since the original zip only contains source files.

Tested locally with `bazel build` and benchmark targets.