### PR TITLE
rules_dart@0.1.6

### DIFF
--- a/modules/rules_dart/0.1.6/MODULE.bazel
+++ b/modules/rules_dart/0.1.6/MODULE.bazel
@@ -1,0 +1,66 @@
+"Bazel dependencies"
+
+module(
+    name = "rules_dart",
+
+    # NOTE:
+    # version = "0.1.6",
+    #
+    # Always leave version unset or set to "" (the default). The default value
+    # can prevent issues when the module is used via non-registry overrides
+    # (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).
+    #
+    # The publish.yaml GitHub Action sets the version in the registry to the
+    # release version by patching this MODULE.bazel file in the pull request to
+    # the BCR.
+    #
+    # For more info, see this Slack thread:
+    # https://bazelbuild.slack.com/archives/CA31HN1T3/p1750406404452179
+
+    # NOTE:
+    # compatibility_level = 0,
+    #
+    # Bumping compatibility_level too frequently is discouraged because it's
+    # very disruptive: as soon as a module is requested at two different
+    # compatibility levels in the dependency tree, users will see an error.
+    #
+    # As such, the compatibility_level (1) should be bumped *only* when the
+    # breaking change affects most use cases and isn't easy to migrate and/or
+    # work-around, and (2) *in the same commit* that introduces an incompatible
+    # (breaking) change.
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "package_metadata", version = "0.0.7")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# The Gazelle plugin at //gazelle/dart is a go_library, so its BUILD file
+# loads @io_bazel_rules_go//go:def.bzl. In bzlmod, BUILD files are evaluated
+# in the context of their owning module — so rules_go must be a regular (not
+# dev) dependency for the plugin to be loadable from downstream modules.
+# The Go SDK and toolchain are only fetched if a target in //gazelle/... is
+# actually built; they are not downloaded for normal Dart-only usage.
+bazel_dep(name = "gazelle", version = "0.47.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "io_bazel_rules_go")
+
+bazel_dep(name = "rules_multitool", version = "1.11.1", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.6.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependency = True)
+bazel_dep(name = "bazel_lib", version = "3.2.2", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1", dev_dependency = True)
+
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.9.2")
+
+dart = use_extension("//dart:extensions.bzl", "dart")
+dart.toolchain(dart_version = "3.11.2")
+use_repo(dart, "dart_toolchains")
+
+register_toolchains("@dart_toolchains//:all")
+
+multitool = use_extension(
+    "@rules_multitool//multitool:extension.bzl",
+    "multitool",
+    dev_dependency = True,
+)
+multitool.hub(lockfile = "//:multitool.lock.json")
+use_repo(multitool, "multitool")

--- a/modules/rules_dart/0.1.6/attestations.json
+++ b/modules/rules_dart/0.1.6/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/aran/rules_dart/releases/download/v0.1.6/source.json.intoto.jsonl",
+            "integrity": "sha256-7SjFCNO2z9JcJRXtFqCyzvjSsmWOSOQpkYQI1SLgmwY="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/aran/rules_dart/releases/download/v0.1.6/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-SaViZLClQ2IqvJToMt6bC02rqDA/VN/cU2Lk62pY2I0="
+        },
+        "rules_dart-v0.1.6.tar.gz": {
+            "url": "https://github.com/aran/rules_dart/releases/download/v0.1.6/rules_dart-v0.1.6.tar.gz.intoto.jsonl",
+            "integrity": "sha256-HGrgq+1OUg43XikvJ+wDu8JBiYlH/idLXbWHUTPeFeI="
+        }
+    }
+}

--- a/modules/rules_dart/0.1.6/patches/module_dot_bazel_version.patch
+++ b/modules/rules_dart/0.1.6/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -3,9 +3,9 @@
+ module(
+     name = "rules_dart",
+ 
+     # NOTE:
+-    # version = "",
++    # version = "0.1.6",
+     #
+     # Always leave version unset or set to "" (the default). The default value
+     # can prevent issues when the module is used via non-registry overrides
+     # (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).

--- a/modules/rules_dart/0.1.6/presubmit.yml
+++ b/modules/rules_dart/0.1.6/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204", "windows"]
+    bazel: ["9.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_dart/0.1.6/source.json
+++ b/modules/rules_dart/0.1.6/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-VtpYNYbFZqLFNAoPPnPsEACXoQ7bpRPtUyYGfBcFWBg=",
+    "strip_prefix": "rules_dart-0.1.6",
+    "url": "https://github.com/aran/rules_dart/releases/download/v0.1.6/rules_dart-v0.1.6.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-WQBEqg+8T8FRqV23leEaA4kOD5t3mwwKMohooKxeQ0M="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_dart/metadata.json
+++ b/modules/rules_dart/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/aran/rules_dart",
+    "maintainers": [
+        {
+            "email": "aran.donohue@gmail.com",
+            "github": "aran",
+            "name": "Aran Donohue",
+            "github_user_id": 5295
+        }
+    ],
+    "repository": [
+        "github:aran/rules_dart"
+    ],
+    "versions": [
+        "0.1.6"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/aran/rules_dart/releases/tag/v0.1.6

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_