### PR TITLE
pico-sdk.2.2.2-develop.bcr.20260420-79b38e95

### DIFF
--- a/modules/pico-sdk/2.2.2-develop.bcr.20260420-79b38e95/MODULE.bazel
+++ b/modules/pico-sdk/2.2.2-develop.bcr.20260420-79b38e95/MODULE.bazel
@@ -1,0 +1,172 @@
+module(
+    name = "pico-sdk",
+    version = "2.2.2-develop.bcr.20260420-79b38e95",
+)
+
+bazel_dep(name = "platforms", version = "0.0.9")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
+bazel_dep(name = "rules_python", version = "0.36.0")
+bazel_dep(name = "picotool", version = "2.2.0")
+bazel_dep(name = "rules_cc", version = "0.0.10")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "arm_gcc_linux-aarch64",
+    build_file = "//bazel/toolchain:gcc_arm_none_eabi.BUILD",
+    sha256 = "8fd8b4a0a8d44ab2e195ccfbeef42223dfb3ede29d80f14dcf2183c34b8d199a",
+    strip_prefix = "arm-gnu-toolchain-13.2.Rel1-aarch64-arm-none-eabi",
+    urls = [
+        "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-aarch64-arm-none-eabi.tar.xz",
+        "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-aarch64-arm-none-eabi.tar.xz",
+    ],
+)
+
+http_archive(
+    name = "arm_gcc_linux-x86_64",
+    build_file = "//bazel/toolchain:gcc_arm_none_eabi.BUILD",
+    sha256 = "6cd1bbc1d9ae57312bcd169ae283153a9572bd6a8e4eeae2fedfbc33b115fdbb",
+    strip_prefix = "arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi",
+    urls = [
+        "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz",
+        "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz",
+    ],
+)
+
+http_archive(
+    name = "arm_gcc_win-x86_64",
+    build_file = "//bazel/toolchain:gcc_arm_none_eabi.BUILD",
+    sha256 = "51d933f00578aa28016c5e3c84f94403274ea7915539f8e56c13e2196437d18f",
+    strip_prefix = "arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-arm-none-eabi",
+    urls = [
+        "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi.zip",
+        "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi.zip",
+    ],
+)
+
+http_archive(
+    name = "arm_gcc_mac-x86_64",
+    build_file = "//bazel/toolchain:gcc_arm_none_eabi.BUILD",
+    sha256 = "075faa4f3e8eb45e59144858202351a28706f54a6ec17eedd88c9fb9412372cc",
+    strip_prefix = "arm-gnu-toolchain-13.2.Rel1-darwin-x86_64-arm-none-eabi",
+    urls = [
+        "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz",
+        "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz",
+    ],
+)
+
+http_archive(
+    name = "arm_gcc_mac-aarch64",
+    build_file = "//bazel/toolchain:gcc_arm_none_eabi.BUILD",
+    sha256 = "39c44f8af42695b7b871df42e346c09fee670ea8dfc11f17083e296ea2b0d279",
+    strip_prefix = "arm-gnu-toolchain-13.2.Rel1-darwin-arm64-arm-none-eabi",
+    urls = [
+        "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-arm64-arm-none-eabi.tar.xz",
+        "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-arm64-arm-none-eabi.tar.xz",
+    ],
+)
+
+http_archive(
+    name = "clang_linux-x86_64",
+    build_file = "//bazel/toolchain:clang.BUILD",
+    sha256 = "82302f8f0d9cb1062e60756147403c1525e965e1d7b777fab8076c74c7a5a19b",
+    type = "zip",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/linux-amd64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c",
+)
+
+http_archive(
+    name = "clang_win-x86_64",
+    build_file = "//bazel/toolchain:clang.BUILD",
+    sha256 = "2e9b8ac889838754e5305b6fd73c7bba7a6ec7364f1ce8ac60268b6d3bc61e6c",
+    type = "zip",
+    # Windows doesn't like `:` in the produced filename, so replace it with `%3A`.
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/windows-amd64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c".replace("git_revision:", "git_revision%3A"),
+)
+
+http_archive(
+    name = "clang_mac-x86_64",
+    build_file = "//bazel/toolchain:clang.BUILD",
+    sha256 = "d3f2ef6f391ef66141092cfdf07facd18d2587a25616e1251e6e6b13b05ab3df",
+    type = "zip",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-amd64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c",
+)
+
+http_archive(
+    name = "clang_mac-aarch64",
+    build_file = "//bazel/toolchain:clang.BUILD",
+    sha256 = "61109b8464e9213ef8b9bfe55ce56298b94d4c66eaea308cf2b6556b0b85429e",
+    type = "zip",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-arm64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c",
+)
+
+new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
+# TODO: Provide tinyusb as a proper Bazel module.
+new_git_repository(
+    name = "tinyusb",
+    build_file = "//src/rp2_common/tinyusb:tinyusb.BUILD",
+    commit = "86ad6e56c1700e85f1c5678607a762cfe3aa2f47",  # keep-in-sync-with-submodule: lib/tinyusb
+    remote = "https://github.com/hathach/tinyusb.git",
+)
+
+# TODO: Provide btstack as a proper Bazel module.
+new_git_repository(
+    name = "btstack",
+    build_file = "//src/rp2_common/pico_btstack:btstack.BUILD",
+    commit = "420dc137399796c88b0013ee09f157046018923e",  # keep-in-sync-with-submodule: lib/btstack
+    remote = "https://github.com/bluekitchen/btstack.git",
+)
+
+# TODO: Provide cyw43-driver as a proper Bazel module.
+new_git_repository(
+    name = "cyw43-driver",
+    build_file = "//src/rp2_common/pico_cyw43_driver:cyw43-driver.BUILD",
+    commit = "dd7568229f3bf7a37737b9e1ef250c26efe75b23",  # keep-in-sync-with-submodule: lib/cyw43-driver
+    remote = "https://github.com/georgerobotics/cyw43-driver.git",
+)
+
+# TODO: Provide lwip as a proper Bazel module.
+new_git_repository(
+    name = "lwip",
+    build_file = "//src/rp2_common/pico_lwip:lwip.BUILD",
+    commit = "77dcd25a72509eb83f72b033d219b1d40cd8eb95",  # keep-in-sync-with-submodule: lib/lwip
+    remote = "https://github.com/lwip-tcpip/lwip.git",
+)
+
+new_git_repository(
+    name = "mbedtls",
+    build_file = "//src/rp2_common/pico_mbedtls:mbedtls.BUILD",
+    commit = "107ea89daaefb9867ea9121002fbbdf926780e98",  # keep-in-sync-with-submodule: lib/mbedtls
+    remote = "https://github.com/Mbed-TLS/mbedtls.git",
+)
+
+register_toolchains(
+    "//bazel/toolchain:linux-aarch64-rp2040",
+    "//bazel/toolchain:linux-aarch64-rp2350",
+    "//bazel/toolchain:linux-x86_64-rp2040",
+    "//bazel/toolchain:linux-x86_64-rp2350",
+    "//bazel/toolchain:win-x86_64-rp2040",
+    "//bazel/toolchain:win-x86_64-rp2350",
+    "//bazel/toolchain:mac-x86_64-rp2040",
+    "//bazel/toolchain:mac-x86_64-rp2350",
+    "//bazel/toolchain:mac-aarch64-rp2040",
+    "//bazel/toolchain:mac-aarch64-rp2350",
+    # Require users to opt-in to the Pico SDK's toolchains.
+    dev_dependency = True,
+)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    configure_coverage_tool = True,
+    python_version = "3.9",
+)
+
+use_repo(python, "pythons_hub")
+register_toolchains(
+    "@pythons_hub//:all",
+    dev_dependency = True,
+)
+register_toolchains(
+    "@rules_python//python/runtime_env_toolchains:all",
+    dev_dependency = True,
+)

