### PR TITLE
Add p4c 1.2.5.11

### DIFF
--- a/modules/p4c/1.2.5.11/MODULE.bazel
+++ b/modules/p4c/1.2.5.11/MODULE.bazel
@@ -1,0 +1,44 @@
+module(
+    name = "p4c",
+    version = "1.2.5.11",
+)
+
+bazel_dep(name = "abseil-cpp", version = "20260107.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "boost.algorithm", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.format", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.functional", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.graph", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.iostreams", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.multi_index", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.multiprecision", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.serialization", version = "1.90.0.bcr.1")
+bazel_dep(name = "googleapis", version = "0.0.0-20260223-edfe7983")
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1")
+bazel_dep(name = "protobuf", version = "33.5")
+bazel_dep(name = "rules_bison", version = "0.4")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_flex", version = "0.4")
+bazel_dep(name = "rules_license", version = "1.0.0")
+
+# Transitive dep of rules_bison and rules_flex; pinned to 0.3 for Bazel 9+ compatibility.
+bazel_dep(name = "rules_m4", version = "0.3")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "z3", version = "4.15.2")
+bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
+
+p4c_repositories = use_extension("//bazel:repositories.bzl", "p4c_repositories")
+use_repo(
+    p4c_repositories,
+    "inja",
+)
+
+p4c_ir_extensions = use_extension("//bazel:extensions.bzl", "p4c_ir_extensions")
+use_repo(
+    p4c_ir_extensions,
+    "p4c_ir_extensions",
+)
+
+# Used by the `tools/format-bazel-files.sh` script.
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = True)

--- a/modules/p4c/1.2.5.11/patches/set_version.patch
+++ b/modules/p4c/1.2.5.11/patches/set_version.patch
@@ -1,0 +1,10 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "p4c",
+-    version = "head",  # Fill in concrete versions only on release branches/in the BCR.
++    version = "1.2.5.11",
+ )
+ 
+ bazel_dep(name = "abseil-cpp", version = "20260107.1")

--- a/modules/p4c/1.2.5.11/presubmit.yml
+++ b/modules/p4c/1.2.5.11/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform: ["ubuntu2204", "ubuntu2404"]
+  bazel: ["7.x", "8.x", "9.x"]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      # p4c requires C++20. The .bazelrc in the source tree sets these flags,
+      # but BCR presubmit builds don't load it.
+      - "--cxxopt=-std=c++20"
+      - "--host_cxxopt=-std=c++20"
+    build_targets:
+      - "@p4c//..."

--- a/modules/p4c/1.2.5.11/source.json
+++ b/modules/p4c/1.2.5.11/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-+DuN2lJ0sZYTUyH6iVm6z6N0n9cVcGE0rBqmGgjGlKs=",
+    "strip_prefix": "p4c-1.2.5.11",
+    "url": "https://github.com/p4lang/p4c/releases/download/v1.2.5.11/p4c-1.2.5.11.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "set_version.patch": "sha256-ML6WMUr3YOJ8ywdc7bGtURTnas6EBwDFG5QLwmWfdD8="
+    }
+}

--- a/modules/p4c/metadata.json
+++ b/modules/p4c/metadata.json
@@ -1,0 +1,32 @@
+{
+    "homepage": "https://github.com/p4lang/p4c",
+    "maintainers": [
+        {
+            "github": "smolkaj",
+            "github_user_id": 6642034,
+            "name": "Steffen Smolka"
+        },
+        {
+            "github": "fruffy",
+            "github_user_id": 5960321,
+            "name": "Fabian Ruffy"
+        },
+        {
+            "github": "jafingerhut",
+            "github_user_id": 109629,
+            "name": "Andy Fingerhut"
+        },
+        {
+            "github": "matthewtlam",
+            "github_user_id": 20864829,
+            "name": "Matthew Lam"
+        }
+    ],
+    "repository": [
+        "github:p4lang/p4c"
+    ],
+    "versions": [
+        "1.2.5.11"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
## Description

Adds [p4c](https://github.com/p4lang/p4c) v1.2.5.11 — the P4_16 reference compiler — to the BCR. This is the first p4c submission, made possible by the Bzlmod migration completed in this release ([p4lang/p4c#5454](https://github.com/p4lang/p4c/pull/5454), [p4lang/p4c#5497](https://github.com/p4lang/p4c/pull/5497)).

## Module
- **Name:** `p4c`
- **Version:** `1.2.5.11`
- **Source:** https://github.com/p4lang/p4c/releases/tag/v1.2.5.11

## Notes

- The `inja` dependency is not yet in the BCR and is loaded via a module extension defined in p4c's own `bazel/repositories.bzl`. This is self-contained and requires no BCR changes.
- The `p4c_ir_extensions` module extension provides an opt-in mechanism for downstream users to register custom IR extensions; it has no effect unless explicitly used.
- Presubmit builds `@p4c//...` on Ubuntu 22.04 and 24.04 against Bazel 7.x, 8.x, and 9.x.

## Checklist

- [x] Module added under `modules/p4c/`
- [x] `metadata.json` with homepage, maintainers, and repository
- [x] `source.json` pointing to the release tarball with verified SHA-256 integrity
- [x] `MODULE.bazel` with correct version
- [x] `presubmit.yml` covering Ubuntu 22.04/24.04 × Bazel 7/8/9