### PR TITLE
cyclonedds@11.0.1

### DIFF
--- a/modules/cyclonedds/11.0.1/MODULE.bazel
+++ b/modules/cyclonedds/11.0.1/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "cyclonedds",
+    version = "11.0.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "cmake_configure_file", version = "0.1.5")
+bazel_dep(name = "package_metadata", version = "0.0.7")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/modules/cyclonedds/11.0.1/overlay/BUILD.bazel
+++ b/modules/cyclonedds/11.0.1/overlay/BUILD.bazel
@@ -1,0 +1,655 @@
+load("@cmake_configure_file//:cmake_configure_file.bzl", "cmake_configure_file")
+load("@package_metadata//licenses/rules:license.bzl", "license")
+load("@package_metadata//purl:purl.bzl", "purl")
+load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+package_metadata(
+    name = "package_metadata",
+    purl = purl.bazel(
+        module_name(),
+        module_version(),
+    ),
+    visibility = ["//visibility:public"],
+)
+
+license(
+    name = "license",
+    kind = "@package_metadata//licenses/spdx:EPL-2.0",
+    text = "LICENSE",
+)
+
+# Features enabled when there are no extra third-party dependencies. SECURITY
+# (loadable plugins) and TCP_TLS (OpenSSL) are kept off.
+ENABLED_FEATURES = [
+    "DDS_HAS_LIFESPAN",
+    "DDS_HAS_DEADLINE_MISSED",
+    "DDS_HAS_NETWORK_PARTITIONS",
+    "DDS_HAS_TYPELIB",
+    "DDS_HAS_TYPE_DISCOVERY",
+    "DDS_HAS_TOPIC_DISCOVERY",
+    "DDS_HAS_QOS_PROVIDER",
+    "DDS_HAS_TCP",
+]
+
+cmake_configure_file(
+    name = "dds_config_h",
+    src = "src/ddsrt/include/dds/config.h.in",
+    out = "src/ddsrt/include/dds/config.h",
+    defines = [
+        "DDSRT_HAVE_DYNLIB",
+        "DDSRT_HAVE_FILESYSTEM",
+        "DDSRT_HAVE_NETSTAT",
+        "DDSRT_HAVE_RUSAGE",
+        "DDSRT_HAVE_IPV6",
+        "DDSRT_HAVE_SSM",
+        "DDSRT_HAVE_DNS",
+        "DDSRT_HAVE_GETADDRINFO",
+        "DDSRT_HAVE_GETHOSTNAME",
+        "DDSRT_HAVE_INET_NTOP",
+        "DDSRT_HAVE_INET_PTON",
+    ] + select({
+        "@platforms//os:linux": [
+            "DDSRT_HAVE_GETHOSTBYNAME_R",
+            "DDSRT_HAVE_CONDATTR_SETCLOCK",
+        ],
+        "//conditions:default": [],
+    }),
+    undefines = [
+        "DDSRT_WITH_LWIP",
+        "DDSRT_WITH_FREERTOS",
+    ],
+)
+
+cmake_configure_file(
+    name = "dds_features_h",
+    src = "src/ddsrt/include/dds/features.h.in",
+    out = "src/ddsrt/include/dds/features.h",
+    defines = ENABLED_FEATURES,
+    undefines = [
+        "DDS_HAS_SECURITY",
+        "DDS_HAS_TCP_TLS",
+        "DDS_ALLOW_NESTED_DOMAIN",
+        "DDS_IS_STATIC_LIBRARY",
+    ],
+)
+
+cmake_configure_file(
+    name = "dds_version_h",
+    src = "src/ddsrt/include/dds/version.h.in",
+    out = "src/ddsrt/include/dds/version.h",
+    defines = [
+        "PROJECT_NAME=CycloneDDS",
+        "CycloneDDS_VERSION=" + module_version(),
+        "CycloneDDS_VERSION_MAJOR=" + module_version().split(".")[0],
+        "CycloneDDS_VERSION_MINOR=" + module_version().split(".")[1],
+        "CycloneDDS_VERSION_PATCH=" + module_version().split(".")[2],
+        "CycloneDDS_VERSION_TWEAK=0",
+        "CYCLONEDDS_GIT_HASH=",
+    ] + select({
+        "@platforms//os:macos": [
+            "CMAKE_HOST_SYSTEM_NAME=Darwin",
+            "CMAKE_SYSTEM_NAME=Darwin",
+        ],
+        "//conditions:default": [
+            "CMAKE_HOST_SYSTEM_NAME=Linux",
+            "CMAKE_SYSTEM_NAME=Linux",
+        ],
+    }),
+)
+
+cmake_configure_file(
+    name = "idl_version_h",
+    src = "src/idl/include/idl/version.h.in",
+    out = "src/idl/include/idl/version.h",
+    defines = [
+        "CycloneDDS_VERSION=" + module_version(),
+        "CycloneDDS_VERSION_MAJOR=" + module_version().split(".")[0],
+        "CycloneDDS_VERSION_MINOR=" + module_version().split(".")[1],
+        "CycloneDDS_VERSION_PATCH=" + module_version().split(".")[2],
+        "CycloneDDS_VERSION_TWEAK=0",
+    ],
+)
+
+cmake_configure_file(
+    name = "idlc_config_h",
+    src = "src/tools/idlc/src/idlc/config.h.in",
+    out = "src/tools/idlc/src/idlc/config.h",
+    defines = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["HAVE_GETOPT_H"],
+    }),
+)
+
+cmake_configure_file(
+    name = "idlpp_configed_h",
+    src = "src/tools/idlpp/src/configed.H.in",
+    out = "src/tools/idlpp/src/configed.H",
+    defines = [
+        "idlpp_include_dir=.",
+        "idlpp_system_version=ignored",
+        "idlpp_gcc_major_version_define=#define GCC_MAJOR_VERSION \"0\"",
+        "idlpp_gcc_minor_version_define=#define GCC_MINOR_VERSION \"0\"",
+        "idlpp_have_intmax_t=1",
+        "idlpp_have_inttypes_h=1",
+        "idlpp_have_long_long=1",
+        "idlpp_have_stdint_h=1",
+        "idlpp_ll_form=j",
+        "idlpp_host_compiler=GNUC",
+        "idlpp_host_cmp_name=Clang",
+    ] + select({
+        "@platforms//os:linux": [
+            "idlpp_system=SYS_LINUX",
+            "idlpp_host_system=SYS_LINUX",
+            "idlpp_have_stpcpy=1",
+            "idlpp_have_strlcpy=0",
+            "idlpp_have_strlcat=0",
+        ],
+        "@platforms//os:macos": [
+            "idlpp_system=SYS_MAC",
+            "idlpp_host_system=SYS_MAC",
+            "idlpp_have_stpcpy=1",
+            "idlpp_have_strlcpy=1",
+            "idlpp_have_strlcat=1",
+        ],
+        "//conditions:default": [
+            "idlpp_system=SYS_LINUX",
+            "idlpp_host_system=SYS_LINUX",
+            "idlpp_have_stpcpy=0",
+            "idlpp_have_strlcpy=0",
+            "idlpp_have_strlcat=0",
+        ],
+    }),
+)
+
+genrule(
+    name = "dds_export_h",
+    outs = ["src/ddsrt/include/dds/export.h"],
+    cmd = """
+cat >"$@" <<'EOF'
+#ifndef DDS_EXPORT_H
+#define DDS_EXPORT_H
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+# ifdef DDS_BUILD_SHARED
+#  define DDS_EXPORT __declspec(dllexport)
+# else
+#  define DDS_EXPORT __declspec(dllimport)
+# endif
+# define DDS_NO_EXPORT
+#else
+# define DDS_EXPORT __attribute__((visibility("default")))
+# define DDS_NO_EXPORT __attribute__((visibility("hidden")))
+#endif
+
+#define DDS_INLINE_EXPORT DDS_EXPORT
+#define DDS_DEPRECATED __attribute__((__deprecated__))
+#define DDS_DEPRECATED_EXPORT DDS_EXPORT DDS_DEPRECATED
+#define DDS_DEPRECATED_NO_EXPORT DDS_NO_EXPORT DDS_DEPRECATED
+
+#define DDS_EXPORT_INTERNAL_FUNCTION DDS_EXPORT
+
+#endif /* DDS_EXPORT_H */
+EOF
+""",
+)
+
+genrule(
+    name = "idl_export_h",
+    outs = ["src/idl/include/idl/export.h"],
+    cmd = """
+cat >"$@" <<'EOF'
+#ifndef IDL_EXPORT_H
+#define IDL_EXPORT_H
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+# ifdef IDL_BUILD_SHARED
+#  define IDL_EXPORT __declspec(dllexport)
+# else
+#  define IDL_EXPORT __declspec(dllimport)
+# endif
+# define IDL_NO_EXPORT
+#else
+# define IDL_EXPORT __attribute__((visibility("default")))
+# define IDL_NO_EXPORT __attribute__((visibility("hidden")))
+#endif
+
+#define IDL_INLINE_EXPORT IDL_EXPORT
+#define IDL_DEPRECATED __attribute__((__deprecated__))
+#define IDL_DEPRECATED_EXPORT IDL_EXPORT IDL_DEPRECATED
+#define IDL_DEPRECATED_NO_EXPORT IDL_NO_EXPORT IDL_DEPRECATED
+
+#endif /* IDL_EXPORT_H */
+EOF
+""",
+)
+
+genrule(
+    name = "libidlc_export_h",
+    outs = ["src/tools/idlc/include/libidlc/libidlc_export.h"],
+    cmd = """
+cat >"$@" <<'EOF'
+#ifndef LIBIDLC_EXPORT_H
+#define LIBIDLC_EXPORT_H
+
+#define LIBIDLC_EXPORT
+#define LIBIDLC_NO_EXPORT
+
+#endif /* LIBIDLC_EXPORT_H */
+EOF
+""",
+)
+
+# IDL compiler imports a handful of ddsrt headers/sources verbatim with the
+# DDSRT_/ddsrt_ prefixes rewritten to IDL_/idl_.
+[
+    genrule(
+        name = "idl_" + name + "_h",
+        srcs = ["src/ddsrt/include/dds/ddsrt/" + name + ".h"],
+        outs = ["src/idl/include/idl/" + name + ".h"],
+        cmd = "sed -e 's/DDSRT_/IDL_/g' -e 's/ddsrt_/idl_/g' \"$<\" > \"$@\"",
+    )
+    for name in [
+        "attributes",
+        "endian",
+        "misc",
+    ]
+]
+
+genrule(
+    name = "idl_md5_h",
+    srcs = ["src/ddsrt/include/dds/ddsrt/md5.h"],
+    outs = ["src/idl/include/idl/md5.h"],
+    cmd = "sed -e 's/DDSRT_/IDL_/g' -e 's/ddsrt_/idl_/g' \"$<\" > \"$@\"",
+)
+
+genrule(
+    name = "idl_md5_c",
+    srcs = ["src/ddsrt/src/md5.c"],
+    outs = ["src/idl/src/md5.c"],
+    cmd = "sed -e 's/DDSRT_/IDL_/g' -e 's/ddsrt_/idl_/g' -e 's|dds/ddsrt/|idl/|g' \"$<\" > \"$@\"",
+)
+
+DDSRT_COMMON_SRCS = [
+    "src/ddsrt/src/atomics.c",
+    "src/ddsrt/src/avl.c",
+    "src/ddsrt/src/bits.c",
+    "src/ddsrt/src/bswap.c",
+    "src/ddsrt/src/cdtors.c",
+    "src/ddsrt/src/circlist.c",
+    "src/ddsrt/src/dynlib.c",
+    "src/ddsrt/src/dynlib/posix/dynlib.c",
+    "src/ddsrt/src/environ.c",
+    "src/ddsrt/src/environ/posix/environ.c",
+    "src/ddsrt/src/expand_vars.c",
+    "src/ddsrt/src/fibheap.c",
+    "src/ddsrt/src/filesystem/posix/filesystem.c",
+    "src/ddsrt/src/heap/posix/heap.c",
+    "src/ddsrt/src/hopscotch.c",
+    "src/ddsrt/src/ifaddrs.c",
+    "src/ddsrt/src/ifaddrs/posix/ifaddrs.c",
+    "src/ddsrt/src/io.c",
+    "src/ddsrt/src/log.c",
+    "src/ddsrt/src/machineid.c",
+    "src/ddsrt/src/md5.c",
+    "src/ddsrt/src/mh3.c",
+    "src/ddsrt/src/process/posix/process.c",
+    "src/ddsrt/src/random.c",
+    "src/ddsrt/src/random/posix/random.c",
+    "src/ddsrt/src/retcode.c",
+    "src/ddsrt/src/sockets.c",
+    "src/ddsrt/src/sockets/posix/gethostname.c",
+    "src/ddsrt/src/sockets/posix/socket.c",
+    "src/ddsrt/src/string.c",
+    "src/ddsrt/src/strtod.c",
+    "src/ddsrt/src/strtol.c",
+    "src/ddsrt/src/sync/posix/sync.c",
+    "src/ddsrt/src/threads.c",
+    "src/ddsrt/src/threads/posix/threads.c",
+    "src/ddsrt/src/time.c",
+    "src/ddsrt/src/xmlparser.c",
+]
+
+DDSRT_PLATFORM_SRCS = select({
+    "@platforms//os:macos": [
+        "src/ddsrt/src/netstat/darwin/netstat.c",
+        "src/ddsrt/src/rusage/posix/rusage.c",
+        "src/ddsrt/src/time/darwin/time.c",
+    ],
+    "//conditions:default": [
+        "src/ddsrt/src/netstat/linux/netstat.c",
+        "src/ddsrt/src/rusage/posix/rusage.c",
+        "src/ddsrt/src/time/posix/time.c",
+    ],
+})
+
+DDSC_SRCS = [
+    "src/core/ddsc/src/dds_alloc.c",
+    "src/core/ddsc/src/dds_builtin.c",
+    "src/core/ddsc/src/dds_coherent.c",
+    "src/core/ddsc/src/dds_domain.c",
+    "src/core/ddsc/src/dds_dynamic_type.c",
+    "src/core/ddsc/src/dds_entity.c",
+    "src/core/ddsc/src/dds_err_check.c",
+    "src/core/ddsc/src/dds_guardcond.c",
+    "src/core/ddsc/src/dds_guid.c",
+    "src/core/ddsc/src/dds_handles.c",
+    "src/core/ddsc/src/dds_heap_loan.c",
+    "src/core/ddsc/src/dds_init.c",
+    "src/core/ddsc/src/dds_instance.c",
+    "src/core/ddsc/src/dds_listener.c",
+    "src/core/ddsc/src/dds_loaned_sample.c",
+    "src/core/ddsc/src/dds_matched.c",
+    "src/core/ddsc/src/dds_participant.c",
+    "src/core/ddsc/src/dds_psmx.c",
+    "src/core/ddsc/src/dds_publisher.c",
+    "src/core/ddsc/src/dds_qos.c",
+    "src/core/ddsc/src/dds_qos_provider.c",
+    "src/core/ddsc/src/dds_querycond.c",
+    "src/core/ddsc/src/dds_read.c",
+    "src/core/ddsc/src/dds_readcond.c",
+    "src/core/ddsc/src/dds_reader.c",
+    "src/core/ddsc/src/dds_rhc.c",
+    "src/core/ddsc/src/dds_rhc_default.c",
+    "src/core/ddsc/src/dds_serdata_builtintopic.c",
+    "src/core/ddsc/src/dds_serdata_default.c",
+    "src/core/ddsc/src/dds_sertype_builtintopic.c",
+    "src/core/ddsc/src/dds_sertype_default.c",
+    "src/core/ddsc/src/dds_statistics.c",
+    "src/core/ddsc/src/dds_subscriber.c",
+    "src/core/ddsc/src/dds_sysdef_parser.c",
+    "src/core/ddsc/src/dds_sysdef_validation.c",
+    "src/core/ddsc/src/dds_topic.c",
+    "src/core/ddsc/src/dds_waitset.c",
+    "src/core/ddsc/src/dds_whc.c",
+    "src/core/ddsc/src/dds_whc_builtintopic.c",
+    "src/core/ddsc/src/dds_write.c",
+    "src/core/ddsc/src/dds_writer.c",
+]
+
+CDR_SRCS = [
+    "src/core/cdr/src/dds_cdrstream.c",
+]
+
+# Unconditionally compiled DDSI sources (mirrors the unconditional list in
+# src/core/ddsi/CMakeLists.txt).
+DDSI_BASE_SRCS = [
+    "src/core/ddsi/src/ddsi_acknack.c",
+    "src/core/ddsi/src/ddsi_addrset.c",
+    "src/core/ddsi/src/ddsi_bitset.c",
+    "src/core/ddsi/src/ddsi_bswap.c",
+    "src/core/ddsi/src/ddsi_config.c",
+    "src/core/ddsi/src/ddsi_deadline.c",
+    "src/core/ddsi/src/ddsi_debmon.c",
+    "src/core/ddsi/src/ddsi_deliver_locally.c",
+    "src/core/ddsi/src/ddsi_discovery.c",
+    "src/core/ddsi/src/ddsi_discovery_addrset.c",
+    "src/core/ddsi/src/ddsi_discovery_endpoint.c",
+    "src/core/ddsi/src/ddsi_discovery_spdp.c",
+    "src/core/ddsi/src/ddsi_endpoint.c",
+    "src/core/ddsi/src/ddsi_endpoint_match.c",
+    "src/core/ddsi/src/ddsi_entity.c",
+    "src/core/ddsi/src/ddsi_entity_index.c",
+    "src/core/ddsi/src/ddsi_eth.c",
+    "src/core/ddsi/src/ddsi_freelist.c",
+    "src/core/ddsi/src/ddsi_gc.c",
+    "src/core/ddsi/src/ddsi_guid.c",
+    "src/core/ddsi/src/ddsi_handshake.c",
+    "src/core/ddsi/src/ddsi_hbcontrol.c",
+    "src/core/ddsi/src/ddsi_iid.c",
+    "src/core/ddsi/src/ddsi_init.c",
+    "src/core/ddsi/src/ddsi_inverse_uint32_set.c",
+    "src/core/ddsi/src/ddsi_ipaddr.c",
+    "src/core/ddsi/src/ddsi_lat_estim.c",
+    "src/core/ddsi/src/ddsi_lease.c",
+    "src/core/ddsi/src/ddsi_list_genptr.c",
+    "src/core/ddsi/src/ddsi_mcgroup.c",
+    "src/core/ddsi/src/ddsi_misc.c",
+    "src/core/ddsi/src/ddsi_nwinterfaces.c",
+    "src/core/ddsi/src/ddsi_nwpart.c",
+    "src/core/ddsi/src/ddsi_participant.c",
+    "src/core/ddsi/src/ddsi_pcap.c",
+    "src/core/ddsi/src/ddsi_plist.c",
+    "src/core/ddsi/src/ddsi_pmd.c",
+    "src/core/ddsi/src/ddsi_portmapping.c",
+    "src/core/ddsi/src/ddsi_proxy_endpoint.c",
+    "src/core/ddsi/src/ddsi_proxy_participant.c",
+    "src/core/ddsi/src/ddsi_qosmatch.c",
+    "src/core/ddsi/src/ddsi_radmin.c",
+    "src/core/ddsi/src/ddsi_raweth.c",
+    "src/core/ddsi/src/ddsi_receive.c",
+    "src/core/ddsi/src/ddsi_rhc.c",
+    "src/core/ddsi/src/ddsi_security_omg.c",
+    "src/core/ddsi/src/ddsi_security_util.c",
+    "src/core/ddsi/src/ddsi_serdata.c",
+    "src/core/ddsi/src/ddsi_serdata_cdr.c",
+    "src/core/ddsi/src/ddsi_serdata_plist.c",
+    "src/core/ddsi/src/ddsi_serdata_pserop.c",
+    "src/core/ddsi/src/ddsi_sertype.c",
+    "src/core/ddsi/src/ddsi_sertype_cdr.c",
+    "src/core/ddsi/src/ddsi_sertype_plist.c",
+    "src/core/ddsi/src/ddsi_sertype_pserop.c",
+    "src/core/ddsi/src/ddsi_sockwaitset.c",
+    "src/core/ddsi/src/ddsi_spdp_schedule.c",
+    "src/core/ddsi/src/ddsi_ssl.c",
+    "src/core/ddsi/src/ddsi_statistics.c",
+    "src/core/ddsi/src/ddsi_sysdeps.c",
+    "src/core/ddsi/src/ddsi_tcp.c",
+    "src/core/ddsi/src/ddsi_thread.c",
+    "src/core/ddsi/src/ddsi_threadmon.c",
+    "src/core/ddsi/src/ddsi_time.c",
+    "src/core/ddsi/src/ddsi_tkmap.c",
+    "src/core/ddsi/src/ddsi_topic.c",
+    "src/core/ddsi/src/ddsi_tran.c",
+    "src/core/ddsi/src/ddsi_transmit.c",
+    "src/core/ddsi/src/ddsi_udp.c",
+    "src/core/ddsi/src/ddsi_vendor.c",
+    "src/core/ddsi/src/ddsi_vnet.c",
+    "src/core/ddsi/src/ddsi_whc.c",
+    "src/core/ddsi/src/ddsi_wraddrset.c",
+    "src/core/ddsi/src/ddsi_xevent.c",
+    "src/core/ddsi/src/ddsi_xmsg.c",
+    "src/core/ddsi/defconfig.c",
+]
+
+# Feature-conditional DDSI sources gated on the ENABLED_FEATURES set above.
+DDSI_FEATURE_SRCS = [
+    "src/core/ddsi/src/ddsi_lifespan.c",
+    "src/core/ddsi/src/ddsi_discovery_topic.c",
+    "src/core/ddsi/src/ddsi_dynamic_type.c",
+    "src/core/ddsi/src/ddsi_typebuilder.c",
+    "src/core/ddsi/src/ddsi_typelib.c",
+    "src/core/ddsi/src/ddsi_typewrap.c",
+    "src/core/ddsi/src/ddsi_xt_typeinfo.c",
+    "src/core/ddsi/src/ddsi_xt_typemap.c",
+    "src/core/ddsi/src/ddsi_typelookup.c",
+    "src/core/ddsi/src/ddsi_xt_typelookup.c",
+]
+
+DDSI_SRCS = DDSI_BASE_SRCS + DDSI_FEATURE_SRCS
+
+DDS_HDRS = glob([
+    "src/core/cdr/include/**/*.h",
+    "src/core/cdr/src/**/*.h",
+    "src/core/ddsc/include/**/*.h",
+    "src/core/ddsc/src/**/*.h",
+    "src/core/ddsi/include/**/*.h",
+    "src/core/ddsi/src/**/*.h",
+    "src/ddsrt/include/**/*.h",
+    "src/ddsrt/src/**/*.h",
+]) + [
+    ":dds_config_h",
+    ":dds_export_h",
+    ":dds_features_h",
+    ":dds_version_h",
+]
+
+cc_library(
+    name = "ddsc",
+    srcs = DDSRT_COMMON_SRCS + DDSRT_PLATFORM_SRCS + CDR_SRCS + DDSC_SRCS + DDSI_SRCS,
+    hdrs = DDS_HDRS,
+    includes = [
+        "src/core/cdr/include",
+        "src/core/ddsc/include",
+        "src/core/ddsc/src",
+        "src/core/ddsi/include",
+        "src/core/ddsi/src",
+        "src/ddsrt/include",
+        "src/ddsrt/src",
+    ],
+    linkopts = select({
+        "@platforms//os:macos": ["-lpthread"],
+        "//conditions:default": [
+            "-ldl",
+            "-lpthread",
+        ],
+    }),
+    textual_hdrs = [
+        "src/core/cdr/src/dds_cdrstream_keys.part.h",
+        "src/core/cdr/src/dds_cdrstream_write.part.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "cyclonedds",
+    actual = ":ddsc",
+    visibility = ["//visibility:public"],
+)
+
+IDL_SRCS = [
+    "src/idl/src/annotation.c",
+    "src/idl/src/descriptor_type_meta.c",
+    "src/idl/src/directive.c",
+    "src/idl/src/expression.c",
+    "src/idl/src/file.c",
+    "src/idl/src/hashid.c",
+    "src/idl/src/heap.c",
+    "src/idl/src/keylist.c",
+    "src/idl/src/parser.c",
+    "src/idl/src/print.c",
+    "src/idl/src/processor.c",
+    "src/idl/src/scanner.c",
+    "src/idl/src/scope.c",
+    "src/idl/src/string.c",
+    "src/idl/src/symbol.c",
+    "src/idl/src/tree.c",
+    "src/idl/src/vector.c",
+    "src/idl/src/visit.c",
+    ":idl_md5_c",
+]
+
+cc_library(
+    name = "idl",
+    srcs = IDL_SRCS,
+    hdrs = glob([
+        "src/idl/include/idl/*.h",
+        "src/idl/src/*.h",
+    ]) + [
+        ":idl_attributes_h",
+        ":idl_endian_h",
+        ":idl_export_h",
+        ":idl_md5_h",
+        ":idl_misc_h",
+        ":idl_version_h",
+    ],
+    includes = [
+        "src/idl/include",
+        "src/idl/src",
+    ],
+    deps = [":ddsc"],
+)
+
+IDLPP_SRCS = [
+    "src/tools/idlpp/src/directive.c",
+    "src/tools/idlpp/src/eval.c",
+    "src/tools/idlpp/src/expand.c",
+    "src/tools/idlpp/src/main.c",
+    "src/tools/idlpp/src/mbchar.c",
+    "src/tools/idlpp/src/support.c",
+    "src/tools/idlpp/src/system.c",
+]
+
+genrule(
+    name = "idlpp_mcpp_export_h",
+    outs = ["src/tools/idlpp/src/mcpp_export.h"],
+    cmd = """
+cat >"$@" <<'EOF'
+#ifndef MCPP_EXPORT_H
+#define MCPP_EXPORT_H
+
+/* Generated for Bazel; equivalent to CMake static-library export header. */
+#define MCPP_EXPORT
+#define MCPP_NO_EXPORT
+#define MCPP_DEPRECATED __attribute__((__deprecated__))
+#define MCPP_DEPRECATED_EXPORT MCPP_EXPORT MCPP_DEPRECATED
+#define MCPP_DEPRECATED_NO_EXPORT MCPP_NO_EXPORT MCPP_DEPRECATED
+
+#endif /* MCPP_EXPORT_H */
+EOF
+""",
+)
+
+cc_library(
+    name = "idlpp",
+    srcs = IDLPP_SRCS,
+    hdrs = [
+        "src/tools/idlpp/src/internal.H",
+        "src/tools/idlpp/src/mcpp_lib.h",
+        "src/tools/idlpp/src/mcpp_out.h",
+        "src/tools/idlpp/src/system.H",
+        ":idlpp_configed_h",
+        ":idlpp_mcpp_export_h",
+    ],
+    copts = ["-DHAVE_CONFIG_H=1"],
+    includes = ["src/tools/idlpp/src"],
+)
+
+# 11.0 split idlc into a binary plus a separately built C-backend shared
+# library (libcycloneddsidlc) loaded via dlopen. For Bazel we link the backend
+# statically into the idlc binary and replace the dlopen-based dispatch with a
+# small static shim that resolves "c" to the backend's `generate` /
+# `generator_options` symbols directly. See bazel/idlc_generator_static.c.
+LIBIDLC_SRCS = [
+    "src/tools/idlc/src/libidlc/libidlc__descriptor.c",
+    "src/tools/idlc/src/libidlc/libidlc__generator.c",
+    "src/tools/idlc/src/libidlc/libidlc__types.c",
+]
+
+LIBIDLC_HDRS = [
+    "src/tools/idlc/src/libidlc/libidlc__descriptor.h",
+    "src/tools/idlc/src/libidlc/libidlc__generator.h",
+    "src/tools/idlc/src/libidlc/libidlc__types.h",
+    ":libidlc_export_h",
+]
+
+IDLC_SRCS = [
+    "bazel/idlc_generator_static.c",
+    "src/tools/idlc/src/idlc/idlc.c",
+    "src/tools/idlc/src/idlc/options.c",
+] + LIBIDLC_SRCS
+
+cc_binary(
+    name = "idlc",
+    srcs = IDLC_SRCS + LIBIDLC_HDRS + glob([
+        "src/tools/idlc/include/idlc/*.h",
+        "src/tools/idlc/include/libidlc/*.h",
+    ]) + [":idlc_config_h"],
+    includes = [
+        "src/tools/idlc/include",
+        "src/tools/idlc/include/idlc",
+        "src/tools/idlc/include/libidlc",
+        "src/tools/idlc/src/idlc",
+        "src/tools/idlc/src/libidlc",
+    ],
+    linkopts = select({
+        "@platforms//os:linux": ["-ldl"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ddsc",
+        ":idl",
+        ":idlpp",
+    ],
+)

--- a/modules/cyclonedds/11.0.1/overlay/bazel/idlc_generator_static.c
+++ b/modules/cyclonedds/11.0.1/overlay/bazel/idlc_generator_static.c
@@ -1,0 +1,40 @@
+// Statically dispatched IDL generator for the Bazel build of CycloneDDS.
+//
+// Upstream CycloneDDS 11.0 split the C backend into a separately built shared
+// library (libcycloneddsidlc.so) loaded via dlopen at runtime. That makes the
+// idlc binary depend on a co-located .so, which is fragile in Bazel runfiles.
+//
+// This replacement implements the same `idlc_load_generator` /
+// `idlc_unload_generator` ABI but resolves `lang == "c"` directly to the
+// libidlc generator entry points statically linked into the idlc binary. Other
+// languages (e.g. python) are not supported.
+
+#include <string.h>
+
+#include "idlc/generator.h"
+#include "idl/string.h"
+
+extern int generate(const idl_pstate_t *pstate,
+                    const idlc_generator_config_t *config);
+extern const idlc_option_t **generator_options(void);
+
+int idlc_load_generator(idlc_generator_plugin_t *plugin, const char *lang)
+{
+  if (lang == NULL || idl_strcasecmp(lang, "c") != 0)
+    return -1;
+  plugin->handle = NULL;
+  plugin->generator_options = &generator_options;
+  plugin->generator_annotations = NULL;
+  plugin->generate = &generate;
+  return 0;
+}
+
+void idlc_unload_generator(idlc_generator_plugin_t *plugin)
+{
+  if (!plugin)
+    return;
+  plugin->handle = NULL;
+  plugin->generator_options = NULL;
+  plugin->generator_annotations = NULL;
+  plugin->generate = NULL;
+}

--- a/modules/cyclonedds/11.0.1/overlay/examples/BUILD.bazel
+++ b/modules/cyclonedds/11.0.1/overlay/examples/BUILD.bazel
@@ -1,0 +1,183 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+# 11.0 ships idlc as a binary plus a dlopen'd C-backend shared library. The
+# Bazel overlay links the backend statically into idlc and short-circuits
+# `idlc -l c` directly to it (see overlay/bazel/idlc_generator_static.c), so
+# `-l c` works without needing libcycloneddsidlc.so at runtime.
+
+cc_binary(
+    name = "listtopics",
+    srcs = ["listtopics/listtopics.c"],
+    deps = ["@cyclonedds//:ddsc"],
+)
+
+cc_binary(
+    name = "dyntype",
+    srcs = ["dyntype/dyntype.c"],
+    deps = ["@cyclonedds//:ddsc"],
+)
+
+cc_binary(
+    name = "dynsub",
+    srcs = [
+        "dynsub/dynsub.c",
+        "dynsub/dynsub.h",
+        "dynsub/print_sample.c",
+        "dynsub/print_type.c",
+        "dynsub/type_cache.c",
+    ],
+    deps = ["@cyclonedds//:ddsc"],
+)
+
+# Generated IDL outputs go under dynsub_gen/ instead of dynsub/ to avoid the
+# bazel-bin path collision with the dynsub cc_binary output.
+genrule(
+    name = "variouspub_idl_gen",
+    srcs = ["dynsub/variouspub_types.idl"],
+    outs = [
+        "dynsub_gen/variouspub_types.c",
+        "dynsub_gen/variouspub_types.h",
+    ],
+    cmd = "mkdir -p $(RULEDIR)/dynsub_gen && $(location @cyclonedds//:idlc) -l c -Wno-implicit-extensibility -o$(RULEDIR)/dynsub_gen $(location dynsub/variouspub_types.idl)",
+    tools = ["@cyclonedds//:idlc"],
+)
+
+cc_library(
+    name = "variouspub_types",
+    srcs = ["dynsub_gen/variouspub_types.c"],
+    hdrs = ["dynsub_gen/variouspub_types.h"],
+    includes = ["dynsub_gen"],
+    deps = ["@cyclonedds//:ddsc"],
+)
+
+cc_binary(
+    name = "variouspub",
+    srcs = ["dynsub/variouspub.c"],
+    deps = [
+        ":variouspub_types",
+        "@cyclonedds//:ddsc",
+    ],
+)
+
+genrule(
+    name = "helloworld_idl_gen",
+    srcs = ["helloworld/HelloWorldData.idl"],
+    outs = [
+        "helloworld/HelloWorldData.c",
+        "helloworld/HelloWorldData.h",
+    ],
+    cmd = "mkdir -p $(@D)/helloworld && $(location @cyclonedds//:idlc) -l c -Wno-implicit-extensibility -o$(@D)/helloworld $(location helloworld/HelloWorldData.idl)",
+    tools = ["@cyclonedds//:idlc"],
+)
+
+cc_library(
+    name = "helloworld_types",
+    srcs = ["helloworld/HelloWorldData.c"],
+    hdrs = ["helloworld/HelloWorldData.h"],
+    includes = ["helloworld"],
+    deps = ["@cyclonedds//:ddsc"],
+)
+
+cc_binary(
+    name = "helloworld_publisher",
+    srcs = [
+        "helloworld/publisher.c",
+    ],
+    deps = [
+        ":helloworld_types",
+        "@cyclonedds//:ddsc",
+    ],
+)
+
+cc_binary(
+    name = "helloworld_subscriber",
+    srcs = [
+        "helloworld/subscriber.c",
+    ],
+    deps = [
+        ":helloworld_types",
+        "@cyclonedds//:ddsc",
+    ],
+)
+
+genrule(
+    name = "roundtrip_idl_gen",
+    srcs = ["roundtrip/RoundTrip.idl"],
+    outs = [
+        "roundtrip/RoundTrip.c",
+        "roundtrip/RoundTrip.h",
+    ],
+    cmd = "mkdir -p $(@D)/roundtrip && $(location @cyclonedds//:idlc) -l c -o$(@D)/roundtrip $(location roundtrip/RoundTrip.idl)",
+    tools = ["@cyclonedds//:idlc"],
+)
+
+cc_library(
+    name = "roundtrip_types",
+    srcs = ["roundtrip/RoundTrip.c"],
+    hdrs = ["roundtrip/RoundTrip.h"],
+    includes = ["roundtrip"],
+    deps = ["@cyclonedds//:ddsc"],
+)
+
+cc_binary(
+    name = "roundtrip_ping",
+    srcs = [
+        "roundtrip/ping.c",
+    ],
+    deps = [
+        ":roundtrip_types",
+        "@cyclonedds//:ddsc",
+    ],
+)
+
+cc_binary(
+    name = "roundtrip_pong",
+    srcs = [
+        "roundtrip/pong.c",
+    ],
+    deps = [
+        ":roundtrip_types",
+        "@cyclonedds//:ddsc",
+    ],
+)
+
+genrule(
+    name = "throughput_idl_gen",
+    srcs = ["throughput/Throughput.idl"],
+    outs = [
+        "throughput/Throughput.c",
+        "throughput/Throughput.h",
+    ],
+    cmd = "mkdir -p $(@D)/throughput && $(location @cyclonedds//:idlc) -l c -o$(@D)/throughput $(location throughput/Throughput.idl)",
+    tools = ["@cyclonedds//:idlc"],
+)
+
+cc_library(
+    name = "throughput_types",
+    srcs = ["throughput/Throughput.c"],
+    hdrs = ["throughput/Throughput.h"],
+    includes = ["throughput"],
+    deps = ["@cyclonedds//:ddsc"],
+)
+
+cc_binary(
+    name = "throughput_publisher",
+    srcs = [
+        "throughput/publisher.c",
+    ],
+    deps = [
+        ":throughput_types",
+        "@cyclonedds//:ddsc",
+    ],
+)
+
+cc_binary(
+    name = "throughput_subscriber",
+    srcs = [
+        "throughput/subscriber.c",
+    ],
+    deps = [
+        ":throughput_types",
+        "@cyclonedds//:ddsc",
+    ],
+)

--- a/modules/cyclonedds/11.0.1/overlay/examples/MODULE.bazel
+++ b/modules/cyclonedds/11.0.1/overlay/examples/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "cyclonedds_examples",
+)
+
+bazel_dep(name = "cyclonedds", version = "11.0.1")
+local_path_override(
+    module_name = "cyclonedds",
+    path = "..",
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/modules/cyclonedds/11.0.1/presubmit.yml
+++ b/modules/cyclonedds/11.0.1/presubmit.yml
@@ -1,0 +1,33 @@
+matrix:
+  platform:
+    - debian12
+    - debian13
+    - ubuntu2204
+    - ubuntu2404
+    - macos_arm64
+  bazel: [7.x, 8.x, 9.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@cyclonedds//...'
+
+bcr_test_module:
+  module_path: examples
+  matrix:
+    platform:
+      - debian12
+      - debian13
+      - ubuntu2204
+      - ubuntu2404
+      - macos_arm64
+    bazel: [7.x, 8.x, 9.x, rolling]
+  tasks:
+    build_examples:
+      name: Build examples
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - //...

--- a/modules/cyclonedds/11.0.1/source.json
+++ b/modules/cyclonedds/11.0.1/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/eclipse-cyclonedds/cyclonedds/archive/refs/tags/11.0.1.tar.gz",
+    "integrity": "sha256-wl1GB1rWtc7lZL2p5fSVCemm27GouFjnCOs2DTNc+XM=",
+    "strip_prefix": "cyclonedds-11.0.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-vBsw2g9TiErkpju9XzV+HSS5yMakkgdNaTaaxbnxObM=",
+        "bazel/idlc_generator_static.c": "sha256-Lz6nFFTWP/QqGwpYF9/wcso+U4jNxtwK3gdeOjvYkZ8=",
+        "examples/BUILD.bazel": "sha256-/NUT5N7G2kLpgB8GhLO5Wn//HGnzk4+jT+SOKMTZ5cA=",
+        "examples/MODULE.bazel": "sha256-gjZi6dvrgB0rpYh5rYZmJEK5RWPzKPGYQxpYRKIXQ2w="
+    }
+}

--- a/modules/cyclonedds/metadata.json
+++ b/modules/cyclonedds/metadata.json
@@ -12,7 +12,8 @@
         "github:eclipse-cyclonedds/cyclonedds"
     ],
     "versions": [
-        "0.10.5"
+        "0.10.5",
+        "11.0.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
## Summary
- Add cyclonedds 11.0.1, a major upstream version since 0.10.5 with significant source restructuring.
- Enable features that don't introduce new third-party dependencies: `LIFESPAN`, `DEADLINE_MISSED`, `NETWORK_PARTITIONS`, `TYPELIB`, `TYPE_DISCOVERY`, `TOPIC_DISCOVERY`, `QOS_PROVIDER`, `TCP`, `SSM`. `TCP_TLS` (OpenSSL) and `SECURITY` (loadable plugins) remain disabled.
- 11.0 split idlc into a binary plus a `dlopen`'d C-backend shared library. The Bazel overlay links the backend statically into idlc and provides a small shim (`overlay/bazel/idlc_generator_static.c`) that short-circuits `idlc -l c` to the static symbols, avoiding the runfile-tree fragility of a co-located `libcycloneddsidlc.so`.
- The examples overlay grows a new `dyntype` binary, splits the multi-file `dynsub`, and adds `variouspub` with generated IDL types.

## Test plan
- [x] `bazel build @cyclonedds//...` clean — all 40 targets build (Bazel 9.1.0, macOS arm64).
- [x] `bazel build //...` against the bundled `examples/` module — all 18 targets build.
- [x] Linux platform-specific source paths cross-checked against the upstream tarball.
- [ ] Full BCR CI matrix (debian12/13, ubuntu2204/2404, macos_arm64 × Bazel 7.x/8.x/9.x/rolling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)