### PR TITLE
libgit2@1.9.2

### DIFF
--- a/modules/libgit2/1.7.1/MODULE.bazel
+++ b/modules/libgit2/1.7.1/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "libgit2",
+    version = "1.7.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "libssh2", version = "1.11.1.bcr.1")
+bazel_dep(name = "mbedtls", version = "3.6.5")
+bazel_dep(name = "openssl", version = "3.5.5.bcr.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "zlib", version = "1.3.2")

--- a/modules/libgit2/1.7.1/overlay/BUILD.bazel
+++ b/modules/libgit2/1.7.1/overlay/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+string_flag(
+    name = "use_https",
+    build_setting_default = "",
+    values = [
+        "",
+        "openssl",
+        "mbedtls",
+        "securetransport",
+        "winhttp",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+string_flag(
+    name = "use_ssh",
+    build_setting_default = "",
+    values = [
+        "",
+        "libssh2",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libgit2",
+    actual = "//src/libgit2:git2",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libgit2/1.7.1/overlay/deps/http-parser/BUILD.bazel
+++ b/modules/libgit2/1.7.1/overlay/deps/http-parser/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "http-parser",
+    srcs = glob(["*.c"]),
+    hdrs = ["http_parser.h"],
+    strip_include_prefix = "/deps/http-parser",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.7.1/overlay/deps/pcre/BUILD.bazel
+++ b/modules/libgit2/1.7.1/overlay/deps/pcre/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+_CONFIG_H = """
+#define HAVE_MEMMOVE
+
+#define NEWLINE 10
+#define POSIX_MALLOC_THRESHOLD 10
+#define LINK_SIZE 2
+#define PARENS_NEST_LIMIT 250
+#define MATCH_LIMIT 10000000
+#define MATCH_LIMIT_RECURSION MATCH_LIMIT
+
+#define MAX_NAME_SIZE	32
+#define MAX_NAME_COUNT	10000
+"""
+
+write_file(
+    name = "pcre_config_h",
+    out = "config.h",
+    content = [_CONFIG_H],
+    newline = "unix",
+)
+
+cc_library(
+    name = "pcre_config",
+    hdrs = [":pcre_config_h"],
+    strip_include_prefix = "/deps/pcre",
+)
+
+cc_library(
+    name = "pcre_hdrs",
+    hdrs = ["pcre.h"],
+    strip_include_prefix = "/deps/pcre",
+    visibility = ["//:__subpackages__"],
+)
+
+cc_library(
+    name = "pcre",
+    srcs = glob(["*.c"]) + [
+        "pcre_internal.h",
+        "pcreposix.h",
+        "ucp.h",
+    ],
+    implementation_deps = [":pcre_config"],
+    local_defines = ["HAVE_CONFIG_H"],
+    visibility = ["//:__subpackages__"],
+    deps = [":pcre_hdrs"],
+)

--- a/modules/libgit2/1.7.1/overlay/deps/xdiff/BUILD.bazel
+++ b/modules/libgit2/1.7.1/overlay/deps/xdiff/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "xdiff_hdrs",
+    hdrs = glob(["*.h"]),
+    strip_include_prefix = "/deps/xdiff",
+    visibility = ["//:__subpackages__"],
+    deps = ["//src/util:util_hdrs"],
+)
+
+cc_library(
+    name = "xdiff",
+    srcs = glob(["*.c"]),
+    visibility = ["//:__subpackages__"],
+    deps = [":xdiff_hdrs"],
+)

--- a/modules/libgit2/1.7.1/overlay/include/BUILD.bazel
+++ b/modules/libgit2/1.7.1/overlay/include/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "git2",
+    hdrs = [
+        "git2.h",
+    ] + glob([
+        "git2/**/*.h",
+    ]),
+    strip_include_prefix = "/include",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.7.1/overlay/src/libgit2/BUILD.bazel
+++ b/modules/libgit2/1.7.1/overlay/src/libgit2/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "libgit2_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/libgit2",
+    deps = [
+        "//deps/xdiff:xdiff_hdrs",
+        "//include:git2",
+        "//src/util:util_hdrs",
+    ],
+)
+
+cc_library(
+    name = "git2",
+    srcs = glob([
+        "**/*.c",
+        "**/*.h",
+    ]),
+    implementation_deps = [
+        ":libgit2_hdrs",
+        "//deps/http-parser",
+        "//deps/xdiff",
+        "//src/util",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//include:git2",
+    ] + select({
+        "//src/util:use_https_mbedtls": ["@mbedtls"],
+        "//src/util:use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }) + select({
+        "//src/util:use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.7.1/overlay/src/util/BUILD.bazel
+++ b/modules/libgit2/1.7.1/overlay/src/util/BUILD.bazel
@@ -1,0 +1,202 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+config_setting(
+    name = "use_https_openssl",
+    flag_values = {"//:use_https": "openssl"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_mbedtls",
+    flag_values = {"//:use_https": "mbedtls"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_securetransport",
+    flag_values = {"//:use_https": "securetransport"},
+)
+
+config_setting(
+    name = "use_https_winhttp",
+    flag_values = {"//:use_https": "winhttp"},
+)
+
+config_setting(
+    name = "use_ssh_libssh2",
+    flag_values = {"//:use_ssh": "libssh2"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_openssl_windows",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {"//:use_https": "openssl"},
+)
+
+_GIT2_FEATURES_H = """
+#define GIT_REGEX_BUILTIN
+#define GIT_SHA1_COLLISIONDETECT
+#define GIT_THREADS
+#define GIT_TRACE
+#define GIT_USE_NSEC
+"""
+
+write_file(
+    name = "git2_features_h",
+    out = "git2_features.h",
+    content = [_GIT2_FEATURES_H] +
+              select({
+                  "@platforms//cpu:aarch32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:wasm32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:x86_32": ["#define GIT_ARCH_32 1"],
+                  "//conditions:default": ["#define GIT_ARCH_64 1"],
+              }) +
+              select({
+                  "@platforms//os:windows": ["#define GIT_IO_WSAPOLL 1"],
+                  "//conditions:default": [
+                      "#define GIT_IO_POLL 1",
+                      "#define GIT_IO_SELECT 1",
+                  ],
+              }) +
+              select({
+                  "@platforms//os:macos": [
+                      "#define GIT_USE_STAT_MTIMESPEC 1",
+                      "#define GIT_USE_ICONV 1",
+                  ],
+                  "//conditions:default": ["#define GIT_USE_STAT_MTIM 1"],
+              }) +
+              select({
+                  ":use_https_mbedtls": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_MBEDTLS 1",
+                      "#define GIT_SHA256_MBEDTLS 1",
+                  ],
+                  ":use_https_openssl": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_OPENSSL 1",
+                      "#define GIT_SHA256_OPENSSL 1",
+                  ],
+                  ":use_https_securetransport": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_SECURE_TRANSPORT 1",
+                      "#define GIT_SHA256_COMMON_CRYPTO 1",
+                  ],
+                  ":use_https_winhttp": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_WINHTTP 1",
+                      "#define GIT_SHA256_WIN32 1",
+                  ],
+                  "//conditions:default": ["#define GIT_SHA256_BUILTIN"],
+              }) +
+              select({
+                  ":use_ssh_libssh2": [
+                      "#define GIT_SSH 1",
+                      "#define GIT_SSH_MEMORY_CREDENTIALS 1",
+                  ],
+                  "//conditions:default": [],
+              }),
+    newline = "unix",
+)
+
+cc_library(
+    name = "git2_features",
+    hdrs = [":git2_features_h"],
+    strip_include_prefix = "/src/util",
+)
+
+cc_library(
+    name = "util_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/util",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":git2_features",
+        "//deps/pcre:pcre_hdrs",
+        "//include:git2",
+        "@zlib",
+    ] + select({
+        ":use_https_mbedtls": ["@mbedtls"],
+        ":use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }),
+)
+
+GIT2_UTIL_WINDOWS_SRCS = glob(["win32/*"])
+
+GIT2_UTIL_UNIX_SRCS = glob(["unix/*"])
+
+GIT2_UTIL_SRCS = glob(
+    include = ["**/*.c"],
+    exclude = [
+        "hash/builtin.c",
+        "hash/rfc6234/sha224-256.c",
+        "hash/common_crypto.c",
+        "hash/mbedtls.c",
+        "hash/openssl.c",
+        "hash/win32.c",
+    ] + GIT2_UTIL_WINDOWS_SRCS + GIT2_UTIL_UNIX_SRCS,
+)
+
+cc_library(
+    name = "util",
+    srcs = GIT2_UTIL_SRCS + select({
+        "@platforms//os:windows": GIT2_UTIL_WINDOWS_SRCS,
+        "//conditions:default": GIT2_UTIL_UNIX_SRCS,
+    }) + select({
+        ":use_https_mbedtls": ["hash/mbedtls.c"],
+        ":use_https_openssl": ["hash/openssl.c"],
+        ":use_https_securetransport": ["hash/common_crypto.c"],
+        ":use_https_winhttp": ["hash/win32.c"],
+        "//conditions:default": [
+            "hash/builtin.c",
+            "hash/rfc6234/sha224-256.c",
+        ],
+    }),
+    implementation_deps = [
+        "//deps/http-parser",
+        "//deps/pcre",
+        "//deps/xdiff",
+    ],
+    linkopts = select({
+        "@platforms//os:linux": ["-lpthread"],
+        "@platforms//os:windows": [
+            "secur32.lib",
+            "ws2_32.lib",
+            "advapi32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_securetransport": [
+            "-framework Security",
+            "-framework CoreFoundation",
+        ],
+        ":use_https_winhttp": [
+            "winhttp.lib",
+            "rpcrt4.lib",
+            "ole32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "@platforms//os:macos": ["-liconv"],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_openssl_windows": [
+            "user32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    target_compatible_with = select({
+        ":use_https_securetransport": ["@platforms//os:macos"],
+        ":use_https_winhttp": ["@platforms//os:windows"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//:__subpackages__"],
+    deps = [":util_hdrs"] + select({
+        ":use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.7.1/overlay/tests/BUILD.bazel
+++ b/modules/libgit2/1.7.1/overlay/tests/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "version_test",
+    srcs = ["version_test.c"],
+    deps = ["//:libgit2"],
+)

--- a/modules/libgit2/1.7.1/overlay/tests/version_test.c
+++ b/modules/libgit2/1.7.1/overlay/tests/version_test.c
@@ -1,0 +1,38 @@
+#include <git2.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    int major, minor, rev, features, rc;
+
+    rc = git_libgit2_init();
+    if (rc < 0) {
+        fprintf(stderr, "git_libgit2_init failed: %d\n", rc);
+        return 1;
+    }
+
+    rc = git_libgit2_version(&major, &minor, &rev);
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_version failed: %d\n", rc);
+        return 1;
+    }
+    if (major < 1) {
+        fprintf(stderr, "unexpected major version: %d\n", major);
+        return 1;
+    }
+    printf("libgit2 %d.%d.%d\n", major, minor, rev);
+
+    features = git_libgit2_features();
+    if (!(features & GIT_FEATURE_THREADS)) {
+        fprintf(stderr, "expected GIT_FEATURE_THREADS\n");
+        return 1;
+    }
+
+    rc = git_libgit2_shutdown();
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_shutdown failed: %d\n", rc);
+        return 1;
+    }
+
+    return 0;
+}

--- a/modules/libgit2/1.7.1/presubmit.yml
+++ b/modules/libgit2/1.7.1/presubmit.yml
@@ -1,0 +1,45 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_openssl:
+    name: Verify build targets (OpenSSL)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_ssh_libssh2:
+    name: Verify build targets (ssh libssh2)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_combined:
+    name: Verify build targets (Combined)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."

--- a/modules/libgit2/1.7.1/source.json
+++ b/modules/libgit2/1.7.1/source.json
@@ -1,0 +1,17 @@
+{
+    "url": "https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.1.tar.gz",
+    "integrity": "sha256-F9KykvIb44krcE3d/ykyezVk+WCZocU7AO3CMWDHEyc=",
+    "strip_prefix": "libgit2-1.7.1",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-aWBKjEaPLuvFVaKSq5xkf+r4aZc/42Bbz57QzYivv8A=",
+        "deps/http-parser/BUILD.bazel": "sha256-rN1+ZElrhrinMyPoqdYyxwNmA3R9gF5gvnoum/pF9R0=",
+        "deps/pcre/BUILD.bazel": "sha256-LE92UDy/qqpzR/AL3YAJ5vIghMm+h4Mhgw8t4ryqByA=",
+        "deps/xdiff/BUILD.bazel": "sha256-kWOJfhwdeEIbw3SQ1mt+DUvidUfhxVO6nREpiZ5LWHM=",
+        "include/BUILD.bazel": "sha256-Rpi8QCJUzSiLYz7GoIo4aY7fCpQgYJ5I8mdWZLiQV8Y=",
+        "src/libgit2/BUILD.bazel": "sha256-ELOVO8POA+FxBSpjQGFFUvYZ3Hhq7X82YpfiOVstJsg=",
+        "src/util/BUILD.bazel": "sha256-Zt229yBavfEpowtUfYl8Z8HJqmjnDaLJs8mIFLrtroc=",
+        "tests/BUILD.bazel": "sha256-1AYGrF8G0SMW4I+tfd/qfY5J5/zA5gf1Kog4KmeeZd0=",
+        "tests/version_test.c": "sha256-ZQNrL85cwpq0VQY4DijBQza4LA6iiKRj7WXKptpLyjY="
+    }
+}

--- a/modules/libgit2/1.7.2/MODULE.bazel
+++ b/modules/libgit2/1.7.2/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "libgit2",
+    version = "1.7.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "libssh2", version = "1.11.1.bcr.1")
+bazel_dep(name = "mbedtls", version = "3.6.5")
+bazel_dep(name = "openssl", version = "3.5.5.bcr.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "zlib", version = "1.3.2")

--- a/modules/libgit2/1.7.2/overlay/BUILD.bazel
+++ b/modules/libgit2/1.7.2/overlay/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+string_flag(
+    name = "use_https",
+    build_setting_default = "",
+    values = [
+        "",
+        "openssl",
+        "mbedtls",
+        "securetransport",
+        "winhttp",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+string_flag(
+    name = "use_ssh",
+    build_setting_default = "",
+    values = [
+        "",
+        "libssh2",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libgit2",
+    actual = "//src/libgit2:git2",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libgit2/1.7.2/overlay/deps/http-parser/BUILD.bazel
+++ b/modules/libgit2/1.7.2/overlay/deps/http-parser/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "http-parser",
+    srcs = glob(["*.c"]),
+    hdrs = ["http_parser.h"],
+    strip_include_prefix = "/deps/http-parser",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.7.2/overlay/deps/pcre/BUILD.bazel
+++ b/modules/libgit2/1.7.2/overlay/deps/pcre/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+_CONFIG_H = """
+#define HAVE_MEMMOVE
+
+#define NEWLINE 10
+#define POSIX_MALLOC_THRESHOLD 10
+#define LINK_SIZE 2
+#define PARENS_NEST_LIMIT 250
+#define MATCH_LIMIT 10000000
+#define MATCH_LIMIT_RECURSION MATCH_LIMIT
+
+#define MAX_NAME_SIZE	32
+#define MAX_NAME_COUNT	10000
+"""
+
+write_file(
+    name = "pcre_config_h",
+    out = "config.h",
+    content = [_CONFIG_H],
+    newline = "unix",
+)
+
+cc_library(
+    name = "pcre_config",
+    hdrs = [":pcre_config_h"],
+    strip_include_prefix = "/deps/pcre",
+)
+
+cc_library(
+    name = "pcre_hdrs",
+    hdrs = ["pcre.h"],
+    strip_include_prefix = "/deps/pcre",
+    visibility = ["//:__subpackages__"],
+)
+
+cc_library(
+    name = "pcre",
+    srcs = glob(["*.c"]) + [
+        "pcre_internal.h",
+        "pcreposix.h",
+        "ucp.h",
+    ],
+    implementation_deps = [":pcre_config"],
+    local_defines = ["HAVE_CONFIG_H"],
+    visibility = ["//:__subpackages__"],
+    deps = [":pcre_hdrs"],
+)

--- a/modules/libgit2/1.7.2/overlay/deps/xdiff/BUILD.bazel
+++ b/modules/libgit2/1.7.2/overlay/deps/xdiff/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "xdiff_hdrs",
+    hdrs = glob(["*.h"]),
+    strip_include_prefix = "/deps/xdiff",
+    visibility = ["//:__subpackages__"],
+    deps = ["//src/util:util_hdrs"],
+)
+
+cc_library(
+    name = "xdiff",
+    srcs = glob(["*.c"]),
+    visibility = ["//:__subpackages__"],
+    deps = [":xdiff_hdrs"],
+)

--- a/modules/libgit2/1.7.2/overlay/include/BUILD.bazel
+++ b/modules/libgit2/1.7.2/overlay/include/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "git2",
+    hdrs = [
+        "git2.h",
+    ] + glob([
+        "git2/**/*.h",
+    ]),
+    strip_include_prefix = "/include",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.7.2/overlay/src/libgit2/BUILD.bazel
+++ b/modules/libgit2/1.7.2/overlay/src/libgit2/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "libgit2_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/libgit2",
+    deps = [
+        "//deps/xdiff:xdiff_hdrs",
+        "//include:git2",
+        "//src/util:util_hdrs",
+    ],
+)
+
+cc_library(
+    name = "git2",
+    srcs = glob([
+        "**/*.c",
+        "**/*.h",
+    ]),
+    implementation_deps = [
+        ":libgit2_hdrs",
+        "//deps/http-parser",
+        "//deps/xdiff",
+        "//src/util",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//include:git2",
+    ] + select({
+        "//src/util:use_https_mbedtls": ["@mbedtls"],
+        "//src/util:use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }) + select({
+        "//src/util:use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.7.2/overlay/src/util/BUILD.bazel
+++ b/modules/libgit2/1.7.2/overlay/src/util/BUILD.bazel
@@ -1,0 +1,202 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+config_setting(
+    name = "use_https_openssl",
+    flag_values = {"//:use_https": "openssl"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_mbedtls",
+    flag_values = {"//:use_https": "mbedtls"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_securetransport",
+    flag_values = {"//:use_https": "securetransport"},
+)
+
+config_setting(
+    name = "use_https_winhttp",
+    flag_values = {"//:use_https": "winhttp"},
+)
+
+config_setting(
+    name = "use_ssh_libssh2",
+    flag_values = {"//:use_ssh": "libssh2"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_openssl_windows",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {"//:use_https": "openssl"},
+)
+
+_GIT2_FEATURES_H = """
+#define GIT_REGEX_BUILTIN
+#define GIT_SHA1_COLLISIONDETECT
+#define GIT_THREADS
+#define GIT_TRACE
+#define GIT_USE_NSEC
+"""
+
+write_file(
+    name = "git2_features_h",
+    out = "git2_features.h",
+    content = [_GIT2_FEATURES_H] +
+              select({
+                  "@platforms//cpu:aarch32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:wasm32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:x86_32": ["#define GIT_ARCH_32 1"],
+                  "//conditions:default": ["#define GIT_ARCH_64 1"],
+              }) +
+              select({
+                  "@platforms//os:windows": ["#define GIT_IO_WSAPOLL 1"],
+                  "//conditions:default": [
+                      "#define GIT_IO_POLL 1",
+                      "#define GIT_IO_SELECT 1",
+                  ],
+              }) +
+              select({
+                  "@platforms//os:macos": [
+                      "#define GIT_USE_STAT_MTIMESPEC 1",
+                      "#define GIT_USE_ICONV 1",
+                  ],
+                  "//conditions:default": ["#define GIT_USE_STAT_MTIM 1"],
+              }) +
+              select({
+                  ":use_https_mbedtls": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_MBEDTLS 1",
+                      "#define GIT_SHA256_MBEDTLS 1",
+                  ],
+                  ":use_https_openssl": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_OPENSSL 1",
+                      "#define GIT_SHA256_OPENSSL 1",
+                  ],
+                  ":use_https_securetransport": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_SECURE_TRANSPORT 1",
+                      "#define GIT_SHA256_COMMON_CRYPTO 1",
+                  ],
+                  ":use_https_winhttp": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_WINHTTP 1",
+                      "#define GIT_SHA256_WIN32 1",
+                  ],
+                  "//conditions:default": ["#define GIT_SHA256_BUILTIN"],
+              }) +
+              select({
+                  ":use_ssh_libssh2": [
+                      "#define GIT_SSH 1",
+                      "#define GIT_SSH_MEMORY_CREDENTIALS 1",
+                  ],
+                  "//conditions:default": [],
+              }),
+    newline = "unix",
+)
+
+cc_library(
+    name = "git2_features",
+    hdrs = [":git2_features_h"],
+    strip_include_prefix = "/src/util",
+)
+
+cc_library(
+    name = "util_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/util",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":git2_features",
+        "//deps/pcre:pcre_hdrs",
+        "//include:git2",
+        "@zlib",
+    ] + select({
+        ":use_https_mbedtls": ["@mbedtls"],
+        ":use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }),
+)
+
+GIT2_UTIL_WINDOWS_SRCS = glob(["win32/*"])
+
+GIT2_UTIL_UNIX_SRCS = glob(["unix/*"])
+
+GIT2_UTIL_SRCS = glob(
+    include = ["**/*.c"],
+    exclude = [
+        "hash/builtin.c",
+        "hash/rfc6234/sha224-256.c",
+        "hash/common_crypto.c",
+        "hash/mbedtls.c",
+        "hash/openssl.c",
+        "hash/win32.c",
+    ] + GIT2_UTIL_WINDOWS_SRCS + GIT2_UTIL_UNIX_SRCS,
+)
+
+cc_library(
+    name = "util",
+    srcs = GIT2_UTIL_SRCS + select({
+        "@platforms//os:windows": GIT2_UTIL_WINDOWS_SRCS,
+        "//conditions:default": GIT2_UTIL_UNIX_SRCS,
+    }) + select({
+        ":use_https_mbedtls": ["hash/mbedtls.c"],
+        ":use_https_openssl": ["hash/openssl.c"],
+        ":use_https_securetransport": ["hash/common_crypto.c"],
+        ":use_https_winhttp": ["hash/win32.c"],
+        "//conditions:default": [
+            "hash/builtin.c",
+            "hash/rfc6234/sha224-256.c",
+        ],
+    }),
+    implementation_deps = [
+        "//deps/http-parser",
+        "//deps/pcre",
+        "//deps/xdiff",
+    ],
+    linkopts = select({
+        "@platforms//os:linux": ["-lpthread"],
+        "@platforms//os:windows": [
+            "secur32.lib",
+            "ws2_32.lib",
+            "advapi32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_securetransport": [
+            "-framework Security",
+            "-framework CoreFoundation",
+        ],
+        ":use_https_winhttp": [
+            "winhttp.lib",
+            "rpcrt4.lib",
+            "ole32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "@platforms//os:macos": ["-liconv"],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_openssl_windows": [
+            "user32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    target_compatible_with = select({
+        ":use_https_securetransport": ["@platforms//os:macos"],
+        ":use_https_winhttp": ["@platforms//os:windows"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//:__subpackages__"],
+    deps = [":util_hdrs"] + select({
+        ":use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.7.2/overlay/tests/BUILD.bazel
+++ b/modules/libgit2/1.7.2/overlay/tests/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "version_test",
+    srcs = ["version_test.c"],
+    deps = ["//:libgit2"],
+)

--- a/modules/libgit2/1.7.2/overlay/tests/version_test.c
+++ b/modules/libgit2/1.7.2/overlay/tests/version_test.c
@@ -1,0 +1,38 @@
+#include <git2.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    int major, minor, rev, features, rc;
+
+    rc = git_libgit2_init();
+    if (rc < 0) {
+        fprintf(stderr, "git_libgit2_init failed: %d\n", rc);
+        return 1;
+    }
+
+    rc = git_libgit2_version(&major, &minor, &rev);
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_version failed: %d\n", rc);
+        return 1;
+    }
+    if (major < 1) {
+        fprintf(stderr, "unexpected major version: %d\n", major);
+        return 1;
+    }
+    printf("libgit2 %d.%d.%d\n", major, minor, rev);
+
+    features = git_libgit2_features();
+    if (!(features & GIT_FEATURE_THREADS)) {
+        fprintf(stderr, "expected GIT_FEATURE_THREADS\n");
+        return 1;
+    }
+
+    rc = git_libgit2_shutdown();
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_shutdown failed: %d\n", rc);
+        return 1;
+    }
+
+    return 0;
+}

--- a/modules/libgit2/1.7.2/presubmit.yml
+++ b/modules/libgit2/1.7.2/presubmit.yml
@@ -1,0 +1,45 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_openssl:
+    name: Verify build targets (OpenSSL)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_ssh_libssh2:
+    name: Verify build targets (ssh libssh2)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_combined:
+    name: Verify build targets (Combined)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."

--- a/modules/libgit2/1.7.2/source.json
+++ b/modules/libgit2/1.7.2/source.json
@@ -1,0 +1,17 @@
+{
+    "url": "https://github.com/libgit2/libgit2/archive/refs/tags/v1.7.2.tar.gz",
+    "integrity": "sha256-3jhOKdfvyTMMbNsSbr+INCtQJdkg3LfGRd762FGV6n8=",
+    "strip_prefix": "libgit2-1.7.2",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-aWBKjEaPLuvFVaKSq5xkf+r4aZc/42Bbz57QzYivv8A=",
+        "deps/http-parser/BUILD.bazel": "sha256-rN1+ZElrhrinMyPoqdYyxwNmA3R9gF5gvnoum/pF9R0=",
+        "deps/pcre/BUILD.bazel": "sha256-LE92UDy/qqpzR/AL3YAJ5vIghMm+h4Mhgw8t4ryqByA=",
+        "deps/xdiff/BUILD.bazel": "sha256-kWOJfhwdeEIbw3SQ1mt+DUvidUfhxVO6nREpiZ5LWHM=",
+        "include/BUILD.bazel": "sha256-Rpi8QCJUzSiLYz7GoIo4aY7fCpQgYJ5I8mdWZLiQV8Y=",
+        "src/libgit2/BUILD.bazel": "sha256-ELOVO8POA+FxBSpjQGFFUvYZ3Hhq7X82YpfiOVstJsg=",
+        "src/util/BUILD.bazel": "sha256-Zt229yBavfEpowtUfYl8Z8HJqmjnDaLJs8mIFLrtroc=",
+        "tests/BUILD.bazel": "sha256-1AYGrF8G0SMW4I+tfd/qfY5J5/zA5gf1Kog4KmeeZd0=",
+        "tests/version_test.c": "sha256-ZQNrL85cwpq0VQY4DijBQza4LA6iiKRj7WXKptpLyjY="
+    }
+}

--- a/modules/libgit2/1.8.1.bcr.2/MODULE.bazel
+++ b/modules/libgit2/1.8.1.bcr.2/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "libgit2",
+    version = "1.8.1.bcr.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "libssh2", version = "1.11.1.bcr.1")
+bazel_dep(name = "mbedtls", version = "3.6.5")
+bazel_dep(name = "openssl", version = "3.5.5.bcr.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "zlib", version = "1.3.2")

--- a/modules/libgit2/1.8.1.bcr.2/overlay/BUILD.bazel
+++ b/modules/libgit2/1.8.1.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+string_flag(
+    name = "use_https",
+    build_setting_default = "",
+    values = [
+        "",
+        "openssl",
+        "mbedtls",
+        "securetransport",
+        "winhttp",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+string_flag(
+    name = "use_ssh",
+    build_setting_default = "",
+    values = [
+        "",
+        "exec",
+        "libssh2",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libgit2",
+    actual = "//src/libgit2:git2",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libgit2/1.8.1.bcr.2/overlay/deps/llhttp/BUILD.bazel
+++ b/modules/libgit2/1.8.1.bcr.2/overlay/deps/llhttp/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "llhttp",
+    srcs = glob(["*.c"]),
+    hdrs = ["llhttp.h"],
+    strip_include_prefix = "/deps/llhttp",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.8.1.bcr.2/overlay/deps/pcre/BUILD.bazel
+++ b/modules/libgit2/1.8.1.bcr.2/overlay/deps/pcre/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+_CONFIG_H = """
+#define HAVE_MEMMOVE
+
+#define NEWLINE 10
+#define POSIX_MALLOC_THRESHOLD 10
+#define LINK_SIZE 2
+#define PARENS_NEST_LIMIT 250
+#define MATCH_LIMIT 10000000
+#define MATCH_LIMIT_RECURSION MATCH_LIMIT
+
+#define MAX_NAME_SIZE	32
+#define MAX_NAME_COUNT	10000
+"""
+
+write_file(
+    name = "pcre_config_h",
+    out = "config.h",
+    content = [_CONFIG_H],
+    newline = "unix",
+)
+
+cc_library(
+    name = "pcre_config",
+    hdrs = [":pcre_config_h"],
+    strip_include_prefix = "/deps/pcre",
+)
+
+cc_library(
+    name = "pcre_hdrs",
+    hdrs = ["pcre.h"],
+    strip_include_prefix = "/deps/pcre",
+    visibility = ["//:__subpackages__"],
+)
+
+cc_library(
+    name = "pcre",
+    srcs = glob(["*.c"]) + [
+        "pcre_internal.h",
+        "pcreposix.h",
+        "ucp.h",
+    ],
+    implementation_deps = [":pcre_config"],
+    local_defines = ["HAVE_CONFIG_H"],
+    visibility = ["//:__subpackages__"],
+    deps = [":pcre_hdrs"],
+)

--- a/modules/libgit2/1.8.1.bcr.2/overlay/deps/xdiff/BUILD.bazel
+++ b/modules/libgit2/1.8.1.bcr.2/overlay/deps/xdiff/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "xdiff_hdrs",
+    hdrs = glob(["*.h"]),
+    strip_include_prefix = "/deps/xdiff",
+    visibility = ["//:__subpackages__"],
+    deps = ["//src/util:util_hdrs"],
+)
+
+cc_library(
+    name = "xdiff",
+    srcs = glob(["*.c"]),
+    visibility = ["//:__subpackages__"],
+    deps = [":xdiff_hdrs"],
+)

--- a/modules/libgit2/1.8.1.bcr.2/overlay/include/BUILD.bazel
+++ b/modules/libgit2/1.8.1.bcr.2/overlay/include/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "git2",
+    hdrs = [
+        "git2.h",
+    ] + glob([
+        "git2/**/*.h",
+    ]),
+    strip_include_prefix = "/include",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.8.1.bcr.2/overlay/src/libgit2/BUILD.bazel
+++ b/modules/libgit2/1.8.1.bcr.2/overlay/src/libgit2/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "libgit2_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/libgit2",
+    deps = [
+        "//deps/xdiff:xdiff_hdrs",
+        "//include:git2",
+        "//src/util:util_hdrs",
+    ],
+)
+
+cc_library(
+    name = "git2",
+    srcs = glob([
+        "**/*.c",
+        "**/*.h",
+    ]),
+    implementation_deps = [
+        ":libgit2_hdrs",
+        "//deps/llhttp",
+        "//deps/xdiff",
+        "//src/util",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//include:git2",
+    ] + select({
+        "//src/util:use_https_mbedtls": ["@mbedtls"],
+        "//src/util:use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }) + select({
+        "//src/util:use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.8.1.bcr.2/overlay/src/util/BUILD.bazel
+++ b/modules/libgit2/1.8.1.bcr.2/overlay/src/util/BUILD.bazel
@@ -1,0 +1,212 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+config_setting(
+    name = "use_https_openssl",
+    flag_values = {"//:use_https": "openssl"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_mbedtls",
+    flag_values = {"//:use_https": "mbedtls"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_securetransport",
+    flag_values = {"//:use_https": "securetransport"},
+)
+
+config_setting(
+    name = "use_https_winhttp",
+    flag_values = {"//:use_https": "winhttp"},
+)
+
+config_setting(
+    name = "use_ssh_libssh2",
+    flag_values = {"//:use_ssh": "libssh2"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_ssh_exec",
+    flag_values = {"//:use_ssh": "exec"},
+)
+
+config_setting(
+    name = "use_https_openssl_windows",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {"//:use_https": "openssl"},
+)
+
+_GIT2_FEATURES_H = """
+#define GIT_REGEX_BUILTIN
+#define GIT_SHA1_COLLISIONDETECT
+#define GIT_HTTPPARSER_BUILTIN
+#define GIT_THREADS
+#define GIT_TRACE
+#define GIT_USE_NSEC
+"""
+
+write_file(
+    name = "git2_features_h",
+    out = "git2_features.h",
+    content = [_GIT2_FEATURES_H] +
+              select({
+                  "@platforms//cpu:aarch32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:wasm32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:x86_32": ["#define GIT_ARCH_32 1"],
+                  "//conditions:default": ["#define GIT_ARCH_64 1"],
+              }) +
+              select({
+                  "@platforms//os:windows": ["#define GIT_IO_WSAPOLL 1"],
+                  "//conditions:default": [
+                      "#define GIT_IO_POLL 1",
+                      "#define GIT_IO_SELECT 1",
+                  ],
+              }) +
+              select({
+                  "@platforms//os:macos": [
+                      "#define GIT_USE_STAT_MTIMESPEC 1",
+                      "#define GIT_USE_ICONV 1",
+                  ],
+                  "//conditions:default": ["#define GIT_USE_STAT_MTIM 1"],
+              }) +
+              select({
+                  ":use_https_mbedtls": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_MBEDTLS 1",
+                      "#define GIT_SHA256_MBEDTLS 1",
+                  ],
+                  ":use_https_openssl": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_OPENSSL 1",
+                      "#define GIT_SHA256_OPENSSL 1",
+                  ],
+                  ":use_https_securetransport": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_SECURE_TRANSPORT 1",
+                      "#define GIT_SHA256_COMMON_CRYPTO 1",
+                  ],
+                  ":use_https_winhttp": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_WINHTTP 1",
+                      "#define GIT_SHA256_WIN32 1",
+                  ],
+                  "//conditions:default": ["#define GIT_SHA256_BUILTIN"],
+              }) +
+              select({
+                  ":use_ssh_exec": [
+                      "#define GIT_SSH 1",
+                      "#define GIT_SSH_EXEC 1",
+                  ],
+                  ":use_ssh_libssh2": [
+                      "#define GIT_SSH 1",
+                      "#define GIT_SSH_LIBSSH2 1",
+                      "#define GIT_SSH_LIBSSH2_MEMORY_CREDENTIALS 1",
+                  ],
+                  "//conditions:default": [],
+              }),
+    newline = "unix",
+)
+
+cc_library(
+    name = "git2_features",
+    hdrs = [":git2_features_h"],
+    strip_include_prefix = "/src/util",
+)
+
+cc_library(
+    name = "util_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/util",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":git2_features",
+        "//deps/pcre:pcre_hdrs",
+        "//include:git2",
+        "@zlib",
+    ] + select({
+        ":use_https_mbedtls": ["@mbedtls"],
+        ":use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }),
+)
+
+GIT2_UTIL_WINDOWS_SRCS = glob(["win32/*"])
+
+GIT2_UTIL_UNIX_SRCS = glob(["unix/*"])
+
+GIT2_UTIL_SRCS = glob(
+    include = ["**/*.c"],
+    exclude = [
+        "hash/builtin.c",
+        "hash/rfc6234/sha224-256.c",
+        "hash/common_crypto.c",
+        "hash/mbedtls.c",
+        "hash/openssl.c",
+        "hash/win32.c",
+    ] + GIT2_UTIL_WINDOWS_SRCS + GIT2_UTIL_UNIX_SRCS,
+)
+
+cc_library(
+    name = "util",
+    srcs = GIT2_UTIL_SRCS + select({
+        "@platforms//os:windows": GIT2_UTIL_WINDOWS_SRCS,
+        "//conditions:default": GIT2_UTIL_UNIX_SRCS,
+    }) + select({
+        ":use_https_mbedtls": ["hash/mbedtls.c"],
+        ":use_https_openssl": ["hash/openssl.c"],
+        ":use_https_securetransport": ["hash/common_crypto.c"],
+        ":use_https_winhttp": ["hash/win32.c"],
+        "//conditions:default": [
+            "hash/builtin.c",
+            "hash/rfc6234/sha224-256.c",
+        ],
+    }),
+    implementation_deps = [
+        "//deps/pcre",
+        "//deps/xdiff",
+    ],
+    linkopts = select({
+        "@platforms//os:linux": ["-lpthread"],
+        "@platforms//os:windows": [
+            "secur32.lib",
+            "ws2_32.lib",
+            "advapi32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_securetransport": [
+            "-framework Security",
+            "-framework CoreFoundation",
+        ],
+        ":use_https_winhttp": [
+            "winhttp.lib",
+            "rpcrt4.lib",
+            "ole32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "@platforms//os:macos": ["-liconv"],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_openssl_windows": [
+            "user32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    target_compatible_with = select({
+        ":use_https_securetransport": ["@platforms//os:macos"],
+        ":use_https_winhttp": ["@platforms//os:windows"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//:__subpackages__"],
+    deps = [":util_hdrs"] + select({
+        ":use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.8.1.bcr.2/overlay/tests/BUILD.bazel
+++ b/modules/libgit2/1.8.1.bcr.2/overlay/tests/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "version_test",
+    srcs = ["version_test.c"],
+    deps = ["//:libgit2"],
+)

--- a/modules/libgit2/1.8.1.bcr.2/overlay/tests/version_test.c
+++ b/modules/libgit2/1.8.1.bcr.2/overlay/tests/version_test.c
@@ -1,0 +1,38 @@
+#include <git2.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    int major, minor, rev, features, rc;
+
+    rc = git_libgit2_init();
+    if (rc < 0) {
+        fprintf(stderr, "git_libgit2_init failed: %d\n", rc);
+        return 1;
+    }
+
+    rc = git_libgit2_version(&major, &minor, &rev);
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_version failed: %d\n", rc);
+        return 1;
+    }
+    if (major < 1) {
+        fprintf(stderr, "unexpected major version: %d\n", major);
+        return 1;
+    }
+    printf("libgit2 %d.%d.%d\n", major, minor, rev);
+
+    features = git_libgit2_features();
+    if (!(features & GIT_FEATURE_THREADS)) {
+        fprintf(stderr, "expected GIT_FEATURE_THREADS\n");
+        return 1;
+    }
+
+    rc = git_libgit2_shutdown();
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_shutdown failed: %d\n", rc);
+        return 1;
+    }
+
+    return 0;
+}

--- a/modules/libgit2/1.8.1.bcr.2/presubmit.yml
+++ b/modules/libgit2/1.8.1.bcr.2/presubmit.yml
@@ -1,0 +1,53 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_openssl:
+    name: Verify build targets (OpenSSL)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_ssh_exec:
+    name: Verify build targets (ssh exec)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=exec"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_ssh_libssh2:
+    name: Verify build targets (ssh libssh2)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_combined:
+    name: Verify build targets (Combined)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."

--- a/modules/libgit2/1.8.1.bcr.2/source.json
+++ b/modules/libgit2/1.8.1.bcr.2/source.json
@@ -1,0 +1,17 @@
+{
+    "url": "https://github.com/libgit2/libgit2/archive/refs/tags/v1.8.1.tar.gz",
+    "integrity": "sha256-jB6vDPB8ug6QIZIL+6lQIUAiB4btXYqOxsetkXRSL44=",
+    "strip_prefix": "libgit2-1.8.1",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-CpzYYlke2eGnCCv+hP7OQhb8DgWaI4H+ZLldFusUoc4=",
+        "deps/llhttp/BUILD.bazel": "sha256-XLmlczQX4YDVuIz+pon+dosGRRlO08VAL/Zm4dvmrM8=",
+        "deps/pcre/BUILD.bazel": "sha256-LE92UDy/qqpzR/AL3YAJ5vIghMm+h4Mhgw8t4ryqByA=",
+        "deps/xdiff/BUILD.bazel": "sha256-kWOJfhwdeEIbw3SQ1mt+DUvidUfhxVO6nREpiZ5LWHM=",
+        "include/BUILD.bazel": "sha256-Rpi8QCJUzSiLYz7GoIo4aY7fCpQgYJ5I8mdWZLiQV8Y=",
+        "src/libgit2/BUILD.bazel": "sha256-tT76XClJxKoo9XOUOnWBN2Wot65BBfISjB2+xvYr4M0=",
+        "src/util/BUILD.bazel": "sha256-sE3IDfwfUc8nHHCQQrD0rIH8l1dEYBpQkLPbQTNayug=",
+        "tests/BUILD.bazel": "sha256-1AYGrF8G0SMW4I+tfd/qfY5J5/zA5gf1Kog4KmeeZd0=",
+        "tests/version_test.c": "sha256-ZQNrL85cwpq0VQY4DijBQza4LA6iiKRj7WXKptpLyjY="
+    }
+}

--- a/modules/libgit2/1.9.0.bcr.1/MODULE.bazel
+++ b/modules/libgit2/1.9.0.bcr.1/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "libgit2",
+    version = "1.9.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "libssh2", version = "1.11.1.bcr.1")
+bazel_dep(name = "mbedtls", version = "3.6.5")
+bazel_dep(name = "openssl", version = "3.5.5.bcr.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "zlib", version = "1.3.2")

--- a/modules/libgit2/1.9.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/libgit2/1.9.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+string_flag(
+    name = "use_https",
+    build_setting_default = "",
+    values = [
+        "",
+        "openssl",
+        "mbedtls",
+        "securetransport",
+        "winhttp",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+string_flag(
+    name = "use_ssh",
+    build_setting_default = "",
+    values = [
+        "",
+        "exec",
+        "libssh2",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libgit2",
+    actual = "//src/libgit2:git2",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libgit2/1.9.0.bcr.1/overlay/deps/llhttp/BUILD.bazel
+++ b/modules/libgit2/1.9.0.bcr.1/overlay/deps/llhttp/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "llhttp",
+    srcs = glob(["*.c"]),
+    hdrs = ["llhttp.h"],
+    strip_include_prefix = "/deps/llhttp",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.9.0.bcr.1/overlay/deps/pcre/BUILD.bazel
+++ b/modules/libgit2/1.9.0.bcr.1/overlay/deps/pcre/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+_CONFIG_H = """
+#define HAVE_MEMMOVE
+
+#define NEWLINE 10
+#define POSIX_MALLOC_THRESHOLD 10
+#define LINK_SIZE 2
+#define PARENS_NEST_LIMIT 250
+#define MATCH_LIMIT 10000000
+#define MATCH_LIMIT_RECURSION MATCH_LIMIT
+
+#define MAX_NAME_SIZE	32
+#define MAX_NAME_COUNT	10000
+"""
+
+write_file(
+    name = "pcre_config_h",
+    out = "config.h",
+    content = [_CONFIG_H],
+    newline = "unix",
+)
+
+cc_library(
+    name = "pcre_config",
+    hdrs = [":pcre_config_h"],
+    strip_include_prefix = "/deps/pcre",
+)
+
+cc_library(
+    name = "pcre_hdrs",
+    hdrs = ["pcre.h"],
+    strip_include_prefix = "/deps/pcre",
+    visibility = ["//:__subpackages__"],
+)
+
+cc_library(
+    name = "pcre",
+    srcs = glob(["*.c"]) + [
+        "pcre_internal.h",
+        "pcreposix.h",
+        "ucp.h",
+    ],
+    implementation_deps = [":pcre_config"],
+    local_defines = ["HAVE_CONFIG_H"],
+    visibility = ["//:__subpackages__"],
+    deps = [":pcre_hdrs"],
+)

--- a/modules/libgit2/1.9.0.bcr.1/overlay/deps/xdiff/BUILD.bazel
+++ b/modules/libgit2/1.9.0.bcr.1/overlay/deps/xdiff/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "xdiff_hdrs",
+    hdrs = glob(["*.h"]),
+    strip_include_prefix = "/deps/xdiff",
+    visibility = ["//:__subpackages__"],
+    deps = ["//src/util:util_hdrs"],
+)
+
+cc_library(
+    name = "xdiff",
+    srcs = glob(["*.c"]),
+    visibility = ["//:__subpackages__"],
+    deps = [":xdiff_hdrs"],
+)

--- a/modules/libgit2/1.9.0.bcr.1/overlay/include/BUILD.bazel
+++ b/modules/libgit2/1.9.0.bcr.1/overlay/include/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "git2",
+    hdrs = [
+        "git2.h",
+    ] + glob([
+        "git2/**/*.h",
+    ]),
+    strip_include_prefix = "/include",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.9.0.bcr.1/overlay/src/libgit2/BUILD.bazel
+++ b/modules/libgit2/1.9.0.bcr.1/overlay/src/libgit2/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "libgit2_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/libgit2",
+    deps = [
+        "//deps/xdiff:xdiff_hdrs",
+        "//include:git2",
+        "//src/util:util_hdrs",
+    ],
+)
+
+cc_library(
+    name = "git2",
+    srcs = glob([
+        "**/*.c",
+        "**/*.h",
+    ]),
+    implementation_deps = [
+        ":libgit2_hdrs",
+        "//deps/llhttp",
+        "//deps/xdiff",
+        "//src/util",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//include:git2",
+    ] + select({
+        "//src/util:use_https_mbedtls": ["@mbedtls"],
+        "//src/util:use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }) + select({
+        "//src/util:use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.9.0.bcr.1/overlay/src/util/BUILD.bazel
+++ b/modules/libgit2/1.9.0.bcr.1/overlay/src/util/BUILD.bazel
@@ -1,0 +1,212 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+config_setting(
+    name = "use_https_openssl",
+    flag_values = {"//:use_https": "openssl"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_mbedtls",
+    flag_values = {"//:use_https": "mbedtls"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_securetransport",
+    flag_values = {"//:use_https": "securetransport"},
+)
+
+config_setting(
+    name = "use_https_winhttp",
+    flag_values = {"//:use_https": "winhttp"},
+)
+
+config_setting(
+    name = "use_ssh_libssh2",
+    flag_values = {"//:use_ssh": "libssh2"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_ssh_exec",
+    flag_values = {"//:use_ssh": "exec"},
+)
+
+config_setting(
+    name = "use_https_openssl_windows",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {"//:use_https": "openssl"},
+)
+
+_GIT2_FEATURES_H = """
+#define GIT_REGEX_BUILTIN
+#define GIT_SHA1_COLLISIONDETECT
+#define GIT_HTTPPARSER_BUILTIN
+#define GIT_THREADS
+#define GIT_TRACE
+#define GIT_USE_NSEC
+"""
+
+write_file(
+    name = "git2_features_h",
+    out = "git2_features.h",
+    content = [_GIT2_FEATURES_H] +
+              select({
+                  "@platforms//cpu:aarch32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:wasm32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:x86_32": ["#define GIT_ARCH_32 1"],
+                  "//conditions:default": ["#define GIT_ARCH_64 1"],
+              }) +
+              select({
+                  "@platforms//os:windows": ["#define GIT_IO_WSAPOLL 1"],
+                  "//conditions:default": [
+                      "#define GIT_IO_POLL 1",
+                      "#define GIT_IO_SELECT 1",
+                  ],
+              }) +
+              select({
+                  "@platforms//os:macos": [
+                      "#define GIT_USE_STAT_MTIMESPEC 1",
+                      "#define GIT_USE_ICONV 1",
+                  ],
+                  "//conditions:default": ["#define GIT_USE_STAT_MTIM 1"],
+              }) +
+              select({
+                  ":use_https_mbedtls": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_MBEDTLS 1",
+                      "#define GIT_SHA256_MBEDTLS 1",
+                  ],
+                  ":use_https_openssl": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_OPENSSL 1",
+                      "#define GIT_SHA256_OPENSSL 1",
+                  ],
+                  ":use_https_securetransport": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_SECURE_TRANSPORT 1",
+                      "#define GIT_SHA256_COMMON_CRYPTO 1",
+                  ],
+                  ":use_https_winhttp": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_WINHTTP 1",
+                      "#define GIT_SHA256_WIN32 1",
+                  ],
+                  "//conditions:default": ["#define GIT_SHA256_BUILTIN"],
+              }) +
+              select({
+                  ":use_ssh_exec": [
+                      "#define GIT_SSH 1",
+                      "#define GIT_SSH_EXEC 1",
+                  ],
+                  ":use_ssh_libssh2": [
+                      "#define GIT_SSH 1",
+                      "#define GIT_SSH_LIBSSH2 1",
+                      "#define GIT_SSH_LIBSSH2_MEMORY_CREDENTIALS 1",
+                  ],
+                  "//conditions:default": [],
+              }),
+    newline = "unix",
+)
+
+cc_library(
+    name = "git2_features",
+    hdrs = [":git2_features_h"],
+    strip_include_prefix = "/src/util",
+)
+
+cc_library(
+    name = "util_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/util",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":git2_features",
+        "//deps/pcre:pcre_hdrs",
+        "//include:git2",
+        "@zlib",
+    ] + select({
+        ":use_https_mbedtls": ["@mbedtls"],
+        ":use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }),
+)
+
+GIT2_UTIL_WINDOWS_SRCS = glob(["win32/*"])
+
+GIT2_UTIL_UNIX_SRCS = glob(["unix/*"])
+
+GIT2_UTIL_SRCS = glob(
+    include = ["**/*.c"],
+    exclude = [
+        "hash/builtin.c",
+        "hash/rfc6234/sha224-256.c",
+        "hash/common_crypto.c",
+        "hash/mbedtls.c",
+        "hash/openssl.c",
+        "hash/win32.c",
+    ] + GIT2_UTIL_WINDOWS_SRCS + GIT2_UTIL_UNIX_SRCS,
+)
+
+cc_library(
+    name = "util",
+    srcs = GIT2_UTIL_SRCS + select({
+        "@platforms//os:windows": GIT2_UTIL_WINDOWS_SRCS,
+        "//conditions:default": GIT2_UTIL_UNIX_SRCS,
+    }) + select({
+        ":use_https_mbedtls": ["hash/mbedtls.c"],
+        ":use_https_openssl": ["hash/openssl.c"],
+        ":use_https_securetransport": ["hash/common_crypto.c"],
+        ":use_https_winhttp": ["hash/win32.c"],
+        "//conditions:default": [
+            "hash/builtin.c",
+            "hash/rfc6234/sha224-256.c",
+        ],
+    }),
+    implementation_deps = [
+        "//deps/pcre",
+        "//deps/xdiff",
+    ],
+    linkopts = select({
+        "@platforms//os:linux": ["-lpthread"],
+        "@platforms//os:windows": [
+            "secur32.lib",
+            "ws2_32.lib",
+            "advapi32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_securetransport": [
+            "-framework Security",
+            "-framework CoreFoundation",
+        ],
+        ":use_https_winhttp": [
+            "winhttp.lib",
+            "rpcrt4.lib",
+            "ole32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "@platforms//os:macos": ["-liconv"],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_openssl_windows": [
+            "user32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    target_compatible_with = select({
+        ":use_https_securetransport": ["@platforms//os:macos"],
+        ":use_https_winhttp": ["@platforms//os:windows"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//:__subpackages__"],
+    deps = [":util_hdrs"] + select({
+        ":use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.9.0.bcr.1/overlay/tests/BUILD.bazel
+++ b/modules/libgit2/1.9.0.bcr.1/overlay/tests/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "version_test",
+    srcs = ["version_test.c"],
+    deps = ["//:libgit2"],
+)

--- a/modules/libgit2/1.9.0.bcr.1/overlay/tests/version_test.c
+++ b/modules/libgit2/1.9.0.bcr.1/overlay/tests/version_test.c
@@ -1,0 +1,46 @@
+#include <git2.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    int major, minor, rev, features, rc;
+
+    rc = git_libgit2_init();
+    if (rc < 0) {
+        fprintf(stderr, "git_libgit2_init failed: %d\n", rc);
+        return 1;
+    }
+
+    rc = git_libgit2_version(&major, &minor, &rev);
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_version failed: %d\n", rc);
+        return 1;
+    }
+    if (major < 1) {
+        fprintf(stderr, "unexpected major version: %d\n", major);
+        return 1;
+    }
+    printf("libgit2 %d.%d.%d\n", major, minor, rev);
+
+    features = git_libgit2_features();
+    if (!(features & GIT_FEATURE_THREADS)) {
+        fprintf(stderr, "expected GIT_FEATURE_THREADS\n");
+        return 1;
+    }
+    if (!(features & GIT_FEATURE_COMPRESSION)) {
+        fprintf(stderr, "expected GIT_FEATURE_COMPRESSION\n");
+        return 1;
+    }
+    if (!(features & GIT_FEATURE_SHA1)) {
+        fprintf(stderr, "expected GIT_FEATURE_SHA1\n");
+        return 1;
+    }
+
+    rc = git_libgit2_shutdown();
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_shutdown failed: %d\n", rc);
+        return 1;
+    }
+
+    return 0;
+}

--- a/modules/libgit2/1.9.0.bcr.1/presubmit.yml
+++ b/modules/libgit2/1.9.0.bcr.1/presubmit.yml
@@ -1,0 +1,53 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_openssl:
+    name: Verify build targets (OpenSSL)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_ssh_exec:
+    name: Verify build targets (ssh exec)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=exec"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_ssh_libssh2:
+    name: Verify build targets (ssh libssh2)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_combined:
+    name: Verify build targets (Combined)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."

--- a/modules/libgit2/1.9.0.bcr.1/source.json
+++ b/modules/libgit2/1.9.0.bcr.1/source.json
@@ -1,0 +1,17 @@
+{
+    "url": "https://github.com/libgit2/libgit2/archive/refs/tags/v1.9.0.tar.gz",
+    "integrity": "sha256-dbJ9TW30S9NOL3BmPP2Zj17EHmgOHlkyOLvlF6hMftI=",
+    "strip_prefix": "libgit2-1.9.0",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-CpzYYlke2eGnCCv+hP7OQhb8DgWaI4H+ZLldFusUoc4=",
+        "deps/llhttp/BUILD.bazel": "sha256-XLmlczQX4YDVuIz+pon+dosGRRlO08VAL/Zm4dvmrM8=",
+        "deps/pcre/BUILD.bazel": "sha256-LE92UDy/qqpzR/AL3YAJ5vIghMm+h4Mhgw8t4ryqByA=",
+        "deps/xdiff/BUILD.bazel": "sha256-kWOJfhwdeEIbw3SQ1mt+DUvidUfhxVO6nREpiZ5LWHM=",
+        "include/BUILD.bazel": "sha256-Rpi8QCJUzSiLYz7GoIo4aY7fCpQgYJ5I8mdWZLiQV8Y=",
+        "src/libgit2/BUILD.bazel": "sha256-tT76XClJxKoo9XOUOnWBN2Wot65BBfISjB2+xvYr4M0=",
+        "src/util/BUILD.bazel": "sha256-sE3IDfwfUc8nHHCQQrD0rIH8l1dEYBpQkLPbQTNayug=",
+        "tests/BUILD.bazel": "sha256-1AYGrF8G0SMW4I+tfd/qfY5J5/zA5gf1Kog4KmeeZd0=",
+        "tests/version_test.c": "sha256-RbSCHI9z2jUXPZ+JAab3uF1c1avO9L8gLwrxPybDLpc="
+    }
+}

--- a/modules/libgit2/1.9.1.bcr.1/MODULE.bazel
+++ b/modules/libgit2/1.9.1.bcr.1/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "libgit2",
+    version = "1.9.1.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "libssh2", version = "1.11.1.bcr.1")
+bazel_dep(name = "mbedtls", version = "3.6.5")
+bazel_dep(name = "openssl", version = "3.5.5.bcr.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "zlib", version = "1.3.2")

--- a/modules/libgit2/1.9.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/libgit2/1.9.1.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+string_flag(
+    name = "use_https",
+    build_setting_default = "",
+    values = [
+        "",
+        "openssl",
+        "mbedtls",
+        "securetransport",
+        "winhttp",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+string_flag(
+    name = "use_ssh",
+    build_setting_default = "",
+    values = [
+        "",
+        "exec",
+        "libssh2",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libgit2",
+    actual = "//src/libgit2:git2",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libgit2/1.9.1.bcr.1/overlay/deps/llhttp/BUILD.bazel
+++ b/modules/libgit2/1.9.1.bcr.1/overlay/deps/llhttp/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "llhttp",
+    srcs = glob(["*.c"]),
+    hdrs = ["llhttp.h"],
+    strip_include_prefix = "/deps/llhttp",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.9.1.bcr.1/overlay/deps/pcre/BUILD.bazel
+++ b/modules/libgit2/1.9.1.bcr.1/overlay/deps/pcre/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+_CONFIG_H = """
+#define HAVE_MEMMOVE
+
+#define NEWLINE 10
+#define POSIX_MALLOC_THRESHOLD 10
+#define LINK_SIZE 2
+#define PARENS_NEST_LIMIT 250
+#define MATCH_LIMIT 10000000
+#define MATCH_LIMIT_RECURSION MATCH_LIMIT
+
+#define MAX_NAME_SIZE	32
+#define MAX_NAME_COUNT	10000
+"""
+
+write_file(
+    name = "pcre_config_h",
+    out = "config.h",
+    content = [_CONFIG_H],
+    newline = "unix",
+)
+
+cc_library(
+    name = "pcre_config",
+    hdrs = [":pcre_config_h"],
+    strip_include_prefix = "/deps/pcre",
+)
+
+cc_library(
+    name = "pcre_hdrs",
+    hdrs = ["pcre.h"],
+    strip_include_prefix = "/deps/pcre",
+    visibility = ["//:__subpackages__"],
+)
+
+cc_library(
+    name = "pcre",
+    srcs = glob(["*.c"]) + [
+        "pcre_internal.h",
+        "pcreposix.h",
+        "ucp.h",
+    ],
+    implementation_deps = [":pcre_config"],
+    local_defines = ["HAVE_CONFIG_H"],
+    visibility = ["//:__subpackages__"],
+    deps = [":pcre_hdrs"],
+)

--- a/modules/libgit2/1.9.1.bcr.1/overlay/deps/xdiff/BUILD.bazel
+++ b/modules/libgit2/1.9.1.bcr.1/overlay/deps/xdiff/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "xdiff_hdrs",
+    hdrs = glob(["*.h"]),
+    strip_include_prefix = "/deps/xdiff",
+    visibility = ["//:__subpackages__"],
+    deps = ["//src/util:util_hdrs"],
+)
+
+cc_library(
+    name = "xdiff",
+    srcs = glob(["*.c"]),
+    visibility = ["//:__subpackages__"],
+    deps = [":xdiff_hdrs"],
+)

--- a/modules/libgit2/1.9.1.bcr.1/overlay/include/BUILD.bazel
+++ b/modules/libgit2/1.9.1.bcr.1/overlay/include/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "git2",
+    hdrs = [
+        "git2.h",
+    ] + glob([
+        "git2/**/*.h",
+    ]),
+    strip_include_prefix = "/include",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.9.1.bcr.1/overlay/src/libgit2/BUILD.bazel
+++ b/modules/libgit2/1.9.1.bcr.1/overlay/src/libgit2/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "libgit2_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/libgit2",
+    deps = [
+        "//deps/xdiff:xdiff_hdrs",
+        "//include:git2",
+        "//src/util:util_hdrs",
+    ],
+)
+
+cc_library(
+    name = "git2",
+    srcs = glob([
+        "**/*.c",
+        "**/*.h",
+    ]),
+    implementation_deps = [
+        ":libgit2_hdrs",
+        "//deps/llhttp",
+        "//deps/xdiff",
+        "//src/util",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//include:git2",
+    ] + select({
+        "//src/util:use_https_mbedtls": ["@mbedtls"],
+        "//src/util:use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }) + select({
+        "//src/util:use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.9.1.bcr.1/overlay/src/util/BUILD.bazel
+++ b/modules/libgit2/1.9.1.bcr.1/overlay/src/util/BUILD.bazel
@@ -1,0 +1,212 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+config_setting(
+    name = "use_https_openssl",
+    flag_values = {"//:use_https": "openssl"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_mbedtls",
+    flag_values = {"//:use_https": "mbedtls"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_securetransport",
+    flag_values = {"//:use_https": "securetransport"},
+)
+
+config_setting(
+    name = "use_https_winhttp",
+    flag_values = {"//:use_https": "winhttp"},
+)
+
+config_setting(
+    name = "use_ssh_libssh2",
+    flag_values = {"//:use_ssh": "libssh2"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_ssh_exec",
+    flag_values = {"//:use_ssh": "exec"},
+)
+
+config_setting(
+    name = "use_https_openssl_windows",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {"//:use_https": "openssl"},
+)
+
+_GIT2_FEATURES_H = """
+#define GIT_REGEX_BUILTIN
+#define GIT_SHA1_COLLISIONDETECT
+#define GIT_HTTPPARSER_BUILTIN
+#define GIT_THREADS
+#define GIT_TRACE
+#define GIT_USE_NSEC
+"""
+
+write_file(
+    name = "git2_features_h",
+    out = "git2_features.h",
+    content = [_GIT2_FEATURES_H] +
+              select({
+                  "@platforms//cpu:aarch32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:wasm32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:x86_32": ["#define GIT_ARCH_32 1"],
+                  "//conditions:default": ["#define GIT_ARCH_64 1"],
+              }) +
+              select({
+                  "@platforms//os:windows": ["#define GIT_IO_WSAPOLL 1"],
+                  "//conditions:default": [
+                      "#define GIT_IO_POLL 1",
+                      "#define GIT_IO_SELECT 1",
+                  ],
+              }) +
+              select({
+                  "@platforms//os:macos": [
+                      "#define GIT_USE_STAT_MTIMESPEC 1",
+                      "#define GIT_USE_ICONV 1",
+                  ],
+                  "//conditions:default": ["#define GIT_USE_STAT_MTIM 1"],
+              }) +
+              select({
+                  ":use_https_mbedtls": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_MBEDTLS 1",
+                      "#define GIT_SHA256_MBEDTLS 1",
+                  ],
+                  ":use_https_openssl": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_OPENSSL 1",
+                      "#define GIT_SHA256_OPENSSL 1",
+                  ],
+                  ":use_https_securetransport": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_SECURE_TRANSPORT 1",
+                      "#define GIT_SHA256_COMMON_CRYPTO 1",
+                  ],
+                  ":use_https_winhttp": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_WINHTTP 1",
+                      "#define GIT_SHA256_WIN32 1",
+                  ],
+                  "//conditions:default": ["#define GIT_SHA256_BUILTIN"],
+              }) +
+              select({
+                  ":use_ssh_exec": [
+                      "#define GIT_SSH 1",
+                      "#define GIT_SSH_EXEC 1",
+                  ],
+                  ":use_ssh_libssh2": [
+                      "#define GIT_SSH 1",
+                      "#define GIT_SSH_LIBSSH2 1",
+                      "#define GIT_SSH_LIBSSH2_MEMORY_CREDENTIALS 1",
+                  ],
+                  "//conditions:default": [],
+              }),
+    newline = "unix",
+)
+
+cc_library(
+    name = "git2_features",
+    hdrs = [":git2_features_h"],
+    strip_include_prefix = "/src/util",
+)
+
+cc_library(
+    name = "util_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/util",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":git2_features",
+        "//deps/pcre:pcre_hdrs",
+        "//include:git2",
+        "@zlib",
+    ] + select({
+        ":use_https_mbedtls": ["@mbedtls"],
+        ":use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }),
+)
+
+GIT2_UTIL_WINDOWS_SRCS = glob(["win32/*"])
+
+GIT2_UTIL_UNIX_SRCS = glob(["unix/*"])
+
+GIT2_UTIL_SRCS = glob(
+    include = ["**/*.c"],
+    exclude = [
+        "hash/builtin.c",
+        "hash/rfc6234/sha224-256.c",
+        "hash/common_crypto.c",
+        "hash/mbedtls.c",
+        "hash/openssl.c",
+        "hash/win32.c",
+    ] + GIT2_UTIL_WINDOWS_SRCS + GIT2_UTIL_UNIX_SRCS,
+)
+
+cc_library(
+    name = "util",
+    srcs = GIT2_UTIL_SRCS + select({
+        "@platforms//os:windows": GIT2_UTIL_WINDOWS_SRCS,
+        "//conditions:default": GIT2_UTIL_UNIX_SRCS,
+    }) + select({
+        ":use_https_mbedtls": ["hash/mbedtls.c"],
+        ":use_https_openssl": ["hash/openssl.c"],
+        ":use_https_securetransport": ["hash/common_crypto.c"],
+        ":use_https_winhttp": ["hash/win32.c"],
+        "//conditions:default": [
+            "hash/builtin.c",
+            "hash/rfc6234/sha224-256.c",
+        ],
+    }),
+    implementation_deps = [
+        "//deps/pcre",
+        "//deps/xdiff",
+    ],
+    linkopts = select({
+        "@platforms//os:linux": ["-lpthread"],
+        "@platforms//os:windows": [
+            "secur32.lib",
+            "ws2_32.lib",
+            "advapi32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_securetransport": [
+            "-framework Security",
+            "-framework CoreFoundation",
+        ],
+        ":use_https_winhttp": [
+            "winhttp.lib",
+            "rpcrt4.lib",
+            "ole32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "@platforms//os:macos": ["-liconv"],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_openssl_windows": [
+            "user32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    target_compatible_with = select({
+        ":use_https_securetransport": ["@platforms//os:macos"],
+        ":use_https_winhttp": ["@platforms//os:windows"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//:__subpackages__"],
+    deps = [":util_hdrs"] + select({
+        ":use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.9.1.bcr.1/overlay/tests/BUILD.bazel
+++ b/modules/libgit2/1.9.1.bcr.1/overlay/tests/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "version_test",
+    srcs = ["version_test.c"],
+    deps = ["//:libgit2"],
+)

--- a/modules/libgit2/1.9.1.bcr.1/overlay/tests/version_test.c
+++ b/modules/libgit2/1.9.1.bcr.1/overlay/tests/version_test.c
@@ -1,0 +1,46 @@
+#include <git2.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    int major, minor, rev, features, rc;
+
+    rc = git_libgit2_init();
+    if (rc < 0) {
+        fprintf(stderr, "git_libgit2_init failed: %d\n", rc);
+        return 1;
+    }
+
+    rc = git_libgit2_version(&major, &minor, &rev);
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_version failed: %d\n", rc);
+        return 1;
+    }
+    if (major < 1) {
+        fprintf(stderr, "unexpected major version: %d\n", major);
+        return 1;
+    }
+    printf("libgit2 %d.%d.%d\n", major, minor, rev);
+
+    features = git_libgit2_features();
+    if (!(features & GIT_FEATURE_THREADS)) {
+        fprintf(stderr, "expected GIT_FEATURE_THREADS\n");
+        return 1;
+    }
+    if (!(features & GIT_FEATURE_COMPRESSION)) {
+        fprintf(stderr, "expected GIT_FEATURE_COMPRESSION\n");
+        return 1;
+    }
+    if (!(features & GIT_FEATURE_SHA1)) {
+        fprintf(stderr, "expected GIT_FEATURE_SHA1\n");
+        return 1;
+    }
+
+    rc = git_libgit2_shutdown();
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_shutdown failed: %d\n", rc);
+        return 1;
+    }
+
+    return 0;
+}

--- a/modules/libgit2/1.9.1.bcr.1/presubmit.yml
+++ b/modules/libgit2/1.9.1.bcr.1/presubmit.yml
@@ -1,0 +1,53 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_openssl:
+    name: Verify build targets (OpenSSL)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_ssh_exec:
+    name: Verify build targets (ssh exec)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=exec"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_ssh_libssh2:
+    name: Verify build targets (ssh libssh2)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_combined:
+    name: Verify build targets (Combined)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."

--- a/modules/libgit2/1.9.1.bcr.1/source.json
+++ b/modules/libgit2/1.9.1.bcr.1/source.json
@@ -1,0 +1,16 @@
+{
+    "url": "https://github.com/libgit2/libgit2/archive/refs/tags/v1.9.1.tar.gz",
+    "integrity": "sha256-FMqzAUsretdZcP9FSOg2FfdNcZr+AKpHm0qInB4T/AA=",
+    "strip_prefix": "libgit2-1.9.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-CpzYYlke2eGnCCv+hP7OQhb8DgWaI4H+ZLldFusUoc4=",
+        "deps/llhttp/BUILD.bazel": "sha256-XLmlczQX4YDVuIz+pon+dosGRRlO08VAL/Zm4dvmrM8=",
+        "deps/pcre/BUILD.bazel": "sha256-LE92UDy/qqpzR/AL3YAJ5vIghMm+h4Mhgw8t4ryqByA=",
+        "deps/xdiff/BUILD.bazel": "sha256-kWOJfhwdeEIbw3SQ1mt+DUvidUfhxVO6nREpiZ5LWHM=",
+        "include/BUILD.bazel": "sha256-Rpi8QCJUzSiLYz7GoIo4aY7fCpQgYJ5I8mdWZLiQV8Y=",
+        "src/libgit2/BUILD.bazel": "sha256-tT76XClJxKoo9XOUOnWBN2Wot65BBfISjB2+xvYr4M0=",
+        "src/util/BUILD.bazel": "sha256-sE3IDfwfUc8nHHCQQrD0rIH8l1dEYBpQkLPbQTNayug=",
+        "tests/BUILD.bazel": "sha256-1AYGrF8G0SMW4I+tfd/qfY5J5/zA5gf1Kog4KmeeZd0=",
+        "tests/version_test.c": "sha256-RbSCHI9z2jUXPZ+JAab3uF1c1avO9L8gLwrxPybDLpc="
+    }
+}

--- a/modules/libgit2/1.9.2/MODULE.bazel
+++ b/modules/libgit2/1.9.2/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "libgit2",
+    version = "1.9.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "libssh2", version = "1.11.1.bcr.1")
+bazel_dep(name = "mbedtls", version = "3.6.5")
+bazel_dep(name = "openssl", version = "3.5.5.bcr.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "zlib", version = "1.3.2")

--- a/modules/libgit2/1.9.2/overlay/BUILD.bazel
+++ b/modules/libgit2/1.9.2/overlay/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+string_flag(
+    name = "use_https",
+    build_setting_default = "",
+    values = [
+        "",
+        "openssl",
+        "mbedtls",
+        "securetransport",
+        "winhttp",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+string_flag(
+    name = "use_ssh",
+    build_setting_default = "",
+    values = [
+        "",
+        "exec",
+        "libssh2",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libgit2",
+    actual = "//src/libgit2:git2",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libgit2/1.9.2/overlay/deps/llhttp/BUILD.bazel
+++ b/modules/libgit2/1.9.2/overlay/deps/llhttp/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "llhttp",
+    srcs = glob(["*.c"]),
+    hdrs = ["llhttp.h"],
+    strip_include_prefix = "/deps/llhttp",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.9.2/overlay/deps/pcre/BUILD.bazel
+++ b/modules/libgit2/1.9.2/overlay/deps/pcre/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+_CONFIG_H = """
+#define HAVE_MEMMOVE
+
+#define NEWLINE 10
+#define POSIX_MALLOC_THRESHOLD 10
+#define LINK_SIZE 2
+#define PARENS_NEST_LIMIT 250
+#define MATCH_LIMIT 10000000
+#define MATCH_LIMIT_RECURSION MATCH_LIMIT
+
+#define MAX_NAME_SIZE	32
+#define MAX_NAME_COUNT	10000
+"""
+
+write_file(
+    name = "pcre_config_h",
+    out = "config.h",
+    content = [_CONFIG_H],
+    newline = "unix",
+)
+
+cc_library(
+    name = "pcre_config",
+    hdrs = [":pcre_config_h"],
+    strip_include_prefix = "/deps/pcre",
+)
+
+cc_library(
+    name = "pcre_hdrs",
+    hdrs = ["pcre.h"],
+    strip_include_prefix = "/deps/pcre",
+    visibility = ["//:__subpackages__"],
+)
+
+cc_library(
+    name = "pcre",
+    srcs = glob(["*.c"]) + [
+        "pcre_internal.h",
+        "pcreposix.h",
+        "ucp.h",
+    ],
+    implementation_deps = [":pcre_config"],
+    local_defines = ["HAVE_CONFIG_H"],
+    visibility = ["//:__subpackages__"],
+    deps = [":pcre_hdrs"],
+)

--- a/modules/libgit2/1.9.2/overlay/deps/xdiff/BUILD.bazel
+++ b/modules/libgit2/1.9.2/overlay/deps/xdiff/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "xdiff_hdrs",
+    hdrs = glob(["*.h"]),
+    strip_include_prefix = "/deps/xdiff",
+    visibility = ["//:__subpackages__"],
+    deps = ["//src/util:util_hdrs"],
+)
+
+cc_library(
+    name = "xdiff",
+    srcs = glob(["*.c"]),
+    visibility = ["//:__subpackages__"],
+    deps = [":xdiff_hdrs"],
+)

--- a/modules/libgit2/1.9.2/overlay/include/BUILD.bazel
+++ b/modules/libgit2/1.9.2/overlay/include/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "git2",
+    hdrs = [
+        "git2.h",
+    ] + glob([
+        "git2/**/*.h",
+    ]),
+    strip_include_prefix = "/include",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/libgit2/1.9.2/overlay/src/libgit2/BUILD.bazel
+++ b/modules/libgit2/1.9.2/overlay/src/libgit2/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "libgit2_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/libgit2",
+    deps = [
+        "//deps/xdiff:xdiff_hdrs",
+        "//include:git2",
+        "//src/util:util_hdrs",
+    ],
+)
+
+cc_library(
+    name = "git2",
+    srcs = glob([
+        "**/*.c",
+        "**/*.h",
+    ]),
+    implementation_deps = [
+        ":libgit2_hdrs",
+        "//deps/llhttp",
+        "//deps/xdiff",
+        "//src/util",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//include:git2",
+    ] + select({
+        "//src/util:use_https_mbedtls": ["@mbedtls"],
+        "//src/util:use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }) + select({
+        "//src/util:use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.9.2/overlay/src/util/BUILD.bazel
+++ b/modules/libgit2/1.9.2/overlay/src/util/BUILD.bazel
@@ -1,0 +1,212 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+config_setting(
+    name = "use_https_openssl",
+    flag_values = {"//:use_https": "openssl"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_mbedtls",
+    flag_values = {"//:use_https": "mbedtls"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_https_securetransport",
+    flag_values = {"//:use_https": "securetransport"},
+)
+
+config_setting(
+    name = "use_https_winhttp",
+    flag_values = {"//:use_https": "winhttp"},
+)
+
+config_setting(
+    name = "use_ssh_libssh2",
+    flag_values = {"//:use_ssh": "libssh2"},
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "use_ssh_exec",
+    flag_values = {"//:use_ssh": "exec"},
+)
+
+config_setting(
+    name = "use_https_openssl_windows",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {"//:use_https": "openssl"},
+)
+
+_GIT2_FEATURES_H = """
+#define GIT_REGEX_BUILTIN
+#define GIT_SHA1_COLLISIONDETECT
+#define GIT_HTTPPARSER_BUILTIN
+#define GIT_THREADS
+#define GIT_TRACE
+#define GIT_USE_NSEC
+"""
+
+write_file(
+    name = "git2_features_h",
+    out = "git2_features.h",
+    content = [_GIT2_FEATURES_H] +
+              select({
+                  "@platforms//cpu:aarch32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:wasm32": ["#define GIT_ARCH_32 1"],
+                  "@platforms//cpu:x86_32": ["#define GIT_ARCH_32 1"],
+                  "//conditions:default": ["#define GIT_ARCH_64 1"],
+              }) +
+              select({
+                  "@platforms//os:windows": ["#define GIT_IO_WSAPOLL 1"],
+                  "//conditions:default": [
+                      "#define GIT_IO_POLL 1",
+                      "#define GIT_IO_SELECT 1",
+                  ],
+              }) +
+              select({
+                  "@platforms//os:macos": [
+                      "#define GIT_USE_STAT_MTIMESPEC 1",
+                      "#define GIT_USE_ICONV 1",
+                  ],
+                  "//conditions:default": ["#define GIT_USE_STAT_MTIM 1"],
+              }) +
+              select({
+                  ":use_https_mbedtls": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_MBEDTLS 1",
+                      "#define GIT_SHA256_MBEDTLS 1",
+                  ],
+                  ":use_https_openssl": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_OPENSSL 1",
+                      "#define GIT_SHA256_OPENSSL 1",
+                  ],
+                  ":use_https_securetransport": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_SECURE_TRANSPORT 1",
+                      "#define GIT_SHA256_COMMON_CRYPTO 1",
+                  ],
+                  ":use_https_winhttp": [
+                      "#define GIT_HTTPS 1",
+                      "#define GIT_WINHTTP 1",
+                      "#define GIT_SHA256_WIN32 1",
+                  ],
+                  "//conditions:default": ["#define GIT_SHA256_BUILTIN"],
+              }) +
+              select({
+                  ":use_ssh_exec": [
+                      "#define GIT_SSH 1",
+                      "#define GIT_SSH_EXEC 1",
+                  ],
+                  ":use_ssh_libssh2": [
+                      "#define GIT_SSH 1",
+                      "#define GIT_SSH_LIBSSH2 1",
+                      "#define GIT_SSH_LIBSSH2_MEMORY_CREDENTIALS 1",
+                  ],
+                  "//conditions:default": [],
+              }),
+    newline = "unix",
+)
+
+cc_library(
+    name = "git2_features",
+    hdrs = [":git2_features_h"],
+    strip_include_prefix = "/src/util",
+)
+
+cc_library(
+    name = "util_hdrs",
+    hdrs = glob(["**/*.h"]),
+    strip_include_prefix = "/src/util",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":git2_features",
+        "//deps/pcre:pcre_hdrs",
+        "//include:git2",
+        "@zlib",
+    ] + select({
+        ":use_https_mbedtls": ["@mbedtls"],
+        ":use_https_openssl": ["@openssl//:ssl"],
+        "//conditions:default": [],
+    }),
+)
+
+GIT2_UTIL_WINDOWS_SRCS = glob(["win32/*"])
+
+GIT2_UTIL_UNIX_SRCS = glob(["unix/*"])
+
+GIT2_UTIL_SRCS = glob(
+    include = ["**/*.c"],
+    exclude = [
+        "hash/builtin.c",
+        "hash/rfc6234/sha224-256.c",
+        "hash/common_crypto.c",
+        "hash/mbedtls.c",
+        "hash/openssl.c",
+        "hash/win32.c",
+    ] + GIT2_UTIL_WINDOWS_SRCS + GIT2_UTIL_UNIX_SRCS,
+)
+
+cc_library(
+    name = "util",
+    srcs = GIT2_UTIL_SRCS + select({
+        "@platforms//os:windows": GIT2_UTIL_WINDOWS_SRCS,
+        "//conditions:default": GIT2_UTIL_UNIX_SRCS,
+    }) + select({
+        ":use_https_mbedtls": ["hash/mbedtls.c"],
+        ":use_https_openssl": ["hash/openssl.c"],
+        ":use_https_securetransport": ["hash/common_crypto.c"],
+        ":use_https_winhttp": ["hash/win32.c"],
+        "//conditions:default": [
+            "hash/builtin.c",
+            "hash/rfc6234/sha224-256.c",
+        ],
+    }),
+    implementation_deps = [
+        "//deps/pcre",
+        "//deps/xdiff",
+    ],
+    linkopts = select({
+        "@platforms//os:linux": ["-lpthread"],
+        "@platforms//os:windows": [
+            "secur32.lib",
+            "ws2_32.lib",
+            "advapi32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_securetransport": [
+            "-framework Security",
+            "-framework CoreFoundation",
+        ],
+        ":use_https_winhttp": [
+            "winhttp.lib",
+            "rpcrt4.lib",
+            "ole32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "@platforms//os:macos": ["-liconv"],
+        "//conditions:default": [],
+    }) + select({
+        ":use_https_openssl_windows": [
+            "user32.lib",
+            "crypt32.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    target_compatible_with = select({
+        ":use_https_securetransport": ["@platforms//os:macos"],
+        ":use_https_winhttp": ["@platforms//os:windows"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//:__subpackages__"],
+    deps = [":util_hdrs"] + select({
+        ":use_ssh_libssh2": ["@libssh2"],
+        "//conditions:default": [],
+    }),
+)

--- a/modules/libgit2/1.9.2/overlay/tests/BUILD.bazel
+++ b/modules/libgit2/1.9.2/overlay/tests/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "version_test",
+    srcs = ["version_test.c"],
+    deps = ["//:libgit2"],
+)

--- a/modules/libgit2/1.9.2/overlay/tests/version_test.c
+++ b/modules/libgit2/1.9.2/overlay/tests/version_test.c
@@ -1,0 +1,46 @@
+#include <git2.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    int major, minor, rev, features, rc;
+
+    rc = git_libgit2_init();
+    if (rc < 0) {
+        fprintf(stderr, "git_libgit2_init failed: %d\n", rc);
+        return 1;
+    }
+
+    rc = git_libgit2_version(&major, &minor, &rev);
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_version failed: %d\n", rc);
+        return 1;
+    }
+    if (major < 1) {
+        fprintf(stderr, "unexpected major version: %d\n", major);
+        return 1;
+    }
+    printf("libgit2 %d.%d.%d\n", major, minor, rev);
+
+    features = git_libgit2_features();
+    if (!(features & GIT_FEATURE_THREADS)) {
+        fprintf(stderr, "expected GIT_FEATURE_THREADS\n");
+        return 1;
+    }
+    if (!(features & GIT_FEATURE_COMPRESSION)) {
+        fprintf(stderr, "expected GIT_FEATURE_COMPRESSION\n");
+        return 1;
+    }
+    if (!(features & GIT_FEATURE_SHA1)) {
+        fprintf(stderr, "expected GIT_FEATURE_SHA1\n");
+        return 1;
+    }
+
+    rc = git_libgit2_shutdown();
+    if (rc != 0) {
+        fprintf(stderr, "git_libgit2_shutdown failed: %d\n", rc);
+        return 1;
+    }
+
+    return 0;
+}

--- a/modules/libgit2/1.9.2/presubmit.yml
+++ b/modules/libgit2/1.9.2/presubmit.yml
@@ -1,0 +1,53 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_openssl:
+    name: Verify build targets (OpenSSL)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_ssh_exec:
+    name: Verify build targets (ssh exec)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=exec"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_ssh_libssh2:
+    name: Verify build targets (ssh libssh2)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+    test_targets:
+      - "@libgit2//..."
+  verify_targets_combined:
+    name: Verify build targets (Combined)
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+      - "--@libgit2//:use_ssh=libssh2"
+      - "--@libgit2//:use_https=openssl"
+    test_targets:
+      - "@libgit2//..."

--- a/modules/libgit2/1.9.2/source.json
+++ b/modules/libgit2/1.9.2/source.json
@@ -1,0 +1,16 @@
+{
+    "url": "https://github.com/libgit2/libgit2/archive/refs/tags/v1.9.2.tar.gz",
+    "integrity": "sha256-bwl8gvwG7OT0BTn7F+nUG68aWi/CaxuFYtIbibw1X+Y=",
+    "strip_prefix": "libgit2-1.9.2",
+    "overlay": {
+        "BUILD.bazel": "sha256-CpzYYlke2eGnCCv+hP7OQhb8DgWaI4H+ZLldFusUoc4=",
+        "deps/llhttp/BUILD.bazel": "sha256-XLmlczQX4YDVuIz+pon+dosGRRlO08VAL/Zm4dvmrM8=",
+        "deps/pcre/BUILD.bazel": "sha256-LE92UDy/qqpzR/AL3YAJ5vIghMm+h4Mhgw8t4ryqByA=",
+        "deps/xdiff/BUILD.bazel": "sha256-kWOJfhwdeEIbw3SQ1mt+DUvidUfhxVO6nREpiZ5LWHM=",
+        "include/BUILD.bazel": "sha256-Rpi8QCJUzSiLYz7GoIo4aY7fCpQgYJ5I8mdWZLiQV8Y=",
+        "src/libgit2/BUILD.bazel": "sha256-tT76XClJxKoo9XOUOnWBN2Wot65BBfISjB2+xvYr4M0=",
+        "src/util/BUILD.bazel": "sha256-sE3IDfwfUc8nHHCQQrD0rIH8l1dEYBpQkLPbQTNayug=",
+        "tests/BUILD.bazel": "sha256-1AYGrF8G0SMW4I+tfd/qfY5J5/zA5gf1Kog4KmeeZd0=",
+        "tests/version_test.c": "sha256-RbSCHI9z2jUXPZ+JAab3uF1c1avO9L8gLwrxPybDLpc="
+    }
+}

--- a/modules/libgit2/metadata.json
+++ b/modules/libgit2/metadata.json
@@ -4,18 +4,24 @@
         {
             "email": "john@john-millikin.com",
             "github": "jmillikin",
-            "name": "John Millikin",
-            "github_user_id": 646128
+            "github_user_id": 646128,
+            "name": "John Millikin"
         }
     ],
     "repository": [
         "github:libgit2/libgit2"
     ],
     "versions": [
+        "1.7.1",
+        "1.7.2",
         "1.8.1",
         "1.8.1.bcr.1",
+        "1.8.1.bcr.2",
         "1.9.0",
-        "1.9.1"
+        "1.9.0.bcr.1",
+        "1.9.1",
+        "1.9.1.bcr.1",
+        "1.9.2"
     ],
     "yanked_versions": {}
 }

--- a/modules/libssh2/1.11.1.bcr.1/MODULE.bazel
+++ b/modules/libssh2/1.11.1.bcr.1/MODULE.bazel
@@ -1,0 +1,15 @@
+"""https://libssh2.org/"""
+
+module(
+    name = "libssh2",
+    version = "1.11.1.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "mbedtls", version = "3.6.5")
+bazel_dep(name = "openssl", version = "3.5.5.bcr.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc_autoconf", version = "0.5.4")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "zlib", version = "1.3.2")

--- a/modules/libssh2/1.11.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/libssh2/1.11.1.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,314 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_cc_autoconf//autoconf:autoconf.bzl", "autoconf")
+load("@rules_cc_autoconf//autoconf:autoconf_hdr.bzl", "autoconf_hdr")
+load("@rules_cc_autoconf//autoconf:checks.bzl", "checks", "macros")
+load("@rules_cc_autoconf//autoconf:package_info.bzl", "package_info")
+
+string_flag(
+    name = "crypto_backend",
+    build_setting_default = "openssl",
+    values = [
+        "openssl",
+        "mbedtls",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "use_zlib",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "crypto_backend_openssl",
+    flag_values = {":crypto_backend": "openssl"},
+)
+
+config_setting(
+    name = "crypto_backend_mbedtls",
+    flag_values = {":crypto_backend": "mbedtls"},
+)
+
+config_setting(
+    name = "use_zlib_enabled",
+    flag_values = {":use_zlib": "True"},
+)
+
+package_info(
+    name = "package",
+    module_bazel = "MODULE.bazel",
+)
+
+# Header and function checks from configure.ac / CMakeLists.txt
+autoconf(
+    name = "configure_ac",
+    checks = macros.AC_CHECK_HEADERS([
+        "unistd.h",
+        "inttypes.h",
+        "sys/select.h",
+        "sys/uio.h",
+        "sys/socket.h",
+        "sys/ioctl.h",
+        "sys/time.h",
+        "sys/un.h",
+        "arpa/inet.h",
+        "netinet/in.h",
+        "windows.h",
+    ]) + macros.AC_CHECK_FUNCS([
+        "gettimeofday",
+        "strtoll",
+        "snprintf",
+        "explicit_bzero",
+        "explicit_memset",
+        "memset_s",
+        "poll",
+        "select",
+    ]) + [
+
+        # Non-blocking socket support (cmake/CheckNonblockingSocketSupport.cmake)
+        # O_NONBLOCK: POSIX non-blocking via fcntl, excluding SunOS 4 / AIX 3 / BeOS
+        checks.AC_TRY_COMPILE(
+            name = "ac_cv_have_o_nonblock",
+            code = """\
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#if defined(sun) || defined(__sun__) || defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+# if defined(__SVR4) || defined(__srv4__)
+#  define PLATFORM_SOLARIS
+# else
+#  define PLATFORM_SUNOS4
+# endif
+#endif
+#if (defined(_AIX) || defined(__xlC__)) && !defined(_AIX41)
+# define PLATFORM_AIX_V3
+#endif
+
+#if defined(PLATFORM_SUNOS4) || defined(PLATFORM_AIX_V3) || defined(__BEOS__)
+#error "O_NONBLOCK does not work on this platform"
+#endif
+
+int main(void)
+{
+    int socket = 0;
+    (void)fcntl(socket, F_SETFL, O_NONBLOCK);
+    return 0;
+}
+""",
+            define = "HAVE_O_NONBLOCK",
+        ),
+
+        # FIONBIO: old-style unix ioctl non-blocking (fallback when O_NONBLOCK unavailable)
+        checks.AC_TRY_COMPILE(
+            name = "ac_cv_have_fionbio",
+            code = """\
+#include <unistd.h>
+#include <stropts.h>
+
+int main(void)
+{
+    int socket = 0;
+    int flags = 0;
+    (void)ioctl(socket, FIONBIO, &flags);
+    return 0;
+}
+""",
+            define = "HAVE_FIONBIO",
+            requires = ["!HAVE_O_NONBLOCK"],
+        ),
+
+        # IoctlSocket: Amiga-style non-blocking (fallback when FIONBIO unavailable)
+        checks.AC_TRY_COMPILE(
+            name = "ac_cv_have_ioctlsocket_case",
+            code = """\
+#include <sys/ioctl.h>
+
+int main(void)
+{
+    int socket = 0;
+    (void)IoctlSocket(socket, FIONBIO, (long)1);
+    return 0;
+}
+""",
+            define = "HAVE_IOCTLSOCKET_CASE",
+            requires = [
+                "!HAVE_O_NONBLOCK",
+                "!HAVE_FIONBIO",
+            ],
+        ),
+
+        # SO_NONBLOCK: BeOS-style non-blocking (last fallback)
+        checks.AC_TRY_COMPILE(
+            name = "ac_cv_have_so_nonblock",
+            code = """\
+#include <socket.h>
+
+int main(void)
+{
+    long b = 1;
+    int socket = 0;
+    (void)setsockopt(socket, SOL_SOCKET, SO_NONBLOCK, &b, sizeof(b));
+    return 0;
+}
+""",
+            define = "HAVE_SO_NONBLOCK",
+            requires = [
+                "!HAVE_O_NONBLOCK",
+                "!HAVE_FIONBIO",
+                "!HAVE_IOCTLSOCKET_CASE",
+            ],
+        ),
+    ],
+    deps = [":package"],
+)
+
+# Generate libssh2_config.h from the autotools template
+autoconf_hdr(
+    name = "gen_libssh2_config_h",
+    out = "src/libssh2_config.h",
+    template = "src/libssh2_config.h.in",
+    deps = [":configure_ac"],
+)
+
+LIBSSH2_SRCS = [
+    "src/agent.c",
+    "src/bcrypt_pbkdf.c",
+    "src/channel.c",
+    "src/comp.c",
+    "src/chacha.c",
+    "src/cipher-chachapoly.c",
+    "src/crypt.c",
+    "src/crypto.c",
+    "src/global.c",
+    "src/hostkey.c",
+    "src/keepalive.c",
+    "src/kex.c",
+    "src/knownhost.c",
+    "src/mac.c",
+    "src/misc.c",
+    "src/packet.c",
+    "src/pem.c",
+    "src/poly1305.c",
+    "src/publickey.c",
+    "src/scp.c",
+    "src/session.c",
+    "src/sftp.c",
+    "src/transport.c",
+    "src/userauth.c",
+    "src/userauth_kbd_packet.c",
+    "src/version.c",
+]
+
+LIBSSH2_INTERNAL_HDRS = [
+    "src/chacha.h",
+    "src/channel.h",
+    "src/cipher-chachapoly.h",
+    "src/comp.h",
+    "src/crypto.h",
+    "src/crypto_config.h",
+    "src/libgcrypt.h",
+    "src/libssh2_priv.h",
+    "src/libssh2_setup.h",
+    "src/mac.h",
+    "src/mbedtls.h",
+    "src/misc.h",
+    "src/openssl.h",
+    "src/os400qc3.h",
+    "src/packet.h",
+    "src/poly1305.h",
+    "src/session.h",
+    "src/sftp.h",
+    "src/transport.h",
+    "src/userauth.h",
+    "src/userauth_kbd_packet.h",
+    "src/wincng.h",
+]
+
+# These .c files are #include'd by other translation units, not compiled
+# directly: crypto.c includes the backend, bcrypt_pbkdf.c includes blowfish.c,
+# and agent.c includes agent_win.c.
+LIBSSH2_TEXTUAL_SRCS = [
+    "src/agent_win.c",
+    "src/blowfish.c",
+    "src/libgcrypt.c",
+    "src/mbedtls.c",
+    "src/openssl.c",
+    "src/os400qc3.c",
+    "src/wincng.c",
+]
+
+DEFINES = [
+    "HAVE_CONFIG_H",
+] + select({
+    ":crypto_backend_mbedtls": ["LIBSSH2_MBEDTLS"],
+    ":crypto_backend_openssl": ["LIBSSH2_OPENSSL"],
+    "//conditions:default": [],
+}) + select({
+    ":use_zlib_enabled": ["LIBSSH2_HAVE_ZLIB"],
+    "//conditions:default": [],
+})
+
+[
+    cc_library(
+        name = name,
+        testonly = kwargs.get("testonly", None),
+        srcs = LIBSSH2_SRCS + LIBSSH2_INTERNAL_HDRS + [
+            ":gen_libssh2_config_h",
+        ],
+        hdrs = glob(["include/*.h"]),
+        includes = [
+            "include",
+            "src",
+        ],
+        linkopts = select({
+            "@platforms//os:windows": [
+                "-DEFAULTLIB:ws2_32.lib",
+                "-DEFAULTLIB:bcrypt.lib",
+                "-DEFAULTLIB:crypt32.lib",
+                "-DEFAULTLIB:advapi32.lib",
+                "-DEFAULTLIB:user32.lib",
+            ],
+            "//conditions:default": [],
+        }),
+        local_defines = DEFINES,
+        textual_hdrs = LIBSSH2_TEXTUAL_SRCS,
+        visibility = kwargs.get("visibility", None),
+        deps = select({
+            ":crypto_backend_mbedtls": ["@mbedtls"],
+            ":crypto_backend_openssl": ["@openssl//:crypto"],
+            "//conditions:default": [],
+        }) + select({
+            ":use_zlib_enabled": ["@zlib"],
+            "//conditions:default": [],
+        }),
+    )
+    for name, kwargs in {
+        "ssh2": {
+            "visibility": ["//visibility:public"],
+        },
+        "ssh2_testonly": {
+            "testonly": True,
+        },
+    }.items()
+]
+
+alias(
+    name = "libssh2",
+    actual = ":ssh2",
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "test_simple",
+    srcs = ["tests/test_simple.c"],
+    defines = DEFINES,
+    includes = [
+        "include",
+        "src",
+    ],
+    deps = [":ssh2_testonly"],
+)

--- a/modules/libssh2/1.11.1.bcr.1/presubmit.yml
+++ b/modules/libssh2/1.11.1.bcr.1/presubmit.yml
@@ -1,0 +1,22 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - ubuntu2004
+    - ubuntu2004_arm64
+    - ubuntu2204
+    - ubuntu2204_arm64
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "@libssh2//..."

--- a/modules/libssh2/1.11.1.bcr.1/source.json
+++ b/modules/libssh2/1.11.1.bcr.1/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://libssh2.org/download/libssh2-1.11.1.tar.xz",
+    "strip_prefix": "libssh2-1.11.1",
+    "integrity": "sha256-mVTLVMT1SBmKfL660ki9yH3WS9JhhXCKKUsrUHceN2k=",
+    "overlay": {
+        "BUILD.bazel": "sha256-OLZLVW2pJUbQxYf7aMyqyg/J9lOb0CMKnLDEhuD2M3U="
+    }
+}

--- a/modules/libssh2/metadata.json
+++ b/modules/libssh2/metadata.json
@@ -12,7 +12,8 @@
         "https://libssh2.org/download/"
     ],
     "versions": [
-        "1.11.1"
+        "1.11.1",
+        "1.11.1.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This change introduces the following flags
```bash
# Enable HTTPS support with the specific https provider: OpenSSL or mbedTLS
--@libgit2//:use_https
# Enables SSH support for ether exec or libssh2
--@libgit2//:use_ssh
```

These changes were also added to previous versions:
- 1.7.1
- 1.7.2
- 1.8.1.bcr.2
- 1.9.0.bcr.1
- 1.9.1.bcr.1

Note that the core targets without any of these flags should sufficiently identical and not include any additional external dependencies