### PR TITLE
hdrhistogram_c@0.11.9

### DIFF
--- a/modules/hdrhistogram_c/0.11.9/MODULE.bazel
+++ b/modules/hdrhistogram_c/0.11.9/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "hdrhistogram_c",
+    version = "0.11.9",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "zlib",
+    version = "1.3.1.bcr.1",
+)

--- a/modules/hdrhistogram_c/0.11.9/patches/add_build_file.patch
+++ b/modules/hdrhistogram_c/0.11.9/patches/add_build_file.patch
@@ -1,0 +1,37 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,34 @@
++cc_library(
++    name = "hdrhistogram_c",
++    srcs = [
++        "src/hdr_atomic.h",
++        "src/hdr_encoding.c",
++        "src/hdr_encoding.h",
++        "src/hdr_endian.h",
++        "src/hdr_histogram.c",
++        "src/hdr_histogram_log.c",
++        "src/hdr_interval_recorder.c",
++        "src/hdr_malloc.h",
++        "src/hdr_tests.h",
++        "src/hdr_thread.c",
++        "src/hdr_time.c",
++        "src/hdr_writer_reader_phaser.c",
++    ],
++    hdrs = [
++        "include/hdr/hdr_histogram.h",
++        "include/hdr/hdr_histogram_log.h",
++        "include/hdr/hdr_histogram_version.h",
++        "include/hdr/hdr_interval_recorder.h",
++        "include/hdr/hdr_thread.h",
++        "include/hdr/hdr_time.h",
++        "include/hdr/hdr_writer_reader_phaser.h",
++    ],
++    copts = [
++        "-std=gnu99",
++        "-Wno-implicit-function-declaration",
++        "-Wno-error",
++    ],
++    includes = ["include"],
++    visibility = ["//visibility:public"],
++    deps = ["@zlib"],
++)

--- a/modules/hdrhistogram_c/0.11.9/patches/module_dot_bazel.patch
+++ b/modules/hdrhistogram_c/0.11.9/patches/module_dot_bazel.patch
@@ -1,0 +1,13 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,10 @@
++module(
++    name = "hdrhistogram_c",
++    version = "0.11.9",
++    compatibility_level = 1,
++)
++
++bazel_dep(
++    name = "zlib",
++    version = "1.3.1.bcr.1",
++)

--- a/modules/hdrhistogram_c/0.11.9/presubmit.yml
+++ b/modules/hdrhistogram_c/0.11.9/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@hdrhistogram_c//:hdrhistogram_c'

--- a/modules/hdrhistogram_c/0.11.9/source.json
+++ b/modules/hdrhistogram_c/0.11.9/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/HdrHistogram/HdrHistogram_c/archive/refs/tags/0.11.9.tar.gz",
+    "integrity": "sha256-DrX9ufH4xLnG6zGVAvjZ4omRr/+4QYZyphdBmThVZQ4=",
+    "strip_prefix": "HdrHistogram_c-0.11.9",
+    "patches": {
+        "add_build_file.patch": "sha256-GMcDyYkTMN0rKarbGap6P+irQHIcNgMc7/M1drurLr0=",
+        "module_dot_bazel.patch": "sha256-tQjPLGdHmHGkczjQ0PaxSbNFc8Se4FaJOekShsO4KH4="
+    },
+    "patch_strip": 0
+}

--- a/modules/hdrhistogram_c/metadata.json
+++ b/modules/hdrhistogram_c/metadata.json
@@ -10,7 +10,8 @@
         "github:HdrHistogram/HdrHistogram_c"
     ],
     "versions": [
-        "0.11.2"
+        "0.11.2",
+        "0.11.9"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds version 0.11.9 of [HdrHistogram_c](https://github.com/HdrHistogram/HdrHistogram_c).

Release: https://github.com/HdrHistogram/HdrHistogram_c/releases/tag/0.11.9

Notable changes from 0.11.2:
- Add support for rejecting values larger than the max trackable value
- Memory leak fixes in `hdr_histogram_log`
- Divide-by-zero fix
- CMake `INSTALL_INTERFACE` correctness fix
- Fuzz testing support

## Patch changes vs. 0.11.2
Public headers moved upstream from `src/*.h` to `include/hdr/*.h`. The BUILD patch is updated accordingly: `hdrs` now reference `include/hdr/...` and `includes = ["include"]` is added so consumers can `#include <hdr/hdr_histogram.h>`. Private headers (`hdr_atomic.h`, `hdr_encoding.h`, `hdr_endian.h`, `hdr_malloc.h`, `hdr_tests.h`) remain in `src/` and are listed in `srcs`.

## Source URL
Upstream does not attach release artifacts; using the same `archive/refs/tags/<version>.tar.gz` form as 0.11.2.