### PR TITLE
Add tl-expected@1.3.1

### DIFF
--- a/modules/tl-expected/1.3.1/MODULE.bazel
+++ b/modules/tl-expected/1.3.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "tl-expected",
+    version = "1.3.1",
+    compatibility_level = 0,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.18")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/tl-expected/1.3.1/overlay/BUILD.bazel
+++ b/modules/tl-expected/1.3.1/overlay/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+)
+
+exports_files(["COPYING"])
+
+license(
+    name = "license",
+    package_name = "expected",
+    license_kinds = ["@rules_license//licenses/spdx:CC0-1.0"],
+    license_text = "COPYING",
+    package_url = "https://github.com/TartanLlama/expected",
+)
+
+cc_library(
+    name = "tl-expected",
+    hdrs = ["include/tl/expected.hpp"],
+    includes = ["include"],
+    features = ["parse_headers"],
+    visibility = ["//visibility:public"],
+)

--- a/modules/tl-expected/1.3.1/presubmit.yml
+++ b/modules/tl-expected/1.3.1/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian10
+  - debian11
+  - ubuntu2204
+  - ubuntu2404
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@tl-expected'

--- a/modules/tl-expected/1.3.1/source.json
+++ b/modules/tl-expected/1.3.1/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/TartanLlama/expected/archive/refs/tags/v1.3.1.tar.gz",
+    "integrity": "sha256-mgT09HL7tcML9gQC8cpibEp2mH+GeXjQuKNderP7j+c=",
+    "strip_prefix": "expected-1.3.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-SVYwEAH10dn9T+NKGTHW8rIOKsWUZk+gOEbdYQax9QE="
+    }
+}

--- a/modules/tl-expected/metadata.json
+++ b/modules/tl-expected/metadata.json
@@ -11,7 +11,8 @@
         "github:TartanLlama/expected"
     ],
     "versions": [
-        "1.1.0"
+        "1.1.0",
+        "1.3.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This PR:
* Updates tl-expected to 1.3.1
* Adds license details
* Adds Bazel 9.x into the test matrix
* Adds "parse_headers" to cc-library so the tests will work