### PR TITLE
reflect-cpp@30e9b927c2c8309fe12e0b1450816420422701f9

### DIFF
--- a/modules/reflect-cpp/30e9b927c2c8309fe12e0b1450816420422701f9/MODULE.bazel
+++ b/modules/reflect-cpp/30e9b927c2c8309fe12e0b1450816420422701f9/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "reflect-cpp",
+    version = "30e9b927c2c8309fe12e0b1450816420422701f9",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.3")
+bazel_dep(name = "yyjson", version = "0.10.0")
+bazel_dep(name = "yaml-cpp", version = "0.8.0")
+bazel_dep(name = "capnp-cpp", version = "1.1.0")

--- a/modules/reflect-cpp/30e9b927c2c8309fe12e0b1450816420422701f9/patches/add_build_file.patch
+++ b/modules/reflect-cpp/30e9b927c2c8309fe12e0b1450816420422701f9/patches/add_build_file.patch
@@ -1,0 +1,52 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,49 @@
++cc_library(
++    name = "reflect-cpp",
++    hdrs = glob(
++        [
++            "include/rfl.hpp",
++            "include/rfl/*.hpp",
++            "include/rfl/atomic/**",
++            "include/rfl/generic/**",
++            "include/rfl/internal/**",
++            "include/rfl/io/**",
++            "include/rfl/json/**",
++            "include/rfl/capnproto/**",
++            "include/rfl/parsing/**",
++            "include/rfl/thirdparty/**",
++            "include/rfl/yaml/**",
++        ],
++        exclude = [
++            "include/rfl/avro.hpp",
++            "include/rfl/bson.hpp",
++            "include/rfl/cbor.hpp",
++            "include/rfl/flexbuf.hpp",
++            "include/rfl/msgpack.hpp",
++            "include/rfl/toml.hpp",
++            "include/rfl/ubjson.hpp",
++            "include/rfl/xml.hpp",
++        ]
++    ),
++    srcs = glob([
++        "src/rfl/Generic.cpp",
++        "src/rfl/generic/**",
++        "src/rfl/internal/**",
++        "src/rfl/json/**",
++        "src/rfl/capnproto/**",
++        "src/rfl/parsing/**",
++        "src/rfl/yaml/**",
++    ]),
++    includes = ["include"],
++    deps = [
++        "@yaml-cpp",
++        "@yyjson",
++        "@capnp-cpp//src/capnp",
++        "@capnp-cpp//src/capnp:capnpc",
++    ],
++    copts = ["--std=c++20"],
++    visibility = ["//visibility:public"],
++    defines = [
++      "REFLECT_CPP_C_ARRAYS_OR_INHERITANCE",
++    ]
++)

--- a/modules/reflect-cpp/30e9b927c2c8309fe12e0b1450816420422701f9/patches/module_dot_bazel.patch
+++ b/modules/reflect-cpp/30e9b927c2c8309fe12e0b1450816420422701f9/patches/module_dot_bazel.patch
@@ -1,0 +1,13 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,10 @@
++module(
++    name = "reflect-cpp",
++    version = "30e9b927c2c8309fe12e0b1450816420422701f9",
++    bazel_compatibility = [">=7.2.1"],
++)
++
++bazel_dep(name = "rules_cc", version = "0.2.3")
++bazel_dep(name = "yyjson", version = "0.10.0")
++bazel_dep(name = "yaml-cpp", version = "0.8.0")
++bazel_dep(name = "capnp-cpp", version = "1.1.0")

--- a/modules/reflect-cpp/30e9b927c2c8309fe12e0b1450816420422701f9/presubmit.yml
+++ b/modules/reflect-cpp/30e9b927c2c8309fe12e0b1450816420422701f9/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  # - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  # - windows
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@reflect-cpp//:reflect-cpp'

--- a/modules/reflect-cpp/30e9b927c2c8309fe12e0b1450816420422701f9/source.json
+++ b/modules/reflect-cpp/30e9b927c2c8309fe12e0b1450816420422701f9/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/getml/reflect-cpp/archive/30e9b927c2c8309fe12e0b1450816420422701f9.tar.gz",
+    "integrity": "sha256-vtnqmRElOsC8mnnf1ONK+CBKbZqqLICdh1EJlk3omWk=",
+    "strip_prefix": "reflect-cpp-30e9b927c2c8309fe12e0b1450816420422701f9",
+    "patches": {
+        "add_build_file.patch": "sha256-5pH/qwD+lAWaVOThm495yahdjmyUeYycHBxcTrKQmMk=",
+        "module_dot_bazel.patch": "sha256-5cJRmMF8dD8QlXI3/R/WCt89zVWj3uGJgYqvTygmDeI="
+    },
+    "patch_strip": 0
+}

--- a/modules/reflect-cpp/metadata.json
+++ b/modules/reflect-cpp/metadata.json
@@ -12,7 +12,8 @@
         "github:getml/reflect-cpp"
     ],
     "versions": [
-        "0.22.0"
+        "0.22.0",
+        "30e9b927c2c8309fe12e0b1450816420422701f9"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
## Summary

- Add reflect-cpp at commit `30e9b927c2c8309fe12e0b1450816420422701f9`, which fixes Cap'n Proto serialization of unsigned integer types ([getml/reflect-cpp#635](https://github.com/getml/reflect-cpp/pull/635)).
- The BUILD.bazel and presubmit.yml are carried over from the existing `0.22.0` version unchanged.

@bazel-io skip_check unstable_url
