### PR TITLE
pigz@8.bcr.1 for Bazel 9 Compatability

### DIFF
--- a/modules/pigz/2.8.bcr.1/MODULE.bazel
+++ b/modules/pigz/2.8.bcr.1/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "pigz",
+    version = "2.8.bcr.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "zopfli", version = "1.0.3.bcr.2")
+bazel_dep(name = "zlib", version = "1.3")

--- a/modules/pigz/2.8.bcr.1/patches/add_build_file.patch
+++ b/modules/pigz/2.8.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,30 @@
+--- /dev/null	2023-06-26 14:23:42
++++ BUILD.bazel	2023-06-26 14:23:36
+@@ -0,0 +1,27 @@
++load("@rules_cc//cc:defs.bzl", "cc_binary")
++
++_COPTS = ["-O3", "-Wall", "-Wextra", "-Wno-unknown-pragmas", "-Wcast-qual"]
++
++cc_binary(
++    name = "pigz",
++    srcs = [
++        "pigz.c",
++        "try.c",
++        "try.h",
++        "yarn.c",
++        "yarn.h",
++    ],
++    copts = _COPTS,
++    linkopts = [
++        "-lm",
++        "-lpthread",
++    ],
++    visibility = ["//visibility:public"],
++    deps = ["@zopfli", "@zlib"],
++)
++
++alias(
++    name = "bin",
++    actual = ":pigz",
++    visibility = ["//visibility:public"],
++)

--- a/modules/pigz/2.8.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/pigz/2.8.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,13 @@
+--- /dev/null	2023-06-26 13:35:45
++++ MODULE.bazel	2023-06-26 13:33:20
+@@ -0,0 +1,10 @@
++module(
++    name = "pigz",
++    version = "2.8.bcr.1",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "platforms", version = "0.0.8")
++bazel_dep(name = "rules_cc", version = "0.0.17")
++bazel_dep(name = "zopfli", version = "1.0.3.bcr.2")
++bazel_dep(name = "zlib", version = "1.3")

--- a/modules/pigz/2.8.bcr.1/patches/pigz.c.patch
+++ b/modules/pigz/2.8.bcr.1/patches/pigz.c.patch
@@ -1,0 +1,11 @@
+--- pigz.c
++++ pigz.c
+@@ -429,7 +429,7 @@
+ #endif
+
+ #ifndef NOZOPFLI
+-#  include "zopfli/src/zopfli/deflate.h"    // ZopfliDeflatePart(),
++#  include "zopfli/deflate.h"               // ZopfliDeflatePart(),
+                                             // ZopfliInitOptions(),
+                                             // ZopfliOptions
+ #endif

--- a/modules/pigz/2.8.bcr.1/presubmit.yml
+++ b/modules/pigz/2.8.bcr.1/presubmit.yml
@@ -1,0 +1,23 @@
+matrix:
+  platform:
+  - rockylinux8
+  - debian10
+  - debian11
+  - ubuntu2004
+  - ubuntu2204
+  - ubuntu2404
+  - macos
+  # Failing with pthread.h not found
+  # - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@pigz'

--- a/modules/pigz/2.8.bcr.1/source.json
+++ b/modules/pigz/2.8.bcr.1/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://zlib.net/pigz/pigz-2.8.tar.gz",
+    "integrity": "sha256-64crTw4fDr5Zyfe9jFBsQgSJO6aoSS3jHfQW8NUXD9A=",
+    "strip_prefix": "pigz-2.8",
+    "patches": {
+        "pigz.c.patch": "sha256-1l1OISVugG+ihFgUu1ICN1+TunasUB4SMcKIGHnx3Ls=",
+        "add_build_file.patch": "sha256-WT0foZmsk9/JCeehOBKwaOuM4ps4aateygvHbRuOVKc=",
+        "module_dot_bazel.patch": "sha256-zWxKzY+vJeG2uTUA2SN7ALGxLm0qRQ3TylkrKFIjUAI="
+    },
+    "patch_strip": 0
+}

--- a/modules/pigz/metadata.json
+++ b/modules/pigz/metadata.json
@@ -13,7 +13,8 @@
     ],
     "versions": [
         "2.7",
-        "2.8"
+        "2.8",
+        "2.8.bcr.1"
     ],
     "yanked_versions": {}
 }

