### PR TITLE
jemalloc@5.3.0-bcr.test5

### DIFF
--- a/modules/jemalloc/5.3.0-bcr.test5/MODULE.bazel
+++ b/modules/jemalloc/5.3.0-bcr.test5/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "jemalloc",
+    version = "5.3.0-bcr.3",
+    bazel_compatibility = [">=7.4.0"],  # need support for "overlay" directory and cxxopts in cc_binary
+    compatibility_level = 5,
+)
+
+bazel_dep(name = "bazel_lib", version = "5.3.0-bcr.test5")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "libunwind", version = "1.8.3")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_shell", version = "0.4.1")

--- a/modules/jemalloc/5.3.0-bcr.test5/attestations.json
+++ b/modules/jemalloc/5.3.0-bcr.test5/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/sallustfire/jemalloc/releases/download/5.3.0-bcr.test5/source.json.intoto.jsonl",
+            "integrity": "sha256-zgzo61qUPUocTcjehZYSryAq7sY5W2LXgBz0JSGuIdQ="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/sallustfire/jemalloc/releases/download/5.3.0-bcr.test5/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-fNnCykG6UaZR5ykxb8YYLttozdecF4CuHgdLTTraV7w="
+        },
+        "jemalloc-5.3.0-bcr.test5.tar.gz": {
+            "url": "https://github.com/sallustfire/jemalloc/releases/download/5.3.0-bcr.test5/jemalloc-5.3.0-bcr.test5.tar.gz.intoto.jsonl",
+            "integrity": "sha256-ihHauvDLhfq87YLyRR4iSswQ+j+60L0uBUi2Fd3H9Ck="
+        }
+    }
+}

--- a/modules/jemalloc/5.3.0-bcr.test5/patches/module_dot_bazel_version.patch
+++ b/modules/jemalloc/5.3.0-bcr.test5/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -4,9 +4,9 @@
+     bazel_compatibility = [">=7.4.0"],  # need support for "overlay" directory and cxxopts in cc_binary
+     compatibility_level = 5,
+ )
+ 
+-bazel_dep(name = "bazel_lib", version = "3.2.2")
++bazel_dep(name = "bazel_lib", version = "5.3.0-bcr.test5")
+ bazel_dep(name = "bazel_skylib", version = "1.8.2")
+ bazel_dep(name = "libunwind", version = "1.8.3")
+ bazel_dep(name = "platforms", version = "0.0.11")
+ bazel_dep(name = "rules_cc", version = "0.2.4")

--- a/modules/jemalloc/5.3.0-bcr.test5/presubmit.yml
+++ b/modules/jemalloc/5.3.0-bcr.test5/presubmit.yml
@@ -1,0 +1,37 @@
+matrix:
+  platform:
+    - fedora40
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+  bazel: ["7.x", "8.x", "9.x", "rolling"]
+tasks:
+  verify_jemalloc:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@jemalloc"
+
+bcr_test_module:
+  module_path: examples
+  matrix:
+    platform:
+      - fedora40
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - ubuntu2404
+      - macos
+      - macos_arm64
+    bazel: ["7.x", "8.x", "9.x", "rolling"]
+  tasks:
+    verify_examples:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."
+      test_targets:
+        - "//..."

--- a/modules/jemalloc/5.3.0-bcr.test5/source.json
+++ b/modules/jemalloc/5.3.0-bcr.test5/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/sallustfire/jemalloc/releases/download/5.3.0-bcr.test5/jemalloc-5.3.0-bcr.test5.tar.gz",
+    "strip_prefix": "jemalloc-5.3.0-bcr.test5",
+    "integrity": "sha256-0VBVwqpTVcGAojfI8qCxAZXBX73/ui0PkU2QpkhgGKo=",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-CSR3wynjqv+4F9HCbYPLv331pQLjEjxI1tqH2UDAEX8="
+    },
+    "patch_strip": 1
+}

--- a/modules/jemalloc/metadata.json
+++ b/modules/jemalloc/metadata.json
@@ -18,7 +18,8 @@
         "5.3.0-bcr.alpha.2",
         "5.3.0-bcr.alpha.3",
         "5.3.0-bcr.alpha.4",
-        "5.3.0-bcr.alpha.5"
+        "5.3.0-bcr.alpha.5",
+        "5.3.0-bcr.test5"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/sallustfire/jemalloc/releases/tag/5.3.0-bcr.test5

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_