### PR TITLE
pkg-config: make compile with bazel 9

### DIFF
--- a/modules/pkg-config/0.29.2.bcr.1/MODULE.bazel
+++ b/modules/pkg-config/0.29.2.bcr.1/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "pkg-config",
+    version = "0.29.2.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "glib", version = "2.82.2.bcr.8")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/pkg-config/0.29.2.bcr.1/overlay/BUILD.bazel
+++ b/modules/pkg-config/0.29.2.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,58 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+PKG_CONFIG_PC_PATH = ":".join([
+    "/usr/local/lib/pkgconfig",
+    "/usr/local/share/pkgconfig",
+    "/usr/lib/pkgconfig",
+    "/usr/share/pkgconfig",
+])
+
+expand_template(
+    name = "config_h",
+    out = "config.h",
+    substitutions = {},
+    template = select({
+        "@platforms//os:windows": "config.h.win32",
+    }),
+)
+
+cc_binary(
+    name = "pkg-config",
+    srcs = [
+        "main.c",
+        "parse.c",
+        "parse.h",
+        "pkg.c",
+        "pkg.h",
+        "rpmvercmp.c",
+        "rpmvercmp.h",
+    ] + select({
+        "@platforms//os:windows": [":config_h"],
+        "//conditions:default": [],
+    }),
+    local_defines = [
+    ] + select({
+        "@platforms//os:windows": [
+            "HAVE_CONFIG_H",
+            "PKG_CONFIG_PC_PATH='\"\"'",
+            "PKG_CONFIG_SYSTEM_INCLUDE_PATH='\"\"'",
+            "PKG_CONFIG_SYSTEM_LIBRARY_PATH='\"\"'",
+        ],
+        "//conditions:default": [
+            "VERSION='\"0.29.2\"'",
+            "ENABLE_INDIRECT_DEPS=0",
+            "ENABLE_DEFINE_PREFIX=0",
+            "PKG_CONFIG_PC_PATH='\"%s\"'" % (PKG_CONFIG_PC_PATH,),
+            "PKG_CONFIG_SYSTEM_INCLUDE_PATH='\"/usr/include\"'",
+            "PKG_CONFIG_SYSTEM_LIBRARY_PATH='\"/usr/lib:/lib\"'",
+        ],
+    }) + select({
+        "@platforms//os:macos": [
+            "_DARWIN_USE_64_BIT_INODE=1",
+        ],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = ["@glib//glib"],
+)

--- a/modules/pkg-config/0.29.2.bcr.1/patches/deprecation_warnings.patch
+++ b/modules/pkg-config/0.29.2.bcr.1/patches/deprecation_warnings.patch
@@ -1,0 +1,12 @@
+--- parse.c
++++ parse.c
+@@ -1111,7 +1111,7 @@ parse_package_file (const char *key, const char *path,
+ 
+   if (path)
+     {
+-      pkg->pcfiledir = g_dirname (path);
++      pkg->pcfiledir = g_path_get_dirname (path);
+     }
+   else
+     {
+

--- a/modules/pkg-config/0.29.2.bcr.1/presubmit.yml
+++ b/modules/pkg-config/0.29.2.bcr.1/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - debian11
+  - ubuntu2004
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@pkg-config'

--- a/modules/pkg-config/0.29.2.bcr.1/source.json
+++ b/modules/pkg-config/0.29.2.bcr.1/source.json
@@ -1,0 +1,12 @@
+{
+    "url": "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz",
+    "integrity": "sha256-b8acAWiMlFilfrmhZkyaujcszaQgoCv0Qp/mEOfn1ZE=",
+    "strip_prefix": "pkg-config-0.29.2",
+    "patch_strip": 0,
+    "patches": {
+        "deprecation_warnings.patch": "sha256-z0uL1uDVyK3x3IMeNjfl/KolpVehq9T9TWAAWk8E0WY="
+    },
+    "overlay": {
+        "BUILD.bazel": "sha256-LrPaQ+7Jh+QofuZNpL5IFPP96U7220FJEdcylwCRjeA="
+    }
+}

--- a/modules/pkg-config/metadata.json
+++ b/modules/pkg-config/metadata.json
@@ -12,7 +12,8 @@
         "https://pkgconfig.freedesktop.org/releases"
     ],
     "versions": [
-        "0.29.2"
+        "0.29.2",
+        "0.29.2.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
In bazel 9, we explicitly have to load cc_binary from rules_cc. I bumped glib to pick up bazel 9 fixes in it. I also deleted overlay/MODULE.bazel, my builds still work without it so I think it isn't required.

Tested by passing --registry to my repository. Als ran `bazel run //tools:bcr_validation -- --check=pkg-config@0.29.2.bcr.1`