### PR TITLE
feat(bcr_validation): Don't flag innocuous presubmit.yml changes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -76,7 +76,7 @@ Validations performed in the scripts are:
 - Verify the integrity values of the source archive and patch files (if any) are correct.
 - Verify the checked-in `MODULE.bazel` file matches the one in the extracted and patched source tree.
 - Verify the `compatibility_level` in `MODULE.bazel` matches the previous version. If the bump is intentional, you can comment `@bazel-io skip_check compatibility_level` in the PR to skip this check.
-- Check if the module is new or the `presubmit.yml` file is changed compared to the last version, if so a BCR maintainer review will be required to run jobs specified in `presubmit.yml`.
+- Check if the module is new or the `presubmit.yml` file is too different compared to the last version, if so a BCR maintainer review will be required to run jobs specified in `presubmit.yml`.
 
 Additional validations implemented in the [bcr_presubmit.py](https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazel-central-registry/bcr_presubmit.py) script:
 

--- a/docs/bcr-policies.md
+++ b/docs/bcr-policies.md
@@ -21,7 +21,7 @@ Registry maintainers and module maintainers maintain the BCR. BCR maintainers ar
 - Review and accept contributions made by the community that align with the BCR contribution policy. Maintainers can merge any PR they have carefully reviewed and is passing CI. BCR maintainer attention is required when:
   - A PR changes a module that has no existing maintainers: this requires the BCR maintainer to approve the PR using GitHub's PR review workflow.
     - This includes when the PR adds an entirely new module, or if the module's sole existing maintainer is also the PR author (since a PR author cannot approve their own PR).
-  - A PR changes the presubmit.yml file for a module: this requires the BCR maintainer to apply the `presubmit-auto-run` label to unblock CI.
+  - A PR changes the presubmit.yml file for a module, beyond just platform names or bazel versions: this requires the BCR maintainer to apply the `presubmit-auto-run` label to unblock CI.
   - A PR author is a first-time contributor to the BCR: this requires the BCR maintainer to click the "Approve and run" button to unblock certain GitHub actions.
 - Assess the health of the BCR by monitoring the BCR testing and serving infrastructure.
 - Identify and appoint module maintainers.

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -464,7 +464,7 @@ class BcrValidator:
             self.report(BcrValidationResult.GOOD, "The git_repository appears stable.")
 
     def verify_presubmit_yml_change(self, module_name, version):
-        """Verify if the presubmit.yml is the same as the previous version."""
+        """Verify if the presubmit.yml is similar enough to the previous version."""
         latest_snapshot = self.upstream.get_latest_module_version(module_name)
         if not latest_snapshot:
             self.report(
@@ -472,30 +472,59 @@ class BcrValidator:
                 f"Module version {module_name}@{version} is new, the presubmit.yml file "
                 "should be reviewed by a BCR maintainer.",
             )
-        else:
-            previous_presubmit_content = latest_snapshot.presubmit_yml_lines()
-            current_presubmit_yml = self.registry.get_presubmit_yml_path(module_name, version)
-            current_presubmit_content = open(current_presubmit_yml, "r").readlines()
-            diff = list(
-                unified_diff(
-                    previous_presubmit_content,
-                    current_presubmit_content,
-                    fromfile="HEAD",
-                    tofile=str(current_presubmit_yml),
-                )
+            return
+
+        # Load the current yaml from the local fork but the previous yml from upstream.
+        # (The local fork might not have merged the latest upstream changes.)
+        previous_presubmit_lines = latest_snapshot.presubmit_yml_lines()
+        current_presubmit_yml = self.registry.get_presubmit_yml_path(module_name, version)
+        current_presubmit_lines = open(current_presubmit_yml, "r").readlines()
+
+        # When nothing at all is changed, we don't even need to parse the documents.
+        if current_presubmit_lines == previous_presubmit_lines:
+            self.report(
+                BcrValidationResult.GOOD,
+                "The presubmit.yml file exactly matches the previous version.",
             )
-            if diff:
-                self.report(
-                    BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW,
-                    f"The presubmit.yml file of {module_name}@{version} doesn't match its previous version "
-                    f"{module_name}@{latest_snapshot.version}, the following presubmit.yml file change "
-                    "should be reviewed by a BCR maintainer.\n    " + "    ".join(diff),
-                )
-            else:
-                self.report(
-                    BcrValidationResult.GOOD,
-                    "The presubmit.yml file matches the previous version.",
-                )
+            return
+
+        # We'll compare the parsed representation of the two presubmit.yml files.
+        # Differences in only comments / whitespace don't need BCR maintainer review.
+        previous_presubmit_doc = yaml.safe_load("".join(previous_presubmit_lines))
+        current_presubmit_doc = yaml.safe_load("".join(current_presubmit_lines))
+        if current_presubmit_doc == previous_presubmit_doc:
+            self.report(
+                BcrValidationResult.GOOD,
+                "The presubmit.yml file matches the previous version, modulo comments and whitespace.",
+            )
+            return
+
+        # Differences in only platform names or bazel versions don't need BCR maintainer review.
+        for doc in (previous_presubmit_doc, current_presubmit_doc):
+            for scrub in ("bazel", "platform"):
+                doc.setdefault("matrix", {})[scrub] = None
+        if current_presubmit_doc == previous_presubmit_doc:
+            self.report(
+                BcrValidationResult.GOOD,
+                "The presubmit.yml file matches the previous version, modulo supported platforms and versions.",
+            )
+            return
+
+        # The files were not similar enough. Flag for BCR maintainer review.
+        diff = list(
+            unified_diff(
+                previous_presubmit_lines,
+                current_presubmit_lines,
+                fromfile="HEAD",
+                tofile=str(current_presubmit_yml),
+            )
+        )
+        self.report(
+            BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW,
+            f"The presubmit.yml file of {module_name}@{version} differs from its previous version "
+            f"{module_name}@{latest_snapshot.version}, the following presubmit.yml file change "
+            "should be reviewed by a BCR maintainer.\n    " + "    ".join(diff),
+        )
 
     def add_module_dot_bazel_patch(self, diff, module_name, version):
         """Adding a patch file for MODULE.bazel according to the diff result."""


### PR DESCRIPTION
Closes #7105.

In addition to the requested "allow formatting/comment changes", this also allows changes to the platform and bazel version support matrix.  I have seen a lot of module bumps lately being stuck waiting for BCR maintainer review just because the bump added "9.x" to their supported bazel versions.