### PR TITLE
oidn-weights@0.0.0-20210406-a34b764, oidn@1.4.3

### DIFF
--- a/modules/oidn-weights/0.0.0-20210406-a34b764/MODULE.bazel
+++ b/modules/oidn-weights/0.0.0-20210406-a34b764/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "oidn-weights",
+    version = "0.0.0-20210406-a34b764",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)

--- a/modules/oidn-weights/0.0.0-20210406-a34b764/overlay/BUILD.bazel
+++ b/modules/oidn-weights/0.0.0-20210406-a34b764/overlay/BUILD.bazel
@@ -1,0 +1,40 @@
+"""
+    SPDX-FileCopyrightText: 2023-2025 Julian Amann <dev@vertexwahn.de>
+    SPDX-License-Identifier: Apache-2.0
+"""
+
+exports_files(
+    [
+        "rt_alb.tza",
+        "rt_hdr.tza",
+        "rt_hdr_alb.tza",
+        "rt_hdr_alb_nrm.tza",
+        "rt_hdr_calb_cnrm.tza",
+        "rt_ldr.tza",
+        "rt_ldr_alb.tza",
+        "rt_ldr_alb_nrm.tza",
+        "rt_ldr_calb_cnrm.tza",
+        "rt_nrm.tza",
+        "rtlightmap_dir.tza",
+        "rtlightmap_hdr.tza",
+    ],
+)
+
+filegroup(
+    name = "weights",
+    srcs = [
+        "rt_alb.tza",
+        "rt_hdr.tza",
+        "rt_hdr_alb.tza",
+        "rt_hdr_alb_nrm.tza",
+        "rt_hdr_calb_cnrm.tza",
+        "rt_ldr.tza",
+        "rt_ldr_alb.tza",
+        "rt_ldr_alb_nrm.tza",
+        "rt_ldr_calb_cnrm.tza",
+        "rt_nrm.tza",
+        "rtlightmap_dir.tza",
+        "rtlightmap_hdr.tza",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/modules/oidn-weights/0.0.0-20210406-a34b764/overlay/MODULE.bazel
+++ b/modules/oidn-weights/0.0.0-20210406-a34b764/overlay/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "oidn-weights",
+    version = "0.0.0-20210406-a34b764",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)

--- a/modules/oidn-weights/0.0.0-20210406-a34b764/presubmit.yml
+++ b/modules/oidn-weights/0.0.0-20210406-a34b764/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform:
+  - macos_arm64
+  - ubuntu2404
+  - windows
+  bazel: [8.x, 9.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@oidn-weights//:weights'

--- a/modules/oidn-weights/0.0.0-20210406-a34b764/source.json
+++ b/modules/oidn-weights/0.0.0-20210406-a34b764/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/RenderKit/oidn-weights/archive/a34b7641349c5a79e46a617d61709c35df5d6c28.zip",
+    "integrity": "sha256-WH4u9a/UJIFraoV3VibHD++bA2eCsegZXepBP2J9M8M=",
+    "strip_prefix": "oidn-weights-a34b7641349c5a79e46a617d61709c35df5d6c28",
+    "overlay": {
+        "BUILD.bazel": "sha256-0f+v7bR3T6hV4uuWQQGxfPpZgeH6P9ZRD3yAOjUYOQo=",
+        "MODULE.bazel": "sha256-Tya5pW7fLbL24VwZDYqYa3iphoe8f5uxo9g6hLfFqUQ="
+    }
+}

--- a/modules/oidn-weights/metadata.json
+++ b/modules/oidn-weights/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://www.openimagedenoise.org/",
+    "maintainers": [
+        {
+            "email": "julian.amann@tum.de",
+            "github": "Vertexwahn",
+            "github_user_id": 3775001,
+            "name": "Julian Amann"
+        }
+    ],
+    "repository": [
+        "github:RenderKit/oidn-weights"
+    ],
+    "versions": [
+        "0.0.0-20210406-a34b764"
+    ],
+    "yanked_versions": {}
+}

