### PR TITLE
toolchains_rpmbuild_prebuilt@2026.3.15

### DIFF
--- a/modules/toolchains_rpmbuild_prebuilt/2026.3.15/MODULE.bazel
+++ b/modules/toolchains_rpmbuild_prebuilt/2026.3.15/MODULE.bazel
@@ -1,0 +1,45 @@
+"Prebuilt, statically linked rpmbuild toolchain for rules_pkg pkg_rpm()"
+
+module(
+    name = "toolchains_rpmbuild_prebuilt",
+    version = "2026.3.15",
+    bazel_compatibility = [">=7.0.0"],
+    compatibility_level = 0,
+)
+
+# ==================
+# || Dependencies ||
+# ==================
+bazel_dep(name = "rules_pkg", version = "1.2.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# ======================
+# || Dev Dependencies ||
+# ======================
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.6.1", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "1.9.0", dev_dependency = True)
+bazel_dep(name = "toolchains_cc", dev_dependency = True)
+git_override(
+    module_name = "toolchains_cc",
+    remote = "https://github.com/reutermj/toolchains_cc.git",
+    commit = "468a678c8ec5cffe00399bae0abf69af2ff0f4f8",
+)
+
+# ================
+# || Toolchains ||
+# ================
+prebuilt_rpmbuild_toolchain = use_repo_rule("//:defs.bzl", "prebuilt_rpmbuild_toolchain")
+prebuilt_rpmbuild_toolchain(name = "rpmbuild", dev_dependency = True)
+register_toolchains("@rpmbuild", dev_dependency = True)
+
+cc_toolchains = use_extension("@toolchains_cc//:extensions.bzl", "cc_toolchains", dev_dependency = True)
+cc_toolchains.declare(name = "cc")
+use_repo(cc_toolchains, "cc")
+register_toolchains("@cc", dev_dependency = True)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
+python.toolchain(
+    python_version = "3.12",
+    is_default = True,
+)

--- a/modules/toolchains_rpmbuild_prebuilt/2026.3.15/presubmit.yml
+++ b/modules/toolchains_rpmbuild_prebuilt/2026.3.15/presubmit.yml
@@ -1,0 +1,10 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform: ["ubuntu2004"]
+    bazel: ["7.x", "8.x", "9.x"]
+  tasks:
+    run_test_module:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}

--- a/modules/toolchains_rpmbuild_prebuilt/2026.3.15/source.json
+++ b/modules/toolchains_rpmbuild_prebuilt/2026.3.15/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-gfIz7qj7oIj1DDrNm3GHSqnT/DUQjcyFCKjLSYn0+j4=",
+    "strip_prefix": "",
+    "url": "https://github.com/reutermj/toolchains_rpmbuild_prebuilt/releases/download/2026.3.15/toolchains_rpmbuild_prebuilt-2026.3.15.tar.gz"
+}

--- a/modules/toolchains_rpmbuild_prebuilt/metadata.json
+++ b/modules/toolchains_rpmbuild_prebuilt/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/reutermj/toolchains_rpmbuild_prebuilt",
+    "maintainers": [
+        {
+            "name": "Mark Reuter",
+            "email": "13319190+reutermj@users.noreply.github.com",
+            "github": "reutermj",
+            "github_user_id": 13319190
+        }
+    ],
+    "repository": [
+        "github:reutermj/toolchains_rpmbuild_prebuilt"
+    ],
+    "versions": [
+        "2026.3.15"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/reutermj/toolchains_rpmbuild_prebuilt/releases/tag/2026.3.15

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_