### PR TITLE
Publish sign-here@1.0.11

### DIFF
--- a/modules/sign-here/1.0.11/MODULE.bazel
+++ b/modules/sign-here/1.0.11/MODULE.bazel
@@ -1,0 +1,19 @@
+module(
+    name = "sign-here",
+    version = "1.0.11",
+)
+
+bazel_dep(name = "rules_apple", version = "4.5.2", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_swift", version = "3.5.0", max_compatibility_level = 3, repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "swift_argument_parser", version = "1.3.1.2", repo_name = "com_github_apple_swift_argument_parser")
+
+non_module_dependencies = use_extension("//:extensions.bzl", "non_module_dependencies")
+use_repo(
+    non_module_dependencies,
+    "SwiftSnapshotTesting",
+    "SwiftSyntax",
+    "SwiftToolsSupportCore",
+    "com_github_apple_swift_system",
+    "com_github_kylef_pathkit",
+    "mockolo",
+)

--- a/modules/sign-here/1.0.11/presubmit.yml
+++ b/modules/sign-here/1.0.11/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["macos"]
+    bazel: ["7.x", "8.x"]
+  tasks:
+    run_tests:
+      name: "Run e2e bzlmod test"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."

--- a/modules/sign-here/1.0.11/source.json
+++ b/modules/sign-here/1.0.11/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-FtSCY6Cuziw4E7/6srH/92hZwmmWil5SK69KTha2hcg=",
+    "strip_prefix": "sign-here-1.0.11",
+    "url": "https://github.com/Tinder/sign-here/releases/download/v1.0.11/sign-here-v1.0.11.tar.gz"
+}

--- a/modules/sign-here/metadata.json
+++ b/modules/sign-here/metadata.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://github.com/Tinder/sign-here",
+    "maintainers": [
+        {
+            "name": "Maxwell Elliott",
+            "email": "maxwell@elliott.now",
+            "github": "maxwellE",
+            "github_user_id": 566328
+        },
+        {
+            "name": "Maxwell Elliott (Tinder)",
+            "email": "maxwell.elliott@tinder.com",
+            "github": "tinder-maxwellelliott",
+            "github_user_id": 56700854
+        }
+    ],
+    "repository": [
+        "github:Tinder/sign-here"
+    ],
+    "versions": [
+        "1.0.11"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/Tinder/sign-here/releases/tag/v1.0.11

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_