### PR TITLE
Add open62541@1.4.16

### DIFF
--- a/modules/open62541/1.4.16/MODULE.bazel
+++ b/modules/open62541/1.4.16/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "open62541",
+    version = "1.4.16",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "openssl", version = "3.5.5.bcr.1")
+bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/open62541/1.4.16/overlay/BUILD.bazel
+++ b/modules/open62541/1.4.16/overlay/BUILD.bazel
@@ -1,0 +1,332 @@
+#open62541 - open source OPC UA implementation
+
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load(":open62541.bzl", "generate_config_h", "generate_datatypes", "generate_nodeset")
+
+package(
+    # open62541 has **many** circular header dependencies, including some
+    # required for codegen steps. We disable layering check for now. Upstream
+    # is making improvements to this situation, so we can likely add the check
+    # back in the future.
+    features = ["-layering_check"],
+)
+
+licenses(["reciprocal"])
+
+exports_files(["LICENSE"])
+
+OPEN62541_HEADERS = glob([
+    "include/**/*.h",
+    "plugins/include/open62541/plugin/historydata/*.h",
+]) + [
+    "include/open62541/statuscodes.h",
+    "plugins/crypto/openssl/securitypolicy_openssl_common.h",
+    "plugins/crypto/openssl/ua_openssl_version_abstraction.h",
+    "plugins/include/open62541/client_config_default.h",
+    "plugins/include/open62541/plugin/accesscontrol_default.h",
+    "plugins/include/open62541/plugin/create_certificate.h",
+    "plugins/include/open62541/plugin/log_stdout.h",
+    "plugins/include/open62541/plugin/nodestore_default.h",
+    "plugins/include/open62541/plugin/pki_default.h",
+    "plugins/include/open62541/plugin/securitypolicy_default.h",
+    "plugins/include/open62541/server_config_default.h",
+]
+
+# Public entrypoint to open62541. Depend on this target.
+cc_library(
+    name = "open62541",
+    hdrs = [":nodeid_header"] + OPEN62541_HEADERS,
+    features = [
+        "-parse_headers",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":common",
+        ":open62541_impl",
+        ":types",
+    ],
+)
+
+cc_library(
+    name = "open62541_impl",
+    srcs = glob(
+        [
+            "src/**/*.c",
+            "src/**/*.h",
+            "src/*.h",
+            "plugins/crypto/openssl/*.c",
+            "plugins/historydata/*.c",
+            "arch/eventloop*",
+        ],
+        exclude = [
+            "src/pubsub/**/*.c",
+            "src/ua_types_encoding_xml.*",
+            "arch/eventloop_mqtt.c",
+        ],
+    ) + [
+        "arch/common/ua_timer.c",
+        "arch/common/ua_timer.h",
+        "arch/posix/ua_clock.c",
+        "include/open62541/statuscodes.c",
+        "plugins/crypto/ua_pki_none.c",
+        "plugins/crypto/ua_securitypolicy_none.c",
+        "plugins/ua_accesscontrol_default.c",
+        "plugins/ua_config_default.c",
+        "plugins/ua_log_stdout.c",
+        "plugins/ua_nodestore_hashmap.c",
+        ":namespace0",
+    ],
+    hdrs = OPEN62541_HEADERS,
+    copts = [
+        "-Iplugins/crypto/openssl",
+        "-Isrc/util",
+        "-Isrc/server",
+        "-Isrc/client",
+        "-Isrc",
+        "-Ideps",
+        "-Isrc/pubsub",
+        "-Iplugins/include",
+        "-Wno-unused-variable",
+        "-Wno-incompatible-pointer-types",
+        "-Wno-missing-braces",
+        "-Wno-vla",
+        "-Wno-macro-redefined",
+        "-DHAVE_CONFIG_H",
+    ],
+    features = [
+        "-parse_headers",
+    ],
+    includes = [
+        "include",
+        "plugins/include",
+        # These should all be -Idir copts, but we can't represent that in a way that's compatible with cross-repo dependencies. See https://github.com/bazelbuild/bazel/pull/23518.
+        "src/util",
+        "src/server",
+        "src/client",
+        "src",
+        "deps",
+        "src/pubsub",
+        "plugins/include",
+    ],
+    deps = [
+        ":base64",
+        ":common",
+        ":cj5",
+        ":itoa",
+        ":libc_time",
+        ":mp_printf",
+        ":open62541_queue",
+        ":parse_num",
+        ":pcg_basic",
+        ":transport",
+        ":types",
+        ":ziptree",
+        "@openssl//:crypto",
+    ],
+)
+
+# Generates a header containing node IDs.
+genrule(
+    name = "nodeid_header",
+    srcs = ["//:tools/schema/NodeIds.csv"],
+    outs = ["include/open62541/nodeids.h"],
+    cmd = "./$(location //:generate_nodeid_header) $< $(RULEDIR)/include/open62541/nodeids NS0",
+    tools = ["//:generate_nodeid_header"],
+)
+
+# Generates config.h
+generate_config_h(
+    name = "config_h",
+    output_path = "include/open62541/config.h",
+    version = module_version(),
+)
+
+# Contains common dependencies required for subsequent codegen steps.
+cc_library(
+    name = "common",
+    hdrs = [
+        "arch/posix/ua_architecture.h",
+        "include/open62541/common.h",
+        ":config_h",
+        ":include/open62541/nodeids.h",
+    ],
+    copts = [
+        "-DHAVE_CONFIG_H",
+    ],
+    defines = [
+        "UA_ARCHITECTURE_POSIX",
+    ],
+    features = [
+        "-parse_headers",
+    ],
+    includes = [
+        "arch",
+        "include",
+    ],
+)
+
+generate_datatypes(
+    name = "types",
+    builtin = True,
+    file_csv = "//:tools/schema/NodeIds.csv",
+    files_bsd = ["//:tools/schema/Opc.Ua.Types.bsd"],
+    prefix = "include/open62541",
+    visibility = ["//visibility:public"],
+)
+
+generate_datatypes(
+    name = "transport",
+    builtin = True,
+    file_csv = "//:tools/schema/NodeIds.csv",
+    files_bsd = ["//:tools/schema/Custom.Opc.Ua.Transport.bsd"],
+    files_selected = "//:tools/schema/datatypes_transport.txt",
+    prefix = "include/open62541",
+    deps = [":types"],
+    visibility = ["//visibility:public"],
+)
+
+generate_nodeset(
+    name = "namespace0",
+    files = [
+        # Note that this list is ordering-dependent!
+        "//:tools/schema/Opc.Ua.NodeSet2.Reduced.xml",
+        "//:tools/schema/Opc.Ua.NodeSet2.DiagnosticsMinimal.xml",
+        "//:tools/schema/Opc.Ua.NodeSet2.EventsMinimal.xml",
+        "//:tools/schema/Opc.Ua.NodeSet2.HistorizingMinimal.xml",
+        "//:tools/schema/Opc.Ua.NodeSet2.PubSubMinimal.xml",
+        "//:tools/schema/Opc.Ua.NodeSet2.Part8_Subset.xml",
+    ],
+    ignore = "//:tools/nodeset_compiler/NodeID_NS0_Base.txt",
+    internal = True,
+    prefix = "include/open62541",
+)
+
+cc_library(
+    name = "statuscodes",
+    hdrs = [":include/open62541/statuscodes.h"],
+    deps = [":common"],
+)
+
+genrule(
+    name = "statuscodes_gen",
+    srcs = ["//:tools/schema/StatusCode.csv"],
+    outs = [
+        "include/open62541/statuscodes.h",
+        "include/open62541/statuscodes.c",
+    ],
+    cmd = "./$(location //:generate_statuscode_descriptions) $< $(RULEDIR)/include/open62541/statuscodes",
+    tools = ["//:generate_statuscode_descriptions"],
+)
+
+cc_library(
+    name = "ziptree",
+    srcs = ["deps/ziptree.c"],
+    hdrs = ["deps/ziptree.h"],
+    includes = ["deps"],
+)
+
+cc_library(
+    name = "pcg_basic",
+    srcs = ["deps/pcg_basic.c"],
+    hdrs = ["deps/pcg_basic.h"],
+    includes = ["deps"],
+    deps = [":common"],
+)
+
+cc_library(
+    name = "libc_time",
+    srcs = ["deps/libc_time.c"],
+    hdrs = ["deps/libc_time.h"],
+    includes = ["deps"],
+)
+
+cc_library(
+    name = "base64",
+    srcs = ["deps/base64.c"],
+    hdrs = ["deps/base64.h"],
+    includes = ["deps"],
+    deps = [
+        ":common",
+        ":types",
+    ],
+)
+
+cc_library(
+    name = "parse_num",
+    srcs = ["deps/parse_num.c"],
+    hdrs = ["deps/parse_num.h"],
+    includes = ["deps"],
+)
+
+cc_library(
+    name = "mp_printf",
+    srcs = ["deps/mp_printf.c"],
+    hdrs = ["deps/mp_printf.h"],
+    includes = ["deps"],
+    deps = [":dtoa"],
+)
+
+cc_library(
+    name = "dtoa",
+    srcs = ["deps/dtoa.c"],
+    hdrs = ["deps/dtoa.h"],
+    includes = ["deps"],
+)
+
+cc_library(
+    name = "itoa",
+    srcs = ["deps/itoa.c"],
+    hdrs = ["deps/itoa.h"],
+    includes = ["deps"],
+    deps = [":types"],
+)
+
+cc_library(
+    name = "cj5",
+    srcs = ["deps/cj5.c"],
+    hdrs = ["deps/cj5.h"],
+    includes = ["deps"],
+    deps = [":parse_num"],
+)
+
+cc_library(
+    name = "open62541_queue",
+    hdrs = ["deps/open62541_queue.h"],
+)
+
+py_binary(
+    name = "generate_datatypes",
+    srcs = [
+        "tools/generate_datatypes.py",
+    ],
+    main = "tools/generate_datatypes.py",
+    deps = [":nodeset_compiler_lib"],
+)
+
+py_binary(
+    name = "generate_nodeid_header",
+    srcs = ["tools/generate_nodeid_header.py"],
+)
+
+py_library(
+    name = "nodeset_compiler_lib",
+    srcs = glob(
+        ["tools/nodeset_compiler/*.py"],
+        exclude = ["tools/nodeset_compiler/nodeset_compiler.py"],
+    ),
+    imports = ["tools", "tools/nodeset_compiler"],
+)
+
+py_binary(
+    name = "nodeset_compiler",
+    srcs = ["tools/nodeset_compiler/nodeset_compiler.py"],
+    main = "tools/nodeset_compiler/nodeset_compiler.py",
+    deps = [":nodeset_compiler_lib"],
+)
+
+py_binary(
+    name = "generate_statuscode_descriptions",
+    srcs = ["tools/generate_statuscode_descriptions.py"],
+)

