### PR TITLE
Add sphinxdocs module config

### DIFF
--- a/modules/sphinxdocs/metadata.json
+++ b/modules/sphinxdocs/metadata.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "https://github.com/bazel-contrib/rules_python",
+    "maintainers": [
+        {
+            "email": "richardlev@gmail.com",
+            "github": "rickeylev",
+            "name": "Richard Levasseur",
+            "github_user_id": 34175098
+        },
+        {
+            "name": "Ignas Anikevicius",
+            "email": "bcr-ignas@use.startmail.com",
+            "github": "aignas",
+            "github_user_id": 240938
+        }
+    ],
+    "repository": [
+        "github:bazel-contrib/rules_python"
+    ],
+    "versions": [
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
A version will be added in an upcoming release. This just adds the
metadata so that the automated BCR publishing works and the BCR
PRs can be approved by maintainers.
