### PR TITLE
Fix Dependabot PR Hijacking in update_requirements.yml

### DIFF
--- a/.github/workflows/update_requirements.yml
+++ b/.github/workflows/update_requirements.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}
 
       - name: Setup Bazel


### PR DESCRIPTION
This patch removes the explicit `ref: ${{ github.head_ref }}` checkout 
in the `pull_request_target` workflow to prevent Dependabot PR Hijacking 
supply chain vulnerabilities. Checking out untrusted code while highly 
privileged secrets are in the environment allows an attacker to hijack 
a Dependabot PR and execute arbitrary code during `bazel run`.

---
 .github/workflows/update_requirements.yml | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)

diff --git a/.github/workflows/update_requirements.yml b/.github/workflows/update_requirements.yml
index a1b2c3d..e4f5g6h 100644
--- a/.github/workflows/update_requirements.yml
+++ b/.github/workflows/update_requirements.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
           token: ${{ secrets.BCR_PR_REVIEW_HELPER_TOKEN }}
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
