### PR TITLE
p4c@1.2.5.11.bcr.1, fourward@0.1.0

### DIFF
--- a/modules/fourward/0.1.0/MODULE.bazel
+++ b/modules/fourward/0.1.0/MODULE.bazel
@@ -1,0 +1,80 @@
+module(
+    name = "fourward",
+    version = "0.1.0",
+    bazel_compatibility = [">=9.0.0"],
+)
+
+# --- Core build rules ---
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_kotlin", version = "2.3.0")
+bazel_dep(name = "rules_java", version = "9.3.0")
+bazel_dep(name = "rules_python", version = "1.4.1")
+bazel_dep(name = "rules_jvm_external", version = "6.10")
+
+# --- Protobuf & gRPC ---
+
+bazel_dep(name = "protobuf", version = "33.5")
+bazel_dep(name = "grpc-java", version = "1.78.0")
+bazel_dep(name = "grpc_kotlin", version = "1.5.0")
+
+# --- P4 ecosystem ---
+
+# p4runtime provides p4info.proto, p4runtime.proto, and p4data.proto.
+bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
+
+# p4c provides the compiler frontend and midend that our backend builds on.
+bazel_dep(name = "p4c", version = "1.2.5.11.bcr.1")
+
+# p4-constraints validates @entry_restriction / @action_restriction annotations.
+bazel_dep(name = "p4_constraints", version = "20260311.0")
+
+# --- JVM dependencies ---
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.install(
+    artifacts = [
+        "com.google.protobuf:protobuf-java:4.29.3",
+        "com.google.protobuf:protobuf-java-util:4.29.3",
+        "com.google.protobuf:protobuf-kotlin:4.29.3",
+        "junit:junit:4.13.2",
+        "com.facebook:ktfmt:0.61",
+        "io.gitlab.arturbosch.detekt:detekt-cli:1.23.8",
+        # gRPC Kotlin runtime
+        "io.grpc:grpc-kotlin-stub:1.4.3",
+        "io.grpc:grpc-netty-shaded:1.68.1",
+        "io.grpc:grpc-services:1.68.1",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1",
+        "javax.annotation:javax.annotation-api:1.3.2",
+    ],
+    known_contributing_modules = [
+        "grpc-java",
+        "protobuf",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+)
+use_repo(maven, "maven")
+
+# --- Python (cram test runner) ---
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.12")
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "pip",
+    python_version = "3.12",
+    requirements_lock = "//:requirements.txt",
+)
+use_repo(pip, "pip")
+
+# --- Dev tools ---
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = True)

--- a/modules/fourward/0.1.0/patches/bcr.patch
+++ b/modules/fourward/0.1.0/patches/bcr.patch
@@ -1,0 +1,55 @@
+--- a/MODULE.bazel	2026-03-28 23:44:20.250758858 -0700
++++ b/MODULE.bazel	2026-03-28 23:44:35.555491918 -0700
+@@ -28,34 +28,11 @@
+ bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
+ 
+ # p4c provides the compiler frontend and midend that our backend builds on.
+-# The git_override adds targets not yet in upstream p4c:
+-#   - //p4include package (exports_files + filegroup for individual includes)
+-#   - //testdata/p4_16_samples:* (exports_files for corpus/BMv2 tests)
+-#   - macOS build fix (HAVE_PIPE2 / HAVE_UCONTEXT_H)
+-# Upstream PR: https://github.com/p4lang/p4c/pull/5533
+-# Once merged and released to BCR, drop the git_override.
+-bazel_dep(name = "p4c", version = "1.2.5.11")
+-git_override(
+-    module_name = "p4c",
+-    commit = "c7e38ae7a338973098ab73d08f631c98c470b71c",
+-    remote = "https://github.com/smolkaj/p4c.git",
+-)
++bazel_dep(name = "p4c", version = "1.2.5.11.bcr.1")
+ 
+ # p4-constraints validates @entry_restriction / @action_restriction annotations.
+ bazel_dep(name = "p4_constraints", version = "20260311.0")
+ 
+-# BMv2 (behavioral-model) — v1model reference simulator for differential testing.
+-# Patched to add native Bazel build rules (no Thrift, no nanomsg).
+-# Dev-only: not needed by downstream consumers of the 4ward module.
+-bazel_dep(name = "behavioral_model", version = "head", dev_dependency = True)
+-git_override(
+-    module_name = "behavioral_model",
+-    commit = "6c7c93e5484e069c539b5c990bf37c531599894a",
+-    patch_strip = 1,
+-    patches = ["//bazel:behavioral_model.patch"],
+-    remote = "https://github.com/p4lang/behavioral-model.git",
+-)
+-
+ # --- JVM dependencies ---
+ 
+ maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+@@ -101,16 +78,3 @@
+ # --- Dev tools ---
+ 
+ bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = True)
+-
+-# Runs clang-tidy as a Bazel aspect — no compile_commands.json needed.
+-# Usage: bazel build //p4c_backend/... --config=clang-tidy
+-bazel_dep(name = "bazel_clang_tidy", dev_dependency = True)
+-git_override(
+-    module_name = "bazel_clang_tidy",
+-    # Pin to the commit before "Add builtin include flags for clang-tidy"
+-    # (c4d35e0).  That commit passes cc_toolchain.built_in_include_directories
+-    # as explicit -isystem flags, which promotes /usr/include out of clang's
+-    # internal search order and breaks #include_next from <cstdlib>.
+-    commit = "9e54bbb15d1939a9d030c52f3032886a0b278f98",
+-    remote = "https://github.com/erenon/bazel_clang_tidy.git",
+-)