--- a/modules/pico-sdk/2.2.2-develop.bcr.20260420-79b38e95/patches/bazel.patch
+++ b/modules/pico-sdk/2.2.2-develop.bcr.20260420-79b38e95/patches/bazel.patch
@@ -1,0 +1,83 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 504926d..aa0cdfd 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "pico-sdk",
+-    version = "2.2.1-develop",
++    version = "2.2.2-develop.bcr.20260420-79b38e95",
+ )
+ 
+ bazel_dep(name = "platforms", version = "0.0.9")
+diff --git a/bazel/util/pico_linker_scripts.bzl b/bazel/util/pico_linker_scripts.bzl
+index 8bdc18e..5629b90 100644
+--- a/bazel/util/pico_linker_scripts.bzl
++++ b/bazel/util/pico_linker_scripts.bzl
+@@ -1,4 +1,6 @@
+ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
++load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
++load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+ 
+ def _linker_scripts_impl(ctx):
+     link_flags = []
+diff --git a/src/rp2_common/pico_btstack/btstack.BUILD b/src/rp2_common/pico_btstack/btstack.BUILD
+index 90fc6e9..6c30f41 100644
+--- a/src/rp2_common/pico_btstack/btstack.BUILD
++++ b/src/rp2_common/pico_btstack/btstack.BUILD
+@@ -1,5 +1,6 @@
+ load("@rules_python//python:defs.bzl", "py_binary")
+ load("@pico-sdk//bazel:defs.bzl", "compatible_with_config", "incompatible_with_config")
++load("@rules_cc//cc:cc_library.bzl", "cc_library")
+ 
+ package(default_visibility = ["//visibility:public"])
+ 
+diff --git a/src/rp2_common/pico_cyw43_driver/cyw43-driver.BUILD b/src/rp2_common/pico_cyw43_driver/cyw43-driver.BUILD
+index 582faa6..4a3f243 100644
+--- a/src/rp2_common/pico_cyw43_driver/cyw43-driver.BUILD
++++ b/src/rp2_common/pico_cyw43_driver/cyw43-driver.BUILD
+@@ -1,4 +1,5 @@
+ load("@pico-sdk//bazel:defs.bzl", "compatible_with_pico_w")
++load("@rules_cc//cc:cc_library.bzl", "cc_library")
+ 
+ package(default_visibility = ["//visibility:public"])
+ 
+diff --git a/src/rp2_common/pico_lwip/lwip.BUILD b/src/rp2_common/pico_lwip/lwip.BUILD
+index c76d42d..00108a2 100644
+--- a/src/rp2_common/pico_lwip/lwip.BUILD
++++ b/src/rp2_common/pico_lwip/lwip.BUILD
+@@ -1,4 +1,5 @@
+ load("@pico-sdk//bazel:defs.bzl", "incompatible_with_config", "compatible_with_config")
++load("@rules_cc//cc:cc_library.bzl", "cc_library")
+ 
+ package(default_visibility = ["//visibility:public"])
+ 
+diff --git a/src/rp2_common/pico_mbedtls/mbedtls.BUILD b/src/rp2_common/pico_mbedtls/mbedtls.BUILD
+index c8b8564..ede1a97 100644
+--- a/src/rp2_common/pico_mbedtls/mbedtls.BUILD
++++ b/src/rp2_common/pico_mbedtls/mbedtls.BUILD
+@@ -1,4 +1,5 @@
+ load("@pico-sdk//bazel:defs.bzl", "incompatible_with_config")
++load("@rules_cc//cc:cc_library.bzl", "cc_library")
+ 
+ package(default_visibility = ["//visibility:public"])
+ 
+diff --git a/src/rp2_common/tinyusb/tinyusb.BUILD b/src/rp2_common/tinyusb/tinyusb.BUILD
+index ea0a5c3..ed55ec3 100644
+--- a/src/rp2_common/tinyusb/tinyusb.BUILD
++++ b/src/rp2_common/tinyusb/tinyusb.BUILD
+@@ -1,3 +1,5 @@
++load("@rules_cc//cc:cc_library.bzl", "cc_library")
++
+ package(default_visibility = ["//visibility:public"])
+ 
+ exports_files(
+diff --git a/test/pico_async_context_test/BUILD.bazel b/test/pico_async_context_test/BUILD.bazel
+index 2028e58..f9179ba 100644
+--- a/test/pico_async_context_test/BUILD.bazel
++++ b/test/pico_async_context_test/BUILD.bazel
+@@ -1,3 +1,4 @@
++load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+ load("//bazel:defs.bzl", "compatible_with_rp2")
+ 
+ package(default_visibility = ["//visibility:public"])

--- a/modules/pico-sdk/2.2.2-develop.bcr.20260420-79b38e95/presubmit.yml
+++ b/modules/pico-sdk/2.2.2-develop.bcr.20260420-79b38e95/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+  # Needs GCC >=10, so can't use ubuntu2004 until a host toolchain is vendored.
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@pico-sdk//src/host/pico_stdlib'

--- a/modules/pico-sdk/2.2.2-develop.bcr.20260420-79b38e95/source.json
+++ b/modules/pico-sdk/2.2.2-develop.bcr.20260420-79b38e95/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/raspberrypi/pico-sdk/archive/79b38e9543116e9be524388ae4650393e6453026.tar.gz",
+    "integrity": "sha256-/NAAnrZRi7gcVW8ARd3vvN/qWpxcTjmryunmbXSzIzM=",
+    "strip_prefix": "pico-sdk-79b38e9543116e9be524388ae4650393e6453026",
+    "patches": {
+        "bazel.patch": "sha256-aClsXqKm+k8GRkS+OUZbQqR93LAHnZD14Eri1jUUVdY="
+    },
+    "patch_strip": 1
+}

--- a/modules/pico-sdk/metadata.json
+++ b/modules/pico-sdk/metadata.json
@@ -38,7 +38,8 @@
         "2.2.0",
         "2.2.1-develop.bcr.20250915-8fcd44a1",
         "2.2.2-develop.bcr.20260105-1cc19a21",
-        "2.2.2-develop.bcr.20260401-79b38e95"
+        "2.2.2-develop.bcr.20260401-79b38e95",
+        "2.2.2-develop.bcr.20260420-79b38e95"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Patches the pico-sdk developer branch at commit 79b38e95 for use in BCR, with minimal additional patches for Bazel 9