### PR TITLE
libaio@0.3.113.bcr.0

### DIFF
--- a/modules/libaio/0.3.113.bcr.0/MODULE.bazel
+++ b/modules/libaio/0.3.113.bcr.0/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "libaio",
+    version = "0.3.113.bcr.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/libaio/0.3.113.bcr.0/overlay/BUILD.bazel
+++ b/modules/libaio/0.3.113.bcr.0/overlay/BUILD.bazel
@@ -1,0 +1,59 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+
+filegroup(
+    name = "libaio.map",
+    srcs = ["src/libaio.map"],
+)
+
+cc_library(
+    name = "aio",
+    srcs = [
+        "src/compat-0_1.c",
+        "src/io_cancel.c",
+        "src/io_destroy.c",
+        "src/io_getevents.c",
+        "src/io_pgetevents.c",
+        "src/io_queue_init.c",
+        "src/io_queue_release.c",
+        "src/io_queue_run.c",
+        "src/io_queue_wait.c",
+        "src/io_setup.c",
+        "src/io_submit.c",
+        "src/raw_syscall.c",
+    ],
+    hdrs = [
+        "src/libaio.h",
+    ],
+    includes = ["src"],
+    linkstatic = True,
+    textual_hdrs = [
+        "src/aio_ring.h",
+        "src/syscall.h",
+        "src/vsys_def.h",
+        "src/syscall-alpha.h",
+        "src/syscall-arm.h",
+        "src/syscall-generic.h",
+        "src/syscall-i386.h",
+        "src/syscall-ia64.h",
+        "src/syscall-ppc.h",
+        "src/syscall-s390.h",
+        "src/syscall-sparc.h",
+        "src/syscall-x86_64.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_shared_library(
+    name = "aio_shared",
+    additional_linker_inputs = [
+        ":libaio.map",
+    ],
+    shared_lib_name = "libaio.so",
+    user_link_flags = [
+        "-Wl,--version-script=$(location :libaio.map)",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":aio",
+    ],
+)

--- a/modules/libaio/0.3.113.bcr.0/overlay/MODULE.bazel
+++ b/modules/libaio/0.3.113.bcr.0/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "libaio",
+    version = "0.3.113.bcr.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/libaio/0.3.113.bcr.0/presubmit.yml
+++ b/modules/libaio/0.3.113.bcr.0/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  bazel: [7.x, 8.x, 9.x, rolling]
+  platform:
+    - debian13
+    - rockylinux8
+    - ubuntu2404
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@libaio//:aio"
+      - "@libaio//:aio_shared"

--- a/modules/libaio/0.3.113.bcr.0/source.json
+++ b/modules/libaio/0.3.113.bcr.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz",
+    "integrity": "sha256-HFYcIGcMXAnMhDemIgCMBpPGp4FsHzAzLaN5aVOy9FQ=",
+    "strip_prefix": "libaio-0.3.113",
+    "overlay": {
+        "BUILD.bazel": "sha256-8YrvnChFLkUnj3FHpnnqd2ujPi1CAsBGW3KEH5Ea00E=",
+        "MODULE.bazel": "sha256-yPFj1pWazrz26r8a5vvnoYOrOLTA3G6b8zVV5duzToI="
+    }
+}

--- a/modules/libaio/metadata.json
+++ b/modules/libaio/metadata.json
@@ -10,6 +10,10 @@
         "https://pagure.io/libaio"
     ],
     "versions": [
-        "0.3.113"
-    ]
+        "0.3.113",
+        "0.3.113.bcr.0"
+    ],
+    "yanked_versions": {
+        "0.3.113": "0.3.113 has a shared library linking issue."
+    }
 }


### PR DESCRIPTION
The previous version had a bug in the shared library build. The root cause was that the `version-script` in `linkopts` was being passed to both static and shared builds - unnecessary for static libraries and causing errors in that context.

This version switches to `cc_shared_library` and splits the targets accordingly, which makes the build structure clearer.