### PR TITLE
Added module: trlc@2.0.4 to BCR

### DIFF
--- a/modules/trlc/2.0.4/MODULE.bazel
+++ b/modules/trlc/2.0.4/MODULE.bazel
@@ -1,0 +1,115 @@
+module(
+    name = "trlc",
+    compatibility_level = 1,
+    version = "2.0.4",
+)
+
+bazel_dep(
+    name = "rules_python",
+    version = "1.1.0",
+)
+
+bazel_dep(
+    name = "buildifier_prebuilt",
+    version = "8.2.1.1",
+    dev_dependency = True,
+)
+
+bazel_dep(
+    name = "aspect_rules_lint",
+    version = "2.2.0",
+    dev_dependency = True,
+)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+
+python.toolchain(python_version = "3.9")
+python.toolchain(python_version = "3.10")
+python.toolchain(python_version = "3.11")
+python.toolchain(
+    is_default = True,
+    python_version = "3.12",
+    configure_coverage_tool = True,
+)
+
+use_repo(python, "python_versions")
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
+[
+    pip.parse(
+        hub_name = "trlc_dependencies",
+        python_version = python_version,
+        requirements_lock = "//:requirements_lock.txt",
+    )
+    for python_version in [
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+    ]
+]
+
+use_repo(pip, "trlc_dependencies")
+
+[
+    pip.parse(
+        hub_name = "trlc_sphinx_dependencies",
+        python_version = python_version,
+        requirements_lock = "//tools/sphinx:requirements.txt",
+    )
+    for python_version in [
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+    ]
+]
+
+use_repo(pip, "trlc_sphinx_dependencies")
+
+# Dev-only pip hub: tools required for linting, static analysis, etc.
+pip_dev = use_extension(
+    "@rules_python//python/extensions:pip.bzl",
+    "pip",
+    dev_dependency = True,
+)
+
+pip_dev.parse(
+    hub_name = "trlc_dev_dependencies",
+    python_version = "3.12",
+    requirements_lock = "//:requirements_dev_lock.txt",
+)
+
+use_repo(pip_dev, "trlc_dev_dependencies")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# ---------------------------------------------------------------------------
+# CVC5 binary archives
+# Keep in synch with CVC5_DEFAULT_VERSION in util/fetch_cvc5.py
+# and requirements.txt / requirements_dev.txt
+# ---------------------------------------------------------------------------
+http_archive(
+    name = "cvc5_linux",
+    build_file = "@trlc//:cvc5.BUILD",
+    sha256 = "30abf22d8042f3c4d3eb1120c595abd461f92f276a6d1264895fb4403b5fb3fd",
+    strip_prefix = "cvc5-Linux-x86_64-static-gpl",
+    url = "https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.2/cvc5-Linux-x86_64-static-gpl.zip",
+)
+
+http_archive(
+    name = "cvc5_mac",
+    build_file = "@trlc//:cvc5.BUILD",
+    sha256 = "9b00ae44d51903cd830e281c97066d7e4c0a57f1aa6c5b275435d3016427be64",
+    strip_prefix = "cvc5-macOS-arm64-static-gpl",
+    url = "https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.2/cvc5-macOS-arm64-static-gpl.zip",
+)
+
+http_archive(
+    name = "cvc5_windows",
+    build_file = "@trlc//:cvc5.BUILD",
+    sha256 = "206d55380f9a0ccf43541756b5ce2be487efcbbf322b93dc1de662856c70e5cc",
+    strip_prefix = "cvc5-Win64-x86_64-static",
+    url = "https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.2/cvc5-Win64-x86_64-static.zip",
+)

--- a/modules/trlc/2.0.4/patches/module_dot_bazel_version.patch
+++ b/modules/trlc/2.0.4/patches/module_dot_bazel_version.patch
@@ -1,0 +1,17 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,11 +1,11 @@
+ module(
+     name = "trlc",
+     compatibility_level = 1,
+-    version = "0.0.0",
++    version = "2.0.4",
+ )
+ 
+ bazel_dep(
+     name = "rules_python",
+     version = "1.1.0",
+ )
+
+
+

--- a/modules/trlc/2.0.4/presubmit.yml
+++ b/modules/trlc/2.0.4/presubmit.yml
@@ -1,0 +1,28 @@
+incompatible_flags:
+  "--incompatible_config_setting_private_default_visibility":
+    - 8.x
+  "--incompatible_disable_starlark_host_transitions":
+    - 8.x
+  "--incompatible_disable_native_repo_rules":
+    - 8.x
+  "--incompatible_strict_action_env":
+    - 8.x
+matrix:
+  platform:
+  - ubuntu2004
+  - ubuntu2204
+  bazel:
+  - 8.x
+tasks:
+  verify_api_examples:
+    name: "Verify api-examples"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - "--@@rules_python+//python/config_settings:python_version=3.12"
+    build_targets:
+    - "@trlc//api-examples/..."
+    test_flags:
+    - "--@@rules_python+//python/config_settings:python_version=3.12"
+    test_targets:
+    - "@trlc//api-examples/..."

--- a/modules/trlc/2.0.4/source.json
+++ b/modules/trlc/2.0.4/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-z+70haMweSQAjYaMrf0xN0CuUpvKA0/GGxaCw8mXKJM=",
+    "strip_prefix": "trlc-trlc-2.0.4",
+    "url": "https://github.com/bmw-software-engineering/trlc/archive/refs/tags/trlc-2.0.4.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-SKoIeJD9rACzuPnSgBpdh/9XSAjie8HMXygFRh8Y1VM="
+    },
+    "patch_strip": 1
+}

--- a/modules/trlc/metadata.json
+++ b/modules/trlc/metadata.json
@@ -1,0 +1,25 @@
+{
+    "homepage": "https://github.com/bmw-software-engineering/trlc",
+    "maintainers": [
+        {
+            "email": "ambujsingh7566180876@gmail.com",
+            "github": "AAmbuj",
+            "name": "Ambuj Singh Kushwaha",
+            "github_user_id": 73685939
+        },
+        {
+            "email": "rahulsutariya0001@gmail.com",
+            "github": "Rahul-Sutariya",
+            "name": "RAHUL SUTARIYA",
+            "github_user_id": 113970414
+        }
+    ],
+    "repository": [
+        "github:bmw-software-engineering/trlc"
+    ],
+    "versions": [
+        "2.0.4"
+    ],
+    "yanked_versions": {}
+}
+


### PR DESCRIPTION
Added trlc version 2.0.4 (release tag trlc-2.0.4)
MODULE.bazel with dependencies on rules_python and cvc5.
Maintainer: Ambuj Singh Kushwaha [ambujsingh7566180876@gmail.com]