### PR TITLE
highwayhash@0.0.0-20240305-5ad3bf8.bcr.1

### DIFF
--- a/modules/highwayhash/0.0.0-20240305-5ad3bf8.bcr.1/MODULE.bazel
+++ b/modules/highwayhash/0.0.0-20240305-5ad3bf8.bcr.1/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "highwayhash",
+    version = "0.0.0-20240305-5ad3bf8.bcr.1",
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/highwayhash/0.0.0-20240305-5ad3bf8.bcr.1/patches/add_build_file.patch
+++ b/modules/highwayhash/0.0.0-20240305-5ad3bf8.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,281 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,278 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++package(
++    default_visibility = ["//visibility:public"],
++    features = ["header_modules"],
++)
++
++licenses(["notice"])
++
++#-----------------------------------------------------------------------------
++# Platform-specific
++
++cc_library(
++    name = "compiler_specific",
++    hdrs = ["highwayhash/compiler_specific.h"],
++)
++
++cc_library(
++    name = "arch_specific",
++    srcs = ["highwayhash/arch_specific.cc"],
++    hdrs = ["highwayhash/arch_specific.h"],
++    deps = [":compiler_specific"],
++)
++
++cc_library(
++    name = "endianess",
++    hdrs = ["highwayhash/endianess.h"],
++)
++
++cc_library(
++    name = "instruction_sets",
++    srcs = ["highwayhash/instruction_sets.cc"],
++    hdrs = ["highwayhash/instruction_sets.h"],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++    ],
++)
++
++cc_library(
++    name = "iaca",
++    hdrs = ["highwayhash/iaca.h"],
++    deps = [":compiler_specific"],
++)
++
++cc_library(
++    name = "os_specific",
++    srcs = ["highwayhash/os_specific.cc"],
++    hdrs = ["highwayhash/os_specific.h"],
++    textual_hdrs = select({
++        "@platforms//os:macos": [
++            "highwayhash/os_mac.h",
++            "highwayhash/os_mac.cc",
++        ],
++        "//conditions:default": [],
++    }),
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++    ],
++)
++
++#-----------------------------------------------------------------------------
++# Vectors
++
++cc_library(
++    name = "scalar",
++    textual_hdrs = ["highwayhash/scalar.h"],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++    ],
++)
++
++cc_library(
++    name = "vector128",
++    textual_hdrs = ["highwayhash/vector128.h"],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++    ],
++)
++
++cc_library(
++    name = "vector256",
++    textual_hdrs = ["highwayhash/vector256.h"],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++    ],
++)
++
++#-----------------------------------------------------------------------------
++# SipHash
++
++cc_library(
++    name = "sip_hash",
++    srcs = ["highwayhash/sip_hash.cc"],
++    hdrs = [
++        "highwayhash/sip_hash.h",
++        "highwayhash/state_helpers.h",
++    ],
++    visibility = ["//visibility:public"],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++        ":endianess",
++    ],
++)
++
++#-----------------------------------------------------------------------------
++# HighwayHash
++
++cc_library(
++    name = "hh_types",
++    hdrs = ["highwayhash/hh_types.h"],
++    deps = [":instruction_sets"],
++)
++
++cc_library(
++    name = "load3",
++    textual_hdrs = ["highwayhash/load3.h"],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++        ":endianess",
++    ],
++)
++
++cc_library(
++    name = "hh_avx2",
++    srcs = ["highwayhash/hh_avx2.cc"],
++    hdrs = ["highwayhash/highwayhash_target.h"],
++    copts = select({
++        "@platforms//cpu:x86_64": ["-mavx2"],
++        "//conditions:default": ["-DHH_DISABLE_TARGET_SPECIFIC"],
++    }),
++    textual_hdrs = [
++        "highwayhash/hh_avx2.h",
++        "highwayhash/highwayhash_target.cc",
++        "highwayhash/highwayhash.h",
++        "highwayhash/hh_buffer.h",
++    ],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++        ":hh_types",
++        ":iaca",
++        ":load3",
++        ":vector128",
++        ":vector256",
++    ],
++)
++
++cc_library(
++    name = "hh_sse41",
++    srcs = ["highwayhash/hh_sse41.cc"],
++    hdrs = ["highwayhash/highwayhash_target.h"],
++    copts = select({
++        "@platforms//cpu:x86_64": ["-msse4.1"],
++        "//conditions:default": ["-DHH_DISABLE_TARGET_SPECIFIC"],
++    }),
++    textual_hdrs = [
++        "highwayhash/hh_sse41.h",
++        "highwayhash/highwayhash_target.cc",
++        "highwayhash/highwayhash.h",
++        "highwayhash/hh_buffer.h",
++    ],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++        ":hh_types",
++        ":iaca",
++        ":load3",
++        ":vector128",
++    ],
++)
++
++cc_library(
++    name = "hh_neon",
++    srcs = [
++        "highwayhash/hh_neon.cc",
++        "highwayhash/vector_neon.h",
++    ],
++    hdrs = ["highwayhash/highwayhash_target.h"],
++    copts = select({
++        "@platforms//cpu:aarch64": [],
++        "//conditions:default": ["-DHH_DISABLE_TARGET_SPECIFIC"],
++    }),
++    textual_hdrs = [
++        "highwayhash/highwayhash_target.cc",
++        "highwayhash/highwayhash.h",
++        "highwayhash/hh_buffer.h",
++        "highwayhash/hh_neon.h",
++    ],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++        ":hh_types",
++        ":load3",
++    ],
++)
++
++cc_library(
++    name = "hh_vsx",
++    srcs = ["highwayhash/hh_vsx.cc"],
++    hdrs = ["highwayhash/highwayhash_target.h"],
++    textual_hdrs = [
++        "highwayhash/highwayhash_target.cc",
++        "highwayhash/highwayhash.h",
++        "highwayhash/hh_buffer.h",
++        "highwayhash/hh_vsx.h",
++    ],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++        ":hh_types",
++        ":load3",
++    ],
++)
++
++cc_library(
++    name = "hh_portable",
++    srcs = ["highwayhash/hh_portable.cc"],
++    hdrs = ["highwayhash/highwayhash_target.h"],
++    textual_hdrs = [
++        "highwayhash/hh_portable.h",
++        "highwayhash/highwayhash_target.cc",
++        "highwayhash/highwayhash.h",
++        "highwayhash/hh_buffer.h",
++    ],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++        ":hh_types",
++        ":iaca",
++        ":load3",
++        ":scalar",
++    ],
++)
++
++# For users of the HighwayHashT template
++cc_library(
++    name = "highwayhash",
++    hdrs = ["highwayhash/highwayhash.h"],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++        ":hh_portable",
++        ":hh_types",
++    ] + select({
++        "@platforms//cpu:ppc": [":hh_vsx"],
++        "@platforms//cpu:aarch64": [":hh_neon"],
++        "//conditions:default": [
++            ":hh_avx2",
++            ":hh_sse41",
++            ":iaca",
++        ],
++    }),
++)
++
++# For users of InstructionSets<HighwayHash> runtime dispatch
++cc_library(
++    name = "highwayhash_dynamic",
++    hdrs = ["highwayhash/highwayhash_target.h"],
++    deps = [
++        ":arch_specific",
++        ":compiler_specific",
++        ":hh_portable",
++        ":hh_types",
++    ] + select({
++        "@platforms//cpu:aarch64": [":hh_neon"],
++        "//conditions:default": [
++            ":hh_avx2",
++            ":hh_sse41",
++        ],
++    }),
++)

