### PR TITLE
stdexec@0.0.0-20260427-35670665

### DIFF
--- a/modules/stdexec/0.0.0-20260427-35670665/MODULE.bazel
+++ b/modules/stdexec/0.0.0-20260427-35670665/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "stdexec",
+    version = "0.0.0-20260427-35670665",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/stdexec/0.0.0-20260427-35670665/overlay/tests/BUILD.bazel
+++ b/modules/stdexec/0.0.0-20260427-35670665/overlay/tests/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "smoke",
+    srcs = ["smoke.cc"],
+    copts = ["-std=c++20"],
+    deps = ["@stdexec//:stdexec"],
+)

--- a/modules/stdexec/0.0.0-20260427-35670665/overlay/tests/MODULE.bazel
+++ b/modules/stdexec/0.0.0-20260427-35670665/overlay/tests/MODULE.bazel
@@ -1,0 +1,7 @@
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "stdexec")
+
+local_path_override(
+    module_name = "stdexec",
+    path = "..",
+)

--- a/modules/stdexec/0.0.0-20260427-35670665/overlay/tests/smoke.cc
+++ b/modules/stdexec/0.0.0-20260427-35670665/overlay/tests/smoke.cc
@@ -1,0 +1,7 @@
+#include <stdexec/execution.hpp>
+
+int main() {
+    auto work = stdexec::just(2) | stdexec::then([](int value) { return value * value; });
+    auto result = stdexec::sync_wait(std::move(work));
+    return result.has_value() && std::get<0>(*result) == 4 ? 0 : 1;
+}

--- a/modules/stdexec/0.0.0-20260427-35670665/patches/add_build_file.patch
+++ b/modules/stdexec/0.0.0-20260427-35670665/patches/add_build_file.patch
@@ -1,0 +1,11 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "stdexec",
++    hdrs = glob(["include/**"]),
++    includes = ["include"],
++    visibility = ["//visibility:public"],
++)

--- a/modules/stdexec/0.0.0-20260427-35670665/patches/module_dot_bazel.patch
+++ b/modules/stdexec/0.0.0-20260427-35670665/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "stdexec",
++    version = "0.0.0-20260427-35670665",
++    bazel_compatibility = [">=7.2.1"],
++)
++
++bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/stdexec/0.0.0-20260427-35670665/presubmit.yml
+++ b/modules/stdexec/0.0.0-20260427-35670665/presubmit.yml
@@ -1,6 +1,5 @@
 matrix:
   platform:
-  - debian11
   - ubuntu2204
   - macos
   - macos_arm64
@@ -21,7 +20,6 @@ bcr_test_module:
   module_path: tests
   matrix:
     platform:
-    - debian11
     - ubuntu2204
     - macos
     - macos_arm64

--- a/modules/stdexec/0.0.0-20260427-35670665/presubmit.yml
+++ b/modules/stdexec/0.0.0-20260427-35670665/presubmit.yml
@@ -25,11 +25,11 @@ bcr_test_module:
     - ubuntu2204
     - macos
     - macos_arm64
-  bazel:
-    - 7.x
-    - 8.x
-    - 9.x
-    - rolling
+    bazel:
+      - 7.x
+      - 8.x
+      - 9.x
+      - rolling
   tasks:
     test_smoke:
       name: Test smoke consumer

--- a/modules/stdexec/0.0.0-20260427-35670665/presubmit.yml
+++ b/modules/stdexec/0.0.0-20260427-35670665/presubmit.yml
@@ -1,0 +1,39 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+  - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@stdexec//:stdexec'
+bcr_test_module:
+  module_path: tests
+  matrix:
+    platform:
+    - debian11
+    - ubuntu2204
+    - macos
+    - macos_arm64
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+    - rolling
+  tasks:
+    test_smoke:
+      name: Test smoke consumer
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - //:smoke

--- a/modules/stdexec/0.0.0-20260427-35670665/source.json
+++ b/modules/stdexec/0.0.0-20260427-35670665/source.json
@@ -1,0 +1,15 @@
+{
+    "url": "https://github.com/NVIDIA/stdexec/archive/3567066576cd3ae1b68ffa342bc4063c05e109d7.tar.gz",
+    "integrity": "sha256-9AVk0OkpsjUBCoIuqd9k7+BKP4A+irVk4Y3Xqe7T9I8=",
+    "strip_prefix": "stdexec-3567066576cd3ae1b68ffa342bc4063c05e109d7",
+    "patches": {
+        "add_build_file.patch": "sha256-GQA2xACi34ChtA1paCNuFHcEwsmRHFqy+9xXTCRz3WA=",
+        "module_dot_bazel.patch": "sha256-7GBhG0CnoVn62QMp62dKRLN6ts/n3DJKydChT/lQ/qk="
+    },
+    "patch_strip": 0,
+    "overlay": {
+        "tests/BUILD.bazel": "sha256-+9GW26hNVnlqrpz/yQuRVHMtW9qaAem2D7lpVuXgOhk=",
+        "tests/MODULE.bazel": "sha256-KYaU1IRjufYCEwWoV0cDt8sw3g/13ntQHB/Ka5iW5iE=",
+        "tests/smoke.cc": "sha256-xXlQfw9DE0SrokfGhqei4zoNVngOSTAwGfhLOjki520="
+    }
+}

--- a/modules/stdexec/metadata.json
+++ b/modules/stdexec/metadata.json
@@ -12,6 +12,7 @@
         "github:NVIDIA/stdexec"
     ],
     "versions": [
+        "0.0.0-20260427-35670665",
         "5473e9daf50cb8829cfe12fb6b64f5f74a08bcf7",
         "5d9f3bfb032e9d71b2292b7add7d90cbf9d037a9",
         "73559e8963dab7a4ece32ede22f6472c9a815032"


### PR DESCRIPTION
Updates `stdexec` to latest upstream snapshot `0.0.0-20260427-35670665`.

Also fixes Bazel 9.x compatibility, expands presubmit to `7.x`, `8.x`, `9.x`, and `rolling`, and adds a smoke test.