--- a/modules/oidn/1.4.3/MODULE.bazel
+++ b/modules/oidn/1.4.3/MODULE.bazel
@@ -1,0 +1,41 @@
+module(
+    name = "oidn",
+    version = "1.4.3",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_python", version = "1.8.3")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "onetbb", version = "2021.13.0")
+bazel_dep(name = "onednn", version = "2.7.3")
+bazel_dep(name = "rules_ispc")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "oidn-weights", version = "0.0.0-20210406-a34b764")
+bazel_dep(name = "catch2", version = "3.8.1")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+local_path_override(
+    module_name = "onednn",
+    path = "../oneDNN-2.7.3",
+)
+
+local_path_override(
+    module_name = "rules_ispc",
+    path = "../../devertexwahn/bazel/rules/rules_ispc",
+)
+
+ispc = use_extension("@rules_ispc//:extensions.bzl", "ispc")
+ispc.download()
+use_repo(
+    ispc,
+    "ispc_linux_x86_64",
+    "ispc_osx_arm64",
+    "ispc_osx_x86_64",
+    "ispc_windows_x86_64",
+)
+
+register_toolchains(
+    "@rules_ispc//tools:all",
+    dev_dependency = True,
+)

--- a/modules/oidn/1.4.3/MODULE.bazel
+++ b/modules/oidn/1.4.3/MODULE.bazel
@@ -9,21 +9,11 @@ bazel_dep(name = "rules_python", version = "1.8.3")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "onetbb", version = "2021.13.0")
 bazel_dep(name = "onednn", version = "2.7.3")
-bazel_dep(name = "rules_ispc")
+bazel_dep(name = "rules_ispc", version = "0.0.6")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "oidn-weights", version = "0.0.0-20210406-a34b764")
 bazel_dep(name = "catch2", version = "3.8.1")
 bazel_dep(name = "platforms", version = "1.0.0")
-
-local_path_override(
-    module_name = "onednn",
-    path = "../oneDNN-2.7.3",
-)
-
-local_path_override(
-    module_name = "rules_ispc",
-    path = "../../devertexwahn/bazel/rules/rules_ispc",
-)
 
 ispc = use_extension("@rules_ispc//:extensions.bzl", "ispc")
 ispc.download()

