### PR TITLE
Add lobster 0.13.2 module

### DIFF
--- a/modules/lobster/0.13.2/MODULE.bazel
+++ b/modules/lobster/0.13.2/MODULE.bazel
@@ -1,0 +1,48 @@
+module(
+    name = "lobster",
+    compatibility_level = 1,
+    version = "0.13.2",
+)
+
+bazel_dep(
+    name = "rules_python",
+    version = "1.5.1",
+)
+
+bazel_dep(name = "rules_python_gazelle_plugin", version = "1.5.1")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+
+python.defaults(
+    python_version = "3.9",
+)
+
+python.toolchain(
+    configure_coverage_tool = True,
+    python_version = "3.9",
+)
+
+use_repo(python, "python_versions")
+
+bazel_dep(name = "googletest", version = "1.13.0")
+bazel_dep(name = "trlc", version = "2.0.4")
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
+pip.parse(
+    hub_name = "lobster_dependencies",
+    python_version = "3.11",
+    requirements_lock = "//:requirements.txt",
+)
+
+pip.parse(
+    hub_name = "pip",
+    python_version = "3.9",
+    requirements_lock = "//:requirements_lock_3_9.txt",
+    requirements_windows = "//:requirements_windows_3_9.txt",
+)
+
+use_repo(pip, "pip")
+
+bazel_dep(name = "gazelle", version = "0.44.0", repo_name = "bazel_gazelle")
+use_repo(python, "python_3_9")

--- a/modules/lobster/0.13.2/patches/module_bazel_trlc_version.patch
+++ b/modules/lobster/0.13.2/patches/module_bazel_trlc_version.patch
@@ -1,0 +1,31 @@
+--- a/MODULE.bazel	2026-05-05 07:49:24.974114676 +0200
++++ b/MODULE.bazel	2026-05-05 07:49:24.974538615 +0200
+@@ -14,9 +14,7 @@
+ python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+ 
+ python.defaults(
+-    # Use python.defaults if you have defined multiple toolchain versions.
+     python_version = "3.9",
+-    python_version_env = "BAZEL_PYTHON_VERSION",
+ )
+ 
+ python.toolchain(
+@@ -27,7 +25,7 @@
+ use_repo(python, "python_versions")
+ 
+ bazel_dep(name = "googletest", version = "1.13.0")
+-bazel_dep(name = "trlc", version = "0.0.0")
++bazel_dep(name = "trlc", version = "2.0.4")
+ 
+ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+ 
+@@ -48,9 +46,3 @@
+ 
+ bazel_dep(name = "gazelle", version = "0.44.0", repo_name = "bazel_gazelle")
+ use_repo(python, "python_3_9")
+-
+-git_override(
+-    commit = "650b51a47264a4f232b3341f473527710fc32669",
+-    module_name = "trlc",
+-    remote = "https://github.com/bmw-software-engineering/trlc.git",
+-)

--- a/modules/lobster/0.13.2/presubmit.yml
+++ b/modules/lobster/0.13.2/presubmit.yml
@@ -1,0 +1,28 @@
+---
+matrix:
+  platform:
+    - ubuntu2004
+    - ubuntu2204
+  bazel:
+    - 8.x
+tasks:
+  run_test_module:
+    name: Run test module
+    bazel: ${{ bazel }}
+    platform: ${{ platform }}
+    build_flags:
+      - "--@@rules_python+//python/config_settings:python_version=3.9"
+    build_targets:
+      - "@lobster//:lobster"
+      - "@lobster//:lobster-ci-report"
+      - "@lobster//:lobster-codebeamer"
+      - "@lobster//:lobster-cpp"
+      - "@lobster//:lobster-cpptest"
+      - "@lobster//:lobster-gtest"
+      - "@lobster//:lobster-html-report"
+      - "@lobster//:lobster-json"
+      - "@lobster//:lobster-online-report"
+      - "@lobster//:lobster-online-report-nogit"
+      - "@lobster//:lobster-python"
+      - "@lobster//:lobster-report"
+      - "@lobster//:lobster-trlc"

--- a/modules/lobster/0.13.2/source.json
+++ b/modules/lobster/0.13.2/source.json
@@ -1,0 +1,9 @@
+{
+  "integrity": "sha256-+103IUmh6pjeiqpTSE4gq1abM7IbdbQ5sOotZHrfK8g=",
+  "strip_prefix": "lobster-lobster-1.0.2",
+  "url": "https://github.com/bmw-software-engineering/lobster/archive/refs/tags/lobster-1.0.2.tar.gz",
+  "patches": {
+    "module_bazel_trlc_version.patch": "sha256-L9z9hyet01RdDV7qq3lTBpZpkFI3OOlDtF5uCYbvHFY="
+  },
+  "patch_strip": 1
+}

--- a/modules/lobster/metadata.json
+++ b/modules/lobster/metadata.json
@@ -1,0 +1,24 @@
+{
+  "homepage": "https://github.com/bmw-software-engineering/lobster",
+  "maintainers": [
+  {
+      "email": "rahulsutariya0001@gmail.com",
+      "github": "Rahul-Sutariya",
+      "name": "RAHUL SUTARIYA",
+      "github_user_id": 113970414
+  },
+  {
+      "email": "ambujsingh7566180876@gmail.com",
+      "github": "AAmbuj",
+      "name": "Ambuj Singh Kushwaha",
+      "github_user_id": 73685939
+  }
+  ],
+  "repository": [
+    "github:bmw-software-engineering/lobster"
+  ],
+  "versions": [
+    "0.13.2"
+  ],
+  "yanked_versions": {}
+}


### PR DESCRIPTION
- Added lobster version 0.13.2 (release tag lobster-1.0.2)
- MODULE.bazel with dependencies on rules_python, gazelle, googletest, and trlc
- Configured presubmit tests for all lobster binary targets
- Added patch to replace trlc git_override with BCR version 2.0.4
- Maintainer: RAHUL SUTARIYA & AAmbuj