### PR TITLE
jsonnet_go v0.22.0-rc1

### DIFF
--- a/modules/jsonnet_go/0.22.0-rc1/MODULE.bazel
+++ b/modules/jsonnet_go/0.22.0-rc1/MODULE.bazel
@@ -1,0 +1,52 @@
+module(name = "jsonnet_go", version = "0.22.0-rc1")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# NB: update_cpp_jsonnet.sh looks for these.
+CPP_JSONNET_SHA256 = "0bbba601b86357eb75ea88145d69e95f1fe3738573b7bec782c52b0672b97ec0"
+
+CPP_JSONNET_GITHASH = "1b19a3578c268d3967a5f5b16925970c72fbc528"
+
+CPP_JSONNET_RELEASE_VERSION = "v0.22.0-rc1"
+
+CPP_JSONNET_STRIP_PREFIX = (
+    "jsonnet-" + (
+        CPP_JSONNET_RELEASE_VERSION if CPP_JSONNET_RELEASE_VERSION else CPP_JSONNET_GITHASH
+    )
+)
+
+CPP_JSONNET_URL = (
+    "https://github.com/google/jsonnet/releases/download/%s/jsonnet-%s.tar.gz" % (
+        CPP_JSONNET_RELEASE_VERSION,
+        CPP_JSONNET_RELEASE_VERSION,
+    ) if CPP_JSONNET_RELEASE_VERSION else "https://github.com/google/jsonnet/archive/%s.tar.gz" % CPP_JSONNET_GITHASH
+)
+
+# We don't use a normal bazel_dep reference for the cpp_jsonnet module,
+# because we want to pin to the specific jsonnet commit (which might not
+# even exactly match a released version).
+http_archive(
+    name = "cpp_jsonnet",
+    sha256 = CPP_JSONNET_SHA256,
+    strip_prefix = CPP_JSONNET_STRIP_PREFIX,
+    urls = [CPP_JSONNET_URL],
+)
+
+bazel_dep(name = "gazelle", version = "0.47.0")
+bazel_dep(name = "rules_go", version = "0.59.0")
+
+# rules_cc is needed, because we pull in cpp_jsonnet Bazel module to get the standard library.
+bazel_dep(name = "rules_cc", version = "0.2.14")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.from_file(go_mod = "//:go.mod")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_fatih_color",
+    "com_github_sergi_go_diff",
+    "io_k8s_sigs_yaml",
+    "org_golang_x_crypto",
+)

--- a/modules/jsonnet_go/0.22.0-rc1/patches/module_dot_bazel.patch
+++ b/modules/jsonnet_go/0.22.0-rc1/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,4 +1,4 @@
+-module(name = "jsonnet_go")
++module(name = "jsonnet_go", version = "0.22.0-rc1")
+ 
+ http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+ 

--- a/modules/jsonnet_go/0.22.0-rc1/presubmit.yml
+++ b/modules/jsonnet_go/0.22.0-rc1/presubmit.yml
@@ -1,0 +1,37 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@jsonnet_go//...'
+bcr_test_module:
+  module_path: examples/bazel
+  matrix:
+    platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    bazel:
+    - 9.x
+    - 8.x
+    - 7.x
+  tasks:
+    run_test_module:
+      name: Build example module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - '//:use_go_jsonnet_lib'
+        - '//:use_go_jsonnet'

--- a/modules/jsonnet_go/0.22.0-rc1/source.json
+++ b/modules/jsonnet_go/0.22.0-rc1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/google/go-jsonnet/releases/download/v0.22.0-rc1/go-jsonnet-v0.22.0-rc1.tar.gz",
+    "integrity": "sha256-cPIuhBcCPZnGCFjVlt4IdocQWPXNuSjJvito8lssSZU=",
+    "strip_prefix": "go-jsonnet-v0.22.0-rc1",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-gEppm92sR482Gk3niJdJU2uTllXy/MnLRUeQkthD1NU="
+    }
+}

--- a/modules/jsonnet_go/metadata.json
+++ b/modules/jsonnet_go/metadata.json
@@ -3,9 +3,9 @@
     "maintainers": [
         {
             "email": "jpa.bartholomew@gmail.com",
-            "name": "John Bartholomew",
             "github": "johnbartholomew",
-            "github_user_id": 115749
+            "github_user_id": 115749,
+            "name": "John Bartholomew"
         }
     ],
     "repository": [
@@ -14,7 +14,8 @@
     "versions": [
         "0.20.0",
         "0.21.0-rc2",
-        "0.21.0"
+        "0.21.0",
+        "0.22.0-rc1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
https://github.com/google/go-jsonnet/releases/tag/v0.22.0-rc1

`MODULE.bazel` patch just sets the module version. I removed the explicit version from upstream because of course the master branch isn't really _at_ any particular version... maybe I'll set up release branches or change the way I tag things at some point to include explicit version on the tagged release commits.

(This is Go Jsonnet, the C++ Jsonnet BCR update is at #7928)