### PR TITLE
Add rules_gherkin@0.2.0 for Bazel 9 compatibility

### DIFF
--- a/modules/rules_gherkin/0.2.0/MODULE.bazel
+++ b/modules/rules_gherkin/0.2.0/MODULE.bazel
@@ -1,0 +1,18 @@
+module(
+    name = "rules_gherkin",
+    version = "0.2.0",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_cc", version = "0.0.16")
+
+# Ruby SDK setup
+# Note: rules_ruby bazel_dep needed for rb_binary in BUILD file
+# Note: ruby toolchain and bundle_fetch configured in root MODULE.bazel
+bazel_dep(name = "rules_ruby", version = "0.19.0")
+
+# Import the @cucumber repository created in root MODULE.bazel
+ruby = use_extension("@rules_ruby//ruby:extensions.bzl", "ruby")
+use_repo(ruby, "cucumber")
+
+bazel_dep(name = "cucumber-cpp", version = "0.8.0.bcr.1")

--- a/modules/rules_gherkin/0.2.0/presubmit.yml
+++ b/modules/rules_gherkin/0.2.0/presubmit.yml
@@ -1,0 +1,26 @@
+bcr_test_module:
+  module_path: examples
+  matrix:
+    platform:
+    - debian12
+    - ubuntu2204
+    - ubuntu2404
+    - macos_arm64
+    bazel:
+    - 8.x
+    - 7.x
+    - 9.x
+
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - '--cxxopt=-std=c++17'
+      test_flags:
+        - '--cxxopt=-std=c++17'
+      build_targets:
+      - //...
+      test_targets:
+      - //...

--- a/modules/rules_gherkin/0.2.0/source.json
+++ b/modules/rules_gherkin/0.2.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/swift-nav/rules_gherkin/archive/refs/tags/v0.2.0.tar.gz",
+    "integrity": "sha256-6r2Mf8e/AwK41Vh9MJ+bDPEev32RxPw5hlFmx3pXUKU=",
+    "strip_prefix": "rules_gherkin-0.2.0"
+}

--- a/modules/rules_gherkin/metadata.json
+++ b/modules/rules_gherkin/metadata.json
@@ -11,7 +11,8 @@
         "github:swift-nav/rules_gherkin"
     ],
     "versions": [
-        "0.1.0"
+        "0.1.0",
+        "0.2.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Update all necessary dependencies to provide Bazel 9 compatibility for rules_gherkin.