--- a/modules/zopfli/1.0.3.bcr.2/MODULE.bazel
+++ b/modules/zopfli/1.0.3.bcr.2/MODULE.bazel
@@ -1,0 +1,8 @@
+"Bazel module declaration"
+module(
+    name = "zopfli",
+    version = "1.0.3.bcr.2",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.17")

--- a/modules/zopfli/1.0.3.bcr.2/patches/add_build_file.patch
+++ b/modules/zopfli/1.0.3.bcr.2/patches/add_build_file.patch
@@ -1,0 +1,66 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,63 @@
++load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
++
++cc_library(
++    # Named to produce "libzopfli.{a,so}"
++    # avoiding https://github.com/bazelbuild/bazel-central-registry/issues/716
++    name = "zopfli",
++    srcs = glob(["src/zopfli/*.c"], exclude = ["**/*_bin.c"]),
++    hdrs = glob(["src/zopfli/*.h"]),
++    linkopts = ["-lm"],
++    strip_include_prefix = "src/",
++    visibility = ["//visibility:public"],
++)
++
++cc_binary(
++    name = "bin",
++    srcs = ["src/zopfli/zopfli_bin.c"],
++    # To build zopfli, compile all .c source files under src/zopfli to a single binary
++    # with C, and link to the standard C math library, e.g.:
++    # gcc src/zopfli/*.c -O2 -W -Wall -Wextra -Wno-unused-function -ansi -pedantic -lm -o zopfli
++    copts = select({
++        "@bazel_tools//src/conditions:windows": [],
++        "//conditions:default": [
++            "-Wno-unused-function",
++        ],
++    }),
++    deps = [":zopfli"],
++)
++
++cc_library(
++    name = "lodepng",
++    srcs = glob(
++        ["src/zopflipng/lodepng/*.cpp"],
++        exclude = ["**/*_bin.*"],
++    ),
++    hdrs = glob(["src/zopflipng/lodepng/*.h"]),
++    strip_include_prefix = "src/",
++)
++
++cc_library(
++    name = "zopflipng_lib",
++    srcs = glob(
++        ["src/zopflipng/*.cc"],
++        exclude = ["**/*_bin.*"],
++    ),
++    hdrs = glob(["src/zopflipng/*.h"]),
++    strip_include_prefix = "src/",
++    deps = [
++        ":lodepng",
++        ":zopfli",
++    ],
++)
++
++cc_binary(
++    name = "zopflipng",
++    srcs = ["src/zopflipng/zopflipng_bin.cc"],
++    copts = select({
++        "@bazel_tools//src/conditions:windows": [],
++        "//conditions:default": [
++            "-Wno-unused-function",
++        ],
++    }),
++    deps = [":zopflipng_lib"],
++)

--- a/modules/zopfli/1.0.3.bcr.2/patches/module_dot_bazel.patch
+++ b/modules/zopfli/1.0.3.bcr.2/patches/module_dot_bazel.patch
@@ -1,0 +1,11 @@
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,8 @@
++"Bazel module declaration"
++module(
++    name = "zopfli",
++    version = "1.0.3.bcr.2",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "rules_cc", version = "0.0.17")

--- a/modules/zopfli/1.0.3.bcr.2/presubmit.yml
+++ b/modules/zopfli/1.0.3.bcr.2/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+  - 6.x
+  platform:
+  - rockylinux8
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@zopfli//...'

--- a/modules/zopfli/1.0.3.bcr.2/source.json
+++ b/modules/zopfli/1.0.3.bcr.2/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/google/zopfli/archive/refs/tags/zopfli-1.0.3.tar.gz",
+    "integrity": "sha256-6VWnc59xrzfvM0nE+hQcZI6HdbzrIZW+B+hvjmOIFL0=",
+    "strip_prefix": "zopfli-zopfli-1.0.3",
+    "patches": {
+        "add_build_file.patch": "sha256-6nUHFq6irQBvJ1ebvJJXRh2KNemvqNJK6IgEGRFt6bg=",
+        "module_dot_bazel.patch": "sha256-beaeRGOEQDNLaaGO70dNU+Nf2WuqWtUd48kbs8gYOM0="
+    },
+    "patch_strip": 0
+}

--- a/modules/zopfli/metadata.json
+++ b/modules/zopfli/metadata.json
@@ -13,7 +13,8 @@
     ],
     "versions": [
         "1.0.3",
-        "1.0.3.bcr.1"
+        "1.0.3.bcr.1",
+        "1.0.3.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Updated dependencies to provide Pigz compatibility with Bazel 9.