### PR TITLE
bug: fix integrity hash calculation on windows

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -505,7 +505,7 @@ module(
         current = source.get("patches", {}).keys()
         patch_files = [patch_dir / p for p in current]
         patch_files.extend(patch_dir / p for p in available if p not in current)
-        patches = {str(patch.relative_to(patch_dir)): integrity(read(patch)) for patch in patch_files}
+        patches = {patch.relative_to(patch_dir).as_posix(): integrity(read(patch)) for patch in patch_files}
         if patches:
             source["patches"] = patches
         else:
@@ -521,7 +521,7 @@ module(
                     if p.is_file() and p.name != "MODULE.bazel.lock"
                 ]
             )
-        overlay_integrities = {str(file): integrity(read(overlay_dir / file)) for file in overlay_files}
+        overlay_integrities = {file.as_posix(): integrity(read(overlay_dir / file)) for file in overlay_files}
         if overlay_files:
             source["overlay"] = overlay_integrities
         else:

--- a/tools/requirements.in
+++ b/tools/requirements.in
@@ -1,6 +1,7 @@
 pyyaml
 validators
 click
+colorama
 networkx
 numpy
 scipy

--- a/tools/requirements_lock.txt
+++ b/tools/requirements_lock.txt
@@ -276,6 +276,10 @@ click==8.3.1 \
     # via
     #   -r tools/requirements.in
     #   uvicorn
+colorama==0.4.6 \
+    --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+    # via -r tools/requirements.in
 cryptography==46.0.5 \
     --hash=sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72 \
     --hash=sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235 \


### PR DESCRIPTION
In the process of debugging a few windows build errors I realized that the integrity hash calculation is not done correctly on windows.  This PR is basically a combination of https://github.com/bazelbuild/bazel-central-registry/pull/7459 with an additional fix to use `.as_posix()` in stead of `str()` to ensure the path is delimited by single forward-slashes `/` and not double back-slashes `\\`. I have confirmed this fix to work on both linux and windows.