--- a/modules/fourward/0.1.0/presubmit.yml
+++ b/modules/fourward/0.1.0/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  platform: ["ubuntu2204", "ubuntu2404"]
+  bazel: ["9.x"]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      # p4c (transitive dep) requires C++20.
+      - "--cxxopt=-std=c++20"
+      - "--host_cxxopt=-std=c++20"
+    build_targets:
+      - "@fourward//simulator:simulator_lib"
+      - "@fourward//simulator:ir_java_proto"
+      - "@fourward//simulator:ir_cc_proto"
+      - "@fourward//simulator:simulator_java_proto"
+      - "@fourward//p4runtime:p4runtime_lib"
+      - "@fourward//p4c_backend:p4c_backend_lib"
+      - "@fourward//p4c_backend:p4c-4ward"

--- a/modules/fourward/0.1.0/source.json
+++ b/modules/fourward/0.1.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-tcNY2AwPI+anDJ9ylXM6uHVFJKraYXtDUAaiwmIGEj0=",
+    "strip_prefix": "4ward-0.1.0",
+    "url": "https://github.com/smolkaj/4ward/archive/refs/tags/v0.1.0.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "bcr.patch": "sha256-Ye9j+2aI8UYTuvynZXISTEUaF7DMAcwts0tYcXHkk98="
+    }
+}

--- a/modules/fourward/metadata.json
+++ b/modules/fourward/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/smolkaj/4ward",
+    "maintainers": [
+        {
+            "github": "smolkaj",
+            "github_user_id": 6642034,
+            "name": "Steffen Smolka"
+        }
+    ],
+    "repository": [
+        "github:smolkaj/4ward"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}

--- a/modules/p4c/1.2.5.11.bcr.1/MODULE.bazel
+++ b/modules/p4c/1.2.5.11.bcr.1/MODULE.bazel
@@ -1,0 +1,44 @@
+module(
+    name = "p4c",
+    version = "1.2.5.11.bcr.1",
+)
+
+bazel_dep(name = "abseil-cpp", version = "20260107.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "boost.algorithm", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.format", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.functional", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.graph", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.iostreams", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.multi_index", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.multiprecision", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.serialization", version = "1.90.0.bcr.1")
+bazel_dep(name = "googleapis", version = "0.0.0-20260223-edfe7983")
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1")
+bazel_dep(name = "protobuf", version = "33.5")
+bazel_dep(name = "rules_bison", version = "0.4")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_flex", version = "0.4")
+bazel_dep(name = "rules_license", version = "1.0.0")
+
+# Transitive dep of rules_bison and rules_flex; pinned to 0.3 for Bazel 9+ compatibility.
+bazel_dep(name = "rules_m4", version = "0.3")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "z3", version = "4.15.2")
+bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
+
+p4c_repositories = use_extension("//bazel:repositories.bzl", "p4c_repositories")
+use_repo(
+    p4c_repositories,
+    "inja",
+)
+
+p4c_ir_extensions = use_extension("//bazel:extensions.bzl", "p4c_ir_extensions")
+use_repo(
+    p4c_ir_extensions,
+    "p4c_ir_extensions",
+)
+
+# Used by the `tools/format-bazel-files.sh` script.
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = True)

