### PR TITLE
fourward@20260405.1

### DIFF
--- a/modules/fourward/20260405.1/MODULE.bazel
+++ b/modules/fourward/20260405.1/MODULE.bazel
@@ -1,0 +1,95 @@
+module(
+    name = "fourward",
+    version = "20260405.1",
+    bazel_compatibility = [">=8.0.0"],
+)
+
+# --- Core build rules ---
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_kotlin", version = "2.3.0")
+bazel_dep(name = "rules_java", version = "9.3.0")
+bazel_dep(name = "rules_python", version = "1.4.1")
+bazel_dep(name = "rules_jvm_external", version = "6.10")
+
+# --- Protobuf & gRPC ---
+
+bazel_dep(name = "protobuf", version = "33.5")
+bazel_dep(name = "grpc", version = "1.80.0.bcr.1")  # For cc_grpc_library (dataplane_cc_grpc).
+bazel_dep(name = "grpc-java", version = "1.78.0")
+bazel_dep(name = "grpc_kotlin", version = "1.5.0")
+
+# --- P4 ecosystem ---
+
+# p4runtime provides p4info.proto, p4runtime.proto, and p4data.proto.
+bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
+
+# p4c provides the compiler frontend and midend that our backend builds on.
+bazel_dep(name = "p4c", version = "1.2.5.11.bcr.1")
+
+# p4-constraints validates @entry_restriction / @action_restriction annotations.
+bazel_dep(name = "p4_constraints", version = "20260311.0")
+
+# --- JVM dependencies ---
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.install(
+    name = "fourward_maven",
+    artifacts = [
+        "com.google.protobuf:protobuf-java:4.29.3",
+        "com.google.protobuf:protobuf-java-util:4.29.3",
+        "com.google.protobuf:protobuf-kotlin:4.29.3",
+        "junit:junit:4.13.2",
+        "com.facebook:ktfmt:0.61",
+        "io.gitlab.arturbosch.detekt:detekt-cli:1.23.8",
+        # gRPC runtime. We depend on these via @fourward_maven rather
+        # than @grpc-java//... so that BCR consumers don't need to bless
+        # grpc-java as a contributor to the shared @maven repo.
+        "io.grpc:grpc-api:1.78.0",
+        "io.grpc:grpc-inprocess:1.78.0",
+        "io.grpc:grpc-kotlin-stub:1.4.3",
+        "io.grpc:grpc-netty:1.78.0",
+        "io.grpc:grpc-netty-shaded:1.78.0",
+        "io.grpc:grpc-services:1.78.0",
+        "io.grpc:grpc-stub:1.78.0",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1",
+        "javax.annotation:javax.annotation-api:1.3.2",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+)
+use_repo(maven, "fourward_maven")
+
+# Bless grpc-java and protobuf as contributors to the shared @maven repo
+# so grpc-java's internal BUILD files resolve. See bcr_test_module/ for
+# the rationale and the boilerplate BCR consumers need to replicate.
+maven.install(
+    known_contributing_modules = [
+        "grpc-java",
+        "protobuf",
+    ],
+)
+use_repo(maven, "maven")
+
+# --- Python (cram test runner) ---
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.12")
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "pip",
+    python_version = "3.12",
+    requirements_lock = "//:requirements.txt",
+)
+use_repo(pip, "pip")
+
+# --- Dev tools ---
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = True)