--- a/modules/oidn/1.4.3/overlay/BUILD.bazel
+++ b/modules/oidn/1.4.3/overlay/BUILD.bazel
@@ -1,0 +1,267 @@
+"""
+    SPDX-FileCopyrightText: 2023 Julian Amann <dev@vertexwahn.de>
+    SPDX-License-Identifier: Apache-2.0
+"""
+
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_ispc//:ispc.bzl", "ispc_cc_library")
+load("@rules_python//python:defs.bzl", "py_binary")
+load("//:oidn_generate_cpp_from_blob.bzl", "generate_cpp_from_blob_cc_library")
+
+config_setting(
+    name = "osx_arm64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+config_setting(
+    name = "osx_x86_64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+expand_template(
+    name = "config",
+    out = "include/OpenImageDenoise/config.h",
+    substitutions = {
+        "#cmakedefine OIDN_STATIC_LIB": "",
+        "#cmakedefine OIDN_API_NAMESPACE": "",
+        "@OIDN_VERSION_MAJOR@": "1",
+        "@OIDN_VERSION_MINOR@": "4",
+        "@OIDN_VERSION_PATCH@": "3",
+        "@OIDN_VERSION_NUMBER@": "010403",
+        "@OIDN_VERSION_NOTE": "",
+    },
+    template = "include/OpenImageDenoise/config.h.in",
+)
+
+COMMON_DEFINES = select({
+    ":osx_arm64": [
+        "OIDN_BNNS",
+        "OIDN_STATIC_LIB",
+        "OIDN_FILTER_RT",
+        "OIDN_FILTER_RTLIGHTMAP",
+    ],
+    "//conditions:default": [
+        "OIDN_DNNL",
+        "OIDN_STATIC_LIB",
+        "OIDN_FILTER_RT",
+        "OIDN_FILTER_RTLIGHTMAP",
+    ],
+})
+
+ispc_cc_library(
+    name = "input_reorder_ispc",
+    srcs = [
+        "core/color.isph",
+        "core/image.isph",
+        "core/input_reorder.ispc",
+        "core/math.isph",
+        "core/reorder.isph",
+        "core/tensor.isph",
+        "core/vec.isph",
+    ],
+    out = "input_reorder_ispc.h",
+    defines = COMMON_DEFINES,
+    ispc_main_source_file = "core/input_reorder.ispc",
+)
+
+ispc_cc_library(
+    name = "color_ispc",
+    srcs = [
+        "core/color.ispc",
+        "core/color.isph",
+        "core/image.isph",
+        "core/math.isph",
+        "core/vec.isph",
+    ],
+    out = "color_ispc.h",
+    defines = COMMON_DEFINES,
+    ispc_main_source_file = "core/color.ispc",
+)
+
+ispc_cc_library(
+    name = "output_copy_ispc",
+    srcs = [
+        "core/color.isph",
+        "core/image.isph",
+        "core/math.isph",
+        "core/output_copy.ispc",
+        "core/vec.isph",
+    ],
+    out = "output_copy_ispc.h",
+    defines = COMMON_DEFINES,
+    ispc_main_source_file = "core/output_copy.ispc",
+)
+
+ispc_cc_library(
+    name = "upsample_ispc",
+    srcs = [
+        "core/color.isph",
+        "core/image.isph",
+        "core/math.isph",
+        "core/tensor.isph",
+        "core/upsample.ispc",
+        "core/vec.isph",
+    ],
+    out = "upsample_ispc.h",
+    defines = COMMON_DEFINES,
+    ispc_main_source_file = "core/upsample.ispc",
+)
+
+ispc_cc_library(
+    name = "output_reorder_ispc",
+    srcs = [
+        "core/color.isph",
+        "core/image.isph",
+        "core/math.isph",
+        "core/output_reorder.ispc",
+        "core/reorder.isph",
+        "core/tensor.isph",
+        "core/vec.isph",
+    ],
+    out = "output_reorder_ispc.h",
+    defines = COMMON_DEFINES,
+    ispc_main_source_file = "core/output_reorder.ispc",
+)
+
+cc_library(
+    name = "common",
+    srcs = [
+        "common/barrier.h",
+        "common/exception.h",
+        "common/math.h",
+        "common/platform.cpp",
+        "common/platform.h",
+        "common/ref.h",
+        "common/tasking.cpp",
+        "common/tasking.h",
+        "common/thread.cpp",
+        "common/thread.h",
+        "common/timer.h",
+        "include/OpenImageDenoise/config.h",  # generated
+        "include/OpenImageDenoise/oidn.h",
+        "include/OpenImageDenoise/oidn.hpp",
+    ],
+    defines = COMMON_DEFINES,
+    includes = ["include/OpenImageDenoise"],
+    deps = [
+        "@onetbb//:tbb",
+    ] + select({
+        ":osx_arm64": [],
+        "//conditions:default": ["@onednn"],
+    }),
+)
+
+py_binary(
+    name = "blob_to_cpp",
+    srcs = ["scripts/blob_to_cpp.py"],
+    data = ["@oidn-weights//:weights"],
+)
+
+generate_cpp_from_blob_cc_library(name = "rt_alb.tza")
+
+generate_cpp_from_blob_cc_library(name = "rt_hdr.tza")
+
+generate_cpp_from_blob_cc_library(name = "rt_hdr_alb.tza")
+
+generate_cpp_from_blob_cc_library(name = "rt_hdr_alb_nrm.tza")
+
+generate_cpp_from_blob_cc_library(name = "rt_hdr_calb_cnrm.tza")
+
+generate_cpp_from_blob_cc_library(name = "rt_ldr.tza")
+
+generate_cpp_from_blob_cc_library(name = "rt_ldr_alb.tza")
+
+generate_cpp_from_blob_cc_library(name = "rt_ldr_alb_nrm.tza")
+
+generate_cpp_from_blob_cc_library(name = "rt_ldr_calb_cnrm.tza")
+
+generate_cpp_from_blob_cc_library(name = "rt_nrm.tza")
+
+generate_cpp_from_blob_cc_library(name = "rtlightmap_dir.tza")
+
+generate_cpp_from_blob_cc_library(name = "rtlightmap_hdr.tza")
+
+cc_library(
+    name = "OpenImageDenoise",
+    srcs = [
+        "core/api.cpp",
+        "core/buffer.h",
+        "core/color.cpp",
+        "core/color.h",
+        "core/common.h",
+        "core/conv.h",
+        "core/cpu_buffer.h",
+        "core/cpu_device.cpp",
+        "core/cpu_device.h",
+        "core/data.h",
+        "core/device.cpp",
+        "core/device.h",
+        "core/filter.cpp",
+        "core/filter.h",
+        "core/image.h",
+        "core/input_reorder.cpp",
+        "core/input_reorder.h",
+        "core/network.cpp",
+        "core/network.h",
+        "core/node.h",
+        "core/output_copy.cpp",
+        "core/output_copy.h",
+        "core/output_reorder.cpp",
+        "core/output_reorder.h",
+        "core/pool.h",
+        "core/progress.h",
+        "core/reorder.h",
+        "core/scratch.cpp",
+        "core/scratch.h",
+        "core/tensor.h",
+        "core/tza.cpp",
+        "core/tza.h",
+        "core/unet.cpp",
+        "core/unet.h",
+        "core/upsample.cpp",
+        "core/upsample.h",
+        "core/vec.h",
+    ],
+    hdrs = [
+        "include/OpenImageDenoise/config.h",
+        "include/OpenImageDenoise/oidn.h",
+        "include/OpenImageDenoise/oidn.hpp",
+    ],
+    defines = COMMON_DEFINES,
+    includes = [
+        "core",
+        "include",
+    ],
+    linkopts = select({
+        "//:osx_arm64": ["-framework Accelerate"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":color_ispc",
+        ":common",
+        ":input_reorder_ispc",
+        ":output_copy_ispc",
+        ":output_reorder_ispc",
+        ":rt_alb.tza",
+        ":rt_hdr.tza",
+        ":rt_hdr_alb.tza",
+        ":rt_hdr_alb_nrm.tza",
+        ":rt_hdr_calb_cnrm.tza",
+        ":rt_ldr.tza",
+        ":rt_ldr_alb.tza",
+        ":rt_ldr_alb_nrm.tza",
+        ":rt_ldr_calb_cnrm.tza",
+        ":rt_nrm.tza",
+        ":rtlightmap_dir.tza",
+        ":rtlightmap_hdr.tza",
+        ":upsample_ispc",
+    ],
+)

--- a/modules/oidn/1.4.3/overlay/MODULE.bazel
+++ b/modules/oidn/1.4.3/overlay/MODULE.bazel
@@ -1,0 +1,41 @@
+module(
+    name = "oidn",
+    version = "1.4.3",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_python", version = "1.8.3")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "onetbb", version = "2021.13.0")
+bazel_dep(name = "onednn", version = "2.7.3")
+bazel_dep(name = "rules_ispc")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "oidn-weights", version = "0.0.0-20210406-a34b764")
+bazel_dep(name = "catch2", version = "3.8.1")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+local_path_override(
+    module_name = "onednn",
+    path = "../oneDNN-2.7.3",
+)
+
+local_path_override(
+    module_name = "rules_ispc",
+    path = "../../devertexwahn/bazel/rules/rules_ispc",
+)
+
+ispc = use_extension("@rules_ispc//:extensions.bzl", "ispc")
+ispc.download()
+use_repo(
+    ispc,
+    "ispc_linux_x86_64",
+    "ispc_osx_arm64",
+    "ispc_osx_x86_64",
+    "ispc_windows_x86_64",
+)
+
+register_toolchains(
+    "@rules_ispc//tools:all",
+    dev_dependency = True,
+)

--- a/modules/oidn/1.4.3/overlay/MODULE.bazel
+++ b/modules/oidn/1.4.3/overlay/MODULE.bazel
@@ -9,21 +9,11 @@ bazel_dep(name = "rules_python", version = "1.8.3")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "onetbb", version = "2021.13.0")
 bazel_dep(name = "onednn", version = "2.7.3")
-bazel_dep(name = "rules_ispc")
+bazel_dep(name = "rules_ispc", version = "0.0.6")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "oidn-weights", version = "0.0.0-20210406-a34b764")
 bazel_dep(name = "catch2", version = "3.8.1")
 bazel_dep(name = "platforms", version = "1.0.0")