--- a/modules/highwayhash/0.0.0-20240305-5ad3bf8.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/highwayhash/0.0.0-20240305-5ad3bf8.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "highwayhash",
++    version = "0.0.0-20240305-5ad3bf8.bcr.1",
++)
++
++bazel_dep(name = "platforms", version = "1.0.0")
++bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/highwayhash/0.0.0-20240305-5ad3bf8.bcr.1/presubmit.yml
+++ b/modules/highwayhash/0.0.0-20240305-5ad3bf8.bcr.1/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - macos
+  - macos_arm64
+  - ubuntu2204
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@highwayhash//...'

--- a/modules/highwayhash/0.0.0-20240305-5ad3bf8.bcr.1/source.json
+++ b/modules/highwayhash/0.0.0-20240305-5ad3bf8.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/google/highwayhash/archive/5ad3bf8444cfc663b11bf367baaa31f36e7ff7c8.tar.gz",
+    "integrity": "sha256-dEp0gr0f5NnP5mMuwlS5J+y5v2URYZU9OByx5Pbz+6M=",
+    "strip_prefix": "highwayhash-5ad3bf8444cfc663b11bf367baaa31f36e7ff7c8",
+    "patches": {
+        "add_build_file.patch": "sha256-HRG0dA3lX07Mwxj8EbB9bTjVcAZ15fCD9IfG8ev9d24=",
+        "module_dot_bazel.patch": "sha256-WLt5bdttBle/ODe+KtK6A/xoY7ga3dAF1/Zd1fkRyNw="
+    },
+    "patch_strip": 0
+}

--- a/modules/highwayhash/metadata.json
+++ b/modules/highwayhash/metadata.json
@@ -10,7 +10,8 @@
         "github:google/highwayhash"
     ],
     "versions": [
-        "0.0.0-20240305-5ad3bf8"
+        "0.0.0-20240305-5ad3bf8",
+        "0.0.0-20240305-5ad3bf8.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
- Use `@platforms` for feature selection.
- Use `@rules_cc` for `cc_library`.
- In presubmit.yml
  - Add bazel 8.x and 9.x.
  - Drop bazel 6.x.
  - Add macos and macos_arm64.
  - Upgrade to Debian 11, Ubuntu 2204.

Fixes: #7528