### PR TITLE
diff.bzl@0.5.0

### DIFF
--- a/modules/diff.bzl/0.5.0/MODULE.bazel
+++ b/modules/diff.bzl/0.5.0/MODULE.bazel
@@ -1,0 +1,26 @@
+"Bazel dependencies"
+
+module(name = "diff.bzl",
+    version = "0.5.0",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "package_metadata", version = "0.0.6")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+
+diffutils = use_extension("//diff:extensions.bzl", "diffutils")
+diffutils.toolchain()
+use_repo(diffutils, "diffutils_toolchains")
+use_repo(diffutils, "diffutils")
+
+register_toolchains("@diffutils_toolchains//:all")
+
+########################################################
+# diff.bzl development dependencies
+########################################################
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1", dev_dependency = True)
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.6.0", dev_dependency = True)
+bazel_dep(name = "protobuf", version = "34.0.bcr.1", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)

--- a/modules/diff.bzl/0.5.0/attestations.json
+++ b/modules/diff.bzl/0.5.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/kormide/diff.bzl/releases/download/v0.5.0/source.json.intoto.jsonl",
+            "integrity": "sha256-ZdWpvUCoiMTmQ0kzSFNbaK1kO0eL1AJqVIAQXQFxDiU="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/kormide/diff.bzl/releases/download/v0.5.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-bHSQidHBWJC9wV/XlsrJTVtW3hFm/dJ+dXd99Ut1Eos="
+        },
+        "diff.bzl-v0.5.0.tar.gz": {
+            "url": "https://github.com/kormide/diff.bzl/releases/download/v0.5.0/diff.bzl-v0.5.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-aTO24E6CL7U7jyIn6CXPKiLAnjKy+MtUk9M4k0q9KrU="
+        }
+    }
+}

--- a/modules/diff.bzl/0.5.0/patches/module_dot_bazel_version.patch
+++ b/modules/diff.bzl/0.5.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,9 @@
+ "Bazel dependencies"
+ 
+-module(name = "diff.bzl")
++module(name = "diff.bzl",
++    version = "0.5.0",
++)
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.8.2")
+ bazel_dep(name = "package_metadata", version = "0.0.6")
+ bazel_dep(name = "platforms", version = "1.0.0")

--- a/modules/diff.bzl/0.5.0/presubmit.yml
+++ b/modules/diff.bzl/0.5.0/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204"]
+    bazel: ["9.x", "8.x"]
+  tasks:
+    run_tests:
+      name: "Run smoke test"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/diff.bzl/0.5.0/source.json
+++ b/modules/diff.bzl/0.5.0/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-r0FI/26bNavCTcSrBY7bcUfqudVMRa8pNeEo4OY+p/4=",
+    "strip_prefix": "diff.bzl-0.5.0",
+    "docs_url": "https://github.com/kormide/diff.bzl/releases/download/v0.5.0/diff.bzl-v0.5.0.docs.tar.gz",
+    "url": "https://github.com/kormide/diff.bzl/releases/download/v0.5.0/diff.bzl-v0.5.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-hW/LPHEAp4G6+hkcWicVAG0umuOhGnml5GVIeajPKQA="
+    },
+    "patch_strip": 1
+}

--- a/modules/diff.bzl/metadata.json
+++ b/modules/diff.bzl/metadata.json
@@ -18,7 +18,8 @@
         "github:kormide/diff.bzl"
     ],
     "versions": [
-        "0.4.3"
+        "0.4.3",
+        "0.5.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/kormide/diff.bzl/releases/tag/v0.5.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_