### PR TITLE
Publish gcc_toolchain@0.9.2

### DIFF
--- a/modules/gcc_toolchain/0.9.2/MODULE.bazel
+++ b/modules/gcc_toolchain/0.9.2/MODULE.bazel
@@ -1,0 +1,66 @@
+module(name = "gcc_toolchain",
+    version = "0.9.2",
+)
+
+# Dependencies
+# ============
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "aspect_bazel_lib", version = "1.40.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.0")
+
+# Local Toolchains
+# ================
+gcc_toolchains = use_extension("//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
+
+[
+    [
+        gcc_toolchains.toolchain(
+            name = "gcc_toolchain_{}".format(arch),
+            target_arch = arch,
+        ),
+        use_repo(gcc_toolchains, "gcc_toolchain_{}".format(arch)),
+        register_toolchains(
+            "@gcc_toolchain_{}//:cc_toolchain".format(arch),
+            "@gcc_toolchain_{}//:fortran_toolchain".format(arch),
+            # Register toolchains as dev dependencies so that we don't pollute the toolchain resolution of consumers.
+            dev_dependency = True,
+        ),
+    ]
+    # Unfortunately, we can't load `ARCHS` directly here.
+    # But the attributes in `gcc_toolchains.toolchain` are gated to only contain values from ARCHS.
+    for arch in [
+        "aarch64",
+        "armv7",
+        "x86_64",
+    ]
+]
+
+# Dev Dependencies (for examples/)
+# ===============================
+bazel_dep(name = "rules_proto", version = "7.1.0", dev_dependency = True)
+bazel_dep(name = "rules_foreign_cc", version = "0.15.0", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.5.6", dev_dependency = True, repo_name = "io_bazel_stardoc")
+# We pin stardoc because a dependency requests a newer version (0.7.2), but the non-workspace flow doesn't work with it.
+single_version_override(
+    module_name = "stardoc",
+    version = "0.5.6",
+)
+
+bazel_dep(name = "protobuf", version = "29.3", dev_dependency = True, repo_name = "com_google_protobuf")
+single_version_override(
+    module_name = "protobuf",
+    patch_strip = 1,
+    patches = [
+        "//third_party/patches:com_google_protobuf.bzlmod.patch",
+    ],
+    version = "29.3",
+)
+
+non_bazel_dependencies = use_extension("//:internal.bzl", "non_bazel_dependencies")
+use_repo(
+    non_bazel_dependencies,
+    "avl",
+    "lapack",
+    "openssl",
+)

--- a/modules/gcc_toolchain/0.9.2/attestations.json
+++ b/modules/gcc_toolchain/0.9.2/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/f0rmiga/gcc-toolchain/releases/download/0.9.2/source.json.intoto.jsonl",
+            "integrity": "sha256-3PrUMyeQC7U2wElqtahUl9rXpj6EybF/kBGmuej3Q58="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/f0rmiga/gcc-toolchain/releases/download/0.9.2/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-BVY6p4O14k34fiemkw+dVKimmmtHbiny4At3Bs5Dg4w="
+        },
+        "gcc-toolchain-0.9.2.tar.gz": {
+            "url": "https://github.com/f0rmiga/gcc-toolchain/releases/download/0.9.2/gcc-toolchain-0.9.2.tar.gz.intoto.jsonl",
+            "integrity": "sha256-vL/qZUKCH/2RE3BgH5fOpn3D70dWrF0ZupmIc4lAphA="
+        }
+    }
+}

--- a/modules/gcc_toolchain/0.9.2/patches/module_dot_bazel_version.patch
+++ b/modules/gcc_toolchain/0.9.2/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,5 +1,7 @@
+-module(name = "gcc_toolchain")
++module(name = "gcc_toolchain",
++    version = "0.9.2",
++)
+ 
+ # Dependencies
+ # ============
+ bazel_dep(name = "bazel_skylib", version = "1.8.1")

--- a/modules/gcc_toolchain/0.9.2/presubmit.yml
+++ b/modules/gcc_toolchain/0.9.2/presubmit.yml
@@ -1,0 +1,14 @@
+bcr_test_module:
+  module_path: examples/bzlmod
+  matrix:
+    platform: ["ubuntu2204"]
+    bazel: [7.x, 8.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--enable_bzlmod"
+      test_targets:
+        - "//..."

--- a/modules/gcc_toolchain/0.9.2/source.json
+++ b/modules/gcc_toolchain/0.9.2/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-5BVZw3MdUJmoM3iNS1RZaUJID/oGufVcpjsbHk2M05I=",
+    "strip_prefix": "gcc-toolchain-0.9.2",
+    "url": "https://github.com/f0rmiga/gcc-toolchain/releases/download/0.9.2/gcc-toolchain-0.9.2.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-cuQIeb9A9l32D/05fB4jLdOmyvlUphzNQCFfzIv1qlI="
+    },
+    "patch_strip": 1
+}

--- a/modules/gcc_toolchain/metadata.json
+++ b/modules/gcc_toolchain/metadata.json
@@ -18,7 +18,8 @@
         "github:f0rmiga/gcc-toolchain"
     ],
     "versions": [
-        "0.9.0"
+        "0.9.0",
+        "0.9.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/f0rmiga/gcc-toolchain/releases/tag/0.9.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_