### PR TITLE
Add rules_apple_remote_xcframework

### DIFF
--- a/modules/rules_apple_remote_xcframework/0.5.2/MODULE.bazel
+++ b/modules/rules_apple_remote_xcframework/0.5.2/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "rules_apple_remote_xcframework",
+    version = "0.5.2",
+    compatibility_level = 1,
+)
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_apple", version = "4.3.3")
+bazel_dep(name = "rules_swift", version = "3.4.2")

--- a/modules/rules_apple_remote_xcframework/0.5.2/presubmit.yml
+++ b/modules/rules_apple_remote_xcframework/0.5.2/presubmit.yml
@@ -1,0 +1,12 @@
+matrix:
+  platform:
+  - macos_arm64
+  bazel:
+  - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@rules_apple_remote_xcframework//remote_xcframework:extensions.bzl'

--- a/modules/rules_apple_remote_xcframework/0.5.2/source.json
+++ b/modules/rules_apple_remote_xcframework/0.5.2/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/saeid-rez/rules_apple_remote_xcframework/releases/download/v0.5.2/rules_apple_remote_xcframework.tar.gz",
+    "integrity": "sha256-VSKRObw/kPsTQ8dgAgIEsqI2BZriwDgschfguGtnaNk=",
+    "strip_prefix": "rules_apple_remote_xcframework-0.5.2"
+}

--- a/modules/rules_apple_remote_xcframework/metadata.json
+++ b/modules/rules_apple_remote_xcframework/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/saeid-rez/rules_apple_remote_xcframework",
+    "maintainers": [
+        {
+            "email": "saeed.rezaei.sa@gmail.com",
+            "github": "saeid-rez",
+            "github_user_id": 5124098,
+            "name": "Saeid Rezaeisadrabadi"
+        }
+    ],
+    "repository": [
+        "github:saeid-rez/rules_apple_remote_xcframework"
+    ],
+    "versions": [
+        "0.5.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adding rules_apple_remote_xcframework, A Bazel module for consuming remote XCFrameworks for iOS applications