### PR TITLE
Yank rules_scala 7.2.3

### DIFF
--- a/modules/rules_scala/metadata.json
+++ b/modules/rules_scala/metadata.json
@@ -36,5 +36,7 @@
         "7.2.3",
         "7.2.4"
     ],
-    "yanked_versions": {}
+    "yanked_versions": {
+        "7.2.3": "removed compatibility_level too soon (https://github.com/bazel-contrib/rules_scala/issues/1816)"
+    }
 }


### PR DESCRIPTION
Per bazel-contrib/rules_scala#1816 and bazel-contrib/rules_scala#1817, this version removed the `compatibility_level` attribute from the `module` directive too soon. This will cause conflicts in the dependency graph in the presence of other `rules_scala` module versions when building with Bazels before 8.6.0 or 9.1.0.

cc: @WojciechMazur @simuons