### PR TITLE
capnp-cpp@1.4.0

### DIFF
--- a/modules/capnp-cpp/1.4.0/MODULE.bazel
+++ b/modules/capnp-cpp/1.4.0/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "capnp-cpp",
+    version = "1.4.0",
+)
+
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
+bazel_dep(name = "boringssl", version = "0.20241024.0")
+bazel_dep(name = "brotli", version = "1.1.0")

--- a/modules/capnp-cpp/1.4.0/patches/bazelmod-compatible-boringssl.patch
+++ b/modules/capnp-cpp/1.4.0/patches/bazelmod-compatible-boringssl.patch
@@ -1,0 +1,13 @@
+diff --git a/c++/src/kj/compat/BUILD.bazel b/c++/src/kj/compat/BUILD.bazel
+index f9e31ce..2350724 100644
+--- a/c++/src/kj/compat/BUILD.bazel
++++ b/c++/src/kj/compat/BUILD.bazel
+@@ -18,7 +18,7 @@ cc_library(
+     visibility = ["//visibility:public"],
+     deps = [
+         "//src/kj:kj-async",
+-        "@ssl",
++        "@boringssl//:ssl",
+     ],
+ )
+ 

--- a/modules/capnp-cpp/1.4.0/patches/fix-ez-rpc-includes.patch
+++ b/modules/capnp-cpp/1.4.0/patches/fix-ez-rpc-includes.patch
@@ -1,0 +1,18 @@
+# ez-rpc.h uses bare includes ("rpc.h", "message.h") which don't work when
+# building with Bazel's sandboxed include paths. See upstream discussion:
+# https://github.com/capnproto/capnproto/discussions/1942
+diff --git a/c++/src/capnp/ez-rpc.h b/c++/src/capnp/ez-rpc.h
+index ef26492..4168ed5 100644
+--- a/c++/src/capnp/ez-rpc.h
++++ b/c++/src/capnp/ez-rpc.h
+@@ -21,8 +21,8 @@
+ 
+ #pragma once
+ 
+-#include "rpc.h"
+-#include "message.h"
++#include "capnp/rpc.h"
++#include "capnp/message.h"
+ 
+ CAPNP_BEGIN_HEADER
+ 

--- a/modules/capnp-cpp/1.4.0/patches/update-module-version.patch
+++ b/modules/capnp-cpp/1.4.0/patches/update-module-version.patch
@@ -1,0 +1,12 @@
+diff --git a/c++/MODULE.bazel b/c++/MODULE.bazel
+index 3f47e58..c3f5bf5 100644
+--- a/c++/MODULE.bazel
++++ b/c++/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "capnp-cpp",
+-    version = "1.1.0",
++    version = "1.4.0",
+ )
+
+ bazel_dep(name = "platforms", version = "0.0.11")

--- a/modules/capnp-cpp/1.4.0/presubmit.yml
+++ b/modules/capnp-cpp/1.4.0/presubmit.yml
@@ -1,0 +1,27 @@
+matrix:
+  platform:
+  - rockylinux8
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  bazel:
+  - rolling
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@capnp-cpp//src/capnp:capnp'
+    - '@capnp-cpp//src/capnp:capnp-rpc'
+    - '@capnp-cpp//src/capnp:capnpc'
+    - '@capnp-cpp//src/capnp:capnp_tool'
+    - '@capnp-cpp//src/capnp:capnpc-c++'
+    - '@capnp-cpp//src/capnp:capnpc-capnp'
+    - '@capnp-cpp//src/capnp:capnp_runtime'

--- a/modules/capnp-cpp/1.4.0/source.json
+++ b/modules/capnp-cpp/1.4.0/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/capnproto/capnproto/archive/refs/tags/v1.4.0.tar.gz",
+    "integrity": "sha256-0UqRSbecBV/unVqneN7+jozuDSoR8HKYZc0w3MNF7vI=",
+    "strip_prefix": "capnproto-1.4.0/c++",
+    "patch_strip": 2,
+    "patches": {
+        "update-module-version.patch": "sha256-jvMVGDWz/UaPRceDgejOwMr/mWnDM/41Q8oL8VV7WHI=",
+        "bazelmod-compatible-boringssl.patch": "sha256-9TgV4vmANjqJzNqZ15a2/5SzNBbF9MOzgePnEckwDMc=",
+        "fix-ez-rpc-includes.patch": "sha256-Co8o5JuG3wtonjkZzcSqHEhcJMllipFNJhUZ+WHLSyM="
+    }
+}

--- a/modules/capnp-cpp/metadata.json
+++ b/modules/capnp-cpp/metadata.json
@@ -12,7 +12,8 @@
         "github:capnproto/capnproto"
     ],
     "versions": [
-        "1.1.0"
+        "1.1.0",
+        "1.4.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds Cap'n Proto C++ v1.4.0 to the registry.

Patches:
- `update-module-version.patch`: Updates the version field in `MODULE.bazel` from `1.1.0` to `1.4.0` (the upstream source was not updated when the release was cut).
- `bazelmod-compatible-boringssl.patch`: Replaces `@ssl` with `@boringssl//:ssl` in `kj-tls` for Bzlmod compatibility.
- `fix-ez-rpc-includes.patch`: Fixes bare includes in `ez-rpc.h` that don't work with Bazel's sandboxed include paths (see https://github.com/capnproto/capnproto/discussions/1942).