### PR TITLE
gutil: improve presubmit for existing versions

### DIFF
--- a/modules/gutil/20250409.0/presubmit.yml
+++ b/modules/gutil/20250409.0/presubmit.yml
@@ -4,7 +4,6 @@ matrix:
   - ubuntu2204
   - ubuntu2404
   bazel:
-  - 7.x
   - 8.x
 tasks:
   verify_targets:
@@ -15,3 +14,6 @@ tasks:
       - '--cxxopt=-std=c++17'
     build_targets:
       - '@gutil//...'
+      # Test targets depending on dev_dependencies must be excluded: dev_deps
+      # are unavailable when building as a non-root module in the BCR presubmit.
+      - '-@gutil//gutil:test_artifact_writer_test'

--- a/modules/gutil/20250502.0/presubmit.yml
+++ b/modules/gutil/20250502.0/presubmit.yml
@@ -15,3 +15,6 @@ tasks:
       - '--cxxopt=-std=c++17'
     build_targets:
       - '@gutil//...'
+      # Test targets depending on dev_dependencies must be excluded: dev_deps
+      # are unavailable when building as a non-root module in the BCR presubmit.
+      - '-@gutil//gutil:test_artifact_writer_test'


### PR DESCRIPTION
Aligns the presubmit configuration for `gutil@20250409.0` and `gutil@20250502.0` with the newer release:

- Build `@gutil//...` instead of two hand-picked targets
- Add `ubuntu2204` and `ubuntu2404` to the platform matrix (keeping `ubuntu2004`)