### PR TITLE
rules_dart@0.1.9

### DIFF
--- a/modules/rules_dart/0.1.9/MODULE.bazel
+++ b/modules/rules_dart/0.1.9/MODULE.bazel
@@ -1,0 +1,52 @@
+"Bazel dependencies"
+
+# NOTE: The version field is intentionally omitted. Leaving it unset (the
+# default "") prevents issues when the module is used via non-registry
+# overrides (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).
+# The publish-to-bcr GitHub Action patches in the release version when
+# submitting to the Bazel Central Registry.
+#
+# NOTE: compatibility_level is omitted (defaults to 0). Bumping it is very
+# disruptive — as soon as a module is requested at two different compatibility
+# levels in the dependency tree, users see an error. Only bump it when the
+# breaking change affects most use cases and isn't easy to work around, and
+# in the same commit that introduces the incompatible change.
+module(
+    name = "rules_dart",
+    version = "0.1.9",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "package_metadata", version = "0.0.7")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# The Gazelle plugin at //gazelle/dart is a go_library, so its BUILD file
+# loads @io_bazel_rules_go//go:def.bzl. In bzlmod, BUILD files are evaluated
+# in the context of their owning module — so rules_go must be a regular (not
+# dev) dependency for the plugin to be loadable from downstream modules.
+# The Go SDK and toolchain are only fetched if a target in //gazelle/... is
+# actually built; they are not downloaded for normal Dart-only usage.
+bazel_dep(name = "gazelle", version = "0.47.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "io_bazel_rules_go")
+
+bazel_dep(name = "rules_multitool", version = "1.11.1", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.6.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependency = True)
+bazel_dep(name = "bazel_lib", version = "3.2.2", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1", dev_dependency = True)
+
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.9.2")
+
+dart = use_extension("//dart:extensions.bzl", "dart")
+dart.toolchain(dart_version = "3.11.2")
+use_repo(dart, "dart_toolchains")
+
+register_toolchains("@dart_toolchains//:all")
+
+multitool = use_extension(
+    "@rules_multitool//multitool:extension.bzl",
+    "multitool",
+    dev_dependency = True,
+)
+multitool.hub(lockfile = "//:multitool.lock.json")
+use_repo(multitool, "multitool")

--- a/modules/rules_dart/0.1.9/attestations.json
+++ b/modules/rules_dart/0.1.9/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/aran/rules_dart/releases/download/v0.1.9/source.json.intoto.jsonl",
+            "integrity": "sha256-5llz/ybhOWcpO30rY570VfLP2HAvZ/wS9VwTrwr5vDc="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/aran/rules_dart/releases/download/v0.1.9/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-P7BED9yO0oE5rZ3mRv11eh3sbsLKe63MIU1c59HHK30="
+        },
+        "rules_dart-v0.1.9.tar.gz": {
+            "url": "https://github.com/aran/rules_dart/releases/download/v0.1.9/rules_dart-v0.1.9.tar.gz.intoto.jsonl",
+            "integrity": "sha256-PGH+o/WRmXTo12hVPFVjhOm5h/66PthlECpIsEi5iAs="
+        }
+    }
+}

--- a/modules/rules_dart/0.1.9/patches/module_dot_bazel_version.patch
+++ b/modules/rules_dart/0.1.9/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -12,8 +12,9 @@
+ # breaking change affects most use cases and isn't easy to work around, and
+ # in the same commit that introduces the incompatible change.
+ module(
+     name = "rules_dart",
++    version = "0.1.9",
+ )
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.9.0")
+ bazel_dep(name = "package_metadata", version = "0.0.7")

--- a/modules/rules_dart/0.1.9/presubmit.yml
+++ b/modules/rules_dart/0.1.9/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204", "windows"]
+    bazel: ["9.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_dart/0.1.9/source.json
+++ b/modules/rules_dart/0.1.9/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-Lb60MxYZSU9Pcfmbwww8OHveXM/vAuHJU9OMrIebJxM=",
+    "strip_prefix": "rules_dart-0.1.9",
+    "url": "https://github.com/aran/rules_dart/releases/download/v0.1.9/rules_dart-v0.1.9.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-HL4S0B+5wuU92TsN7Ep/nQSaNQ9InxlcilUPwvj/Rbg="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_dart/metadata.json
+++ b/modules/rules_dart/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/aran/rules_dart",
+    "maintainers": [
+        {
+            "email": "aran.donohue@gmail.com",
+            "github": "aran",
+            "name": "Aran Donohue",
+            "github_user_id": 5295
+        }
+    ],
+    "repository": [
+        "github:aran/rules_dart"
+    ],
+    "versions": [
+        "0.1.9"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/aran/rules_dart/releases/tag/v0.1.9

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_