### PR TITLE
inferential@1.2.0

### DIFF
--- a/modules/inferential/1.2.0/MODULE.bazel
+++ b/modules/inferential/1.2.0/MODULE.bazel
@@ -1,0 +1,10 @@
+module(name = "inferential", version = "1.2.0")
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "protobuf", version = "29.3")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "libzmq", version = "4.3.5.bcr.4")
+bazel_dep(name = "cppzmq", version = "4.10.0.bcr.1")
+
+# Dev-only (not propagated to consumers)
+bazel_dep(name = "googletest", version = "1.16.0", dev_dependency = True)

--- a/modules/inferential/1.2.0/presubmit.yml
+++ b/modules/inferential/1.2.0/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+  bazel:
+    - 7.x
+tasks:
+  verify_targets:
+    name: Build inferential C++ library
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@inferential//cpp:inferential"
+      - "@inferential//proto:inferential_cc_proto"

--- a/modules/inferential/1.2.0/source.json
+++ b/modules/inferential/1.2.0/source.json
@@ -1,0 +1,7 @@
+{
+    "url": "https://github.com/nalinraut/inferential/archive/refs/tags/v1.2.0.tar.gz",
+    "integrity": "sha256-dCUoh4VKsweqQB/kYV/ZEis2ENNzjtdzNin6USM8AJ4=",
+    "strip_prefix": "inferential-1.2.0",
+    "patches": {},
+    "patch_strip": 0
+}

--- a/modules/inferential/metadata.json
+++ b/modules/inferential/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/nalinraut/inferential",
+    "maintainers": [
+        {
+            "name": "Nalin Raut",
+            "github": "nalinraut",
+            "github_user_id": 33768644
+        }
+    ],
+    "repository": [
+        "github:nalinraut/inferential"
+    ],
+    "versions": [
+        "1.2.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/nalinraut/inferential/releases/tag/v1.2.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_