### PR TITLE
marisa-trie@0.3.1

### DIFF
--- a/modules/marisa-trie/0.3.1/MODULE.bazel
+++ b/modules/marisa-trie/0.3.1/MODULE.bazel
@@ -1,0 +1,10 @@
+"MARISA: Matching Algorithm with Recursively Implemented StorAge."
+
+module(
+    name = "marisa-trie",
+    version = "0.3.1",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/marisa-trie/0.3.1/patches/add_build_file.patch
+++ b/modules/marisa-trie/0.3.1/patches/add_build_file.patch
@@ -1,0 +1,134 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,131 @@
++load("@rules_cc//cc:cc_library.bzl", "cc_library")
++load("@rules_cc//cc:cc_test.bzl", "cc_test")
++
++COPTS = select({
++    "@platforms//os:windows": ["/std:c++17", "/D_WIN32_WINNT=0x0602"],
++    "//conditions:default": ["-std=c++17"],
++})
++
++cc_library(
++    name = "public_headers",
++    hdrs = [
++        "include/marisa.h",
++        "include/marisa/agent.h",
++        "include/marisa/base.h",
++        "include/marisa/iostream.h",
++        "include/marisa/key.h",
++        "include/marisa/keyset.h",
++        "include/marisa/query.h",
++        "include/marisa/stdio.h",
++        "include/marisa/trie.h",
++    ],
++    strip_include_prefix = "include",
++)
++
++cc_library(
++    name = "internal_headers",
++    hdrs = [
++        "lib/marisa/grimoire/algorithm/sort.h",
++        "lib/marisa/grimoire/intrin.h",
++        "lib/marisa/grimoire/io.h",
++        "lib/marisa/grimoire/io/mapper.h",
++        "lib/marisa/grimoire/io/reader.h",
++        "lib/marisa/grimoire/io/writer.h",
++        "lib/marisa/grimoire/trie.h",
++        "lib/marisa/grimoire/trie/cache.h",
++        "lib/marisa/grimoire/trie/config.h",
++        "lib/marisa/grimoire/trie/entry.h",
++        "lib/marisa/grimoire/trie/header.h",
++        "lib/marisa/grimoire/trie/history.h",
++        "lib/marisa/grimoire/trie/key.h",
++        "lib/marisa/grimoire/trie/louds-trie.h",
++        "lib/marisa/grimoire/trie/range.h",
++        "lib/marisa/grimoire/trie/state.h",
++        "lib/marisa/grimoire/trie/tail.h",
++        "lib/marisa/grimoire/vector.h",
++        "lib/marisa/grimoire/vector/bit-vector.h",
++        "lib/marisa/grimoire/vector/flat-vector.h",
++        "lib/marisa/grimoire/vector/pop-count.h",
++        "lib/marisa/grimoire/vector/rank-index.h",
++        "lib/marisa/grimoire/vector/vector.h",
++    ],
++    strip_include_prefix = "lib",
++)
++
++cc_library(
++    name = "marisa-trie",
++    srcs = [
++        "lib/marisa/agent.cc",
++        "lib/marisa/grimoire/io/mapper.cc",
++        "lib/marisa/grimoire/io/reader.cc",
++        "lib/marisa/grimoire/io/writer.cc",
++        "lib/marisa/grimoire/trie/louds-trie.cc",
++        "lib/marisa/grimoire/trie/tail.cc",
++        "lib/marisa/grimoire/vector/bit-vector.cc",
++        "lib/marisa/keyset.cc",
++        "lib/marisa/trie.cc",
++    ],
++    copts = COPTS,
++    visibility = ["//visibility:public"],
++    deps = [
++        ":internal_headers",
++        ":public_headers",
++    ],
++)
++
++cc_library(
++    name = "marisa-assert",
++    testonly = True,
++    hdrs = ["tests/marisa-assert.h"],
++    strip_include_prefix = "tests",
++)
++
++cc_test(
++    name = "base-test",
++    srcs = ["tests/base-test.cc"],
++    copts = COPTS,
++    deps = [
++        ":marisa-assert",
++        ":marisa-trie",
++    ],
++)
++
++cc_test(
++    name = "io-test",
++    srcs = ["tests/io-test.cc"],
++    copts = COPTS,
++    deps = [
++        ":marisa-assert",
++        ":marisa-trie",
++    ],
++)
++
++cc_test(
++    name = "marisa-test",
++    srcs = ["tests/marisa-test.cc"],
++    copts = COPTS,
++    deps = [
++        ":marisa-assert",
++        ":marisa-trie",
++    ],
++)
++
++cc_test(
++    name = "trie-test",
++    srcs = ["tests/trie-test.cc"],
++    copts = COPTS,
++    deps = [
++        ":marisa-assert",
++        ":marisa-trie",
++    ],
++)
++
++# vector-test is not added because of an existing failure.
++# cc_test(
++#     name = "vector-test",
++#     srcs = ["tests/vector-test.cc"],
++#     deps = [
++#         ":marisa-assert",
++#         ":marisa-trie",
++#     ],
++# )

--- a/modules/marisa-trie/0.3.1/patches/module_dot_bazel.patch
+++ b/modules/marisa-trie/0.3.1/patches/module_dot_bazel.patch
@@ -1,0 +1,13 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,10 @@
++"MARISA: Matching Algorithm with Recursively Implemented StorAge."
++
++module(
++    name = "marisa-trie",
++    version = "0.3.1",
++    compatibility_level = 0,
++)
++
++bazel_dep(name = "platforms", version = "1.0.0")
++bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/marisa-trie/0.3.1/presubmit.yml
+++ b/modules/marisa-trie/0.3.1/presubmit.yml
@@ -1,0 +1,27 @@
+matrix:
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@marisa-trie"
+  run_tests:
+    name: Run tests
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "@marisa-trie//:base-test"
+      - "@marisa-trie//:io-test"
+      - "@marisa-trie//:marisa-test"
+      - "@marisa-trie//:trie-test"

--- a/modules/marisa-trie/0.3.1/source.json
+++ b/modules/marisa-trie/0.3.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/s-yata/marisa-trie/archive/refs/tags/v0.3.1.tar.gz",
+    "integrity": "sha256-mG7V4pZ0NeOjkyqMlZgJk65aGWER43dyHwhJytToB/M=",
+    "strip_prefix": "marisa-trie-0.3.1",
+    "patches": {
+        "add_build_file.patch": "sha256-zcCHcGVxe90Ocua4fwHvT5SBFya1YqV30g68g5cxUhc=",
+        "module_dot_bazel.patch": "sha256-myoKbgU637NvRb95NjJSA9Z86QLCVRp1FzDYEhPf6JY="
+    },
+    "patch_strip": 0
+}

--- a/modules/marisa-trie/metadata.json
+++ b/modules/marisa-trie/metadata.json
@@ -10,7 +10,8 @@
         "github:s-yata/marisa-trie"
     ],
     "versions": [
-        "0.2.6"
+        "0.2.6",
+        "0.3.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
## Summary
- Add marisa-trie version 0.3.1
- Updated BUILD patch for v0.3.1 source tree changes (removed `exception.h`, `scoped-array.h`, `scoped-ptr.h` from public headers; removed `algorithm.h` from internal headers)
- Updated presubmit to test with Bazel 7.x and 8.x

## Test plan
- [x] BCR presubmit passes on all platforms (debian10, ubuntu2004, macos, macos_arm64, windows)
- [x] Build targets verified
- [x] Test targets pass (base-test, io-test, marisa-test, trie-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)