--- a/modules/fourward/20260405.1/patches/bcr.patch
+++ b/modules/fourward/20260405.1/patches/bcr.patch
@@ -1,0 +1,72 @@
+--- a/MODULE.bazel	2026-04-05 17:24:24.007553235 -0700
++++ b/MODULE.bazel	2026-04-06 16:26:07.519195295 -0700
+@@ -19,7 +19,7 @@
+ # --- Protobuf & gRPC ---
+ 
+ bazel_dep(name = "protobuf", version = "33.5")
+-bazel_dep(name = "grpc", version = "1.80.0")  # For cc_grpc_library (dataplane_cc_grpc).
++bazel_dep(name = "grpc", version = "1.80.0.bcr.1")  # For cc_grpc_library (dataplane_cc_grpc).
+ bazel_dep(name = "grpc-java", version = "1.78.0")
+ bazel_dep(name = "grpc_kotlin", version = "1.5.0")
+ 
+@@ -29,43 +29,11 @@
+ bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
+ 
+ # p4c provides the compiler frontend and midend that our backend builds on.
+-# BCR consumers get p4c 1.2.5.11.bcr.1 (which has //p4include, testdata
+-# exports, and the macOS build fix). Our own dev builds additionally pin
+-# to the smolkaj/p4c fork via git_override — only honored when fourward
+-# is the root module — because the fork carries the PNA p4testgen STF
+-# backend (p4lang/p4c#5570) and drop-by-default fix (p4lang/p4c#5569)
+-# that our e2e_tests/p4testgen PNA suite needs. Drop the git_override
+-# once both are merged and released to BCR.
+ bazel_dep(name = "p4c", version = "1.2.5.11.bcr.1")
+-git_override(
+-    module_name = "p4c",
+-    commit = "c7e38ae7a338973098ab73d08f631c98c470b71c",
+-    remote = "https://github.com/smolkaj/p4c.git",
+-)
+ 
+ # p4-constraints validates @entry_restriction / @action_restriction annotations.
+ bazel_dep(name = "p4_constraints", version = "20260311.0")
+ 
+-# grpc with Bazel 9 support (native rule autoloading + rules_swift compat).
+-# TODO: Drop once grpc publishes a Bazel-9-compatible release to BCR.
+-git_override(
+-    module_name = "grpc",
+-    commit = "a09a3af54b870cf9d1064f807355721451196329",
+-    remote = "https://github.com/smolkaj/grpc.git",
+-)
+-
+-# BMv2 (behavioral-model) — v1model reference simulator for differential testing.
+-# Patched to add native Bazel build rules (no Thrift, no nanomsg).
+-# Dev-only: not needed by downstream consumers of the 4ward module.
+-bazel_dep(name = "behavioral_model", version = "head", dev_dependency = True)
+-git_override(
+-    module_name = "behavioral_model",
+-    commit = "6c7c93e5484e069c539b5c990bf37c531599894a",
+-    patch_strip = 1,
+-    patches = ["//bazel:behavioral_model.patch"],
+-    remote = "https://github.com/p4lang/behavioral-model.git",
+-)
+-
+ # --- JVM dependencies ---
+ 
+ maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+@@ -125,16 +93,3 @@
+ # --- Dev tools ---
+ 
+ bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = True)
+-
+-# Runs clang-tidy as a Bazel aspect — no compile_commands.json needed.
+-# Usage: bazel build //p4c_backend/... --config=clang-tidy
+-bazel_dep(name = "bazel_clang_tidy", dev_dependency = True)
+-git_override(
+-    module_name = "bazel_clang_tidy",
+-    # Pin to the commit before "Add builtin include flags for clang-tidy"
+-    # (c4d35e0).  That commit passes cc_toolchain.built_in_include_directories
+-    # as explicit -isystem flags, which promotes /usr/include out of clang's
+-    # internal search order and breaks #include_next from <cstdlib>.
+-    commit = "9e54bbb15d1939a9d030c52f3032886a0b278f98",
+-    remote = "https://github.com/erenon/bazel_clang_tidy.git",
+-)

--- a/modules/fourward/20260405.1/presubmit.yml
+++ b/modules/fourward/20260405.1/presubmit.yml
@@ -1,0 +1,19 @@
+bcr_test_module:
+  module_path: bcr_test_module
+  matrix:
+    platform: ["ubuntu2204", "ubuntu2404"]
+    bazel: ["8.x"]
+  tasks:
+    run_test_module:
+      name: "Consumer smoke test"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--cxxopt=-std=c++20"
+        - "--host_cxxopt=-std=c++20"
+        - "--java_runtime_version=remotejdk_21"
+        - "--tool_java_runtime_version=remotejdk_21"
+      build_targets:
+        - "@fourward//..."
+        - "-@fourward//e2e_tests/..."
+        - "-@fourward//examples/..."

--- a/modules/fourward/20260405.1/source.json
+++ b/modules/fourward/20260405.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-aX8qKyWydWn2nlI9FZ088svXRKSxKm3s1qSH5dAcFpQ=",
+    "strip_prefix": "4ward-20260405.1",
+    "url": "https://github.com/smolkaj/4ward/releases/download/20260405.1/fourward-20260405.1.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "bcr.patch": "sha256-8aCNwLssNipk3eb4U4PoejQm+F06K6IX+WxRkkpKYDk="
+    }
+}

--- a/modules/fourward/metadata.json
+++ b/modules/fourward/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/smolkaj/4ward",
+    "maintainers": [
+        {
+            "github": "smolkaj",
+            "github_user_id": 6642034,
+            "name": "Steffen Smolka"
+        }
+    ],
+    "repository": [
+        "github:smolkaj/4ward"
+    ],
+    "versions": [
+        "20260405.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
## Summary

Initial BCR release of [4ward](https://github.com/smolkaj/4ward), a
spec-compliant reference implementation of P4₁₆ and P4Runtime for
dataplane validation and testing.

Depends on #8332 (\`grpc@1.80.0.bcr.1\`) for BCR presubmit
compatibility — grpc 1.80.0 declares \`rules_swift@2.5.0\` which
conflicts with Bazel 9's bundled \`rules_swift@3.1.2\` during the
vendor step (filed #8331).

### BCR patch

Strips \`git_override\` blocks (p4c, grpc, behavioral_model,
bazel_clang_tidy) and non-BCR dev dependencies. Pins grpc to
\`1.80.0.bcr.1\` (rules_swift fix).

### Consumer impact

| Consuming | Consumer MODULE.bazel needs |
|---|---|
| \`//simulator\`, \`//p4c_backend\`, \`//web\`, \`//cli\` | nothing |
| \`//p4runtime:p4runtime_lib\` | \`known_contributing_modules = ["grpc-java", "protobuf"]\` ([example](https://github.com/smolkaj/4ward/blob/main/bcr_test_module/MODULE.bazel)) |

### Local verification

All steps pass locally before submission:

- [x] \`bcr_validation\` — all GOOD
- [x] \`setup_presubmit_repos\` vendor step — passes with Bazel 9 (\`USE_BAZEL_VERSION=latest\`)
- [x] Full build from \`bcr_test_module\` — 82 targets pass with Bazel 8
- [ ] BCR presubmit CI (blocked on #8332)