### PR TITLE
Added missing `yanked_versions` key to rules_verilog

### DIFF
--- a/modules/rules_verilog/metadata.json
+++ b/modules/rules_verilog/metadata.json
@@ -14,5 +14,6 @@
     }
   ],
   "repository": ["github:hw-bzl/bazel_rules_verilog"],
-  "versions": ["0.1.0", "1.0.0", "1.1.0"]
+  "versions": ["0.1.0", "1.0.0", "1.1.0"],
+  "yanked_versions": {}
 }


### PR DESCRIPTION
https://github.com/hw-bzl/rules_verilog/pull/9#issuecomment-4149178390

closes https://github.com/bazelbuild/bazel-central-registry/pull/8172