--- a/modules/open62541/1.4.16/overlay/open62541.bzl
+++ b/modules/open62541/1.4.16/overlay/open62541.bzl
@@ -1,0 +1,247 @@
+"""Code generation tools for open62541."""
+
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+
+def _generate_nodeset_impl(ctx):
+    gen_args = ctx.actions.args()
+    if ctx.attr.internal:
+        gen_args.add("--internal-headers")
+
+    if ctx.file.ignore:
+        gen_args.add("--ignore", ctx.file.ignore.path)
+
+    if ctx.file.blacklist:
+        gen_args.add("--blacklist", ctx.file.blacklist.path)
+
+    file_suffix = ctx.label.name + "_generated"
+    c_file = ctx.actions.declare_file(ctx.attr.prefix + "/" + file_suffix + ".c")
+    h_file = ctx.actions.declare_file(ctx.attr.prefix + "/" + file_suffix + ".h")
+
+    gen_args.add_all(ctx.files.files, format_each = "--xml=%s")
+    gen_args.add(c_file.dirname + "/" + file_suffix)
+
+    all_inputs = depset(ctx.files.files + [ctx.file.ignore])
+
+    ctx.actions.run(
+        executable = ctx.executable._generate_nodeset,
+        outputs = [h_file, c_file],
+        inputs = all_inputs,
+        arguments = [gen_args],
+    )
+
+    return DefaultInfo(files = depset([c_file, h_file]))
+
+generate_nodeset = rule(
+    doc = "Generates C code for given Nodeset XML files.",
+    implementation = _generate_nodeset_impl,
+    attrs = {
+        "files": attr.label_list(allow_files = True),
+        "prefix": attr.string(),
+        "blacklist": attr.label(allow_single_file = True),
+        "ignore": attr.label(allow_single_file = True),
+        "internal": attr.bool(),
+        "_generate_nodeset": attr.label(executable = True, default = "@open62541//:nodeset_compiler", cfg = "exec"),
+    },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    fragments = ["cpp"],
+)
+
+def _generate_config_h_impl(ctx):
+    output_file = ctx.actions.declare_file(ctx.attr.output_path)
+
+    # First collect all the substitutions we'd like to make to generate the config.h file.
+    unordered_substitutions = {
+        "${OPEN62541_VER_MAJOR}": ctx.attr.version.split(".")[0],
+        "${OPEN62541_VER_MINOR}": ctx.attr.version.split(".")[1],
+        "${OPEN62541_VER_PATCH}": ctx.attr.version.split(".")[2],
+        "${OPEN62541_VER_LABEL}": "",
+        "${OPEN62541_VER_COMMIT}": "",
+        "${OPEN62541_VERSION}": ctx.attr.version + "-bazel",
+        "#cmakedefine UA_ARCHITECTURE_WIN32": "#undef UA_ARCHITECTURE_WIN32",
+        "#cmakedefine UA_ARCHITECTURE_POSIX": "#define UA_ARCHITECTURE_POSIX 1",
+        "${UA_LOGLEVEL}": "300",
+        "${UA_MULTITHREADING}": "0",
+        "${UA_ARCHITECTURES_NODEF}": "0",
+        "${UA_ARCHITECTURE}": "posix",
+        "${UA_VALGRIND_INTERACTIVE_INTERVAL}": "1000",
+    }
+
+    defines = [
+        "UA_ENABLE_METHODCALLS",
+        "UA_ENABLE_SUBSCRIPTIONS_EVENTS",
+        "UA_ENABLE_SUBSCRIPTIONS",
+        "UA_ENABLE_DISCOVERY_SEMAPHORE",
+        "UA_ENABLE_ENCRYPTION_OPENSSL",
+        "UA_ENABLE_TYPEDESCRIPTION",
+        "UA_ENABLE_JSON_ENCODING",
+        "UA_ENABLE_PARSING",
+        "UA_ENABLE_STATUSCODE_DESCRIPTIONS",
+        "UA_ENABLE_HISTORIZING",
+        "UA_ENABLE_NODEMANAGEMENT",
+        "UA_ENABLE_DA",
+        "UA_ENABLE_NODESET_COMPILER_DESCRIPTIONS",
+        "UA_GENERATED_NAMESPACE_ZERO",
+        "UA_DEBUG",
+    ]
+
+    undefines = [
+        "UA_ENABLE_DISCOVERY_MULTICAST",
+        "UA_ENABLE_DISCOVERY",
+        "UA_ENABLE_EXPERIMENTAL_HISTORIZING",
+        "UA_ENABLE_WEBSOCKET_SERVER",
+        "UA_ENABLE_UNIT_TEST_FAILURE_HOOKS",
+        "UA_ENABLE_VALGRIND_INTERACTIVE",
+        "UA_PACK_DEBIAN",
+        "UA_ENABLE_AMALGAMATION",
+        "UA_DEBUG_DUMP_PKGS",
+        "UA_DEBUG_FILE_LINE_INFO",
+        "UA_DYNAMIC_LINKING",
+        "UA_ENABLE_DIAGNOSTICS",
+        "UA_ENABLE_MALLOC_SINGLETON",
+        "UA_ENABLE_PUBSUB_ENCRYPTION",
+        "UA_ENABLE_PUBSUB_ETH_UADP",
+        "UA_ENABLE_PUBSUB_DELTAFRAMES",
+        "UA_ENABLE_PUBSUB_MQTT",
+        "UA_ENABLE_PUBSUB_FILE_CONFIG",
+        "UA_ENABLE_PUBSUB_INFORMATIONMODEL_METHODS",
+        "UA_ENABLE_PUBSUB_INFORMATIONMODEL",
+        "UA_ENABLE_PUBSUB_MONITORING",
+        "UA_ENABLE_PUBSUB_BUFMALLOC",
+        "UA_ENABLE_PUBSUB_SKS",
+        "UA_ENABLE_PUBSUB",
+        "UA_ENABLE_SUBSCRIPTION_EVENTS",
+        "UA_ENABLE_XML_ENCODING",
+        "UA_ENABLE_NODESET_INJECTOR",
+        "UA_INFORMATION_MODEL_AUTOLOAD",
+        "UA_ENABLE_ENCRYPTION_MBEDTLS",
+        "UA_ENABLE_TPM2_SECURITY",
+        "UA_ENABLE_ENCRYPTION_LIBRESSL",
+        "UA_ENABLE_SUBSCRIPTIONS_ALARMS_CONDITIONS",
+        "UA_ENABLE_IMMUTABLE_NODES",
+        "UA_ENABLE_INLINABLE_EXPORT",
+        "UA_ENABLE_DETERMINISTIC_RNG",
+        "UA_ENABLE_QUERY",
+        "UA_GENERATED_NAMESPACE_ZERO_FULL",
+        "UA_ENABLE_MQTT_TLS_OPENSSL",
+        "UA_ENABLE_MQTT_TLS_MBEDTLS",
+        "UA_ENABLE_MQTT_TLS",
+        "UA_ENABLE_MQTT",
+        "UA_ENABLE_CERT_REJECTED_DIR",
+        "UA_ENABLE_ALLOW_REUSEADDR",
+    ]
+
+    for undefine in undefines:
+        unordered_substitutions["#cmakedefine %s" % undefine] = "/* #undef %s */" % undefine
+
+    for define in defines:
+        unordered_substitutions["#cmakedefine %s" % define] = "#define %s" % define
+
+    # Build the actual substitutions map. These substitutions are applied in
+    # insertion order, so it's important to apply changes to the longest prefix
+    # first.
+    key_order = sorted(unordered_substitutions.keys(), reverse = True)
+    substitutions = {k: unordered_substitutions[k] for k in key_order}
+
+    ctx.actions.expand_template(
+        template = ctx.file._template_file,
+        output = output_file,
+        substitutions = substitutions,
+    )
+
+    return DefaultInfo(files = depset([output_file]))
+
+generate_config_h = rule(
+    implementation = _generate_config_h_impl,
+    attrs = {
+        "_template_file": attr.label(allow_single_file = True, default = "@open62541//:include/open62541/config.h.in"),
+        "output_path": attr.string(),
+        "version": attr.string(),
+    },
+)
+
+def _generate_datatypes_impl(ctx):
+    file_suffix = ctx.label.name + "_generated"
+
+    c_file = ctx.actions.declare_file(ctx.attr.prefix + "/" + file_suffix + ".c")
+    h_file = ctx.actions.declare_file(ctx.attr.prefix + "/" + file_suffix + ".h")
+    handling_h_file = ctx.actions.declare_file(ctx.attr.prefix + "/" + file_suffix + "_handling.h")
+
+    all_inputs = ctx.files.files_bsd + [ctx.file.file_csv]
+    if ctx.file.files_selected:
+        all_inputs.append(ctx.file.files_selected)
+
+    gen_args = ctx.actions.args()
+    if not ctx.attr.builtin:
+        gen_args.add("--no-builtin")
+
+    gen_args.add_all(ctx.files.files_bsd, format_each = "--type-bsd=%s")
+    gen_args.add("--type-csv=%s" % ctx.file.file_csv.path)
+
+    gen_args.add(c_file.dirname + "/" + ctx.label.name)
+
+    ctx.actions.run(
+        executable = ctx.executable._generate_datatypes,
+        outputs = [c_file, h_file, handling_h_file],
+        inputs = depset(all_inputs),
+        arguments = [gen_args],
+    )
+
+    cc_toolchain = find_cpp_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+    (compilation_context, compilation_outputs) = cc_common.compile(
+        name = ctx.label.name,
+        actions = ctx.actions,
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        srcs = [c_file],
+        public_hdrs = [h_file, handling_h_file],
+        # Pass types.h in as a private header to avoid circular dependencies.
+        private_hdrs = [ctx.file._types_hdr],
+        compilation_contexts = [
+            ctx.attr._common_lib[CcInfo].compilation_context,
+            ctx.attr._statuscodes_lib[CcInfo].compilation_context,
+        ] + [dep[CcInfo].compilation_context for dep in ctx.attr.deps],
+    )
+
+    (linking_context, _linking_outputs) = cc_common.create_linking_context_from_compilation_outputs(
+        name = ctx.label.name,
+        actions = ctx.actions,
+        feature_configuration = feature_configuration,
+        cc_toolchain = cc_toolchain,
+        compilation_outputs = compilation_outputs,
+        linking_contexts = [
+            ctx.attr._common_lib[CcInfo].linking_context,
+            ctx.attr._statuscodes_lib[CcInfo].linking_context,
+        ] + [dep[CcInfo].linking_context for dep in ctx.attr.deps],
+    )
+
+    return [
+        DefaultInfo(files = depset([c_file, h_file])),
+        CcInfo(compilation_context = compilation_context, linking_context = linking_context),
+    ]
+
+generate_datatypes = rule(
+    implementation = _generate_datatypes_impl,
+    attrs = {
+        "builtin": attr.bool(doc = "If true, then builtin types will be generated."),
+        "file_csv": attr.label(allow_single_file = True, doc = "The .csv file containing the node ids."),
+        "files_bsd": attr.label_list(allow_files = True, doc = "The .bsd files containing the type definitions."),
+        "files_selected": attr.label(allow_single_file = True, doc = "Optional text file containing a list of types which should be included in the generation."),
+        "prefix": attr.string(doc = "Generate files under this path."),
+        "deps": attr.label_list(providers = [CcInfo], doc = "Dependencies of the generated C++ code."),
+        "_generate_datatypes": attr.label(executable = True, default = "@open62541//:generate_datatypes", cfg = "exec"),
+        "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
+        "_common_lib": attr.label(default = "@open62541//:common"),
+        "_statuscodes_lib": attr.label(default = "@open62541//:statuscodes"),
+        "_types_hdr": attr.label(allow_single_file = True, default = "@open62541//:include/open62541/types.h"),
+    },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    fragments = ["cpp"],
+)

