### PR TITLE
Add HFSM2@2.10.0

### DIFF
--- a/modules/hfsm2/2.10.0/MODULE.bazel
+++ b/modules/hfsm2/2.10.0/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "hfsm2",
+    version = "2.10.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/hfsm2/2.10.0/overlay/BUILD.bazel
+++ b/modules/hfsm2/2.10.0/overlay/BUILD.bazel
@@ -1,0 +1,40 @@
+"""Bazel build file for HFSM2 C++ library."""
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_license//rules:license.bzl", "license")
+
+package(default_applicable_licenses = [":license"])
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "LICENSE",
+)
+
+cc_library(
+    name = "hfsm2",
+    hdrs = ["include/hfsm2/machine.hpp"],
+    features = ["parse_headers"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "hfsm2_test",
+    size = "small",
+    srcs = glob([
+        "test/**/*.cpp",
+        "test/**/*.hpp",
+        "test/**/*.inl",
+    ]),
+    deps = [
+        ":doctest",
+        ":hfsm2",
+    ],
+)
+
+cc_library(
+    name = "doctest",
+    hdrs = ["external/doctest/doctest.h"],
+    includes = ["external"],
+)

--- a/modules/hfsm2/2.10.0/presubmit.yml
+++ b/modules/hfsm2/2.10.0/presubmit.yml
@@ -1,0 +1,25 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+    - rolling
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@hfsm2'
+    test_targets:
+      - '@hfsm2//:hfsm2_test'

--- a/modules/hfsm2/2.10.0/source.json
+++ b/modules/hfsm2/2.10.0/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/andrew-gresyk/HFSM2/archive/refs/tags/2.10.0.tar.gz",
+    "integrity": "sha256-njRlIf5DbAIO3/cMpkxt+aV6pOsrBu549TO5EHEK4DQ=",
+    "strip_prefix": "HFSM2-2.10.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-u53n6+nyqUeHSyRM/YhJ5hWamFJ/j+VpAx9PPuXMkMU="
+    }
+}

--- a/modules/hfsm2/metadata.json
+++ b/modules/hfsm2/metadata.json
@@ -12,7 +12,8 @@
         "github:andrew-gresyk/HFSM2"
     ],
     "versions": [
-        "2.5.1"
+        "2.5.1",
+        "2.10.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
* Updates HFSM2 to 2.10.0
* Updates rules_cc to 0.2.17
* Remove the extra MODULE file
* Adds Bazel 9.x to the presumbit