### PR TITLE
rules_rocq_rust@0.1.0

### DIFF
--- a/modules/rules_rocq_rust/0.1.0/MODULE.bazel
+++ b/modules/rules_rocq_rust/0.1.0/MODULE.bazel
@@ -1,0 +1,71 @@
+"""Bazel Module for Rocq and coq-of-rust Rules
+
+This module provides Bazel rules for Rocq/Coq theorem proving.
+Uses nixpkgs for hermetic Coq toolchain installation.
+
+NOTE: The root module must configure nixpkgs - see README.md
+"""
+
+module(
+    name = "rules_rocq_rust",
+    version = "0.1.0",
+    compatibility_level = 1,
+)
+
+# Core dependencies
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# Note: rocq-of-rust is built with cargo directly in the repository rule
+# because it requires rustc_private (nightly internals) and crate_universe
+# can't handle edition2024 crates like archery 1.2.2.
+# No Bazel Rust rules needed - cargo handles the build.
+
+# Nix integration for hermetic Coq/Rocq toolchain
+bazel_dep(name = "rules_nixpkgs_core", version = "0.13.0")
+
+# Development dependencies
+bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
+
+# Configure nixpkgs repository for standalone development/testing
+# NOTE: This is dev_dependency=True so it doesn't conflict with root module
+nix_repo = use_extension(
+    "@rules_nixpkgs_core//extensions:repository.bzl",
+    "nix_repo",
+    dev_dependency = True,
+)
+nix_repo.github(
+    name = "nixpkgs",
+    org = "NixOS",
+    repo = "nixpkgs",
+    # nixos-unstable with Rocq 9.0.1, coq-hammer, coqutil (2026-03-06)
+    commit = "aca4d95fce4914b3892661bcb80b8087293536c6",
+    sha256 = "",  # Will be computed on first fetch
+)
+use_repo(nix_repo, "nixpkgs")
+
+# Rocq toolchain extension - uses nixpkgs for hermetic Rocq/Coq
+rocq = use_extension("//rocq:extensions.bzl", "rocq")
+rocq.toolchain(
+    version = "9.0",  # Rocq 9.0.1 (required for real RocqOfRust library)
+    strategy = "nix",   # Hermetic nix-based installation
+    with_rocq_of_rust_deps = True,  # Include coqutil, hammer, smpl
+)
+# smpl is built from source (rocq-9.0 branch) since nixpkgs only has up to Coq 8.15
+# rocq_stdlib is the separate stdlib package for Rocq 9.0
+# hammer_tactics is a separate package from hammer (plugin vs library)
+use_repo(rocq, "rocq_toolchains", "rocq_stdlib", "rocq_coqutil", "rocq_hammer", "rocq_hammer_tactics", "rocq_smpl")
+
+# Register Rocq toolchain
+register_toolchains("@rocq_toolchains//:all")
+
+# rocq-of-rust toolchain extension - translates Rust to Rocq
+rocq_of_rust = use_extension("//coq_of_rust:extensions.bzl", "rocq_of_rust")
+rocq_of_rust.toolchain(
+    # Uses pinned default: 858907dbee116c51d7c6e87511bf5f92d6432ba4
+    use_real_library = True,  # Full library with coqutil + hammer + smpl
+)
+use_repo(rocq_of_rust, "rocq_of_rust_toolchains", "rocq_of_rust_source")
+
+# Register rocq-of-rust toolchain
+register_toolchains("@rocq_of_rust_toolchains//:toolchain")

--- a/modules/rules_rocq_rust/0.1.0/presubmit.yml
+++ b/modules/rules_rocq_rust/0.1.0/presubmit.yml
@@ -1,0 +1,21 @@
+bcr_test_module:
+  module_path: "examples/rust_to_rocq"
+  matrix:
+    platform: ["ubuntu2204"]
+    bazel: ["8.x"]
+  tasks:
+    run_tests:
+      name: "Build rust_to_rocq example"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      environment:
+        # Nix installer updates ~/.profile but Buildkite CI disregards it.
+        # Cargo/rustup installed to ~/.cargo/bin.
+        PATH: /var/lib/buildkite-agent/.nix-profile/bin:/var/lib/buildkite-agent/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        # Rust nightly sysroot lib needed for linking rustc_private crates
+        LIBRARY_PATH: /var/lib/buildkite-agent/.rustup/toolchains/nightly-2024-12-07-x86_64-unknown-linux-gnu/lib
+      shell_commands:
+        - curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
+        - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2024-12-07 -c rustc-dev,rust-src,llvm-tools-preview
+      build_targets:
+        - "//:point_proofs"

--- a/modules/rules_rocq_rust/0.1.0/source.json
+++ b/modules/rules_rocq_rust/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-ZsK1CBhd0QrapFZ32OZ/2ck6vbkR07Qev1Hen2YLETw=",
+    "strip_prefix": "rules_rocq_rust-0.1.0",
+    "url": "https://github.com/pulseengine/rules_rocq_rust/archive/refs/tags/v0.1.0.tar.gz"
+}

--- a/modules/rules_rocq_rust/metadata.json
+++ b/modules/rules_rocq_rust/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/pulseengine/rules_rocq_rust",
+    "maintainers": [
+        {
+            "github": "avrabe",
+            "github_user_id": 10056645
+        }
+    ],
+    "repository": [
+        "github:pulseengine/rules_rocq_rust"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/pulseengine/rules_rocq_rust/releases/tag/v0.1.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_