### PR TITLE
Add verilator@0.2.1

### DIFF
--- a/modules/rules_verilator/0.2.1/MODULE.bazel
+++ b/modules/rules_verilator/0.2.1/MODULE.bazel
@@ -1,0 +1,19 @@
+module(
+    name = "rules_verilator",
+    version = "0.2.1",
+    bazel_compatibility = [">=7.5.0"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "verilator", version = "5.044")
+bazel_dep(name = "rules_verilog", version = "0.1.0")
+bazel_dep(name = "systemc", version = "3.0.2")
+
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
+
+bazel_dep(name = "rules_cc", version = "0.2.8")
+bazel_dep(name = "rules_license", version = "1.0.0")
+
+register_toolchains(
+    "//verilator:verilator_toolchain",
+)

--- a/modules/rules_verilator/0.2.1/presubmit.yml
+++ b/modules/rules_verilator/0.2.1/presubmit.yml
@@ -1,0 +1,24 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform:
+      - debian10
+      - ubuntu2004
+    bazel: [7.x, 8.x, 9.x]
+  tasks:
+    run_tests:
+      name: "Run tests"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//verilator/tests:adder_verilator"
+        - "//verilator/tests:load_and_count_verilator"
+        - "//verilator/tests:nested_module_verilator"
+        - "//verilator/tests:adder_trace_verilator"
+        - "//verilator/tests:hier_top_verilator"
+      test_targets:
+        - "//verilator/tests:adder_test"
+        - "//verilator/tests:load_and_count_test"
+        - "//verilator/tests:nested_module_test"
+        - "//verilator/tests:adder_trace_test"
+        - "//verilator/tests:hierarchical_compile_test"

--- a/modules/rules_verilator/0.2.1/source.json
+++ b/modules/rules_verilator/0.2.1/source.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "sha256-NDNw1uKTdPfw4DRgR+EQvO6phItNbh1owWQzuAXjB/0=",
+  "strip_prefix": "bazel_rules_verilator-0.2.1",
+  "url": "https://github.com/MrAMS/bazel_rules_verilator/releases/download/v0.2.1/bazel_rules_verilator-0.2.1.tar.gz"
+}

--- a/modules/rules_verilator/metadata.json
+++ b/modules/rules_verilator/metadata.json
@@ -7,5 +7,5 @@
     }
   ],
   "repository": ["github:MrAMS/bazel_rules_verilator"],
-  "versions": ["0.1.0", "0.2.0"]
+  "versions": ["0.1.0", "0.2.0", "0.2.1"]
 }


### PR DESCRIPTION
use `rules_verilog` for `verilog_library`
Please check https://github.com/MrAMS/bazel_rules_verilator/compare/v0.2.0...v0.2.1