### PR TITLE
io_github_janhicken_rules_kubebuilder@0.1.1

### DIFF
--- a/modules/io_github_janhicken_rules_kubebuilder/0.1.1/MODULE.bazel
+++ b/modules/io_github_janhicken_rules_kubebuilder/0.1.1/MODULE.bazel
@@ -1,0 +1,49 @@
+"Bazel dependencies"
+
+module(
+    name = "io_github_janhicken_rules_kubebuilder",
+    version = "0.1.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_features", version = "1.42.1")
+bazel_dep(name = "bazel_lib", version = "3.1.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "jq.bzl", version = "0.6.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_go", version = "0.59.0")
+bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "stardoc", version = "0.8.1")
+bazel_dep(name = "tar.bzl", version = "0.7.0")
+bazel_dep(name = "yq.bzl", version = "0.3.4")
+
+# zlib 1.3.1 fixes a compilation issue for darwin_arm64
+single_version_override(
+    module_name = "zlib",
+    version = "1.3.1.bcr.5",
+)
+
+bazel_dep(name = "aspect_rules_lint", version = "2.3.0", dev_dependency = True)
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.9.2", dev_dependency = True)
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.48.0", dev_dependency = True)
+
+kubebuilder = use_extension("@io_github_janhicken_rules_kubebuilder//kubebuilder:extensions.bzl", "kubebuilder")
+kubebuilder.for_kubernetes(version = "1.32.0")
+use_repo(
+    kubebuilder,
+    "chainsaw_toolchains",
+    "controller_gen_toolchains",
+    "docker_toolchains",
+    "envtest_toolchains",
+    "kind_toolchains",
+)
+
+register_toolchains(
+    "@chainsaw_toolchains//:all",
+    "@controller_gen_toolchains//:all",
+    "@docker_toolchains//:all",
+    "@envtest_toolchains//:all",
+    "@kind_toolchains//:all",
+)

--- a/modules/io_github_janhicken_rules_kubebuilder/0.1.1/attestations.json
+++ b/modules/io_github_janhicken_rules_kubebuilder/0.1.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/janhicken/rules_kubebuilder/releases/download/v0.1.1/source.json.intoto.jsonl",
+            "integrity": "sha256-ZS+rQtdb4VhhDxhu7WUWPTOlKVMcLx3KGK/PNtyc4So="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/janhicken/rules_kubebuilder/releases/download/v0.1.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-ESxyLL6awKajpn2nqmIzHznq75fTwY992WqYLOO8OHc="
+        },
+        "rules_kubebuilder-v0.1.1.tar.gz": {
+            "url": "https://github.com/janhicken/rules_kubebuilder/releases/download/v0.1.1/rules_kubebuilder-v0.1.1.tar.gz.intoto.jsonl",
+            "integrity": "sha256-u19cufFlVI6pglCcEZIT2JUeY5wyciDYKIuVE1fd8mg="
+        }
+    }
+}

--- a/modules/io_github_janhicken_rules_kubebuilder/0.1.1/patches/module_dot_bazel_version.patch
+++ b/modules/io_github_janhicken_rules_kubebuilder/0.1.1/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,9 +1,9 @@
+ "Bazel dependencies"
+ 
+ module(
+     name = "io_github_janhicken_rules_kubebuilder",
+-    version = "0.0.0",
++    version = "0.1.1",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "bazel_features", version = "1.42.1")

--- a/modules/io_github_janhicken_rules_kubebuilder/0.1.1/presubmit.yml
+++ b/modules/io_github_janhicken_rules_kubebuilder/0.1.1/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/cronjob-tutorial"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204"]
+    bazel: ["9.x", "8.x", "7.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/io_github_janhicken_rules_kubebuilder/0.1.1/source.json
+++ b/modules/io_github_janhicken_rules_kubebuilder/0.1.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-l/emPFwsFj9B6v0B2Ocl6FCXZlqF6IrdyjLkIigJtxc=",
+    "strip_prefix": "rules_kubebuilder-0.1.1",
+    "url": "https://github.com/janhicken/rules_kubebuilder/releases/download/v0.1.1/rules_kubebuilder-v0.1.1.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-ykv17axRwhRHBr1ZHlIPu3YuJofmCx4cx5P2Br9Qi6w="
+    },
+    "patch_strip": 1
+}

--- a/modules/io_github_janhicken_rules_kubebuilder/metadata.json
+++ b/modules/io_github_janhicken_rules_kubebuilder/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/janhicken/rules_kubebuilder",
+    "maintainers": [
+        {
+            "name": "Jan Hicken",
+            "email": "jan.hicken27+bcr@gmail.com",
+            "github": "janhicken",
+            "github_user_id": 2724840
+        }
+    ],
+    "repository": [
+        "github:janhicken/rules_kubebuilder"
+    ],
+    "versions": [
+        "0.1.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/janhicken/rules_kubebuilder/releases/tag/v0.1.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_