### PR TITLE
aspect_rules_js_rust_wasm_bindgen@0.0.2

### DIFF
--- a/modules/aspect_rules_js_rust_wasm_bindgen/0.0.2/MODULE.bazel
+++ b/modules/aspect_rules_js_rust_wasm_bindgen/0.0.2/MODULE.bazel
@@ -1,0 +1,20 @@
+"""aspect_rules_js_rust_wasm_bindgen"""
+
+module(
+    name = "aspect_rules_js_rust_wasm_bindgen",
+    version = "0.0.2",
+)
+
+bazel_dep(name = "aspect_rules_js", version = "3.0.1")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_rust_wasm_bindgen", version = "0.69.0")
+bazel_dep(name = "rules_rust", version = "0.69.0")
+
+register_toolchains(
+    "@rules_rust_wasm_bindgen//:default_wasm_bindgen_toolchain",
+)
+
+bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True, repo_name = "io_bazel_stardoc")
+bazel_dep(name = "rules_rust_mdbook", version = "0.69.0", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.6.1", dev_dependency = True)

--- a/modules/aspect_rules_js_rust_wasm_bindgen/0.0.2/presubmit.yml
+++ b/modules/aspect_rules_js_rust_wasm_bindgen/0.0.2/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform: ["ubuntu2004", "macos_arm64"]
+    bazel: ["7.x", "8.x", "9.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/aspect_rules_js_rust_wasm_bindgen/0.0.2/source.json
+++ b/modules/aspect_rules_js_rust_wasm_bindgen/0.0.2/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/UebelAndre/aspect_rules_js_rust_wasm_bindgen/releases/download/0.0.2/aspect_rules_js_rust_wasm_bindgen-0.0.2.tar.gz",
+    "strip_prefix": "",
+    "integrity": "sha256-jHejCbe6rWPfjG7xguCqczRpJSM01U+bsw5JHpbzt/s="
+}

--- a/modules/aspect_rules_js_rust_wasm_bindgen/metadata.json
+++ b/modules/aspect_rules_js_rust_wasm_bindgen/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/UebelAndre/aspect_rules_js_rust_wasm_bindgen",
+    "maintainers": [
+        {
+            "email": "26427366+UebelAndre@users.noreply.github.com",
+            "github": "UebelAndre",
+            "github_user_id": 26427366,
+            "name": "UebelAndre"
+        }
+    ],
+    "repository": [
+        "github:UebelAndre/aspect_rules_js_rust_wasm_bindgen"
+    ],
+    "versions": [
+        "0.0.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
I've had visibility complaints about these rules. Having them literally side-by-side in the BCR addresses the concerns brought to me.