### PR TITLE
Update openvdb to 11.0.0.bcr.1 for Boost 1.90.0 compatibility

### DIFF
--- a/modules/openvdb/11.0.0.bcr.1/MODULE.bazel
+++ b/modules/openvdb/11.0.0.bcr.1/MODULE.bazel
@@ -1,0 +1,13 @@
+"""https://www.openvdb.org/"""
+
+module(
+    name = "openvdb",
+    version = "11.0.0.bcr.1",
+    bazel_compatibility = ['>=7.2.1'],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "onetbb", version = "2022.0.0")
+bazel_dep(name = "boost.numeric_conversion", version = "1.90.0.bcr.1")

--- a/modules/openvdb/11.0.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/openvdb/11.0.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,98 @@
+"""OpenVDB BUILD file."""
+
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+expand_template(
+    name = "version",
+    out = "openvdb/openvdb/version.h",
+    substitutions = {
+        "#cmakedefine OPENVDB_IMATH_VERSION": "",
+        "#cmakedefine OPENVDB_USE_BLOSC": "",
+        "#cmakedefine OPENVDB_USE_DELAYED_LOADING": "",
+        "#cmakedefine OPENVDB_USE_EXPLICIT_INSTANTIATION": "",
+        "#cmakedefine OPENVDB_USE_IMATH_HALF": "",
+        "#cmakedefine OPENVDB_USE_ZLIB": "",
+        "${OPENVDB_ABI_VERSION_NUMBER}": "11",
+        "${OPENVDB_NAMESPACE_SUFFIX}": "",
+        "${OPENVDB_PACKED_VERSION}": "0",
+        "${OpenVDB_MAJOR_VERSION}": "11",
+        "${OpenVDB_MINOR_VERSION}": "0",
+        "${OpenVDB_PATCH_VERSION}": "0",
+    },
+    template = "openvdb/openvdb/version.h.in",
+)
+
+filegroup(
+    name = "common_sources_nanovdb",
+    srcs = glob([
+        "nanovdb/nanovdb/*.h",
+        "nanovdb/nanovdb/util/*.h",
+        "nanovdb/nanovdb/util/**/*.h",
+    ]),
+)
+
+filegroup(
+    name = "common_sources_openvdb",
+    srcs = glob([
+        "openvdb/openvdb/*.cc",
+        "openvdb/openvdb/io/*.cc",
+        "openvdb/openvdb/math/*.cc",
+        "openvdb/openvdb/points/*.cc",
+        "openvdb/openvdb/util/*.cc",
+    ]),
+)
+
+filegroup(
+    name = "common_sources_openvdb_inc",
+    srcs = glob([
+        "openvdb/openvdb/math/*.h",
+        "openvdb/openvdb/points/*.h",
+        "openvdb/openvdb/points/impl/*.h",
+        "openvdb/openvdb/io/*.h",
+        "openvdb/openvdb/util/*.h",
+        "openvdb/openvdb/tree/*.h",
+        "openvdb/openvdb/tools/*.h",
+        "openvdb/openvdb/thread/*.h",
+        "openvdb/openvdb/*.h",
+    ]),
+)
+
+cc_library(
+    name = "nanovdb",
+    srcs = [
+        ":common_sources_nanovdb",
+    ],
+    includes = ["nanovdb"],
+    linkopts = select({
+        "@platforms//os:linux": ["-pthread"],
+        "//conditions:default": [],
+    }),
+    linkstatic = True,
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "openvdb",
+    srcs = [
+        ":common_sources_openvdb",
+    ],
+    hdrs = [
+        "openvdb/openvdb/version.h",
+        ":common_sources_openvdb_inc",
+    ],
+    includes = [
+        "openvdb",
+        "openvdb/openvdb",
+    ],
+    linkopts = select({
+        "@platforms//os:linux": ["-pthread"],
+        "//conditions:default": [],
+    }),
+    linkstatic = True,
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boost.numeric_conversion",
+        "@onetbb//:tbb",
+    ],
+)

--- a/modules/openvdb/11.0.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/openvdb/11.0.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,13 @@
+"""https://www.openvdb.org/"""
+
+module(
+    name = "openvdb",
+    version = "11.0.0.bcr.1",
+    bazel_compatibility = ['>=7.2.1'],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "onetbb", version = "2022.0.0")
+bazel_dep(name = "boost.numeric_conversion", version = "1.90.0.bcr.1")

--- a/modules/openvdb/11.0.0.bcr.1/presubmit.yml
+++ b/modules/openvdb/11.0.0.bcr.1/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform: ["ubuntu2004"]
+    bazel: ["7.x", "8.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - //...

--- a/modules/openvdb/11.0.0.bcr.1/source.json
+++ b/modules/openvdb/11.0.0.bcr.1/source.json
@@ -1,6 +1,6 @@
 {
-    "url": "https://github.com/AcademySoftwareFoundation/openvdb/archive/6c044e628a1ac3546eed48b6f5e9c76dfaa2143e.zip",
-    "integrity": "sha256-aPp4z77HlN/Fefp/7asUo8pQQh3745OAdSOkgezFDIE=",
+    "url": "https://github.com/AcademySoftwareFoundation/openvdb/archive/6c044e628a1ac3546eed48b6f5e9c76dfaa2143e.tar.gz",
+    "integrity": "sha256-tpD0SXj1yDEF8vwQwvZKbdVGSPBRwZYGfbOWDiCGIWo=",
     "strip_prefix": "openvdb-6c044e628a1ac3546eed48b6f5e9c76dfaa2143e",
     "overlay": {
         "BUILD.bazel": "sha256-hihKQt5/XChLM9APhwR9lB8RKTZuMlQ/vVMFbORgGDM=",

--- a/modules/openvdb/11.0.0.bcr.1/source.json
+++ b/modules/openvdb/11.0.0.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/AcademySoftwareFoundation/openvdb/archive/6c044e628a1ac3546eed48b6f5e9c76dfaa2143e.zip",
+    "integrity": "sha256-aPp4z77HlN/Fefp/7asUo8pQQh3745OAdSOkgezFDIE=",
+    "strip_prefix": "openvdb-6c044e628a1ac3546eed48b6f5e9c76dfaa2143e",
+    "overlay": {
+        "BUILD.bazel": "sha256-hihKQt5/XChLM9APhwR9lB8RKTZuMlQ/vVMFbORgGDM=",
+        "MODULE.bazel": "sha256-uYcm4uO3DQPF1aJIIr9IRlwve0mUcgj3cZYdUtpAzp8="
+    }
+}

--- a/modules/openvdb/metadata.json
+++ b/modules/openvdb/metadata.json
@@ -12,7 +12,8 @@
         "github:AcademySoftwareFoundation/openvdb"
     ],
     "versions": [
-        "11.0.0"
+        "11.0.0",
+        "11.0.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
### What this PR does / why we need it:
This PR creates a new patch version (`11.0.0.bcr.1`) for the `openvdb` module to bump its `boost.numeric_conversion` dependency to the newly released `1.90.0.bcr.1`. This ensures downstream users can successfully compile OpenVDB in workspaces that have upgraded to Boost 1.90.0.

Additionally, this patch introduces the `bazel_compatibility = [">=7.2.1"]` constraint to `MODULE.bazel` to satisfy current BCR validation requirements for modules utilizing overlay files. All integrity hashes in `source.json` have been updated to reflect the changes.

### Testing:
- Passed local `bcr_validation` checks.
- Passed `setup_presubmit_repos` and successfully compiled (`bazel test //...`) against Boost 1.90.0 in the generated sandboxed test module.