### PR TITLE
gazelle_plugins@0.1.3

### DIFF
--- a/modules/gazelle_plugins/0.1.3/MODULE.bazel
+++ b/modules/gazelle_plugins/0.1.3/MODULE.bazel
@@ -1,0 +1,68 @@
+module(
+    name = "gazelle_plugins",
+    version = "0.1.3",
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_rs", version = "0.0.58")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "protobuf", version = "34.0.bcr.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_go", version = "0.60.0")
+bazel_dep(name = "gazelle", version = "0.50.0")
+
+# rules_rs's experimental toolchains tag target_compatible_with with libc
+# version constraints from @llvm//constraints/libc (e.g. gnu.2.28). Bring in
+# the llvm module just for those constraint definitions; we do NOT register
+# any LLVM toolchain — we only use the constraint labels on a custom host
+# platform (see //:local_gnu_platform).
+bazel_dep(name = "llvm", version = "0.7.3")
+
+# rules_rust facade — exposes @rules_rust at the top level so BUILD files and
+# rules_rs's internal loads resolve to the same canonical repo (a prerequisite
+# for toolchain_type matching).
+rules_rust = use_extension("@rules_rs//rs/experimental:rules_rust.bzl", "rules_rust")
+use_repo(rules_rust, "rules_rust")
+
+# Rust toolchain (rules_rs experimental).
+toolchains = use_extension("@rules_rs//rs/experimental/toolchains:module_extension.bzl", "toolchains")
+toolchains.toolchain(
+    edition = "2021",
+    version = "1.93.0",
+)
+use_repo(toolchains, "default_rust_toolchains")
+
+register_toolchains("@default_rust_toolchains//:all")
+
+# Crate resolution: rules_rs reads Cargo.toml/Cargo.lock directly (no repinning).
+crate = use_extension("@rules_rs//rs:extensions.bzl", "crate")
+crate.from_cargo(
+    name = "crates",
+    cargo_lock = "//:Cargo.lock",
+    cargo_toml = "//:Cargo.toml",
+    platform_triples = [
+        "aarch64-apple-darwin",
+        "aarch64-unknown-linux-gnu",
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-gnu",
+    ],
+    use_experimental_platforms = True,
+)
+use_repo(crate, "crates")
+
+# Prost/tonic codegen toolchains for rust_prost_library.
+rules_rust_prost = use_extension("@rules_rs//rs/experimental:rules_rust_prost.bzl", "rules_rust_prost")
+use_repo(rules_rust_prost, "rules_rust_prost")
+
+register_toolchains("@rules_rust_prost//:default_prost_toolchain")
+
+# Go toolchain + module deps for the gazelle plugin.
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.24.12")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bazelbuild_buildtools",
+    "org_golang_google_protobuf",
+)

--- a/modules/gazelle_plugins/0.1.3/attestations.json
+++ b/modules/gazelle_plugins/0.1.3/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/hermeticbuild/gazelle_plugins/releases/download/v0.1.3/source.json.intoto.jsonl",
+            "integrity": "sha256-HoD3pj/NTb7wc91S+n6tVuTyp9/+afWi5rJTV88Nxfc="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/hermeticbuild/gazelle_plugins/releases/download/v0.1.3/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-JfSxevWMv6hU/IfN9DDM5vPlcx7/QfWk5V6SomrszzY="
+        },
+        "gazelle_plugins-v0.1.3.tar.gz": {
+            "url": "https://github.com/hermeticbuild/gazelle_plugins/releases/download/v0.1.3/gazelle_plugins-v0.1.3.tar.gz.intoto.jsonl",
+            "integrity": "sha256-vt8m8lfUsQ/dlXTg3LxcBcIGb8i/HvaCHWnppS5V3Ek="
+        }
+    }
+}

--- a/modules/gazelle_plugins/0.1.3/patches/module_dot_bazel_version.patch
+++ b/modules/gazelle_plugins/0.1.3/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "gazelle_plugins",
+-    version = "0.0.0",
++    version = "0.1.3",
+ )
+ 
+ bazel_dep(name = "platforms", version = "1.0.0")
+ bazel_dep(name = "rules_rs", version = "0.0.58")

--- a/modules/gazelle_plugins/0.1.3/presubmit.yml
+++ b/modules/gazelle_plugins/0.1.3/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+    - debian11
+    - macos
+    - ubuntu2204
+  bazel:
+    - 9.x
+    - 8.x
+
+tasks:
+  verify_targets:
+    name: Build the Go gazelle plugin
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@gazelle_plugins//ts/..."

--- a/modules/gazelle_plugins/0.1.3/source.json
+++ b/modules/gazelle_plugins/0.1.3/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-Up+uit+uinatVL+DV7sHZyI0HBBhekcl++ZevMrvt+w=",
+    "strip_prefix": "gazelle_plugins-0.1.3",
+    "url": "https://github.com/hermeticbuild/gazelle_plugins/releases/download/v0.1.3/gazelle_plugins-v0.1.3.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-ZIRiAsDNbhfa3fj45NDXocgpyh1AXnUIQ/Ocx5pFzA0="
+    },
+    "patch_strip": 1
+}

--- a/modules/gazelle_plugins/metadata.json
+++ b/modules/gazelle_plugins/metadata.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://github.com/hermeticbuild/gazelle_plugins",
+    "maintainers": [
+        {
+            "name": "Long Ho",
+            "email": "holevietlong@gmail.com",
+            "github": "longlho",
+            "github_user_id": 198255
+        },
+        {
+            "name": "David Zbarsky",
+            "email": "dzbarsky@gmail.com",
+            "github": "dzbarsky",
+            "github_user_id": 1565842
+        }
+    ],
+    "repository": [
+        "github:hermeticbuild/gazelle_plugins"
+    ],
+    "versions": [
+        "0.1.3"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/hermeticbuild/gazelle_plugins/releases/tag/v0.1.3

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_