### PR TITLE
jemalloc@5.3.0-bcr.3

### DIFF
--- a/modules/jemalloc/5.3.0-bcr.3/MODULE.bazel
+++ b/modules/jemalloc/5.3.0-bcr.3/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "jemalloc",
+    version = "5.3.0-bcr.3",
+    bazel_compatibility = [">=7.4.0"],  # need support for "overlay" directory and cxxopts in cc_binary
+    compatibility_level = 5,
+)
+
+bazel_dep(name = "bazel_lib", version = "3.2.2")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "libunwind", version = "1.8.3")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_shell", version = "0.4.1")

--- a/modules/jemalloc/5.3.0-bcr.3/presubmit.yml
+++ b/modules/jemalloc/5.3.0-bcr.3/presubmit.yml
@@ -1,0 +1,37 @@
+matrix:
+  platform:
+    - fedora40
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+  bazel: ["7.x", "8.x", "9.x", "rolling"]
+tasks:
+  verify_jemalloc:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@jemalloc"
+
+bcr_test_module:
+  module_path: examples
+  matrix:
+    platform:
+      - fedora40
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - ubuntu2404
+      - macos
+      - macos_arm64
+    bazel: ["7.x", "8.x", "9.x", "rolling"]
+  tasks:
+    verify_examples:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."
+      test_targets:
+        - "//..."

--- a/modules/jemalloc/5.3.0-bcr.3/source.json
+++ b/modules/jemalloc/5.3.0-bcr.3/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/sallustfire/jemalloc/releases/download/5.3.0-bcr.3/jemalloc-5.3.0-bcr.3.tar.gz",
+    "strip_prefix": "jemalloc-5.3.0-bcr.3",
+    "integrity": "sha256-yiwVpB2ocvd2eqge4d7caorTmC7ZgRBMX4nal5zz99I="
+}

--- a/modules/jemalloc/metadata.json
+++ b/modules/jemalloc/metadata.json
@@ -9,9 +9,11 @@
         }
     ],
     "repository": [
+        "github:sallustfire/jemalloc",
         "github:jemalloc/jemalloc"
     ],
     "versions": [
+        "5.3.0-bcr.3",
         "5.3.0-bcr.alpha.1",
         "5.3.0-bcr.alpha.2",
         "5.3.0-bcr.alpha.3",


### PR DESCRIPTION
Release: https://github.com/sallustfire/jemalloc/releases/tag/5.3.0-bcr.3

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_