-
-local_path_override(
-    module_name = "onednn",
-    path = "../oneDNN-2.7.3",
-)
-
-local_path_override(
-    module_name = "rules_ispc",
-    path = "../../devertexwahn/bazel/rules/rules_ispc",
-)
 
 ispc = use_extension("@rules_ispc//:extensions.bzl", "ispc")
 ispc.download()

--- a/modules/oidn/1.4.3/overlay/oidn_generate_cpp_from_blob.bzl
+++ b/modules/oidn/1.4.3/overlay/oidn_generate_cpp_from_blob.bzl
@@ -1,0 +1,29 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+def generate_cpp_from_blob_cc_library(name, **kwargs):
+    src = "@oidn-weights//:" + name
+    cpp_out = "weights/" + name[0:-4] + ".cpp"
+    header_out = "weights/" + name[0:-4] + ".h"
+    native.genrule(
+        name = "%s_weights_gen" % name,
+        srcs = [src],
+        outs = [
+            cpp_out,
+            header_out,
+        ],
+        cmd = ("./$(location //:blob_to_cpp) $(location {src}) " +
+               "-o $(location {cpp_out}) " +
+               "-H $(location {header_out}) " +
+               "-n oidn::blobs::weights").format(
+            src = src,
+            cpp_out = cpp_out,
+            header_out = header_out,
+        ),
+        tools = ["//:blob_to_cpp"],
+    )
+    cc_library(
+        name = name,
+        srcs = [cpp_out],
+        hdrs = [header_out],
+        **kwargs
+    )

