### PR TITLE
gazelle_py@0.2.4

### DIFF
--- a/modules/gazelle_py/0.2.4/MODULE.bazel
+++ b/modules/gazelle_py/0.2.4/MODULE.bazel
@@ -1,0 +1,87 @@
+module(
+    name = "gazelle_py",
+    version = "0.2.4",
+    # rules_rs 0.0.61 requires Bazel >=8.5.0; we don't use anything beyond
+    # what rules_rs requires, so match its floor.
+    bazel_compatibility = [">=8.5.0"],
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_rs", version = "0.0.61")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "protobuf", version = "34.0.bcr.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_go", version = "0.60.0")
+bazel_dep(name = "gazelle", version = "0.50.0")
+bazel_dep(name = "with_cfg.bzl", version = "0.14.6")
+
+# Source of @llvm//constraints/libc:gnu.2.28 — the libc constraint that
+# rules_rs's Linux toolchains pin via target_compatible_with, applied to our
+# host platform at //platforms:local_gnu.
+bazel_dep(name = "llvm", version = "0.7.3")
+
+# rules_rust facade — exposes @rules_rust so .bazelrc's --config=opt and
+# the with_cfg wrapper in //crates/import_extractor:opt.bzl can reference
+# @rules_rust//:extra_rustc_flags. Also keeps rules_rs's internal loads
+# resolving against the same canonical repo for toolchain_type matching.
+rules_rust = use_extension("@rules_rs//rs:rules_rust.bzl", "rules_rust")
+use_repo(rules_rust, "rules_rust")
+
+# Rust toolchain — propagates to consumers because their gazelle_binary
+# links our staticlib via cgo and needs to build the rust crate. Pinned to
+# ruff 0.15.10's declared MSRV; we don't use anything beyond what ruff
+# requires, so the right floor is theirs.
+toolchains = use_extension(
+    "@rules_rs//rs/toolchains:module_extension.bzl",
+    "toolchains",
+)
+toolchains.toolchain(
+    edition = "2024",
+    version = "1.92.0",
+)
+use_repo(toolchains, "default_rust_toolchains")
+
+register_toolchains("@default_rust_toolchains//:all")
+
+# Crate resolution: rules_rs reads Cargo.toml/Cargo.lock directly (no
+# repinning). Propagates to consumers along with the rust toolchain above.
+#
+# The hub name is namespaced (`gazelle_py_crates` rather than the generic
+# `crates`) so it doesn't collide with consumers' own crate.from_cargo
+# invocations — rules_rs merges hubs by name, and a collision would pair
+# our Cargo.lock against the consumer's Cargo.toml.
+crate = use_extension(
+    "@rules_rs//rs:extensions.bzl",
+    "crate",
+)
+crate.from_cargo(
+    name = "gazelle_py_crates",
+    cargo_lock = "//:Cargo.lock",
+    cargo_toml = "//:Cargo.toml",
+    platform_triples = [
+        "aarch64-apple-darwin",
+        "aarch64-unknown-linux-gnu",
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-gnu",
+    ],
+)
+use_repo(crate, "gazelle_py_crates")
+
+# Prost/tonic codegen toolchains for rust_prost_library.
+rules_rust_prost = use_extension("@rules_rs//rs:rules_rust_prost.bzl", "rules_rust_prost")
+use_repo(rules_rust_prost, "rules_rust_prost")
+
+register_toolchains("@rules_rust_prost//:default_prost_toolchain")
+
+# Go toolchain + module deps for the gazelle plugin.
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.24.12")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bazelbuild_buildtools",
+    "com_github_bmatcuk_doublestar_v4",
+    "com_github_burntsushi_toml",
+    "org_golang_google_protobuf",
+)

--- a/modules/gazelle_py/0.2.4/attestations.json
+++ b/modules/gazelle_py/0.2.4/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/perplexityai/gazelle_py/releases/download/v0.2.4/source.json.intoto.jsonl",
+            "integrity": "sha256-jbp2qfggjYDMOfkCe92GIrFl+yjnNYa7NCC+BLwNK8E="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/perplexityai/gazelle_py/releases/download/v0.2.4/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-g367469z70y/xvCgsXAa3nVmIvyclclv1UauoSY9mBM="
+        },
+        "gazelle_py-v0.2.4.tar.gz": {
+            "url": "https://github.com/perplexityai/gazelle_py/releases/download/v0.2.4/gazelle_py-v0.2.4.tar.gz.intoto.jsonl",
+            "integrity": "sha256-fVp8QfSYIwsI4XnJRMEo8qrE85wQdTbBEsQfB4VMqAA="
+        }
+    }
+}

