### PR TITLE
Fix git compilation on minimal distro

### DIFF
--- a/modules/git/2.53.0/overlay/BUILD.bazel
+++ b/modules/git/2.53.0/overlay/BUILD.bazel
@@ -432,6 +432,7 @@ cc_library(
         "//contrib/bazel:angle_include_shims",
         "//compat:headers",
         "@openssl//:ssl",
+        "@zlib",
     ],
 )
 


### PR DESCRIPTION
```
In file included from external/git+/reftable/tree.c:9:
In file included from external/git+/reftable/system.h:16:
external/git+/compat/zlib-compat.h:27:11: fatal error: 'zlib.h' file not found
   27 | # include <zlib.h>
      |           ^~~~~~~~
1 error generated.
```
Building git with a minimal linux sysroot is failing because the zlib header can't be found, but the module does declare a dependency on it. I think maybe we just forgot to add the dep to the target?

Debugged it and found `git_compat_util` exposes `compat/zlib-compat.h` (via `//compat:headers`) which `#includes <zlib.h>`, but doesn't declare `@zlib` as a dependency. If I add a patch locally to add `@zlib`, the compilation succeeds.