### PR TITLE
Added `yanked_versions` map to `rules_perl`

### DIFF
--- a/modules/rules_perl/metadata.json
+++ b/modules/rules_perl/metadata.json
@@ -10,6 +10,11 @@
             "github": "lalten",
             "github_user_id": 11611719,
             "name": "Laurenz Altenmueller"
+        },
+        {
+            "github": "skeletonkey",
+            "github_user_id": 1487600,
+            "name": "Erik Tank"
         }
     ],
     "repository": [
@@ -27,5 +32,6 @@
         "0.4.2",
         "0.4.3",
         "0.5.0"
-    ]
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
This syncs the `metadata.json` file with what's in `rules_perl` today and relates to https://github.com/bazel-contrib/rules_perl/pull/109#issuecomment-4007282359