### PR TITLE
evidence_store_bazel@0.0.1

### DIFF
--- a/modules/evidence_store_bazel/0.0.1/MODULE.bazel
+++ b/modules/evidence_store_bazel/0.0.1/MODULE.bazel
@@ -1,0 +1,15 @@
+module(
+    name = "evidence_store_bazel",
+    version = "0.0.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_go", version = "0.60.0")
+bazel_dep(name = "gazelle", version = "0.50.0")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.from_file(go_mod = "//:go.mod")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(go_deps, "com_github_stretchr_testify", "in_gopkg_yaml_v3")

--- a/modules/evidence_store_bazel/0.0.1/presubmit.yml
+++ b/modules/evidence_store_bazel/0.0.1/presubmit.yml
@@ -11,10 +11,4 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_targets:
-      - "//cmd/evidence-bazel"
-  verify_tests:
-    name: Run adapter tests
-    platform: ${{ platform }}
-    bazel: ${{ bazel }}
-    test_targets:
-      - "//..."
+      - "@evidence_store_bazel//cmd/evidence-bazel"

--- a/modules/evidence_store_bazel/0.0.1/presubmit.yml
+++ b/modules/evidence_store_bazel/0.0.1/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004
+    - macos
+  bazel: [7.*, 8.*, 9.*]
+
+tasks:
+  verify_build:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "//cmd/evidence-bazel"
+  verify_tests:
+    name: Run adapter tests
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "//..."

--- a/modules/evidence_store_bazel/0.0.1/source.json
+++ b/modules/evidence_store_bazel/0.0.1/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-/oQmSxDV9lf16bHiNfRhWdRxIUqeVP6725OzYGGbogg=",
+    "strip_prefix": "evidence_store_bazel-v0.0.1",
+    "url": "https://github.com/nesono/evidence_store/releases/download/evidence_store_bazel-v0.0.1/evidence_store_bazel-v0.0.1.tar.gz"
+}

--- a/modules/evidence_store_bazel/metadata.json
+++ b/modules/evidence_store_bazel/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/nesono/evidence_store",
+    "maintainers": [
+        {
+            "email": "github@nesono.com",
+            "github": "nesono",
+            "name": "nesono",
+            "github_user_id": 89460
+        }
+    ],
+    "repository": [
+        "github:nesono/evidence_store"
+    ],
+    "versions": [
+        "0.0.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/nesono/evidence_store/releases/tag/evidence_store_bazel-v0.0.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_