--- a/modules/p4c/1.2.5.11.bcr.1/patches/downstream_targets.patch
+++ b/modules/p4c/1.2.5.11.bcr.1/patches/downstream_targets.patch
@@ -1,0 +1,54 @@
+--- a/BUILD.bazel	2026-03-28 23:45:53.635130048 -0700
++++ b/BUILD.bazel	2026-03-28 23:46:10.473836331 -0700
+@@ -19,25 +19,30 @@
+ 
+ exports_files(["LICENSE"])
+ 
+-filegroup(
++# Deprecated: use //p4include instead.
++alias(
+     name = "p4include",
+-    srcs = glob(["p4include/**/*.p4"]),
++    actual = "//p4include",
++    deprecation = "Use @p4c//p4include instead of @p4c//:p4include.",
+ )
+ 
+ genrule(
+     name = "sed_config_h",
+     srcs = ["cmake/config.h.cmake"],
+     outs = ["config.h"],
+-    # TODO: We should actually check these properly instead of just #undefing them.
+-    # Maybe select() can help here?
+     # CONFIG_PKGDATADIR is where p4c should look for p4include at runtime.
+     # This will work only if the binary is executed by Bazel. For a general
+     # solution, we would need to make p4c aware of Bazel, specifically:
+     # https://github.com/bazelbuild/bazel/blob/master/tools/cpp/runfiles/runfiles_src.h
++    # pipe2 is Linux-only (crash.cpp has a pipe()+fcntl() fallback); ucontext.h
++    # requires _XOPEN_SOURCE on macOS SDKs >=14 and is crash-handler register dumps
++    # only. Both are safe to leave undefined everywhere.
+     cmd = "sed -e 's|cmakedefine|define|g' \
+              -e 's|define HAVE_LIBGC 1|undef HAVE_LIBGC|g' \
+              -e 's|define HAVE_LIBBACKTRACE 1|undef HAVE_LIBBACKTRACE|g' \
+              -e 's|define HAVE_MM_MALLOC_H 1|undef HAVE_MM_MALLOC_H|g' \
++             -e 's|define HAVE_PIPE2 1|undef HAVE_PIPE2|g' \
++             -e 's|define HAVE_UCONTEXT_H 1|undef HAVE_UCONTEXT_H|g' \
+              -e 's|@MAX_LOGGING_LEVEL@|10|g' \
+              -e 's|@CONFIG_PKGDATADIR@|external/%s|g' \
+              < $(SRCS) > $(OUTS)" % repository_name(),
+--- a/p4include/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/p4include/BUILD.bazel	2026-03-28 23:46:13.505783444 -0700
+@@ -0,0 +1,7 @@
++exports_files(glob(["**/*.p4"]))
++
++filegroup(
++    name = "p4include",
++    srcs = glob(["**/*.p4"]),
++    visibility = ["//visibility:public"],
++)
+--- a/testdata/p4_16_samples/BUILD.bazel	1969-12-31 16:00:00.000000000 -0800
++++ b/testdata/p4_16_samples/BUILD.bazel	2026-03-28 23:46:16.913723998 -0700
+@@ -0,0 +1,4 @@
++exports_files(glob([
++    "*.p4",
++    "*.stf",
++]))

--- a/modules/p4c/1.2.5.11.bcr.1/patches/set_version.patch
+++ b/modules/p4c/1.2.5.11.bcr.1/patches/set_version.patch
@@ -1,0 +1,10 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "p4c",
+-    version = "head",  # Fill in concrete versions only on release branches/in the BCR.
++    version = "1.2.5.11.bcr.1",
+ )
+
+ bazel_dep(name = "abseil-cpp", version = "20260107.1")

--- a/modules/p4c/1.2.5.11.bcr.1/presubmit.yml
+++ b/modules/p4c/1.2.5.11.bcr.1/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform: ["ubuntu2204", "ubuntu2404"]
+  bazel: ["9.x"]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      # p4c requires C++20. The .bazelrc in the source tree sets these flags,
+      # but BCR presubmit builds don't load it.
+      - "--cxxopt=-std=c++20"
+      - "--host_cxxopt=-std=c++20"
+    build_targets:
+      - "@p4c//..."

--- a/modules/p4c/1.2.5.11.bcr.1/source.json
+++ b/modules/p4c/1.2.5.11.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-+DuN2lJ0sZYTUyH6iVm6z6N0n9cVcGE0rBqmGgjGlKs=",
+    "strip_prefix": "p4c-1.2.5.11",
+    "url": "https://github.com/p4lang/p4c/releases/download/v1.2.5.11/p4c-1.2.5.11.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "set_version.patch": "sha256-P7Ky7FA2ScQmzT9cQeRCA7IrgnKaEXyMtYciCK+Vwbk=",
+        "downstream_targets.patch": "sha256-OsMzLsz3/IEsvU2Fsd3OFcJWmoEMC+CsPv+93wfd8Bs="
+    }
+}

--- a/modules/p4c/metadata.json
+++ b/modules/p4c/metadata.json
@@ -26,7 +26,8 @@
         "github:p4lang/p4c"
     ],
     "versions": [
-        "1.2.5.11"
+        "1.2.5.11",
+        "1.2.5.11.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
## Summary

Two new module versions:

- **p4c 1.2.5.11.bcr.1** — patches in three changes from
  [p4lang/p4c#5533](https://github.com/p4lang/p4c/pull/5533) (already
  merged upstream, but not yet in a tagged release):
  - `//p4include` package with `exports_files` and `filegroup`
  - `//testdata/p4_16_samples` exports
  - macOS build fix (`HAVE_PIPE2` / `HAVE_UCONTEXT_H`)

- **fourward 0.1.0** — initial BCR release of the
  [4ward](https://github.com/smolkaj/4ward) P4 simulator. A
  spec-compliant reference implementation of P4₁₆ and P4Runtime,
  designed for dataplane validation and testing. Depends on
  p4c 1.2.5.11.bcr.1 for the `//p4include` package.

## Test plan

- [x] All patches verified to apply cleanly to source archives
- [x] Patched MODULE.bazel files match BCR MODULE.bazel entries
- [ ] BCR presubmit CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)