### PR TITLE
Add rules_verilog@0.1.0

### DIFF
--- a/modules/rules_verilog/0.1.0/MODULE.bazel
+++ b/modules/rules_verilog/0.1.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "rules_verilog",
+    version = "0.1.0",
+    bazel_compatibility = [">=7.5.0"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2", dev_dependency = True)

--- a/modules/rules_verilog/0.1.0/presubmit.yml
+++ b/modules/rules_verilog/0.1.0/presubmit.yml
@@ -1,0 +1,19 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform:
+      - debian10
+      - ubuntu2004
+    bazel: [7.x, 8.x, 9.x]
+  tasks:
+    run_tests:
+      name: "Run tests"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//verilog/tests:leaf"
+        - "//verilog/tests:dep_a"
+        - "//verilog/tests:dep_b"
+        - "//verilog/tests:top"
+      test_targets:
+        - "//verilog/tests:verilog_library_tests"

--- a/modules/rules_verilog/0.1.0/source.json
+++ b/modules/rules_verilog/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "sha256-TnlSXoZCUiS6g9DysE6CIioDxcgzzs5qk4GtDmRFeu8=",
+  "strip_prefix": "bazel_rules_verilog-0.1.0",
+  "url": "https://github.com/MrAMS/bazel_rules_verilog/releases/download/v0.1.0/bazel_rules_verilog-0.1.0.tar.gz"
+}

--- a/modules/rules_verilog/metadata.json
+++ b/modules/rules_verilog/metadata.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://github.com/MrAMS/bazel_rules_verilog",
+  "maintainers": [
+    {
+      "github": "MrAMS",
+      "github_user_id": 25056812
+    }
+  ],
+  "repository": ["github:MrAMS/bazel_rules_verilog"],
+  "versions": ["0.1.0"]
+}


### PR DESCRIPTION
The primary goal of `rules_verilog` is to provide only the **most foundational** Verilog interfaces (e.g., `verilog_library`). This allows downstream rulesets, such as [rules_verilator](https://github.com/MrAMS/bazel_rules_verilator) or [rules_vivado](https://github.com/CruxML/bazel_rules_vivado), to easily consume them without introducing unnecessary overhead.

This design is intentional and aligns with the Bzlmod's philosophy of high modularity and decoupling.  A massive, monolithic, "kitchen-sink" approach like the old `rules_hdl` is largely an anti-pattern and highly unsuitable in the bzlmod era.

> [!TIP]
> **Q**: Why "kitchen-sink" approach like the old `rules_hdl` is bad in bzlmod era?
> **A**: If a module is a massive monolith, anyone depending on it is forced to download and resolve a massive dependency graph—even if they only need 5% of its functionality. This leads to version conflicts, bloated download times, and slower evaluations. In the Bzlmod era, the best practice is to decouple these into discrete, composable modules so users only pull exactly what they need for their specific hardware pipeline.