### PR TITLE
fourward@20260405.0

### DIFF
--- a/modules/fourward/20260405.0/MODULE.bazel
+++ b/modules/fourward/20260405.0/MODULE.bazel
@@ -1,0 +1,81 @@
+module(
+    name = "fourward",
+    version = "20260405.0",
+    bazel_compatibility = [">=8.0.0"],
+)
+
+# --- Core build rules ---
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_kotlin", version = "2.3.0")
+bazel_dep(name = "rules_java", version = "9.3.0")
+bazel_dep(name = "rules_python", version = "1.4.1")
+bazel_dep(name = "rules_jvm_external", version = "6.10")
+
+# --- Protobuf & gRPC ---
+
+bazel_dep(name = "protobuf", version = "33.5")
+bazel_dep(name = "grpc", version = "1.80.0")  # For cc_grpc_library (dataplane_cc_grpc).
+bazel_dep(name = "grpc-java", version = "1.78.0")
+bazel_dep(name = "grpc_kotlin", version = "1.5.0")
+
+# --- P4 ecosystem ---
+
+# p4runtime provides p4info.proto, p4runtime.proto, and p4data.proto.
+bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
+
+# p4c provides the compiler frontend and midend that our backend builds on.
+bazel_dep(name = "p4c", version = "1.2.5.11.bcr.1")
+
+# p4-constraints validates @entry_restriction / @action_restriction annotations.
+bazel_dep(name = "p4_constraints", version = "20260311.0")
+
+# --- JVM dependencies ---
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.install(
+    artifacts = [
+        "com.google.protobuf:protobuf-java:4.29.3",
+        "com.google.protobuf:protobuf-java-util:4.29.3",
+        "com.google.protobuf:protobuf-kotlin:4.29.3",
+        "junit:junit:4.13.2",
+        "com.facebook:ktfmt:0.61",
+        "io.gitlab.arturbosch.detekt:detekt-cli:1.23.8",
+        # gRPC Kotlin runtime
+        "io.grpc:grpc-kotlin-stub:1.4.3",
+        "io.grpc:grpc-netty-shaded:1.68.1",
+        "io.grpc:grpc-services:1.68.1",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1",
+        "javax.annotation:javax.annotation-api:1.3.2",
+    ],
+    known_contributing_modules = [
+        "grpc-java",
+        "protobuf",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+)
+use_repo(maven, "maven")
+
+# --- Python (cram test runner) ---
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.12")
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "pip",
+    python_version = "3.12",
+    requirements_lock = "//:requirements.txt",
+)
+use_repo(pip, "pip")
+
+# --- Dev tools ---
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = True)

--- a/modules/fourward/20260405.0/patches/bcr.patch
+++ b/modules/fourward/20260405.0/patches/bcr.patch
@@ -1,0 +1,63 @@
+--- a/MODULE.bazel	2026-04-05 11:20:43.644582522 -0700
++++ b/MODULE.bazel	2026-04-05 11:21:29.793745439 -0700
+@@ -29,42 +29,11 @@
+ bazel_dep(name = "p4runtime", version = "1.5.0.bcr.1")
+ 
+ # p4c provides the compiler frontend and midend that our backend builds on.
+-# The git_override adds targets not yet in upstream p4c:
+-#   - //p4include package (exports_files + filegroup for individual includes)
+-#   - //testdata/p4_16_samples:* (exports_files for corpus/BMv2 tests)
+-#   - macOS build fix (HAVE_PIPE2 / HAVE_UCONTEXT_H)
+-# Upstream PR: https://github.com/p4lang/p4c/pull/5533
+-# Once merged and released to BCR, drop the git_override.
+-bazel_dep(name = "p4c", version = "1.2.5.11")
+-git_override(
+-    module_name = "p4c",
+-    commit = "c7e38ae7a338973098ab73d08f631c98c470b71c",
+-    remote = "https://github.com/smolkaj/p4c.git",
+-)
++bazel_dep(name = "p4c", version = "1.2.5.11.bcr.1")
+ 
+ # p4-constraints validates @entry_restriction / @action_restriction annotations.
+ bazel_dep(name = "p4_constraints", version = "20260311.0")
+ 
+-# grpc with Bazel 9 support (native rule autoloading + rules_swift compat).
+-# TODO: Drop once grpc publishes a Bazel-9-compatible release to BCR.
+-git_override(
+-    module_name = "grpc",
+-    commit = "a09a3af54b870cf9d1064f807355721451196329",
+-    remote = "https://github.com/smolkaj/grpc.git",
+-)
+-
+-# BMv2 (behavioral-model) — v1model reference simulator for differential testing.
+-# Patched to add native Bazel build rules (no Thrift, no nanomsg).
+-# Dev-only: not needed by downstream consumers of the 4ward module.
+-bazel_dep(name = "behavioral_model", version = "head", dev_dependency = True)
+-git_override(
+-    module_name = "behavioral_model",
+-    commit = "6c7c93e5484e069c539b5c990bf37c531599894a",
+-    patch_strip = 1,
+-    patches = ["//bazel:behavioral_model.patch"],
+-    remote = "https://github.com/p4lang/behavioral-model.git",
+-)
+-
+ # --- JVM dependencies ---
+ 
+ maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+@@ -110,16 +79,3 @@
+ # --- Dev tools ---
+ 
+ bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = True)
+-
+-# Runs clang-tidy as a Bazel aspect — no compile_commands.json needed.
+-# Usage: bazel build //p4c_backend/... --config=clang-tidy
+-bazel_dep(name = "bazel_clang_tidy", dev_dependency = True)
+-git_override(
+-    module_name = "bazel_clang_tidy",
+-    # Pin to the commit before "Add builtin include flags for clang-tidy"
+-    # (c4d35e0).  That commit passes cc_toolchain.built_in_include_directories
+-    # as explicit -isystem flags, which promotes /usr/include out of clang's
+-    # internal search order and breaks #include_next from <cstdlib>.
+-    commit = "9e54bbb15d1939a9d030c52f3032886a0b278f98",
+-    remote = "https://github.com/erenon/bazel_clang_tidy.git",
+-)

