### PR TITLE
msgpack-c@6.1.0.bcr.1

### DIFF
--- a/modules/msgpack-c/6.1.0.bcr.1/MODULE.bazel
+++ b/modules/msgpack-c/6.1.0.bcr.1/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "msgpack-c",
+    version = "6.1.0.bcr.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/msgpack-c/6.1.0.bcr.1/patches/add_build_file.patch
+++ b/modules/msgpack-c/6.1.0.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,15 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,12 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "msgpack",
++    hdrs = glob([
++        "include/**/*.h",
++        "include/**/*.hpp",
++    ]),
++    defines = ["MSGPACK_NO_BOOST"],
++    includes = ["include"],
++    visibility = ["//visibility:public"],
++)

--- a/modules/msgpack-c/6.1.0.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/msgpack-c/6.1.0.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "msgpack-c",
++    version = "6.1.0.bcr.1",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/msgpack-c/6.1.0.bcr.1/presubmit.yml
+++ b/modules/msgpack-c/6.1.0.bcr.1/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 6.x
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@msgpack-c//:msgpack'

--- a/modules/msgpack-c/6.1.0.bcr.1/source.json
+++ b/modules/msgpack-c/6.1.0.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/msgpack/msgpack-c/releases/download/cpp-6.1.0/msgpack-cxx-6.1.0.tar.gz",
+    "integrity": "sha256-I+3n6TyO/uNDrYxlFMKPNwggflEGrzs+SWmzqe1wOec=",
+    "strip_prefix": "msgpack-cxx-6.1.0",
+    "patches": {
+        "add_build_file.patch": "sha256-PCcsRe0p/RhIywEDzrnF4sipQjKLawxxALCtFonz56c=",
+        "module_dot_bazel.patch": "sha256-98GWbj0OSzG8uTuhZVPbh2yrMVqrjwc+qDauz2XzSc4="
+    },
+    "patch_strip": 0
+}

--- a/modules/msgpack-c/metadata.json
+++ b/modules/msgpack-c/metadata.json
@@ -10,7 +10,8 @@
         "github:msgpack/msgpack-c"
     ],
     "versions": [
-        "6.1.0"
+        "6.1.0",
+        "6.1.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This BCR patch changes the BUILD file so that it loads C++ compilation rules from rules_cc, and thus become compatible with Bazel 9.x.

This patch version also marks the module as compatible with Bazel 8.x, which the unpatched version already was (but wasn't marked as such).