### PR TITLE
Publish cuda_toolchain_types@0.0.1

### DIFF
--- a/modules/cuda_toolchain_types/0.0.1/MODULE.bazel
+++ b/modules/cuda_toolchain_types/0.0.1/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "cuda_toolchain_types",
+    version = "0.0.1",
+    bazel_compatibility = [">=7.4.0"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")

--- a/modules/cuda_toolchain_types/0.0.1/attestations.json
+++ b/modules/cuda_toolchain_types/0.0.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/hermeticbuild/cuda_toolchain_types/releases/download/v0.0.1/source.json.intoto.jsonl",
+            "integrity": "sha256-hRIe5BqC96ToCF49n8qwG8y03CCcRjHSUqvZ3cNf40A="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/hermeticbuild/cuda_toolchain_types/releases/download/v0.0.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-pj8rGUtZhJ4L0kBc3VUu+RxVSi0ueIUjJpQu/lE+ez8="
+        },
+        "cuda_toolchain_types-v0.0.1.tar.gz": {
+            "url": "https://github.com/hermeticbuild/cuda_toolchain_types/releases/download/v0.0.1/cuda_toolchain_types-v0.0.1.tar.gz.intoto.jsonl",
+            "integrity": "sha256-vbDJ5NPfTSsVkh+qphZS1AqcMTRriGxIj4vnw+Ru1W8="
+        }
+    }
+}

--- a/modules/cuda_toolchain_types/0.0.1/patches/module_dot_bazel_version.patch
+++ b/modules/cuda_toolchain_types/0.0.1/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "cuda_toolchain_types",
+-    version = "0.0.0",
++    version = "0.0.1",
+     bazel_compatibility = [">=7.4.0"],
+ )
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.8.2")

--- a/modules/cuda_toolchain_types/0.0.1/presubmit.yml
+++ b/modules/cuda_toolchain_types/0.0.1/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    bazel: [8.x, 9.x, rolling]
+    platform: [debian11, ubuntu2004]
+  tasks:
+    run_test_module:
+      name: Run test module
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      build_targets:
+        - //:all

--- a/modules/cuda_toolchain_types/0.0.1/source.json
+++ b/modules/cuda_toolchain_types/0.0.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-+kEltyGhGOG4Ji3JNlq+xyZGhpUD5ZfU8AnlwaWz+A8=",
+    "strip_prefix": "cuda_toolchain_types-0.0.1",
+    "url": "https://github.com/hermeticbuild/cuda_toolchain_types/releases/download/v0.0.1/cuda_toolchain_types-v0.0.1.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-0G3lcZ+Kv0ZCPeqUG2bpmUUeiAIM81TYEdq4FwxI9PU="
+    },
+    "patch_strip": 1
+}

--- a/modules/cuda_toolchain_types/metadata.json
+++ b/modules/cuda_toolchain_types/metadata.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://github.com/hermeticbuild/cuda_toolchain_types",
+    "maintainers": [
+        {
+            "name": "Corentin Kerisit",
+            "email": "corentin.kerisit@gmail.com",
+            "github": "cerisier",
+            "github_user_id": 1126594
+        },
+        {
+            "name": "David Zbarsky",
+            "email": "dzbarsky@gmail.com",
+            "github": "dzbarsky",
+            "github_user_id": 1565842
+        }
+    ],
+    "repository": [
+        "github:hermeticbuild/cuda_toolchain_types"
+    ],
+    "versions": [
+        "0.0.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/hermeticbuild/cuda_toolchain_types/releases/tag/v0.0.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_