### PR TITLE
Fix security issue #7869: safe archive extraction

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -529,7 +529,12 @@ class BcrValidator:
             "war": "zip",
             "aar": "zip",
         }.get(source.get("archive_type"))
-        shutil.unpack_archive(str(archive_file), output_dir, format=format)
+        # Use PEP 706 safe extraction if available (Python 3.12+)
+        if sys.version_info >= (3, 12):
+            shutil.unpack_archive(str(archive_file), output_dir, format=format, filter="data")
+        else:
+            # Fallback for older Python versions. Since CI is 3.12+, this handles local dev compatibility.
+            shutil.unpack_archive(str(archive_file), output_dir, format=format)
 
     def _download_git_repo(self, source, output_dir):
         run_git("clone", "--depth=1", source["remote"], output_dir)


### PR DESCRIPTION
This change addresses the security vulnerability where untrusted source archives were extracted without sufficient path traversal protection during BCR validation.

It leverages the built-in 'filter="data"' argument in Python 3.12+ (as per PEP 706) to prevent Zip/Tar Slip attacks. A fallback to the previous behavior is maintained for older Python versions, assuming CI will enforce a secure Python environment.

Fixes #7869