### PR TITLE
openmp 21.1.5.bcr.1 : remove unnecessary data dependency.

### DIFF
--- a/modules/openmp/21.1.5.bcr.1/MODULE.bazel
+++ b/modules/openmp/21.1.5.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "openmp",
+    version = "21.1.5.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "rules_python", version = "0.35.0")

--- a/modules/openmp/21.1.5.bcr.1/overlay/BUILD.bazel
+++ b/modules/openmp/21.1.5.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,212 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "openmp",
+    srcs = [
+        "runtime/src/kmp.h",
+        "runtime/src/kmp_affinity.cpp",
+        "runtime/src/kmp_affinity.h",
+        "runtime/src/kmp_alloc.cpp",
+        "runtime/src/kmp_atomic.cpp",
+        "runtime/src/kmp_atomic.h",
+        "runtime/src/kmp_barrier.cpp",
+        "runtime/src/kmp_barrier.h",
+        "runtime/src/kmp_cancel.cpp",
+        "runtime/src/kmp_collapse.cpp",
+        "runtime/src/kmp_collapse.h",
+        "runtime/src/kmp_csupport.cpp",
+        "runtime/src/kmp_debug.cpp",
+        "runtime/src/kmp_debug.h",
+        "runtime/src/kmp_debugger.cpp",
+        "runtime/src/kmp_debugger.h",
+        "runtime/src/kmp_dispatch.cpp",
+        "runtime/src/kmp_dispatch.h",
+        "runtime/src/kmp_dispatch_hier.h",
+        "runtime/src/kmp_environment.cpp",
+        "runtime/src/kmp_environment.h",
+        "runtime/src/kmp_error.cpp",
+        "runtime/src/kmp_error.h",
+        "runtime/src/kmp_ftn_cdecl.cpp",
+        "runtime/src/kmp_ftn_entry.h",
+        "runtime/src/kmp_ftn_extra.cpp",
+        "runtime/src/kmp_ftn_os.h",
+        "runtime/src/kmp_ftn_stdcall.cpp",
+        "runtime/src/kmp_global.cpp",
+        "runtime/src/kmp_gsupport.cpp",
+        "runtime/src/kmp_i18n.cpp",
+        "runtime/src/kmp_i18n.h",
+        "runtime/src/kmp_io.cpp",
+        "runtime/src/kmp_io.h",
+        "runtime/src/kmp_itt.cpp",
+        "runtime/src/kmp_itt.h",
+        "runtime/src/kmp_itt.inl",
+        "runtime/src/kmp_lock.cpp",
+        "runtime/src/kmp_lock.h",
+        "runtime/src/kmp_omp.h",
+        "runtime/src/kmp_os.h",
+        "runtime/src/kmp_platform.h",
+        "runtime/src/kmp_runtime.cpp",
+        "runtime/src/kmp_safe_c_api.h",
+        "runtime/src/kmp_sched.cpp",
+        "runtime/src/kmp_settings.cpp",
+        "runtime/src/kmp_settings.h",
+        "runtime/src/kmp_stats.h",
+        "runtime/src/kmp_str.cpp",
+        "runtime/src/kmp_str.h",
+        "runtime/src/kmp_taskdeps.cpp",
+        "runtime/src/kmp_taskdeps.h",
+        "runtime/src/kmp_tasking.cpp",
+        "runtime/src/kmp_threadprivate.cpp",
+        "runtime/src/kmp_utility.cpp",
+        "runtime/src/kmp_utils.h",
+        "runtime/src/kmp_version.cpp",
+        "runtime/src/kmp_version.h",
+        "runtime/src/kmp_wait_release.cpp",
+        "runtime/src/kmp_wait_release.h",
+        "runtime/src/kmp_wrapper_getpid.h",
+        "runtime/src/kmp_wrapper_malloc.h",
+        "runtime/src/ompd-specific.h",
+        "runtime/src/ompt-event-specific.h",
+        "runtime/src/ompt-general.cpp",
+        "runtime/src/ompt-internal.h",
+        "runtime/src/ompt-specific.h",
+        "runtime/src/z_Linux_asm.S",
+        "runtime/src/z_Linux_util.cpp",
+    ] + [
+        ":default_i18n",
+        ":id_i18n",
+        ":kmp_config",
+    ],
+    hdrs = [
+        "runtime/src/include/omp.h",
+        "runtime/src/include/omp-tools.h",
+    ],
+    copts = [
+        "-Wno-comment",
+    ],
+    includes = [
+        "runtime/src",
+        "runtime/src/include",
+        "runtime/src/thirdparty/ittnotify",
+    ],
+    textual_hdrs = [
+        "runtime/src/ompt-specific.cpp",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+# Get versions with
+# grep "set(LIBOMP_VERSION" runtime/CMakeLists.txt
+OMP_VERSION_STRINGS = {
+    "@LIBOMP_VERSION_MAJOR@": "5",
+    "@LIBOMP_VERSION_MINOR@": "0",
+    "@LIBOMP_VERSION_BUILD@": "0",
+    "@LIBOMP_BUILD_DATE@": "20251104",
+}
+
+expand_template(
+    name = "omp_header",
+    out = "runtime/src/include/omp.h",
+    substitutions = OMP_VERSION_STRINGS,
+    template = "runtime/src/include/omp.h.var",
+)
+
+copy_file(
+    name = "omp_tools_header",
+    src = "runtime/src/include/omp-tools.h.var",
+    out = "runtime/src/include/omp-tools.h",
+)
+
+genrule(
+    name = "default_i18n",
+    srcs = ["runtime/src/i18n/en_US.txt"],
+    outs = ["runtime/src/kmp_i18n_default.inc"],
+    cmd = "$(PYTHON3) $(location runtime/tools/message-converter.py) " +
+          "--default=$@ $<",
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+    tools = ["runtime/tools/message-converter.py"],
+)
+
+genrule(
+    name = "id_i18n",
+    srcs = ["runtime/src/i18n/en_US.txt"],
+    outs = ["runtime/src/kmp_i18n_id.inc"],
+    cmd = "$(PYTHON3) $(location runtime/tools/message-converter.py) " +
+          "--enum=$@ $<",
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+    tools = ["runtime/tools/message-converter.py"],
+)
+
+# Extract defines with
+# awk '/#cmakedefine01/ { print $2;}' runtime/src/kmp_config.h.cmake | sort
+BUILD_DEFINES = {
+    # Everything that is enabled
+    "LIBOMP_ENABLE_ASSERTIONS": 1,
+    "LIBOMP_HAVE_WEAK_ATTRIBUTE": 1,
+    "LIBOMP_OMPT_SUPPORT": 1,
+    "LIBOMP_USE_ADAPTIVE_LOCKS": 1,
+    "RELWITHDEBINFO_BUILD": 1,
+    "LIBOMP_OMPT_OPTIONAL": 1,
+
+    # Not enabled
+    "DEBUG_BUILD": 0,
+    "LIBOMP_ARCH_AARCH64_A64FX": 0,
+    "LIBOMP_ENABLE_SHARED": 0,
+    "LIBOMP_HAVE_ALIGNED_ALLOC": 0,
+    "LIBOMP_HAVE_ATTRIBUTE_RTM": 0,
+    "LIBOMP_HAVE_ATTRIBUTE_WAITPKG": 0,
+    "LIBOMP_HAVE_IMMINTRIN_H": 0,
+    "LIBOMP_HAVE_INTRIN_H": 0,
+    "LIBOMP_HAVE_POSIX_MEMALIGN": 0,
+    "LIBOMP_HAVE_PSAPI": 0,
+    "LIBOMP_HAVE_RTM_INTRINSICS": 0,
+    "LIBOMP_HAVE_WAITPKG_INTRINSICS": 0,
+    "LIBOMP_HAVE_X86INTRIN_H": 0,
+    "LIBOMP_HAVE_XMMINTRIN_H": 0,
+    "LIBOMP_HAVE__ALIGNED_MALLOC": 0,
+    "LIBOMP_HAVE__MM_MALLOC": 0,
+    "LIBOMP_HAVE___BUILTIN_READCYCLECOUNTER": 0,
+    "LIBOMP_HAVE___RDTSC": 0,
+    "LIBOMP_OMPD_SUPPORT": 0,
+    "LIBOMP_OMPT_DEBUG": 0,
+    "LIBOMP_OMPX_TASKGRAPH": 0,
+    "LIBOMP_PROFILING_SUPPORT": 0,
+    "LIBOMP_STATS": 0,
+    "LIBOMP_USE_DEBUGGER": 0,
+    "LIBOMP_USE_HIER_SCHED": 0,
+    "LIBOMP_USE_HWLOC": 0,
+    "LIBOMP_USE_INTERNODE_ALIGNMENT": 0,
+    "LIBOMP_USE_ITT_NOTIFY": 0,
+    "LIBOMP_USE_VERSION_SYMBOLS": 0,
+    "MSVC": 0,
+    "OPENMP_ENABLE_LIBOMPTARGET": 0,
+    "STUBS_LIBRARY": 0,
+}
+
+expand_template(
+    name = "kmp_config",
+    out = "runtime/src/include/kmp_config.h",
+    substitutions = {
+        "#cmakedefine01 {}".format(key): "#define {} {}".format(key, value)
+        for key, value in BUILD_DEFINES.items()
+    } | OMP_VERSION_STRINGS,
+    template = "runtime/src/kmp_config.h.cmake",
+)

--- a/modules/openmp/21.1.5.bcr.1/presubmit.yml
+++ b/modules/openmp/21.1.5.bcr.1/presubmit.yml
@@ -1,0 +1,20 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform:
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2004_arm64
+      - ubuntu2204
+      - ubuntu2404
+      - macos
+      - macos_arm64
+    bazel: ["7.x", "8.x", "9.x"]
+  tasks:
+    verify_targets:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - "//..."

--- a/modules/openmp/21.1.5.bcr.1/source.json
+++ b/modules/openmp/21.1.5.bcr.1/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-21.1.5/openmp-21.1.5.src.tar.xz",
+    "integrity": "sha256-S7/iQPI/hz/l/dTWXge27AwKRyHNDTOQGLH1IM7kigg=",
+    "strip_prefix": "openmp-21.1.5.src",
+    "overlay": {
+        "BUILD.bazel": "sha256-2Pl6liedggKFRc1yp2XAmFfdawB/4F/XmgdC4z2VUgQ="
+    }
+}

--- a/modules/openmp/metadata.json
+++ b/modules/openmp/metadata.json
@@ -18,7 +18,8 @@
         "github:llvm/llvm-project"
     ],
     "versions": [
-        "21.1.5"
+        "21.1.5",
+        "21.1.5.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
There was a vestigial data dependency on `runtime/src/i18n/en_US.txt`, which is not needed as this file is actually compiled in.

Having a data dependency just creates unnecessary runfiles for users of the library.