### PR TITLE
Yank and reserve rules_objc

### DIFF
--- a/modules/rules_objc/metadata.json
+++ b/modules/rules_objc/metadata.json
@@ -6,7 +6,7 @@
             "email": "bcr-maintainers@bazel.build"
         }
     ],
-    "repository": [],
+    "repository": ["github:bazel-contrib/rules_objc"],
     "versions": [
         "0.0.1"
     ],


### PR DESCRIPTION
In the last rules authors meeting, we have decided to enforce a higher standard for `rules_*` modules and will require approval from the rules authors meeting.

The current rules_objc checked in https://github.com/bazelbuild/bazel-central-registry/pull/7894 won't meet those requirements, therefore we have decided to yank the current version.