### PR TITLE
sha256.bzl@0.0.1

### DIFF
--- a/modules/sha256.bzl/0.0.1/MODULE.bazel
+++ b/modules/sha256.bzl/0.0.1/MODULE.bazel
@@ -1,0 +1,47 @@
+module(name = "sha256.bzl",
+    version = "0.0.1",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+
+# ✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂
+# only dev_dependencies below this line
+# ✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂
+
+bazel_dep(name = "rules_java", version = "9.0.3", dev_dependency = True)
+
+http_jar = use_repo_rule("@rules_java//java:http_jar.bzl", "http_jar")
+
+http_jar(
+    name = "starlark_deploy",
+    dev_dependency = True,
+    integrity = "sha256-6/vX8znl2YhBMhvbUnXoOPrM5mygWoYfAw6Ns4qP8EI=",
+    url = "https://github.com/bazelbuild/starlark/raw/7b0a6479463d3830d6bac2cf72bc5ab39c53b330/test_suite/starlark_deploy.jar",
+)
+
+# Go (google/starlark-go)
+bazel_dep(name = "rules_go", version = "0.60.0", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.50.0", dev_dependency = True)
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
+go_deps.from_file(go_mod = "//tests/go:go.mod")
+use_repo(go_deps, "net_starlark_go")
+
+# Rust (facebook/starlark-rust)
+bazel_dep(name = "rules_rust", version = "0.69.0", dev_dependency = True)
+
+crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate", dev_dependency = True)
+crate.spec(
+    package = "starlark",
+    version = "0.12.0",
+)
+crate.spec(
+    package = "starlark_derive",
+    version = "0.12.0",
+)
+crate.spec(
+    package = "anyhow",
+    version = "1.0",
+)
+crate.from_specs()
+use_repo(crate, "crates")

--- a/modules/sha256.bzl/0.0.1/attestations.json
+++ b/modules/sha256.bzl/0.0.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/hermeticbuild/sha256.star/releases/download/v0.0.1/source.json.intoto.jsonl",
+            "integrity": "sha256-YNm6yDnBRtRSovrqN2IKhhNpIAqPhMYq0xxriWZdU/E="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/hermeticbuild/sha256.star/releases/download/v0.0.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-/jsRwA2UF8iWACrSe7yxyqtQ37KhN59j6xsfnOEuGXA="
+        },
+        "sha256.bzl-v0.0.1.tar.gz": {
+            "url": "https://github.com/hermeticbuild/sha256.star/releases/download/v0.0.1/sha256.bzl-v0.0.1.tar.gz.intoto.jsonl",
+            "integrity": "sha256-M+JcUkbvFOx0azVsomu6xNRRWiUb7jn1TRO7xofrXiI="
+        }
+    }
+}

--- a/modules/sha256.bzl/0.0.1/patches/module_dot_bazel_version.patch
+++ b/modules/sha256.bzl/0.0.1/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,5 +1,7 @@
+-module(name = "sha256.bzl")
++module(name = "sha256.bzl",
++    version = "0.0.1",
++)
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.9.0")
+ 
+ # ✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂✂

--- a/modules/sha256.bzl/0.0.1/presubmit.yml
+++ b/modules/sha256.bzl/0.0.1/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204"]
+    bazel: [7.x, 8.x, 9.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/sha256.bzl/0.0.1/source.json
+++ b/modules/sha256.bzl/0.0.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-Bo2uEEBeJPHfiRLhY5wbYsrN3eCsYrtCH3KnhHyqCT4=",
+    "strip_prefix": "sha256.bzl-0.0.1",
+    "url": "https://github.com/hermeticbuild/sha256.star/releases/download/v0.0.1/sha256.bzl-v0.0.1.tar.gz",
+    "docs_url": "https://github.com/hermeticbuild/sha256.star/releases/download/v0.0.1/sha256.bzl-v0.0.1.docs.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-rTXSRp2NT+7G56g+6Wk4NLg1JBaB3gMSGbAtg3uW/o0="
+    },
+    "patch_strip": 1
+}

--- a/modules/sha256.bzl/metadata.json
+++ b/modules/sha256.bzl/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/hermeticbuild/sha256.star",
+    "maintainers": [
+        {
+            "name": "Malte Poll",
+            "email": "1780588+malt3@users.noreply.github.com",
+            "github": "malt3",
+            "github_user_id": 1780588
+        }
+    ],
+    "repository": [
+        "github:hermeticbuild/sha256.star"
+    ],
+    "versions": [
+        "0.0.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/hermeticbuild/sha256.star/releases/tag/v0.0.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_