### PR TITLE
fix(bcr_validation): Exempt zip files from filtering

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -530,7 +530,7 @@ class BcrValidator:
             "aar": "zip",
         }.get(source.get("archive_type"))
         # Use PEP 706 safe extraction if available (Python 3.12+)
-        if sys.version_info >= (3, 12):
+        if sys.version_info >= (3, 12) and format != "zip":
             shutil.unpack_archive(str(archive_file), output_dir, format=format, filter="data")
         else:
             # Fallback for older Python versions. Since CI is 3.12+, this handles local dev compatibility.


### PR DESCRIPTION
The unpack_archive function does not accept `filter=` on zip files.

See https://github.com/bazelbuild/bazel-central-registry/pull/8389#issuecomment-4237237487 for an example failure.

Amends f19436e4.
