### PR TITLE
Update BCR reviewer

### DIFF
--- a/.github/workflows/dismiss_approvals.yml
+++ b/.github/workflows/dismiss_approvals.yml
@@ -15,7 +15,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@88343b58ed92860f43faeabd6c41e16b0aac57b6 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@7073718775007a3cbd2bc5b570bf99ea2581e138 # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/generate_module_diff.yml
+++ b/.github/workflows/generate_module_diff.yml
@@ -22,6 +22,6 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Generate module diff ( ⭐ 🔍 Expand here to see the diff ⭐)
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@88343b58ed92860f43faeabd6c41e16b0aac57b6
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@7073718775007a3cbd2bc5b570bf99ea2581e138
         with:
           action-type: diff_module

--- a/.github/workflows/handle_comment.yml
+++ b/.github/workflows/handle_comment.yml
@@ -15,7 +15,7 @@ jobs:
           egress-policy: audit
 
       - name: Handle @bazel-io commands
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@88343b58ed92860f43faeabd6c41e16b0aac57b6
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@7073718775007a3cbd2bc5b570bf99ea2581e138
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/notify_maintainers.yml
+++ b/.github/workflows/notify_maintainers.yml
@@ -1,6 +1,7 @@
 name: Notify Module Maintainers For PR Review
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths:
@@ -16,7 +17,7 @@ jobs:
           egress-policy: audit
 
       - name: Run BCR PR Reviewer
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@88343b58ed92860f43faeabd6c41e16b0aac57b6 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@7073718775007a3cbd2bc5b570bf99ea2581e138 # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/review_prs.yml
+++ b/.github/workflows/review_prs.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Run BCR PR Reviewer
         if: github.repository_owner == 'bazelbuild'
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@88343b58ed92860f43faeabd6c41e16b0aac57b6 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@7073718775007a3cbd2bc5b570bf99ea2581e138 # master
         with:
           # This token needs to be updated annually on Feb 05.
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}

--- a/.github/workflows/skip_check.yml
+++ b/.github/workflows/skip_check.yml
@@ -18,7 +18,7 @@ jobs:
           egress-policy: audit
 
       - name: Run bot
-        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@88343b58ed92860f43faeabd6c41e16b0aac57b6 # master
+        uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@7073718775007a3cbd2bc5b570bf99ea2581e138 # master
         with:
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}
           action-type: skip_check


### PR DESCRIPTION
Deploy https://github.com/bazelbuild/continuous-integration/pull/2488 and https://github.com/bazelbuild/continuous-integration/pull/2495

BCR maintainers can view their assigned PRs at [this link](https://github.com/bazelbuild/bazel-central-registry/pulls?q=is%3Apr+is%3Aopen+review-requested%3A%40me+-label%3Astale+)