### PR TITLE
Restrict skip_check workflow to repo collaborators and org members

### DIFF
--- a/.github/workflows/skip_check.yml
+++ b/.github/workflows/skip_check.yml
@@ -7,7 +7,11 @@ permissions:
 
 jobs:
   comment_bot:
-    if: startsWith(github.event.comment.body, '@bazel-io skip_check ')
+    if: >
+      startsWith(github.event.comment.body, '@bazel-io skip_check ') &&
+      (github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
The `skip_check.yml` workflow runs on `issue_comment` events without                                                                                       
  verifying the commenter's relationship to the repository. The `if:`                                                                                        
  guard only checks the comment body prefix, so any GitHub user                                                                                              
  commenting `@bazel-io skip_check ...` on any PR causes the bot                                                                                             
  (running with `BCR_PR_REVIEW_HELPER_TOKEN`) to attach one of the                                                                                           
  `skip-*` labels that downstream `review_prs.yml` uses to skip                                                                                              
  validation steps (URL stability, compatibility level, incompatible                                                                                         
  flags).                                                                                                                                                    
                                                                                                                                                             
  This change adds an `author_association` gate so the workflow only                                                                                         
  runs for `MEMBER`, `OWNER`, or `COLLABORATOR` comments. Non-privileged                                                                                     
  commenters' `@bazel-io skip_check` comments become no-ops.                                                             
                                                                                                                                                             
  `author_association` is set by GitHub on the comment payload and is                                                                                        
  not user-controllable, so the gate is enforced at workflow-trigger                                                                                         
  evaluation time before the job (and the privileged token) are                                                                                              
  reached.                                                                                                                                                   
                                                                                                                                                             
  Reported privately via Google OSS VRP (issue 502091851); the OSS VRP                                                                                       
  team requested the fix land via a public PR. Happy to adjust the                                                                                           
  allowed associations or move the check inside the action if you'd                                                      
  prefer. 