--- a/modules/gazelle_py/0.2.4/patches/module_dot_bazel_version.patch
+++ b/modules/gazelle_py/0.2.4/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "gazelle_py",
+-    version = "0.0.0",
++    version = "0.2.4",
+     # rules_rs 0.0.61 requires Bazel >=8.5.0; we don't use anything beyond
+     # what rules_rs requires, so match its floor.
+     bazel_compatibility = [">=8.5.0"],
+ )

--- a/modules/gazelle_py/0.2.4/presubmit.yml
+++ b/modules/gazelle_py/0.2.4/presubmit.yml
@@ -1,0 +1,40 @@
+matrix:
+  # macOS + Ubuntu only — Debian's coverage overlaps Ubuntu's (both glibc
+  # Linux), and our own CI doesn't test on it either, so the BCR cell only
+  # adds runner cost without catching anything new. `macos_arm64` (not bare
+  # `macos`, which still points at Intel runners) since rules_rs's macOS
+  # Rust toolchains target arm64 by default.
+  platform:
+    - macos_arm64
+    - ubuntu2204
+  bazel:
+    # bazelisk wildcard syntax accepts `<major>.x` / `<major>.*`, not
+    # `<major>.<minor>.x` — `8.5.x` errors out with "invalid version".
+    # The supported floor (rules_rs's) is 8.5.0; bazelisk's `8.x` resolves
+    # to the latest 8.y, which currently is comfortably above.
+    - 9.x
+    - 8.x
+
+tasks:
+  verify_targets:
+    name: Build the gazelle_py plugin
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    # rules_rs's Linux Rust toolchains gate target_compatible_with on
+    # @llvm//constraints/libc:gnu.2.28. The default @platforms//host doesn't
+    # carry that constraint, so we pin host_platform here as a build flag —
+    # NOT in any consumer-visible .bazelrc — because BCR's runner shells
+    # out to `bazel info` before the build, and `info` doesn't trigger
+    # bzlmod resolution. Any --host_platform set in `common`/`build:linux`
+    # of an rc that's read by `info` fails with "Repository '@@gazelle_py'
+    # is not defined". Passing the same flag here keeps it scoped to the
+    # actual `bazel build` invocation, by which point @gazelle_py exists.
+    # End consumers must mirror this in their own .bazelrc — see README.
+    build_flags:
+      - "--host_platform=@gazelle_py//platforms:local_gnu"
+    build_targets:
+      # Go gazelle plugin (transitively cgo-links the Rust staticlib).
+      - "@gazelle_py//py/..."
+      # Rust crate — also exercised via py/, but listed explicitly so the
+      # rlib variant + the proto codegen are covered on every platform.
+      - "@gazelle_py//crates/import_extractor/..."

--- a/modules/gazelle_py/0.2.4/source.json
+++ b/modules/gazelle_py/0.2.4/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-tiPwTEfkDzUQ67t5Cbm/ry0pT3xyeX8lfEw4SBtebOs=",
+    "strip_prefix": "gazelle_py-0.2.4",
+    "url": "https://github.com/perplexityai/gazelle_py/releases/download/v0.2.4/gazelle_py-v0.2.4.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-iTq7e5IxPiLfTM+sXwcCq07brSEMWlIfbfFs7GZIlxs="
+    },
+    "patch_strip": 1
+}

--- a/modules/gazelle_py/metadata.json
+++ b/modules/gazelle_py/metadata.json
@@ -1,0 +1,30 @@
+{
+    "homepage": "https://github.com/perplexityai/gazelle_py",
+    "maintainers": [
+        {
+            "name": "Long Ho",
+            "email": "holevietlong@gmail.com",
+            "github": "longlho",
+            "github_user_id": 198255
+        },
+        {
+            "name": "Ravi Agarwal",
+            "email": "ravi@perplexity.ai",
+            "github": "ravi-pplx",
+            "github_user_id": 223930721
+        },
+        {
+            "name": "Alex Langenfeld",
+            "email": "alex.langenfeld@perplexity.ai",
+            "github": "alex-ppl-ai",
+            "github_user_id": 263400979
+        }
+    ],
+    "repository": [
+        "github:perplexityai/gazelle_py"
+    ],
+    "versions": [
+        "0.2.4"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/perplexityai/gazelle_py/releases/tag/v0.2.4

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_