--- a/modules/oidn/1.4.3/presubmit.yml
+++ b/modules/oidn/1.4.3/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform:
+  - macos_arm64
+  - ubuntu2404
+  - windows
+  bazel: [8.x, 9.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@oidn//:OpenImageDenoise'

--- a/modules/oidn/1.4.3/source.json
+++ b/modules/oidn/1.4.3/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/RenderKit/oidn/releases/download/v1.4.2/oidn-1.4.2.src.tar.gz",
+    "integrity": "sha256-5w0nziS0E2R4I3bBs7TwdPdzEMz+X4/+xKE6NH5IoOo=",
+    "strip_prefix": "oidn-weights-a34b7641349c5a79e46a617d61709c35df5d6c28",
+    "overlay": {
+        "BUILD.bazel": "sha256-SGvYISQyw9Id/EaekCXK/ulhie22OPhmV4eBPbRGQwo=",
+        "MODULE.bazel": "sha256-mw6QMkOHKE7AIoRWJsFRb1lmb1VYEKXilphxX0Wi/wU=",
+        "oidn_generate_cpp_from_blob.bzl": "sha256-vieOuEaLr108UPtAtqUA3jKjCASVSYQTeFP2mebFWL8="
+    }
+}

--- a/modules/oidn/1.4.3/source.json
+++ b/modules/oidn/1.4.3/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "oidn-weights-a34b7641349c5a79e46a617d61709c35df5d6c28",
     "overlay": {
         "BUILD.bazel": "sha256-SGvYISQyw9Id/EaekCXK/ulhie22OPhmV4eBPbRGQwo=",
-        "MODULE.bazel": "sha256-mw6QMkOHKE7AIoRWJsFRb1lmb1VYEKXilphxX0Wi/wU=",
+        "MODULE.bazel": "sha256-OW2F+VPWF8maPlyDH2KXo97uI7ISN0hSk3dFQ+X7LD0=",
         "oidn_generate_cpp_from_blob.bzl": "sha256-vieOuEaLr108UPtAtqUA3jKjCASVSYQTeFP2mebFWL8="
     }
 }

--- a/modules/oidn/metadata.json
+++ b/modules/oidn/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://www.openimagedenoise.org/",
+    "maintainers": [
+        {
+            "email": "julian.amann@tum.de",
+            "github": "Vertexwahn",
+            "github_user_id": 3775001,
+            "name": "Julian Amann"
+        }
+    ],
+    "repository": [
+        "github:RenderKit/oidn"
+    ],
+    "versions": [
+        "1.4.3"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This brings oidn-weights@0.0.0-20210406-a34b764 and oidn@1.4.3 to BCR.

oidn-weights is a "pure" data dependency. It provides weights needed for a neural network for image denoising.

Not sure how to get presubmit for `oidn-weights`  correct, since it consist only of files (containing the weights).

Depends-on: https://github.com/bazelbuild/bazel-central-registry/pull/7389


