### PR TITLE
bazel-compdb@1.0.1

### DIFF
--- a/modules/bazel-compdb/1.0.1/MODULE.bazel
+++ b/modules/bazel-compdb/1.0.1/MODULE.bazel
@@ -1,0 +1,77 @@
+module(
+    name = "bazel-compdb",
+    version = "1.0.1",
+)
+
+bazel_dep(name = "rules_go", version = "0.59.0")
+bazel_dep(name = "gazelle", version = "0.47.0")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "protobuf", version = "33.5")
+
+bazel_dep(name = "toolchains_llvm", version = "1.6.0", dev_dependency = True)
+bazel_dep(name = "aspect_rules_lint", version = "2.2.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = True)
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(
+    version = "1.25.1",
+)
+
+llvm = use_extension(
+    "@toolchains_llvm//toolchain/extensions:llvm.bzl",
+    "llvm",
+    dev_dependency = True,
+)
+llvm.toolchain(
+    llvm_version = "20.1.4",
+)
+use_repo(llvm, "llvm_toolchain")
+
+register_toolchains(
+    "@llvm_toolchain//:all",
+    dev_dependency = True,
+)
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_alecthomas_kong",
+    "in_gopkg_yaml_v3",
+    "org_golang_google_protobuf",
+)
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel",
+    build_file_content = """
+package(default_visibility = ["//visibility:public"])
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+
+proto_library(
+    name = "stardoc_output_proto",
+    srcs = ["stardoc_output.proto"],
+    import_prefix = "src/main/protobuf",
+)
+
+proto_library(
+    name = "build_proto",
+    srcs = ["build.proto"],
+    import_prefix = "src/main/protobuf",
+    deps = [":stardoc_output_proto"],
+)
+
+proto_library(
+    name = "analysis_v2_proto",
+    srcs = ["analysis_v2.proto"],
+    import_prefix = "src/main/protobuf",
+    deps = [":build_proto"],
+)
+""",
+    integrity = "sha256-T/Rg0FAsA7Wcdy9zjXdLedbAWaPVDq+MDnczfdh0m9s=",
+    strip_prefix = "bazel-8.0.0/src/main/protobuf",
+    urls = [
+        "https://github.com/bazelbuild/bazel/archive/refs/tags/8.0.0.tar.gz",
+    ],
+)

--- a/modules/bazel-compdb/1.0.1/attestations.json
+++ b/modules/bazel-compdb/1.0.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/calebzulawski/bazel-compdb/releases/download/1.0.1/source.json.intoto.jsonl",
+            "integrity": "sha256-GOEY11zVal+nvPd5muixH1iBCkkzQfnyiyDXASs5ruc="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/calebzulawski/bazel-compdb/releases/download/1.0.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-6uWOewujcIf5zilUEXvNEQzRaSRiO/8VupbNfSC3HsU="
+        },
+        "bazel-compdb-1.0.1.tar.gz": {
+            "url": "https://github.com/calebzulawski/bazel-compdb/releases/download/1.0.1/bazel-compdb-1.0.1.tar.gz.intoto.jsonl",
+            "integrity": "sha256-t8malDwcg2C9ihBFecPps7Oqb68GYxHXxGga5LaRYjk="
+        }
+    }
+}

--- a/modules/bazel-compdb/1.0.1/patches/module_dot_bazel_version.patch
+++ b/modules/bazel-compdb/1.0.1/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "bazel-compdb",
+-    version = "0.0.0",
++    version = "1.0.1",
+ )
+ 
+ bazel_dep(name = "rules_go", version = "0.59.0")
+ bazel_dep(name = "gazelle", version = "0.47.0")

--- a/modules/bazel-compdb/1.0.1/presubmit.yml
+++ b/modules/bazel-compdb/1.0.1/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2204
+    - macos
+    - windows
+  bazel:
+    - 8.x
+    - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@bazel-compdb//:bazel-compdb'

--- a/modules/bazel-compdb/1.0.1/source.json
+++ b/modules/bazel-compdb/1.0.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-0MCPnPRaSWky7Th9cXhXtCdQLJgigYQQ22gme3yEmwA=",
+    "strip_prefix": "bazel-compdb-1.0.1",
+    "url": "https://github.com/calebzulawski/bazel-compdb/releases/download/1.0.1/bazel-compdb-1.0.1.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-NA6tfL2poBKEN9RCIKvjL9tmJgxt/YRbhG27thbSQps="
+    },
+    "patch_strip": 1
+}

--- a/modules/bazel-compdb/metadata.json
+++ b/modules/bazel-compdb/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/calebzulawski/bazel-compdb",
+    "maintainers": [
+        {
+            "name": "Caleb Zulawski",
+            "email": "caleb.zulawski@gmail.com",
+            "github": "calebzulawski",
+            "github_user_id": 563826
+        }
+    ],
+    "repository": [
+        "github:calebzulawski/bazel-compdb"
+    ],
+    "versions": [
+        "1.0.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/calebzulawski/bazel-compdb/releases/tag/1.0.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_