--- a/modules/fourward/20260405.0/presubmit.yml
+++ b/modules/fourward/20260405.0/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  platform: ["ubuntu2204", "ubuntu2404"]
+  bazel: ["8.x"]
+
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      # p4c (transitive dep) requires C++20.
+      - "--cxxopt=-std=c++20"
+      - "--host_cxxopt=-std=c++20"
+      # Use hermetic remote JDK (the .bazelrc sets these, but BCR
+      # presubmit doesn't load it).
+      - "--java_runtime_version=remotejdk_21"
+      - "--tool_java_runtime_version=remotejdk_21"
+    build_targets:
+      - "@fourward//..."
+      - "-@fourward//e2e_tests/..."
+      - "-@fourward//examples/..."

--- a/modules/fourward/20260405.0/source.json
+++ b/modules/fourward/20260405.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-zcocaIwK4Ceei8eRPGuwyJx2EQDnL8dGiWGcfLB4+SU=",
+    "strip_prefix": "4ward-20260405.0",
+    "url": "https://github.com/smolkaj/4ward/releases/download/20260405.0/fourward-20260405.0.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "bcr.patch": "sha256-kKVB4xT2Su9EZk4hXt5wkNNL+Sa4u5gLXdW/27lDIL0="
+    }
+}

--- a/modules/fourward/metadata.json
+++ b/modules/fourward/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/smolkaj/4ward",
+    "maintainers": [
+        {
+            "github": "smolkaj",
+            "github_user_id": 6642034,
+            "name": "Steffen Smolka"
+        }
+    ],
+    "repository": [
+        "github:smolkaj/4ward"
+    ],
+    "versions": [
+        "20260405.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
## Summary

Initial BCR release of [4ward](https://github.com/smolkaj/4ward), a
spec-compliant reference implementation of P4₁₆ and P4Runtime for
dataplane validation and testing.

### Public targets

- \`//simulator:simulator_lib\` — P4 execution engine (Kotlin)
- \`//simulator:ir_java_proto\`, \`//simulator:ir_cc_proto\` — IR protos
- \`//p4runtime:p4runtime_lib\` — P4Runtime gRPC server (Kotlin)
- \`//p4c_backend:p4c_backend_lib\` — p4c backend plugin (C++)
- \`//p4c_backend:p4c-4ward\` — compiler binary

### BCR patch

Strips \`git_override\` blocks for \`p4c\` (uses BCR 1.2.5.11.bcr.1),
\`grpc\` (uses BCR 1.80.0), and dev-only dependencies not in BCR
(\`behavioral_model\`, \`bazel_clang_tidy\`).

Supersedes #8183.