### PR TITLE
add wayland @1.24.0.bcr.1

### DIFF
--- a/modules/wayland/1.24.0.bcr.1/MODULE.bazel
+++ b/modules/wayland/1.24.0.bcr.1/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "wayland",
+    version = "1.24.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "libexpat", version = "2.7.1.bcr.1")
+bazel_dep(name = "libffi", version = "3.4.7.bcr.3")
+bazel_dep(name = "rules_autoconf", version = "0.0.16")
+bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/modules/wayland/1.24.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/wayland/1.24.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,154 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+UPSTREAM_VERSION = module_version().split(".bcr.", 1)[0]
+
+UPSTREAM_VERSION_MAJOR = UPSTREAM_VERSION.split(".")[0]
+
+UPSTREAM_VERSION_MINOR = UPSTREAM_VERSION.split(".")[1]
+
+UPSTREAM_VERSION_PATCH = UPSTREAM_VERSION.split(".")[2]
+
+cc_library(
+    name = "config",
+    hdrs = ["config.h"],
+    deps = ["@rules_autoconf//:config"],
+)
+
+cc_binary(
+    name = "wayland_scanner",
+    srcs = [
+        "src/scanner.c",
+        "src/wayland-util.c",
+        ":wayland_version_h",
+    ] + glob(["src/*.h"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config",
+        "@libexpat",
+    ],
+)
+
+filegroup(
+    name = "wayland_core_protocol",
+    srcs = ["protocol/wayland.xml"],
+)
+
+expand_template(
+    name = "wayland_version_h",
+    out = "wayland-version.h",
+    substitutions = {
+        "@WAYLAND_VERSION_MAJOR@": UPSTREAM_VERSION_MAJOR,
+        "@WAYLAND_VERSION_MINOR@": UPSTREAM_VERSION_MINOR,
+        "@WAYLAND_VERSION_MICRO@": UPSTREAM_VERSION_PATCH,
+        "@WAYLAND_VERSION@": UPSTREAM_VERSION,
+    },
+    template = "src/wayland-version.h.in",
+)
+
+genrule(
+    name = "wayland_core_protocol_sources_static",
+    srcs = [":wayland_core_protocol"],
+    outs = ["wayland-protocol.c"],
+    cmd = "$(location :wayland_scanner) -s public-code < $(location :wayland_core_protocol) > $(location wayland-protocol.c)",
+    tools = [":wayland_scanner"],
+)
+
+genrule(
+    name = "wayland_core_server_protocol_headers",
+    srcs = [":wayland_core_protocol"],
+    outs = ["wayland-server-protocol.h"],
+    cmd = "$(location :wayland_scanner) -s server-header < $(location :wayland_core_protocol) > $(location wayland-server-protocol.h)",
+    tools = [":wayland_scanner"],
+)
+
+genrule(
+    name = "wayland_core_client_protocol_headers",
+    srcs = [":wayland_core_protocol"],
+    outs = ["wayland-client-protocol.h"],
+    cmd = "$(location :wayland_scanner) -s client-header < $(location :wayland_core_protocol) > $(location wayland-client-protocol.h)",
+    tools = [":wayland_scanner"],
+)
+
+cc_library(
+    name = "wayland_server",
+    srcs = [
+        "src/connection.c",
+        "src/event-loop.c",
+        "src/wayland-os.c",
+        "src/wayland-server.c",
+        "src/wayland-shm.c",
+        "src/wayland-util.c",
+        ":wayland_core_protocol_sources_static",
+    ],
+    hdrs = [
+        ":wayland_core_client_protocol_headers",
+        ":wayland_core_server_protocol_headers",
+        ":wayland_version_h",
+    ] + glob(["src/*.h"]),
+    copts = ["-Wno-unused-variable"],
+    includes = [
+        "src",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config",
+        "@libffi",
+    ],
+)
+
+cc_library(
+    name = "wayland_client",
+    srcs = [
+        "src/connection.c",
+        "src/wayland-client.c",
+        "src/wayland-os.c",
+        "src/wayland-util.c",
+        ":wayland_core_protocol_sources_static",
+    ],
+    hdrs = [
+        ":wayland_core_client_protocol_headers",
+        ":wayland_version_h",
+    ] + glob(["src/*.h"]),
+    includes = [
+        "src",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config",
+        "@libffi",
+    ],
+)
+
+cc_library(
+    name = "wayland_cursor",
+    srcs = [
+        "cursor/cursor-data.h",
+        "cursor/os-compatibility.c",
+        "cursor/os-compatibility.h",
+        "cursor/wayland-cursor.c",
+        "cursor/xcursor.c",
+        "cursor/xcursor.h",
+    ],
+    hdrs = ["cursor/wayland-cursor.h"],
+    includes = ["cursor"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config",
+        ":wayland_client",
+    ],
+)
+
+cc_library(
+    name = "wayland_egl",
+    srcs = ["egl/wayland-egl.c"],
+    hdrs = [
+        "egl/wayland-egl.h",
+        "egl/wayland-egl-backend.h",
+        "egl/wayland-egl-core.h",
+    ],
+    includes = ["egl"],
+    visibility = ["//visibility:public"],
+    deps = [":wayland_client"],
+)

--- a/modules/wayland/1.24.0.bcr.1/overlay/config.h
+++ b/modules/wayland/1.24.0.bcr.1/overlay/config.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <rules_autoconf/config.h>
+
+#ifndef HAVE_ACCEPT4
+#define HAVE_ACCEPT4 1
+#endif
+
+#ifndef HAVE_STRNDUP
+#define HAVE_STRNDUP 1
+#endif

--- a/modules/wayland/1.24.0.bcr.1/overlay/tests/BUILD.bazel
+++ b/modules/wayland/1.24.0.bcr.1/overlay/tests/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_library(
+    name = "wayland_test_runner",
+    srcs = [
+        "test-helpers.c",
+        "test-runner.c",
+    ],
+    hdrs = ["test-runner.h"],
+    deps = ["@wayland//:wayland_server"],
+)
+
+[
+    cc_test(
+        name = test_name,
+        srcs = ["{}.c".format(test_name)],
+        deps = [":wayland_test_runner"],
+    )
+    for test_name in [
+        "array-test",
+        "fixed-test",
+        "interface-test",
+        "list-test",
+        "map-test",
+        "message-test",
+    ]
+]
+
+cc_test(
+    name = "enum-validator-test",
+    srcs = [
+        "data/small-server-core.h",
+        "enum-validator-test.c",
+    ],
+    deps = ["@wayland//:wayland_server"],
+)

--- a/modules/wayland/1.24.0.bcr.1/overlay/tests/MODULE.bazel
+++ b/modules/wayland/1.24.0.bcr.1/overlay/tests/MODULE.bazel
@@ -1,0 +1,7 @@
+bazel_dep(name = "wayland")
+local_path_override(
+    module_name = "wayland",
+    path = "..",
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/modules/wayland/1.24.0.bcr.1/presubmit.yml
+++ b/modules/wayland/1.24.0.bcr.1/presubmit.yml
@@ -1,0 +1,34 @@
+matrix:
+  platform:
+  - debian13
+  - ubuntu2204
+  - ubuntu2404
+  bazel: [7.x, 8.x, 9.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@wayland//:wayland_client'
+      - '@wayland//:wayland_cursor'
+      - '@wayland//:wayland_egl'
+      - '@wayland//:wayland_server'
+
+bcr_test_module:
+  module_path: tests
+  matrix:
+    platform:
+    - debian13
+    - ubuntu2204
+    - ubuntu2404
+    bazel: [7.x, 8.x, 9.x, rolling]
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - //...
+      test_targets:
+        - //...

--- a/modules/wayland/1.24.0.bcr.1/source.json
+++ b/modules/wayland/1.24.0.bcr.1/source.json
@@ -1,0 +1,14 @@
+{
+    "integrity": "sha256-eACFiER1H8cRPX3zZ43GtYsmoFYXamXEmgWXYwRb/9U=",
+    "strip_prefix": "wayland-1.24.0",
+    "url": "https://gitlab.freedesktop.org/wayland/wayland/-/archive/1.24.0/wayland-1.24.0.tar.gz",
+    "mirror_urls": [
+        "https://github.com/wep21/wayland/archive/refs/tags/1.24.0.tar.gz"
+    ],
+    "overlay": {
+        "BUILD.bazel": "sha256-RjHH5MrCqK56J/Zi/qq2dnYTctJgDrERjoWN2deSH0E=",
+        "config.h": "sha256-PLZEgm9GkpWqw/BcsBi+H2b3kbMvAWvymUSjycTfEEE=",
+        "tests/BUILD.bazel": "sha256-5SpmaxXuw/6K9RXotgIwvyj8CfonK25QlTQVQNuumWE=",
+        "tests/MODULE.bazel": "sha256-0DfKr1Zl5UJvKlbypoAzEfScqHaWG8aNyOO70SasVZ8="
+    }
+}

--- a/modules/wayland/metadata.json
+++ b/modules/wayland/metadata.json
@@ -12,7 +12,8 @@
         "https://gitlab.freedesktop.org/wayland/wayland"
     ],
     "versions": [
-        "1.24.0"
+        "1.24.0",
+        "1.24.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Removing `src/event-loop.c` from the `wayland_client` target in the overlay. That source references `wl_priv_signal_*`, which is implemented in `wayland-server.c`, so including it in the client library left `@wayland//:wayland_client` with unresolved server-side symbols.

https://gitlab.freedesktop.org/wayland/wayland/-/blob/1.24.0/src/meson.build#L181

```
$ git diff --no-index -- \
  modules/wayland/1.24.0/overlay/BUILD.bazel \
  modules/wayland/1.24.0.bcr.1/overlay/BUILD.bazel
diff --git a/modules/wayland/1.24.0/overlay/BUILD.bazel b/modules/wayland/1.24.0.bcr.1/overlay/BUILD.bazel
index 44635f1d1..68cc3d8a6 100644
--- a/modules/wayland/1.24.0/overlay/BUILD.bazel
+++ b/modules/wayland/1.24.0.bcr.1/overlay/BUILD.bazel
@@ -102,7 +102,6 @@ cc_library(
     name = "wayland_client",
     srcs = [
         "src/connection.c",
-        "src/event-loop.c",
         "src/wayland-client.c",
         "src/wayland-os.c",
         "src/wayland-util.c",
```