### PR TITLE
Add libomp 21.1.8

### DIFF
--- a/modules/libomp/21.1.8/MODULE.bazel
+++ b/modules/libomp/21.1.8/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "libomp",
+    version = "21.1.8",
+    bazel_compatibility = [">=7.0.0"],
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+
+# download prebuilt libomp for host platform
+_libomp = use_extension("//:extensions.bzl", "libomp")
+use_repo(_libomp, "omp")

--- a/modules/libomp/21.1.8/presubmit.yml
+++ b/modules/libomp/21.1.8/presubmit.yml
@@ -1,0 +1,41 @@
+bcr_test_module:
+  module_path: examples
+  matrix:
+    platform:
+      - debian11
+      - ubuntu2204
+      - fedora40
+      - ubuntu2204_arm64
+      - macos
+      - macos_arm64
+      - windows
+    bazel:
+      - 7.x
+      - 8.x
+  tasks:
+    run_test_module:
+      name: Build and test libomp examples
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - //...
+      test_targets:
+        - //...
+      build_flags:
+        - -c opt
+      test_flags:
+        - -c opt
+    run_wasm_tests:
+      name: Build and test wasm targets
+      platform: ubuntu2204
+      bazel: 8.x
+      build_targets:
+        - //...
+      test_targets:
+        - //...
+      build_flags:
+        - --config=wasm
+        - -c opt
+      test_flags:
+        - --config=wasm
+        - -c opt

--- a/modules/libomp/21.1.8/source.json
+++ b/modules/libomp/21.1.8/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-n5RiwS3f8i1cl53mXj61AGmstVQ+DV7vdKu3AgfaZRw=",
+    "strip_prefix": "omp-21.1.8",
+    "url": "https://github.com/miinso/omp/releases/download/v21.1.8/omp-21.1.8.tar.gz"
+}

--- a/modules/libomp/metadata.json
+++ b/modules/libomp/metadata.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://github.com/miinso/omp",
+    "maintainers": [
+        {
+            "github": "miinso",
+            "github_user_id": 46559594,
+            "name": "miinso"
+        }
+    ],
+    "repository": [
+        "github:miinso/omp"
+    ],
+    "versions": ["21.1.8"],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Prebuilt libomp (LLVM OpenMP runtime) for 6 platforms.

https://github.com/miinso/omp