### PR TITLE
Added missing `yanked_versions` key to rules_verilog

### DIFF
--- a/modules/rules_verilog/metadata.json
+++ b/modules/rules_verilog/metadata.json
@@ -1,18 +1,26 @@
 {
-  "homepage": "https://github.com/hw-bzl/bazel_rules_verilog",
-  "maintainers": [
-    {
-      "github": "MrAMS",
-      "github_user_id": 25056812,
-      "name": "Qijia Yang"
-    },
-    {
-      "name": "UebelAndre",
-      "email": "26427366+UebelAndre@users.noreply.github.com",
-      "github": "UebelAndre",
-      "github_user_id": 26427366
-    }
-  ],
-  "repository": ["github:hw-bzl/bazel_rules_verilog"],
-  "versions": ["0.1.0", "1.0.0", "1.1.0"]
+    "homepage": "https://github.com/hw-bzl/rules_verilog",
+    "maintainers": [
+        {
+            "github": "MrAMS",
+            "github_user_id": 25056812,
+            "name": "Qijia Yang"
+        },
+        {
+            "email": "26427366+UebelAndre@users.noreply.github.com",
+            "github": "UebelAndre",
+            "github_user_id": 26427366,
+            "name": "UebelAndre"
+        }
+    ],
+    "repository": [
+        "github:hw-bzl/bazel_rules_verilog",
+        "github:hw-bzl/rules_verilog"
+    ],
+    "versions": [
+        "0.1.0",
+        "1.0.0",
+        "1.1.0"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Relates to https://github.com/bazel-contrib/publish-to-bcr/issues/372