### PR TITLE
diff.bzl@0.4.3

### DIFF
--- a/modules/diff.bzl/0.4.3/MODULE.bazel
+++ b/modules/diff.bzl/0.4.3/MODULE.bazel
@@ -1,0 +1,26 @@
+"Bazel dependencies"
+
+module(name = "diff.bzl",
+    version = "0.4.3",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "package_metadata", version = "0.0.6")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+
+diffutils = use_extension("//diff:extensions.bzl", "diffutils")
+diffutils.toolchain()
+use_repo(diffutils, "diffutils_toolchains")
+use_repo(diffutils, "diffutils")
+
+register_toolchains("@diffutils_toolchains//:all")
+
+########################################################
+# diff.bzl development dependencies
+########################################################
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1", dev_dependency = True)
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.6.0", dev_dependency = True)
+bazel_dep(name = "protobuf", version = "34.0.bcr.1", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)

--- a/modules/diff.bzl/0.4.3/attestations.json
+++ b/modules/diff.bzl/0.4.3/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/kormide/diff.bzl/releases/download/v0.4.3/source.json.intoto.jsonl",
+            "integrity": "sha256-kX2zPAt+7huZ7BmS2qW7E/JO3SlH5wTNVebgJpHhr0c="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/kormide/diff.bzl/releases/download/v0.4.3/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-vluafs/c8NReX6/JHBorQP7WwKMxWY0phlQQWFRpRVY="
+        },
+        "diff.bzl-v0.4.3.tar.gz": {
+            "url": "https://github.com/kormide/diff.bzl/releases/download/v0.4.3/diff.bzl-v0.4.3.tar.gz.intoto.jsonl",
+            "integrity": "sha256-BI0VojrNJ7bugyUWgyGByISeI+KTaZH9uo5tH/+auRw="
+        }
+    }
+}

--- a/modules/diff.bzl/0.4.3/patches/module_dot_bazel_version.patch
+++ b/modules/diff.bzl/0.4.3/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,9 @@
+ "Bazel dependencies"
+ 
+-module(name = "diff.bzl")
++module(name = "diff.bzl",
++    version = "0.4.3",
++)
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.8.2")
+ bazel_dep(name = "package_metadata", version = "0.0.6")
+ bazel_dep(name = "platforms", version = "1.0.0")

--- a/modules/diff.bzl/0.4.3/presubmit.yml
+++ b/modules/diff.bzl/0.4.3/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204"]
+    bazel: ["9.x", "8.x"]
+  tasks:
+    run_tests:
+      name: "Run smoke test"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/diff.bzl/0.4.3/source.json
+++ b/modules/diff.bzl/0.4.3/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-+BY/8obh9mMMQ35c3CcknGDwu+R3Yj/QRQmu+A273/c=",
+    "strip_prefix": "diff.bzl-0.4.3",
+    "docs_url": "https://github.com/kormide/diff.bzl/releases/download/v0.4.3/diff.bzl-v0.4.3.docs.tar.gz",
+    "url": "https://github.com/kormide/diff.bzl/releases/download/v0.4.3/diff.bzl-v0.4.3.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-vS42TAvHz9aa357aOXFPOuhWWEPWetXc4mQBKHAhHh0="
+    },
+    "patch_strip": 1
+}

--- a/modules/diff.bzl/metadata.json
+++ b/modules/diff.bzl/metadata.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://github.com/kormide/diff.bzl",
+    "maintainers": [
+        {
+            "name": "Derek Cormier",
+            "email": "derek.m.cormier@gmail.com",
+            "github": "kormide",
+            "github_user_id": 4948761
+        },
+        {
+            "name": "Alex Eagle",
+            "email": "alex@aspect.build",
+            "github": "alexeagle",
+            "github_user_id": 47395
+        }
+    ],
+    "repository": [
+        "github:kormide/diff.bzl"
+    ],
+    "versions": [
+        "0.4.3"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/kormide/diff.bzl/releases/tag/v0.4.3

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_