### PR TITLE
Add p4_constraints 20260311.0

### DIFF
--- a/modules/p4_constraints/20260311.0/MODULE.bazel
+++ b/modules/p4_constraints/20260311.0/MODULE.bazel
@@ -1,0 +1,22 @@
+module(
+    name = "p4_constraints",
+    version = "20260311.0",
+    bazel_compatibility = [">=7.6.0"],
+)
+
+bazel_dep(name = "abseil-cpp", version = "20260107.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "boost.multiprecision", version = "1.90.0.bcr.1")
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+bazel_dep(name = "gutil", version = "20260309.0")
+bazel_dep(name = "p4c", version = "1.2.5.11")
+bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
+bazel_dep(name = "protobuf", version = "33.5")
+bazel_dep(name = "re2", version = "2025-11-05.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "z3", version = "4.15.2")
+
+# Used by the `format.sh` script.
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = True)

--- a/modules/p4_constraints/20260311.0/presubmit.yml
+++ b/modules/p4_constraints/20260311.0/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform: ["ubuntu2204", "ubuntu2404"]
+  bazel: [7.x, 8.x, 9.x]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--cxxopt=-std=c++20"
+      - "--host_cxxopt=-std=c++20"
+    build_targets:
+      - "@p4_constraints//..."

--- a/modules/p4_constraints/20260311.0/source.json
+++ b/modules/p4_constraints/20260311.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/p4lang/p4-constraints/releases/download/20260311.0/p4-constraints-release-20260311.zip",
+    "strip_prefix": "p4-constraints-release-20260311",
+    "integrity": "sha256-U5LWbhmD9VLhs8qJcEtZpTdGhMz9hTO6k1aHP9d6Gdw="
+}

--- a/modules/p4_constraints/metadata.json
+++ b/modules/p4_constraints/metadata.json
@@ -1,0 +1,37 @@
+{
+    "homepage": "https://github.com/p4lang/p4-constraints",
+    "maintainers": [
+        {
+            "github": "smolkaj",
+            "github_user_id": 6642034,
+            "name": "Steffen Smolka"
+        },
+        {
+            "github": "verios-google",
+            "github_user_id": 110698235,
+            "name": "Victor Rios"
+        },
+        {
+            "github": "matthewtlam",
+            "github_user_id": 20864829,
+            "name": "Matthew Lam"
+        },
+        {
+            "github": "jonathan-dilorenzo",
+            "github_user_id": 2077197,
+            "name": "Jonathan DiLorenzo"
+        },
+        {
+            "github": "kheradmandG",
+            "github_user_id": 90115134,
+            "name": "Ali Kheradmand"
+        }
+    ],
+    "repository": [
+        "github:p4lang/p4-constraints"
+    ],
+    "versions": [
+        "20260311.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
## Summary

Initial BCR release of [`p4-constraints`](https://github.com/p4lang/p4-constraints), a library for specifying and enforcing constraints on P4 program objects at runtime.

- Adds module `p4_constraints` at version `20260311.0`
- Source: [GitHub release](https://github.com/p4lang/p4-constraints/releases/tag/20260311.0)
- Presubmit: builds `@p4_constraints//...` on Ubuntu 22.04/24.04 with Bazel 7.x, 8.x, 9.x

## Test plan

- [ ] BCR presubmit CI passes on all matrix entries


🤖 Generated with [Claude Code](https://claude.com/claude-code)