### PR TITLE
Explicitly instruct pip to use the official PyPI repository for resolving and downloading packages.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,7 @@ pip.parse(
     hub_name = "pip",
     python_version = "3.11",
     requirements_lock = "//tools:requirements_lock.txt",
+    extra_pip_args = ["--index-url", "https://pypi.org/simple"],
 )
 use_repo(pip, "pip")
 


### PR DESCRIPTION
Without explicitly specifying it, depending on the environment of the local machine, the Python script would report an error such as below:
```
% bazel run //tools:add_module 
INFO: Repo rules_python++pip+pip_311_pyyaml defined by rule whl_library in @@rules_python+//python/private/pypi:whl_library.bzl 
ERROR: /usr/local/******/home/******/.cache/bazel/_bazel_********/04df845376b951941daa862d2fb9f417/external/rules_python+/python/private/repo_utils.bzl:83:16: An error occurred during the fetch of repository 'rules_python++pip+pip_311_pyyaml': 
   Traceback (most recent call last): 
        File "/usr/local/******/home/******/.cache/bazel/_bazel_******/04df845376b951941daa862d2fb9f417/external/rules_python+/python/private/pypi/whl_library.bzl", line 372, column 40, in _whl_library_impl 
                pypi_repo_utils.execute_checked( 
        File "/usr/local/******/home/******/.cache/bazel/_bazel_******/04df845376b951941daa862d2fb9f417/external/rules_python+/python/private/pypi/pypi_repo_utils.bzl", line 140, column 38, in _execute_checked 
                return repo_utils.execute_checked( 
        File "/usr/local/******/home/******/.cache/bazel/_bazel_******/04df845376b951941daa862d2fb9f417/external/rules_python+/python/private/repo_utils.bzl", line 228, column 29, in _execute_checked 
                return _execute_internal(fail_on_error = True, *args, **kwargs) 
        File "/usr/local/******/home/******/.cache/bazel/_bazel_******/04df845376b951941daa862d2fb9f417/external/rules_python+/python/private/repo_utils.bzl", line 157, column 27, in _execute_internal 
                return logger.fail(( 
        File "/usr/local/******/home/******/.cache/bazel/_bazel_******/04df845376b951941daa862d2fb9f417/external/rules_python+/python/private/repo_utils.bzl", line 93, column 39, in lambda 
                fail = lambda message_cb: _log(-1, "FAIL", message_cb, fail),
        File "/usr/local/******/home/******/.cache/bazel/_bazel_******/04df845376b951941daa862d2fb9f417/external/rules_python+/python/private/repo_utils.bzl", line 83, column 16, in _log
                printer("\nrules_python:{} {}:".format(
```