### PR TITLE
stdexec@73559e8963dab7a4ece32ede22f6472c9a815032

### DIFF
--- a/modules/stdexec/73559e8963dab7a4ece32ede22f6472c9a815032/MODULE.bazel
+++ b/modules/stdexec/73559e8963dab7a4ece32ede22f6472c9a815032/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "stdexec",
+    version = "73559e8963dab7a4ece32ede22f6472c9a815032",
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.3")

--- a/modules/stdexec/73559e8963dab7a4ece32ede22f6472c9a815032/patches/add_build_file.patch
+++ b/modules/stdexec/73559e8963dab7a4ece32ede22f6472c9a815032/patches/add_build_file.patch
@@ -1,0 +1,9 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,6 @@
++cc_library(
++    name = "stdexec",
++    hdrs = glob(["include/**"]),
++    includes = ["include"],
++    visibility = ["//visibility:public"],
++)

--- a/modules/stdexec/73559e8963dab7a4ece32ede22f6472c9a815032/patches/module_dot_bazel.patch
+++ b/modules/stdexec/73559e8963dab7a4ece32ede22f6472c9a815032/patches/module_dot_bazel.patch
@@ -1,0 +1,9 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,6 @@
++module(
++    name = "stdexec",
++    version = "73559e8963dab7a4ece32ede22f6472c9a815032",
++)
++
++bazel_dep(name = "rules_cc", version = "0.2.3")

--- a/modules/stdexec/73559e8963dab7a4ece32ede22f6472c9a815032/presubmit.yml
+++ b/modules/stdexec/73559e8963dab7a4ece32ede22f6472c9a815032/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@stdexec//:stdexec'

--- a/modules/stdexec/73559e8963dab7a4ece32ede22f6472c9a815032/source.json
+++ b/modules/stdexec/73559e8963dab7a4ece32ede22f6472c9a815032/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/NVIDIA/stdexec/archive/73559e8963dab7a4ece32ede22f6472c9a815032.tar.gz",
+    "integrity": "sha256-QoFe/hLD+Xkv52SKAo8jwkN70YLIjZwb0QxJMj6qbSA=",
+    "strip_prefix": "stdexec-73559e8963dab7a4ece32ede22f6472c9a815032",
+    "patches": {
+        "add_build_file.patch": "sha256-khAEkOsuaUT0i7OTAiQJ0YZgBNJTuS+b+d+qSDHLRlA=",
+        "module_dot_bazel.patch": "sha256-+TmrI27OCSIRTVrUQlm/Sb+hDrI9wne8EbohYMTepM8="
+    },
+    "patch_strip": 0
+}

--- a/modules/stdexec/metadata.json
+++ b/modules/stdexec/metadata.json
@@ -13,7 +13,8 @@
     ],
     "versions": [
         "5473e9daf50cb8829cfe12fb6b64f5f74a08bcf7",
-        "5d9f3bfb032e9d71b2292b7add7d90cbf9d037a9"
+        "5d9f3bfb032e9d71b2292b7add7d90cbf9d037a9",
+        "73559e8963dab7a4ece32ede22f6472c9a815032"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
## Summary

- Add new version of `stdexec` based on commit
`73559e8963dab7a4ece32ede22f6472c9a815032` from
[NVIDIA/stdexec](https://github.com/NVIDIA/stdexec).
- Integrity hashes computed via `bazel run //tools:update_integrity`.
