### PR TITLE
Validate patch file paths stay inside patches directory

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -173,6 +173,17 @@ sh_test(
 )
 
 py_test(
+    name = "registry_test",
+    size = "small",
+    srcs = [
+        "registry_test.py",
+    ],
+    deps = [
+        "registry",
+    ],
+)
+
+py_test(
     name = "version_test",
     srcs = [
         "version_test.py",

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -306,7 +306,13 @@ module(
         return self.get_version_dir(module_name, version) / PRESUBMIT_YML
 
     def get_patch_file_path(self, module_name, version, patch_name):
-        return self.get_version_dir(module_name, version) / "patches" / patch_name
+        patches_dir = (self.get_version_dir(module_name, version) / "patches").resolve()
+        patch_file = (patches_dir / patch_name).resolve()
+        try:
+            patch_file.relative_to(patches_dir)
+        except ValueError as e:
+            raise RegistryException(f"Patch file path `{patch_name}` must point inside the patches directory.") from e
+        return patch_file
 
     def get_module_dot_bazel_path(self, module_name, version):
         return self.get_version_dir(module_name, version) / "MODULE.bazel"

--- a/tools/registry_test.py
+++ b/tools/registry_test.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import pathlib
+import tempfile
+import unittest
+
+from registry import RegistryClient, RegistryException
+
+
+class TestRegistryClient(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+        self.registry_root = pathlib.Path(self.tmp_dir.name)
+        self.registry = RegistryClient(self.registry_root)
+
+    def test_get_patch_file_path_allows_relative_path(self):
+        patch_file = self.registry.get_patch_file_path("foo", "1.0.0", "fix.patch")
+
+        self.assertEqual(
+            patch_file,
+            self.registry_root.resolve() / "modules" / "foo" / "1.0.0" / "patches" / "fix.patch",
+        )
+
+    def test_get_patch_file_path_allows_nested_relative_path(self):
+        patch_file = self.registry.get_patch_file_path("foo", "1.0.0", "subdir/fix.patch")
+
+        self.assertEqual(
+            patch_file,
+            self.registry_root.resolve() / "modules" / "foo" / "1.0.0" / "patches" / "subdir" / "fix.patch",
+        )
+
+    def test_get_patch_file_path_rejects_absolute_path(self):
+        patch_file = pathlib.Path(self.tmp_dir.name) / "outside.patch"
+
+        with self.assertRaisesRegex(RegistryException, "must point inside"):
+            self.registry.get_patch_file_path("foo", "1.0.0", str(patch_file))
+
+    def test_get_patch_file_path_rejects_parent_traversal(self):
+        with self.assertRaisesRegex(RegistryException, "must point inside"):
+            self.registry.get_patch_file_path("foo", "1.0.0", "../outside.patch")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #8657

This validates patch file paths returned by RegistryClient.get_patch_file_path so absolute paths or parent traversal cannot escape the module version's patches directory.

Added regression coverage for:
- normal relative patch paths
- nested relative patch paths
- absolute patch paths
- parent traversal paths

Tested:
bazelisk test //tools:registry_test
bazelisk test //tools:registry_test //tools:version_test //tools:module_selector_test --test_verbose_timeout_warnings