### PR TITLE
fix: validate strip_prefix stays within source directory

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -613,7 +613,9 @@ class BcrValidator:
             self.report(BcrValidationResult.FAILED, f"{module_file} must not be a symlink.")
 
         # Apply patch files if there are any, also verify their integrity values
-        source_root = output_dir.joinpath(source["strip_prefix"] if "strip_prefix" in source else "")
+        source_root = output_dir.joinpath(source.get("strip_prefix", "")).resolve()
+        if not source_root.is_relative_to(output_dir.resolve()):
+            raise BcrValidationException(f"strip_prefix escapes the source directory")
         if "patches" in source:
             for patch_name, expected_integrity in source["patches"].items():
                 patch_file = self.registry.get_patch_file_path(module_name, version, patch_name)


### PR DESCRIPTION
## Path traversal via strip_prefix in CI validation leads to host RCE

`bcr_validation.py` uses `strip_prefix` from the module's `source.json` to construct `source_root` at line 576:

```python
source_root = output_dir.joinpath(source["strip_prefix"])
```

There is no validation that `strip_prefix` stays within `output_dir`. A module author can set `strip_prefix` to `../../` and the resolved `source_root` escapes the temp directory. Patches are then applied with `cwd=source_root` (line 134), so `patch --input` runs with the working directory set to an arbitrary path on the CI host.

A crafted patch can then write to any file writable by the CI user. Since `bcr_validation.py` runs as part of PR validation on the Bazel Central Registry CI, a malicious PR can write files on the CI host and achieve code execution.

Tracked in https://issuetracker.google.com/issues/496471781

## Attack scenario

1. Attacker submits PR to bazelbuild/bazel-central-registry with a new module
2. `source.json` contains `"strip_prefix": "../../../../../../tmp"` (or any host path)
3. Patch file writes a cron job, SSH key, or shell script to a writable location
4. CI runs `bcr_validation.py` on the PR, `apply_patch` executes with `cwd` pointing outside temp dir
5. Patch writes to host filesystem, attacker gets code execution on CI

No reviewer approval needed. CI validation runs automatically on PR creation.

## Fix

Resolve `source_root` and verify it stays within `output_dir` before using it.

```python
source_root = output_dir.joinpath(source.get("strip_prefix", "")).resolve()
if not source_root.is_relative_to(output_dir.resolve()):
    raise BcrValidationException(
        f"strip_prefix escapes the source directory"
    )
```

## Verification

Before: `strip_prefix: "../../tmp"` → `source_root` resolves to `/tmp`, patches write outside temp dir.
After: raises `BcrValidationException`.