### PR TITLE
add reflexxes rml type II

### DIFF
--- a/modules/reflexxes-rmltype2/1.2.7/MODULE.bazel
+++ b/modules/reflexxes-rmltype2/1.2.7/MODULE.bazel
@@ -1,6 +1,7 @@
 module(
     name = "reflexxes-rmltype2",
     version = "1.2.7",
+    bazel_compatibility = [">=7.2.1"],
     compatibility_level = 1,
 )
 

--- a/modules/reflexxes-rmltype2/1.2.7/MODULE.bazel
+++ b/modules/reflexxes-rmltype2/1.2.7/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "reflexxes-rmltype2",
+    version = "1.2.7",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/reflexxes-rmltype2/1.2.7/overlay/BUILD.bazel
+++ b/modules/reflexxes-rmltype2/1.2.7/overlay/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "reflexxes-rmltype2",
+    srcs = glob(["src/TypeIIRML/*.cpp"]),
+    hdrs = glob(["include/*.h"]),
+    # Disabling unwind tables and exceptions prevents .sframe generation.
+    # This avoids a linker error in newer toolchains (Binutils 2.45+) where
+    # .sframe sections are not correctly associated with COMDAT groups,
+    # leading to invalid relocations for discarded template functions.
+    # See: https://sourceware.org/bugzilla/show_bug.cgi?id=33370
+    copts = [
+        "-fno-asynchronous-unwind-tables",
+        "-fno-exceptions",
+    ],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)
+
+# Sample applications as tests
+[
+    cc_test(
+        name = file.split("/")[-1].replace(".cpp", ""),
+        srcs = [file],
+        deps = [":reflexxes-rmltype2"],
+    )
+    for file in glob(["src/RMLPositionSampleApplications/*.cpp"]) + glob(["src/RMLVelocitySampleApplications/*.cpp"])
+]

--- a/modules/reflexxes-rmltype2/1.2.7/presubmit.yml
+++ b/modules/reflexxes-rmltype2/1.2.7/presubmit.yml
@@ -9,6 +9,7 @@ matrix:
     - 7.x
     - 8.x
     - 9.x
+
 tasks:
   verify_targets:
     name: Verify build and test targets

--- a/modules/reflexxes-rmltype2/1.2.7/presubmit.yml
+++ b/modules/reflexxes-rmltype2/1.2.7/presubmit.yml
@@ -1,0 +1,27 @@
+matrix:
+  platform:
+    - rockylinux8
+    - debian10
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build and test targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@reflexxes-rmltype2//:reflexxes-rmltype2'
+    test_targets:
+    - '@reflexxes-rmltype2//:01_RMLPositionSampleApplication'
+    - '@reflexxes-rmltype2//:02_RMLPositionSampleApplication'
+    - '@reflexxes-rmltype2//:03_RMLPositionSampleApplication'
+    - '@reflexxes-rmltype2//:04_RMLVelocitySampleApplication'
+    - '@reflexxes-rmltype2//:05_RMLVelocitySampleApplication'
+    - '@reflexxes-rmltype2//:06_RMLVelocitySampleApplication'
+    - '@reflexxes-rmltype2//:07_RMLPositionSampleApplication'
+    - '@reflexxes-rmltype2//:08_RMLVelocitySampleApplication'

--- a/modules/reflexxes-rmltype2/1.2.7/source.json
+++ b/modules/reflexxes-rmltype2/1.2.7/source.json
@@ -1,0 +1,8 @@
+{
+    "integrity": "sha256-eOfGmWLGNnPPYORLhyAjz0cOVd/FmosvM9dfT3QSSI4=",
+    "strip_prefix": "RMLTypeII-82031115fcf749f82986a9e397e7964007676254",
+    "url": "https://github.com/Reflexxes/RMLTypeII/archive/82031115fcf749f82986a9e397e7964007676254.tar.gz",
+    "overlay": {
+        "BUILD.bazel": "sha256-PQgscFrJMua3+beAkCC5qO3s9SbKNtWzNnQjsXBRjeQ="
+    }
+}

--- a/modules/reflexxes-rmltype2/metadata.json
+++ b/modules/reflexxes-rmltype2/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/Reflexxes/RMLTypeII",
+    "maintainers": [
+        {
+            "email": "sesc@google.com",
+            "github": "sesceu",
+            "github_user_id": 1614558,
+            "name": "Sebastian Schneider"
+        }
+    ],
+    "repository": [
+        "github:Reflexxes/RMLTypeII"
+    ],
+    "versions": [
+        "1.2.7"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds reflexxes realtime motion library type II from https://github.com/Reflexxes/RMLTypeII.

The library doesn't have releases nor tags, but the version (1.2.7) is encoded in some of the header files. I had to add `skip_check unstable_url` though, because of this.