### PR TITLE
Update rules_kotlin to 2.3.20

### DIFF
--- a/modules/rules_kotlin/2.3.20/MODULE.bazel
+++ b/modules/rules_kotlin/2.3.20/MODULE.bazel
@@ -1,0 +1,33 @@
+module(
+    name = "rules_kotlin",
+    version = "2.3.20",
+    compatibility_level = 1,
+    repo_name = "rules_kotlin",
+)
+
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_java", version = "8.9.0")
+bazel_dep(name = "rules_android", version = "0.7.1")
+bazel_dep(name = "bazel_features", version = "1.39.0")
+bazel_dep(name = "bazel_lib", version = "3.1.0")
+
+rules_java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
+use_repo(rules_java_toolchains, "remote_java_tools")
+
+rules_kotlin_extensions = use_extension(
+    "//src/main/starlark/core/repositories:bzlmod_setup.bzl",
+    "rules_kotlin_extensions",
+)
+use_repo(
+    rules_kotlin_extensions,
+    "com_github_google_ksp",
+    "com_github_jetbrains_kotlin",
+    "com_github_pinterest_ktlint",
+    "kotlinx_serialization_core_jvm",
+    "kotlinx_serialization_json",
+    "kotlinx_serialization_json_jvm",
+    "kotlin_build_tools_impl",
+)
+
+register_toolchains("//kotlin/internal:default_toolchain")

--- a/modules/rules_kotlin/2.3.20/patches/module_dot_bazel_version.patch
+++ b/modules/rules_kotlin/2.3.20/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_kotlin",
+-    version = "1.9.0",
++    version = "2.3.20",
+     compatibility_level = 1,
+     repo_name = "rules_kotlin",
+ )
+ 

--- a/modules/rules_kotlin/2.3.20/presubmit.yml
+++ b/modules/rules_kotlin/2.3.20/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform: ["macos_arm64", "ubuntu2004"]
+  bazel: ["7.x", "8.x", "9.x"]
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--enable_bzlmod=true"
+    build_targets:
+      - "@rules_kotlin//kotlin/..."
+      - "@rules_kotlin//src/..."

--- a/modules/rules_kotlin/2.3.20/source.json
+++ b/modules/rules_kotlin/2.3.20/source.json
@@ -1,0 +1,8 @@
+{
+    "integrity": "sha256-E9W3Z9aXRzztm1VUehimq2WrP65UQFVd7uikTIhrUKo=",
+    "url": "https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.20/rules_kotlin-v2.3.20.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-m+v7DSsNa43iiRFaId3MmEb076ESRo5VccERXspr9CQ="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_kotlin/metadata.json
+++ b/modules/rules_kotlin/metadata.json
@@ -4,20 +4,20 @@
         {
             "email": "ben@ben.cm",
             "github": "Bencodes",
-            "name": "Ben Lee",
-            "github_user_id": 2177687
+            "github_user_id": 2177687,
+            "name": "Ben Lee"
         },
         {
             "email": "corbin@mcneely-smith.com",
             "github": "restingbull",
-            "name": "Corbin McNeely-Smith",
-            "github_user_id": 58151731
+            "github_user_id": 58151731,
+            "name": "Corbin McNeely-Smith"
         },
         {
             "email": "nk@snap.com",
             "github": "nkoroste",
-            "name": "Nick Korostelev",
-            "github_user_id": 3020688
+            "github_user_id": 3020688,
+            "name": "Nick Korostelev"
         }
     ],
     "repository": [
@@ -42,7 +42,8 @@
         "2.2.1",
         "2.2.2",
         "2.3.0",
-        "2.3.10"
+        "2.3.10",
+        "2.3.20"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Updates `rules_kotlin` to 2.3.20.

Release: https://github.com/bazel-contrib/rules_kotlin/releases/tag/v2.3.20