### PR TITLE
rules_heir: add v0.0.3

### DIFF
--- a/modules/rules_heir/0.0.3/MODULE.bazel
+++ b/modules/rules_heir/0.0.3/MODULE.bazel
@@ -1,0 +1,18 @@
+module(
+    name = "rules_heir",
+    version = "0.0.3",
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.14")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+
+repos = use_extension("@rules_heir//heir:extensions.bzl", "heir_repositories")
+use_repo(
+    repos,
+    "heir_linux_x86_64",
+)
+
+register_toolchains(
+    "@rules_heir//heir:heir_linux_x86_64_toolchain",
+)

--- a/modules/rules_heir/0.0.3/presubmit.yml
+++ b/modules/rules_heir/0.0.3/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["ubuntu-latest"]
+  platform: ["debian11", "ubuntu2204"]
   bazel: ["7.x", "8.x", "9.x"]
 
 tasks:

--- a/modules/rules_heir/0.0.3/presubmit.yml
+++ b/modules/rules_heir/0.0.3/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform: ["ubuntu-latest"]
+  bazel: ["7.x", "8.x", "9.x"]
+
+tasks:
+  test_hello_world:
+    name: "Test Hello World Example"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    bcr_test_module:
+      module_path: "examples/hello_world"
+      test_targets:
+        - "//...:all"
+
+  test_analysis:
+    name: "Run Analysis Tests"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "//heir/..."

--- a/modules/rules_heir/0.0.3/presubmit.yml
+++ b/modules/rules_heir/0.0.3/presubmit.yml
@@ -17,4 +17,4 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     test_targets:
-      - "//heir/..."
+      - "@rules_heir//heir/..."

--- a/modules/rules_heir/0.0.3/source.json
+++ b/modules/rules_heir/0.0.3/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/j2kun/rules_heir/releases/download/v0.0.3/rules_heir-0.0.3.tar.gz",
+  "integrity": "sha256-GRrCM3tZhRaTK383ktJ95gA/tX4+woJkVS99tJrs9iU=",
+  "strip_prefix": "rules_heir-0.0.3"
+}

--- a/modules/rules_heir/metadata.json
+++ b/modules/rules_heir/metadata.json
@@ -1,0 +1,20 @@
+{
+    "name": "rules_heir",
+    "description": "Bazel rules for the HEIR compiler",
+    "homepage": "https://github.com/j2kun/rules_heir",
+    "maintainers": [
+        {
+            "email": "jkun@google.com",
+            "github": "j2kun",
+            "github_user_id": 2467754,
+            "name": "Jeremy Kun"
+         }
+    ],
+    "repository": [
+        "github:j2kun/rules_heir"
+    ],
+    "versions": [
+        "0.0.3"
+    ],
+    "yanked_versions": {}
+}

--- a/modules/rules_heir/metadata.json
+++ b/modules/rules_heir/metadata.json
@@ -1,6 +1,4 @@
 {
-    "name": "rules_heir",
-    "description": "Bazel rules for the HEIR compiler",
     "homepage": "https://github.com/j2kun/rules_heir",
     "maintainers": [
         {


### PR DESCRIPTION
This PR adds a new module for the rules_heir project (https://github.com/j2kun/rules_heir). This is a set of bazel rules for interacting with the HEIR homomorphic encryption compiler toolchain (https://heir.dev).

Currently the HEIR project releases only have prebuilt binaries for linux, so a followup release of this ruleset will include MacOS and other distributions in the presubmit.