--- a/modules/open62541/1.4.16/patches/ua_types_json_fix.patch
+++ b/modules/open62541/1.4.16/patches/ua_types_json_fix.patch
@@ -1,0 +1,34 @@
+diff --git a/src/ua_types_encoding_json.c b/src/ua_types_encoding_json.c
+index e4a7466a0..3391930b5 100644
+--- a/src/ua_types_encoding_json.c
++++ b/src/ua_types_encoding_json.c
+@@ -17,11 +17,11 @@
+ #include <float.h>
+ #include <math.h>
+ 
+-#include "../deps/itoa.h"
+-#include "../deps/dtoa.h"
+-#include "../deps/parse_num.h"
+-#include "../deps/base64.h"
+-#include "../deps/libc_time.h"
++#include "itoa.h"
++#include "dtoa.h"
++#include "parse_num.h"
++#include "base64.h"
++#include "libc_time.h"
+ 
+ #ifndef UA_ENABLE_PARSING
+ #error UA_ENABLE_PARSING required for JSON encoding
+diff --git a/src/ua_types_encoding_json.h b/src/ua_types_encoding_json.h
+index 0013e9eca..ffb32e170 100644
+--- a/src/ua_types_encoding_json.h
++++ b/src/ua_types_encoding_json.h
+@@ -13,7 +13,7 @@
+ 
+ #include "ua_util_internal.h"
+ 
+-#include "../deps/cj5.h"
++#include "cj5.h"
+ 
+ _UA_BEGIN_DECLS
+ 

