### PR TITLE
Validate strip_prefix stays inside extracted source tree

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -50,6 +50,15 @@ py_binary(
     name = "bcr_validation",
     srcs = ["bcr_validation.py"],
     deps = [
+        ":bcr_validation_lib",
+    ],
+)
+
+py_library(
+    name = "bcr_validation_lib",
+    srcs = ["bcr_validation.py"],
+    imports = ["."],
+    deps = [
         ":attestations",
         ":registry",
         ":slsa",
@@ -179,6 +188,16 @@ py_test(
     ],
     deps = [
         "registry",
+    ],
+)
+
+py_test(
+    name = "bcr_validation_test",
+    srcs = [
+        "bcr_validation_test.py",
+    ],
+    deps = [
+        ":bcr_validation_lib",
     ],
 )
 

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -135,6 +135,17 @@ def apply_patch(work_dir, patch_strip, patch_file):
     )
 
 
+def resolve_source_root(output_dir, strip_prefix):
+    source_root = output_dir.joinpath(strip_prefix).resolve()
+    try:
+        source_root.relative_to(output_dir.resolve())
+    except ValueError as e:
+        raise BcrValidationException(
+            f"The strip_prefix `{strip_prefix}` must point inside the extracted source archive."
+        ) from e
+    return source_root
+
+
 def run_git(*args):
     # Requires git to be installed
     subprocess.run(
@@ -613,7 +624,11 @@ class BcrValidator:
             self.report(BcrValidationResult.FAILED, f"{module_file} must not be a symlink.")
 
         # Apply patch files if there are any, also verify their integrity values
-        source_root = output_dir.joinpath(source["strip_prefix"] if "strip_prefix" in source else "")
+        try:
+            source_root = resolve_source_root(output_dir, source.get("strip_prefix", ""))
+        except BcrValidationException as e:
+            self.report(BcrValidationResult.FAILED, str(e))
+            return
         if "patches" in source:
             for patch_name, expected_integrity in source["patches"].items():
                 patch_file = self.registry.get_patch_file_path(module_name, version, patch_name)

--- a/tools/bcr_validation_test.py
+++ b/tools/bcr_validation_test.py
@@ -1,0 +1,39 @@
+import tempfile
+import unittest
+
+from pathlib import Path
+
+from bcr_validation import BcrValidationException
+from bcr_validation import resolve_source_root
+
+
+class ResolveSourceRootTest(unittest.TestCase):
+    def test_allows_relative_strip_prefix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "source_root"
+            source_root = resolve_source_root(output_dir, "project-1.0.0")
+
+        self.assertEqual(source_root, (output_dir / "project-1.0.0").resolve())
+
+    def test_allows_empty_strip_prefix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "source_root"
+            source_root = resolve_source_root(output_dir, "")
+
+        self.assertEqual(source_root, output_dir.resolve())
+
+    def test_rejects_absolute_strip_prefix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "source_root"
+            with self.assertRaises(BcrValidationException):
+                resolve_source_root(output_dir, "/")
+
+    def test_rejects_parent_traversal_strip_prefix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "source_root"
+            with self.assertRaises(BcrValidationException):
+                resolve_source_root(output_dir, "../escape")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Validate `source.json["strip_prefix"]` before using it as the root for patch and overlay application.

Previously, `verify_module_dot_bazel()` computed `source_root` with:

```python
output_dir.joinpath(source["strip_prefix"])
```
without checking that the resulting path stayed under the extracted source tree. Absolute paths or parent traversal could
therefore make patch and overlay handling operate outside the extraction directory.

This change resolves the candidate source root and rejects values that escape output_dir.

## Changes

- Add resolve_source_root() to canonicalize and confine strip_prefix under the extracted source directory.
- Report a validation failure and stop MODULE.bazel verification when strip_prefix escapes the extracted tree.
- Add regression tests for valid relative values, empty values, absolute paths, and parent traversal.


  ## Testing

 ```bash
  PYTHONPATH=tools /tmp/bcr-poc-venv/bin/python tools/bcr_validation_test.py
  /tmp/bazelisk test //tools:bcr_validation_test

  Results:

  ....
  Ran 4 tests in 0.001s

  OK

  //tools:bcr_validation_test PASSED in 0.3s
  Executed 1 out of 1 test: 1 test passes.
```
