### PR TITLE
rules_dart_proto@0.2.1

### DIFF
--- a/modules/rules_dart_proto/0.2.1/MODULE.bazel
+++ b/modules/rules_dart_proto/0.2.1/MODULE.bazel
@@ -1,0 +1,69 @@
+"Bazel dependencies"
+
+module(
+    name = "rules_dart_proto",
+
+    # NOTE:
+    # version = "0.2.1",
+    #
+    # Always leave version unset or set to "" (the default). The default value
+    # can prevent issues when the module is used via non-registry overrides
+    # (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).
+    #
+    # The publish.yaml GitHub Action sets the version in the registry to the
+    # release version by patching this MODULE.bazel file in the pull request to
+    # the BCR.
+    #
+    # For more info, see this Slack thread:
+    # https://bazelbuild.slack.com/archives/CA31HN1T3/p1750406404452179
+
+    # NOTE:
+    # compatibility_level = 0,
+    #
+    # Bumping compatibility_level too frequently is discouraged because it's
+    # very disruptive: as soon as a module is requested at two different
+    # compatibility levels in the dependency tree, users will see an error.
+    #
+    # As such, the compatibility_level (1) should be bumped *only* when the
+    # breaking change affects most use cases and isn't easy to migrate and/or
+    # work-around, and (2) *in the same commit* that introduces an incompatible
+    # (breaking) change.
+)
+
+bazel_dep(name = "rules_dart", version = "0.2.1")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "protobuf", version = "34.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
+bazel_dep(name = "package_metadata", version = "0.0.7")
+
+bazel_dep(name = "rules_multitool", version = "1.11.1", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1", dev_dependency = True)
+
+# TODO: remove once protobuf upgrades to a rules_android version compatible
+# with Bazel 9.0.1 (rules_android 0.6.4 uses the removed CcInfo builtin).
+bazel_dep(name = "rules_android", version = "0.7.1")
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.9.2")
+
+# Dart toolchain (needed to compile protoc-gen-dart plugin)
+dart = use_extension("@rules_dart//dart:extensions.bzl", "dart")
+dart.toolchain(dart_version = "3.11.4")
+use_repo(dart, "dart_toolchains")
+
+register_toolchains("@dart_toolchains//:all")
+
+# Fetch protoc_plugin and all transitive dependencies from pub.dev
+pub = use_extension("@rules_dart//dart/pub:extensions.bzl", "pub")
+pub.from_lock(
+    name = "dart_proto_deps",
+    lock = "//dart_proto:pubspec.lock",
+)
+use_repo(pub, "dart_proto_deps")
+
+multitool = use_extension(
+    "@rules_multitool//multitool:extension.bzl",
+    "multitool",
+    dev_dependency = True,
+)
+multitool.hub(lockfile = "//:multitool.lock.json")
+use_repo(multitool, "multitool")

--- a/modules/rules_dart_proto/0.2.1/attestations.json
+++ b/modules/rules_dart_proto/0.2.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/aran/rules_dart_proto/releases/download/v0.2.1/source.json.intoto.jsonl",
+            "integrity": "sha256-2BZqycFUC2ue0lcd3IO6BzIEa36yXoUYXSHqS5+WGk4="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/aran/rules_dart_proto/releases/download/v0.2.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-pzvlJ719OYEsdJFut0lGjN+DnejKQ+qF+6kYHwFPpfM="
+        },
+        "rules_dart_proto-v0.2.1.tar.gz": {
+            "url": "https://github.com/aran/rules_dart_proto/releases/download/v0.2.1/rules_dart_proto-v0.2.1.tar.gz.intoto.jsonl",
+            "integrity": "sha256-NEhY4NGnAbf49a615yRgdX0mpVST7AG41iCuv2fY26Y="
+        }
+    }
+}

--- a/modules/rules_dart_proto/0.2.1/patches/module_dot_bazel_version.patch
+++ b/modules/rules_dart_proto/0.2.1/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -3,9 +3,9 @@
+ module(
+     name = "rules_dart_proto",
+ 
+     # NOTE:
+-    # version = "",
++    # version = "0.2.1",
+     #
+     # Always leave version unset or set to "" (the default). The default value
+     # can prevent issues when the module is used via non-registry overrides
+     # (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).

--- a/modules/rules_dart_proto/0.2.1/presubmit.yml
+++ b/modules/rules_dart_proto/0.2.1/presubmit.yml
@@ -1,0 +1,24 @@
+bcr_test_module:
+  module_path: "e2e/simple_proto"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204"]
+    bazel: ["9.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."
+bcr_test_module_grpc:
+  module_path: "e2e/grpc_proto"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204"]
+    bazel: ["9.x"]
+  tasks:
+    run_tests:
+      name: "Run gRPC test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_dart_proto/0.2.1/source.json
+++ b/modules/rules_dart_proto/0.2.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-dF7vtWhED9G9ZLkGRBoSqBMOuo0fU+T47LHjvLzBp94=",
+    "strip_prefix": "rules_dart_proto-0.2.1",
+    "url": "https://github.com/aran/rules_dart_proto/releases/download/v0.2.1/rules_dart_proto-v0.2.1.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-GRWefDQnIR36K1OPo41e4BTFZq0gsmjwKwq60PClczQ="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_dart_proto/metadata.json
+++ b/modules/rules_dart_proto/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/aran/rules_dart_proto",
+    "maintainers": [
+        {
+            "email": "aran.donohue@gmail.com",
+            "github": "aran",
+            "name": "Aran Donohue",
+            "github_user_id": 5295
+        }
+    ],
+    "repository": [
+        "github:aran/rules_dart_proto"
+    ],
+    "versions": [
+        "0.2.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/aran/rules_dart_proto/releases/tag/v0.2.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_