--- a/modules/open62541/1.4.16/presubmit.yml
+++ b/modules/open62541/1.4.16/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@open62541//:open62541'
+    - '@open62541//:types'
+    - '@open62541//:transport'

--- a/modules/open62541/1.4.16/source.json
+++ b/modules/open62541/1.4.16/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://github.com/open62541/open62541/archive/refs/tags/v1.4.16.tar.gz",
+    "integrity": "sha256-7ZaDzpcWtlFPI0WiEoLxRYi/pEBtOOQn8+zMvEpeFAs=",
+    "strip_prefix": "open62541-1.4.16",
+    "patches": {
+        "ua_types_json_fix.patch": "sha256-lszLqhgVLSeBoy7PcyYTPM8cLSO7qHhj2+Nn76yagR0="
+    },
+    "overlay": {
+        "BUILD.bazel": "sha256-sZzSdjDrUQvEOsXUCiwpemgA8zvPfbP+U7HnjT+OKs4=",
+        "open62541.bzl": "sha256-MxVka9V6a5M52oYYNwu5uIc3Ax/x3+f2r7arh9G5Mg8="
+    },
+    "patch_strip": 1
+}

--- a/modules/open62541/metadata.json
+++ b/modules/open62541/metadata.json
@@ -6,6 +6,12 @@
             "github": "mbeards",
             "github_user_id": 1326409,
             "name": "Michael Beardsworth"
+        },
+        {
+            "email": "arjuna@fourgrowers.com",
+            "github": "arjuna-fourgrowers",
+            "name": "Arjuna Ariyaratne",
+            "github_user_id": 201634024
         }
     ],
     "repository": [
@@ -14,7 +20,8 @@
     "versions": [
         "1.4.6",
         "1.4.14",
-        "1.4.14.bcr.1"
+        "1.4.14.bcr.1",
+        "1.4.16"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This PR:
* Updates open62541 to 1.4.16
* Uses OpenSSL directly rather than shimming in boringssl
* Builds in Bazel 9
* As previously discussed with @mbeards adding myself as an maintainer for open62541

@mbeards I tried adding Bazel rules for unit tests but it immediately started failing in 1.5.3. Sounds like there is big changes waiting for us in 1.5.x in addition to the changes in bzl file needed. I will put up a PR when I have time. 