### PR TITLE
rsync@3.4.2

### DIFF
--- a/modules/rsync/3.4.2/MODULE.bazel
+++ b/modules/rsync/3.4.2/MODULE.bazel
@@ -1,0 +1,13 @@
+"""rsync MODULE.bazel file"""
+
+module(
+    name = "rsync",
+    version = "3.4.2",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "openssl", version = "3.5.5.bcr.4")
+bazel_dep(name = "zstd", version = "1.5.7")
+bazel_dep(name = "lz4", version = "1.10.0.bcr.1")
+bazel_dep(name = "xxhash", version = "0.8.3.bcr.1")

--- a/modules/rsync/3.4.2/patches/add_build_file.patch
+++ b/modules/rsync/3.4.2/patches/add_build_file.patch
@@ -1,0 +1,260 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -0,0 +1,257 @@
++load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
++
++RSYNC_CORE_SRCS = [
++    "access.c",
++    "acls.c",
++    "authenticate.c",
++    "backup.c",
++    "batch.c",
++    "chmod.c",
++    "cleanup.c",
++    "clientname.c",
++    "clientserver.c",
++    "compat.c",
++    "connection.c",
++    "checksum.c",
++    "delete.c",
++    "exclude.c",
++    "fileio.c",
++    "flist.c",
++    "generator.c",
++    "hashtable.c",
++    "hlink.c",
++    "io.c",
++    "loadparm.c",
++    "log.c",
++    "main.c",
++    "match.c",
++    "options.c",
++    "params.c",
++    "pipe.c",
++    "progress.c",
++    "receiver.c",
++    "rsync.c",
++    "sender.c",
++    "socket.c",
++    "syscall.c",
++    "token.c",
++    "uidlist.c",
++    "usage.c",
++    "util1.c",
++    "util2.c",
++    "xattrs.c",
++]
++
++RSYNC_LIB_SRCS = [
++    "lib/compat.c",
++    "lib/md5.c",
++    "lib/mdfour.c",
++    "lib/permstring.c",
++    "lib/pool_alloc.c",
++    "lib/snprintf.c",
++    "lib/sysacls.c",
++    "lib/sysxattrs.c",
++    "lib/wildmatch.c",
++]
++
++
++genrule(
++    name = "daemon_parm_h",
++    srcs = [
++        "daemon-parm.awk",
++        "daemon-parm.txt",
++    ],
++    outs = ["daemon-parm.h"],
++    cmd = "awk -f $(location daemon-parm.awk) $(location daemon-parm.txt) && cp daemon-parm.h $@",
++)
++
++genrule(
++    name = "default_cvsignore_h",
++    srcs = [
++        "define-from-md.awk",
++        "rsync.1.md",
++    ],
++    outs = ["default-cvsignore.h"],
++    cmd = "awk -f $(location define-from-md.awk) -v hfile=$@ $(location rsync.1.md)",
++)
++
++genrule(
++    name = "default_dont_compress_h",
++    srcs = [
++        "define-from-md.awk",
++        "rsync.1.md",
++    ],
++    outs = ["default-dont-compress.h"],
++    cmd = "awk -f $(location define-from-md.awk) -v hfile=$@ $(location rsync.1.md)",
++)
++
++genrule(
++    name = "help_rsync_h",
++    srcs = [
++        "help-from-md.awk",
++        "rsync.1.md",
++    ],
++    outs = ["help-rsync.h"],
++    cmd = "awk -f $(location help-from-md.awk) -v hfile=help-rsync.h $(location rsync.1.md) && cp help-rsync.h $@",
++)
++
++genrule(
++    name = "help_rsyncd_h",
++    srcs = [
++        "help-from-md.awk",
++        "rsync.1.md",
++    ],
++    outs = ["help-rsyncd.h"],
++    cmd = "awk -f $(location help-from-md.awk) -v hfile=help-rsyncd.h $(location rsync.1.md) && cp help-rsyncd.h $@",
++)
++
++genrule(
++    name = "rounding_h",
++    srcs = [
++        "byteorder.h",
++        "config.h",
++        "errcode.h",
++        "lib/addrinfo.h",
++        "lib/md-defines.h",
++        "lib/mdigest.h",
++        "lib/pool_alloc.h",
++        "lib/permstring.h",
++        "lib/wildmatch.h",
++        "rounding.c",
++        "rsync.h",
++        ":proto_h",
++        "@openssl//:gen_dir",
++    ],
++    outs = ["rounding.h"],
++    cmd = """
++cp $(location :proto_h) proto.h
++GEN_DIR="$(location @openssl//:gen_dir)"
++OPENSSL_INC_DIR="$$GEN_DIR/include"
++CC="$${CC:-cc}"
++for r in 0 1 3; do
++  if "$$CC" -o rounding -DEXTRA_ROUNDING=$$r -I. -I"$$OPENSSL_INC_DIR" $(location rounding.c) >rounding.out 2>&1; then
++    echo "#define EXTRA_ROUNDING $$r" > $@
++    if test -n "$${HOME-}" && test -f "$${HOME-}/build_farm/build_test.fns"; then
++      echo "EXTRA_ROUNDING is $$r" >&2
++    fi
++    break
++  fi
++done
++rm -f rounding
++if test -f "$@"; then
++  :
++else
++  cat rounding.out >&2
++  echo "Failed to create rounding.h!" >&2
++  exit 1
++fi
++rm -f rounding.out proto.h
++""",
++)
++
++genrule(
++    name = "git_version_h",
++    outs = ["git-version.h"],
++    cmd = """
++if [ -x $(location mkgitver) ]; then
++  $(location mkgitver) || true
++fi
++if [ -s git-version.h ]; then
++  cp git-version.h $@
++else
++  echo '/* RSYNC_GITVER not available (fallback to RSYNC_VERSION). */' > $@
++fi
++""",
++    tools = ["mkgitver"],
++)
++
++genrule(
++    name = "proto_h",
++    srcs = glob(["*.c"]) + [
++        "lib/compat.c",
++        ":daemon_parm_h",
++    ],
++    outs = ["proto.h"],
++    cmd = "awk -f $(location mkproto.awk) $(SRCS) && cp proto.h $@",
++    tools = ["mkproto.awk"],
++)
++
++filegroup(
++    name = "generated_headers",
++    srcs = [
++        ":daemon_parm_h",
++        ":default_cvsignore_h",
++        ":default_dont_compress_h",
++        ":git_version_h",
++        ":help_rsync_h",
++        ":help_rsyncd_h",
++        ":proto_h",
++        ":rounding_h",
++    ],
++)
++
++cc_library(
++    name = "popt",
++    srcs = [
++        "popt/popt.c",
++        "popt/poptconfig.c",
++        "popt/popthelp.c",
++        "popt/poptint.c",
++        "popt/poptparse.c",
++    ],
++    hdrs = glob(["popt/*.h"]) + [
++        "config.h",
++        "popt/lookup3.c",
++    ],
++    defines = ["HAVE_CONFIG_H"],
++    includes = ["popt"],
++)
++
++cc_library(
++    name = "zlib",
++    srcs = glob(["zlib/*.c"]),
++    hdrs = glob(["zlib/*.h"]) + glob([
++        "*.h",
++        "lib/*.h",
++    ]) + [
++        ":generated_headers",
++    ],
++    includes = ["zlib"],
++    deps = [
++        "@openssl//:crypto",
++    ],
++)
++
++cc_library(
++    name = "rsync_lib",
++    srcs = RSYNC_CORE_SRCS + RSYNC_LIB_SRCS,
++    hdrs = glob([
++        "*.h",
++        "lib/*.h",
++    ]) + [
++        ":generated_headers",
++    ],
++    defines = ["HAVE_CONFIG_H"],
++    includes = [
++        "lib",
++        "popt",
++        "zlib",
++    ],
++    linkopts = [
++        "-liconv",
++    ],
++    deps = [
++        ":popt",
++        ":zlib",
++        "@lz4",
++        "@openssl//:crypto",
++        "@xxhash",
++        "@zstd",
++    ],
++)
++
++cc_binary(
++    name = "rsync",
++    visibility = ["//visibility:public"],
++    deps = [":rsync_lib"],
++)

--- a/modules/rsync/3.4.2/patches/add_config_h.patch
+++ b/modules/rsync/3.4.2/patches/add_config_h.patch
@@ -1,0 +1,865 @@
+--- a/config.h
++++ b/config.h
+@@ -0,0 +1,862 @@
++/* config.h.  Generated from config.h.in by configure.  */
++/* config.h.in.  Generated from configure.ac by autoheader.  */
++
++/* Define if building universal (internal helper macro) */
++/* #undef AC_APPLE_UNIVERSAL_BUILD */
++
++/* Define to 1 if link() can hard-link special files. */
++#define CAN_HARDLINK_SPECIAL 1
++
++/* Define to 1 if link() can hard-link symlinks. */
++#define CAN_HARDLINK_SYMLINK 1
++
++/* Define to 1 if chown modifies symlinks. */
++/* #undef CHOWN_MODIFIES_SYMLINK */
++
++/* Undefine if you do not want locale features. By default this is defined. */
++#define CONFIG_LOCALE 1
++
++/* Define to 1 if using 'alloca.c'. */
++/* #undef C_ALLOCA */
++
++/* Define to 1 if using external zlib */
++/* #undef EXTERNAL_ZLIB */
++
++/* Used to make "checker" understand that FD_ZERO() clears memory. */
++/* #undef FORCE_FD_ZERO_MEMSET */
++
++/* Define to the type of elements in the array set by `getgroups'. Usually
++   this is either `int' or `gid_t'. */
++#define GETGROUPS_T gid_t
++
++/* Define to 1 if the 'getpgrp' function requires zero arguments. */
++#define GETPGRP_VOID 1
++
++/* Define to 1 if you have the 'aclsort' function. */
++/* #undef HAVE_ACLSORT */
++
++/* true if you have acl_get_perm_np */
++/* #undef HAVE_ACL_GET_PERM_NP */
++
++/* Define to 1 if you have the <acl/libacl.h> header file. */
++/* #undef HAVE_ACL_LIBACL_H */
++
++/* true if you have AIX ACLs */
++/* #undef HAVE_AIX_ACLS */
++
++/* Define to 1 if you have 'alloca', as a function or macro. */
++#define HAVE_ALLOCA 1
++
++/* Define to 1 if <alloca.h> works. */
++#define HAVE_ALLOCA_H 1
++
++/* Define to 1 if you have the <arpa/inet.h> header file. */
++#define HAVE_ARPA_INET_H 1
++
++/* Define to 1 if you have the <arpa/nameser.h> header file. */
++#define HAVE_ARPA_NAMESER_H 1
++
++/* Define to 1 if you have the 'asprintf' function. */
++#define HAVE_ASPRINTF 1
++
++/* Define to 1 if you have the 'attropen' function. */
++/* #undef HAVE_ATTROPEN */
++
++/* Define to 1 if you have the <attr/xattr.h> header file. */
++/* #undef HAVE_ATTR_XATTR_H */
++
++/* Define to 1 if readdir() is broken */
++/* #undef HAVE_BROKEN_READDIR */
++
++/* Define to 1 if you have the <bsd/string.h> header file. */
++/* #undef HAVE_BSD_STRING_H */
++
++/* Define to 1 if vsprintf has a C99-compatible return value */
++#define HAVE_C99_VSNPRINTF 1
++
++/* Define to 1 if you have the 'chflags' function. */
++#define HAVE_CHFLAGS 1
++
++/* Define to 1 if you have the 'chmod' function. */
++#define HAVE_CHMOD 1
++
++/* Define to 1 if you have the 'chown' function. */
++#define HAVE_CHOWN 1
++
++/* Define to 1 if you have the <compat.h> header file. */
++/* #undef HAVE_COMPAT_H */
++
++/* Define to 1 if you have the "connect" function */
++#define HAVE_CONNECT 1
++
++/* Define to 1 if you have the <ctype.h> header file. */
++#define HAVE_CTYPE_H 1
++
++/* Define to 1 if you have the <dirent.h> header file, and it defines 'DIR'.
++   */
++#define HAVE_DIRENT_H 1
++
++/* Define to 1 if you have the <dl.h> header file. */
++/* #undef HAVE_DL_H */
++
++/* Define if posix_fallocate is efficient (Cygwin) */
++/* #undef HAVE_EFFICIENT_POSIX_FALLOCATE */
++
++/* Define to 1 if errno is declared in errno.h */
++#define HAVE_ERRNO_DECL 1
++
++/* Define to 1 if you have the 'extattr_get_link' function. */
++/* #undef HAVE_EXTATTR_GET_LINK */
++
++/* Define to 1 if you have the fallocate function and it compiles and links
++   without error */
++/* #undef HAVE_FALLOCATE */
++
++/* Define if FALLOC_FL_PUNCH_HOLE is available. */
++/* #undef HAVE_FALLOC_FL_PUNCH_HOLE */
++
++/* Define if FALLOC_FL_ZERO_RANGE is available. */
++/* #undef HAVE_FALLOC_FL_ZERO_RANGE */
++
++/* Define to 1 if you have the 'fchmod' function. */
++#define HAVE_FCHMOD 1
++
++/* Define to 1 if you have the <fcntl.h> header file. */
++#define HAVE_FCNTL_H 1
++
++/* Define to 1 if you have the <float.h> header file. */
++#define HAVE_FLOAT_H 1
++
++/* True if you have FreeBSD xattrs */
++/* #undef HAVE_FREEBSD_XATTRS */
++
++/* Define to 1 if you have the 'fstat' function. */
++#define HAVE_FSTAT 1
++
++/* Define to 1 if you have the 'ftruncate' function. */
++#define HAVE_FTRUNCATE 1
++
++/* Define to 1 if you have the "getaddrinfo" function and required types. */
++#define HAVE_GETADDRINFO 1
++
++/* Define to 1 if you have the 'getattrlist' function. */
++#define HAVE_GETATTRLIST 1
++
++/* Define to 1 if you have the 'getcwd' function. */
++#define HAVE_GETCWD 1
++
++/* Define to 1 if you have the 'getegid' function. */
++#define HAVE_GETEGID 1
++
++/* Define to 1 if you have the 'geteuid' function. */
++#define HAVE_GETEUID 1
++
++/* Define to 1 if you have the 'getgrouplist' function. */
++#define HAVE_GETGROUPLIST 1
++
++/* Define to 1 if you have the 'getgroups' function. */
++#define HAVE_GETGROUPS 1
++
++/* Define to 1 if you have the 'getpass' function. */
++#define HAVE_GETPASS 1
++
++/* Define to 1 if you have the 'getpgrp' function. */
++#define HAVE_GETPGRP 1
++
++/* Define to 1 if gettimeofday() takes a time-zone arg */
++#define HAVE_GETTIMEOFDAY_TZ 1
++
++/* Define to 1 if you have the 'getxattr' function. */
++#define HAVE_GETXATTR 1
++
++/* Define to 1 if you have the <grp.h> header file. */
++#define HAVE_GRP_H 1
++
++/* true if you have HPUX ACLs */
++/* #undef HAVE_HPUX_ACLS */
++
++/* Define to 1 if you have the <iconv.h> header file. */
++#define HAVE_ICONV_H 1
++
++/* Define to 1 if you have the 'iconv_open' function. */
++#define HAVE_ICONV_OPEN 1
++
++/* Define to 1 if the system has the type 'id_t'. */
++#define HAVE_ID_T 1
++
++/* Define to 1 if you have the 'inet_ntop' function. */
++#define HAVE_INET_NTOP 1
++
++/* Define to 1 if you have the 'inet_pton' function. */
++#define HAVE_INET_PTON 1
++
++/* Define to 1 if you have the 'initgroups' function. */
++#define HAVE_INITGROUPS 1
++
++/* Define to 1 if you have the 'innetgr' function. */
++#define HAVE_INNETGR 1
++
++/* Define to 1 if you have the <inttypes.h> header file. */
++#define HAVE_INTTYPES_H 1
++
++/* true if you have IRIX ACLs */
++/* #undef HAVE_IRIX_ACLS */
++
++/* Define to 1 if you have the <langinfo.h> header file. */
++#define HAVE_LANGINFO_H 1
++
++/* Define to 1 if you have the 'lchmod' function. */
++#define HAVE_LCHMOD 1
++
++/* Define to 1 if you have the 'lchown' function. */
++#define HAVE_LCHOWN 1
++
++/* Define to 1 if you have the 'acl' library (-lacl). */
++/* #undef HAVE_LIBACL */
++
++/* Define to 1 if you have the <libcharset.h> header file. */
++#define HAVE_LIBCHARSET_H 1
++
++/* Define to 1 if you have the 'inet' library (-linet). */
++/* #undef HAVE_LIBINET */
++
++/* Define to 1 if you have the 'nsl' library (-lnsl). */
++/* #undef HAVE_LIBNSL */
++
++/* Define to 1 if you have the 'nsl_s' library (-lnsl_s). */
++/* #undef HAVE_LIBNSL_S */
++
++/* Define to 1 if you have the 'popt' library (-lpopt). */
++/* #undef HAVE_LIBPOPT */
++
++/* Define to 1 if you have the 'resolv' library (-lresolv). */
++/* #undef HAVE_LIBRESOLV */
++
++/* Define to 1 if you have the 'sec' library (-lsec). */
++/* #undef HAVE_LIBSEC */
++
++/* Define to 1 if you have the 'socket' library (-lsocket). */
++/* #undef HAVE_LIBSOCKET */
++
++/* Define to 1 if you have the 'z' library (-lz). */
++/* #undef HAVE_LIBZ */
++
++/* Define to 1 if you have the <limits.h> header file. */
++#define HAVE_LIMITS_H 1
++
++/* Define to 1 if you have the 'link' function. */
++#define HAVE_LINK 1
++
++/* Define to 1 if you have the 'linkat' function. */
++#define HAVE_LINKAT 1
++
++/* Define to 1 if you have the <linux/falloc.h> header file. */
++/* #undef HAVE_LINUX_FALLOC_H */
++
++/* True if you have Linux xattrs (or equivalent) */
++/* #undef HAVE_LINUX_XATTRS */
++
++/* Define to 1 if you have the 'locale_charset' function. */
++#define HAVE_LOCALE_CHARSET 1
++
++/* Define to 1 if you have the <locale.h> header file. */
++#define HAVE_LOCALE_H 1
++
++/* Define to 1 if the type `long double' works and has more range or precision
++   than `double'. */
++/* #undef HAVE_LONG_DOUBLE */
++
++/* Define to 1 if the type 'long double' works and has more range or precision
++   than 'double'. */
++/* #undef HAVE_LONG_DOUBLE_WIDER */
++
++/* Define to 1 if you have the 'lseek64' function. */
++/* #undef HAVE_LSEEK64 */
++
++/* Define to 1 if you have the 'lutimes' function. */
++#define HAVE_LUTIMES 1
++
++/* Define to 1 if you have the <lz4.h> header file. */
++#define HAVE_LZ4_H 1
++
++/* Define to 1 if you have the 'mallinfo' function. */
++/* #undef HAVE_MALLINFO */
++
++/* Define to 1 if you have the 'mallinfo2' function. */
++/* #undef HAVE_MALLINFO2 */
++
++/* Define to 1 if you have the <malloc.h> header file. */
++/* #undef HAVE_MALLOC_H */
++
++/* Define to 1 if you have the <mcheck.h> header file. */
++/* #undef HAVE_MCHECK_H */
++
++/* Define to 1 if you have the 'memmove' function. */
++#define HAVE_MEMMOVE 1
++
++/* Define to 1 if you have the 'mkfifo' function. */
++#define HAVE_MKFIFO 1
++
++/* Define to 1 if you have the 'mknod' function. */
++#define HAVE_MKNOD 1
++
++/* Define to 1 if you have the 'mkstemp64' function. */
++/* #undef HAVE_MKSTEMP64 */
++
++/* Define to 1 if you have the 'mktime' function. */
++#define HAVE_MKTIME 1
++
++/* Define to 1 if the system has the type 'mode_t'. */
++#define HAVE_MODE_T 1
++
++/* Define to 1 if you have the 'mtrace' function. */
++/* #undef HAVE_MTRACE */
++
++/* Define to 1 if you have the 'nanosleep' function. */
++#define HAVE_NANOSLEEP 1
++
++/* Define to 1 if you have the <ndir.h> header file, and it defines 'DIR'. */
++/* #undef HAVE_NDIR_H */
++
++/* Define to 1 if you have the <netdb.h> header file. */
++#define HAVE_NETDB_H 1
++
++/* Define to 1 if you have the <netgroup.h> header file. */
++/* #undef HAVE_NETGROUP_H */
++
++/* Define to 1 if you have the <netinet/in_systm.h> header file. */
++#define HAVE_NETINET_IN_SYSTM_H 1
++
++/* Define to 1 if you have the <netinet/ip.h> header file. */
++#define HAVE_NETINET_IP_H 1
++
++/* Define to 1 if you have the 'nl_langinfo' function. */
++#define HAVE_NL_LANGINFO 1
++
++/* Define to 1 if the system has the type 'off_t'. */
++#define HAVE_OFF_T 1
++
++/* Define to 1 if you have the 'open64' function. */
++/* #undef HAVE_OPEN64 */
++
++/* Define to 1 if you have the <openssl/md4.h> header file. */
++#define HAVE_OPENSSL_MD4_H 1
++
++/* Define to 1 if you have the <openssl/md5.h> header file. */
++#define HAVE_OPENSSL_MD5_H 1
++
++/* true if you have Mac OS X ACLs */
++#define HAVE_OSX_ACLS 1
++
++/* True if you have Mac OS X xattrs */
++#define HAVE_OSX_XATTRS 1
++
++/* Define to 1 if the system has the type 'pid_t'. */
++#define HAVE_PID_T 1
++
++/* Define to 1 if you have the <popt.h> header file. */
++/* #undef HAVE_POPT_H */
++
++/* Define to 1 if you have the <popt/popt.h> header file. */
++/* #undef HAVE_POPT_POPT_H */
++
++/* true if you have posix ACLs */
++/* #undef HAVE_POSIX_ACLS */
++
++/* Define to 1 if you have the 'posix_fallocate' function. */
++/* #undef HAVE_POSIX_FALLOCATE */
++
++/* Define to 1 if you have the 'putenv' function. */
++#define HAVE_PUTENV 1
++
++/* Define to 1 if you have the 'readlink' function. */
++#define HAVE_READLINK 1
++
++/* Define to 1 if remote shell is remsh, not rsh */
++/* #undef HAVE_REMSH */
++
++/* Define to 1 if mkstemp() is available and works right */
++#define HAVE_SECURE_MKSTEMP 1
++
++/* Define to 1 if you have the 'setattrlist' function. */
++#define HAVE_SETATTRLIST 1
++
++/* Define to 1 if you have the 'setenv' function. */
++#define HAVE_SETENV 1
++
++/* Define to 1 if you have the 'seteuid' function. */
++#define HAVE_SETEUID 1
++
++/* Define to 1 if you have the 'setgroups' function. */
++#define HAVE_SETGROUPS 1
++
++/* Define to 1 if you have the 'setlocale' function. */
++#define HAVE_SETLOCALE 1
++
++/* Define to 1 if you have the 'setmode' function. */
++#define HAVE_SETMODE 1
++
++/* Define to 1 if you have the 'setsid' function. */
++#define HAVE_SETSID 1
++
++/* Define to 1 if you have the 'setvbuf' function. */
++#define HAVE_SETVBUF 1
++
++/* Define to 1 if you have the 'sigaction' function. */
++#define HAVE_SIGACTION 1
++
++/* Define to 1 if you have the 'sigprocmask' function. */
++#define HAVE_SIGPROCMASK 1
++
++/* Define to 1 if the system has the type 'size_t'. */
++#define HAVE_SIZE_T 1
++
++/* Define to 1 if you have the 'snprintf' function. */
++#define HAVE_SNPRINTF 1
++
++/* Do we have sockaddr_in6.sin6_scope_id? */
++#define HAVE_SOCKADDR_IN6_SCOPE_ID 1
++
++/* Do we have sockaddr_in.sin_len? */
++#define HAVE_SOCKADDR_IN_LEN 1
++
++/* Do we have sockaddr.sa_len? */
++#define HAVE_SOCKADDR_LEN 1
++
++/* Do we have sockaddr_un.sun_len? */
++/* #undef HAVE_SOCKADDR_UN_LEN */
++
++/* Define to 1 if you have the "socketpair" function */
++#define HAVE_SOCKETPAIR 1
++
++/* true if you have solaris ACLs */
++/* #undef HAVE_SOLARIS_ACLS */
++
++/* True if you have Solaris xattrs */
++/* #undef HAVE_SOLARIS_XATTRS */
++
++/* Define to 1 if you have the <stdint.h> header file. */
++#define HAVE_STDINT_H 1
++
++/* Define to 1 if you have the <stdio.h> header file. */
++#define HAVE_STDIO_H 1
++
++/* Define to 1 if you have the <stdlib.h> header file. */
++#define HAVE_STDLIB_H 1
++
++/* Define to 1 if you have the 'stpcpy' function. */
++#define HAVE_STPCPY 1
++
++/* Define to 1 if you have the 'strcasecmp' function. */
++#define HAVE_STRCASECMP 1
++
++/* Define to 1 if you have the 'strchr' function. */
++#define HAVE_STRCHR 1
++
++/* Define to 1 if you have the 'strerror' function. */
++#define HAVE_STRERROR 1
++
++/* Define to 1 if you have the 'strftime' function. */
++#define HAVE_STRFTIME 1
++
++/* Define to 1 if you have the <strings.h> header file. */
++#define HAVE_STRINGS_H 1
++
++/* Define to 1 if you have the <string.h> header file. */
++#define HAVE_STRING_H 1
++
++/* Define to 1 if you have the 'strlcat' function. */
++#define HAVE_STRLCAT 1
++
++/* Define to 1 if you have the 'strlcpy' function. */
++#define HAVE_STRLCPY 1
++
++/* Define to 1 if you have the 'strpbrk' function. */
++#define HAVE_STRPBRK 1
++
++/* Define to 1 if you have the 'strtol' function. */
++#define HAVE_STRTOL 1
++
++/* Define to 1 if the system has the type 'struct addrinfo'. */
++#define HAVE_STRUCT_ADDRINFO 1
++
++/* Define to 1 if the system has the type 'struct sockaddr_storage'. */
++#define HAVE_STRUCT_SOCKADDR_STORAGE 1
++
++/* Define to 1 if the system has the type 'struct stat64'. */
++/* #undef HAVE_STRUCT_STAT64 */
++
++/* Define to 1 if 'st_mtimensec' is a member of 'struct stat'. */
++/* #undef HAVE_STRUCT_STAT_ST_MTIMENSEC */
++
++/* Define to 1 if 'st_mtimespec.tv_nsec' is a member of 'struct stat'. */
++#define HAVE_STRUCT_STAT_ST_MTIMESPEC_TV_NSEC 1
++
++/* Define to 1 if 'st_mtim.tv_nsec' is a member of 'struct stat'. */
++/* #undef HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC */
++
++/* Define to 1 if 'st_rdev' is a member of 'struct stat'. */
++#define HAVE_STRUCT_STAT_ST_RDEV 1
++
++/* Define to 1 if you have the "struct utimbuf" type */
++#define HAVE_STRUCT_UTIMBUF 1
++
++/* Define to 1 if you have the <sys/acl.h> header file. */
++#define HAVE_SYS_ACL_H 1
++
++/* Define to 1 if you have the <sys/attr.h> header file. */
++#define HAVE_SYS_ATTR_H 1
++
++/* Define to 1 if you have the <sys/dir.h> header file, and it defines 'DIR'.
++   */
++/* #undef HAVE_SYS_DIR_H */
++
++/* Define to 1 if you have the <sys/extattr.h> header file. */
++/* #undef HAVE_SYS_EXTATTR_H */
++
++/* Define to 1 if you have the SYS_fallocate syscall number */
++/* #undef HAVE_SYS_FALLOCATE */
++
++/* Define to 1 if you have the <sys/fcntl.h> header file. */
++#define HAVE_SYS_FCNTL_H 1
++
++/* Define to 1 if you have the <sys/file.h> header file. */
++#define HAVE_SYS_FILE_H 1
++
++/* Define to 1 if you have the <sys/filio.h> header file. */
++#define HAVE_SYS_FILIO_H 1
++
++/* Define to 1 if you have the <sys/ioctl.h> header file. */
++#define HAVE_SYS_IOCTL_H 1
++
++/* Define to 1 if you have the <sys/mode.h> header file. */
++/* #undef HAVE_SYS_MODE_H */
++
++/* Define to 1 if you have the <sys/ndir.h> header file, and it defines 'DIR'.
++   */
++/* #undef HAVE_SYS_NDIR_H */
++
++/* Define to 1 if you have the <sys/param.h> header file. */
++#define HAVE_SYS_PARAM_H 1
++
++/* Define to 1 if you have the <sys/select.h> header file. */
++#define HAVE_SYS_SELECT_H 1
++
++/* Define to 1 if you have the <sys/socket.h> header file. */
++#define HAVE_SYS_SOCKET_H 1
++
++/* Define to 1 if you have the <sys/stat.h> header file. */
++#define HAVE_SYS_STAT_H 1
++
++/* Define to 1 if you have the <sys/time.h> header file. */
++#define HAVE_SYS_TIME_H 1
++
++/* Define to 1 if you have the <sys/types.h> header file. */
++#define HAVE_SYS_TYPES_H 1
++
++/* Define to 1 if you have the <sys/unistd.h> header file. */
++#define HAVE_SYS_UNISTD_H 1
++
++/* Define to 1 if you have the <sys/un.h> header file. */
++#define HAVE_SYS_UN_H 1
++
++/* Define to 1 if you have the <sys/wait.h> header file. */
++#define HAVE_SYS_WAIT_H 1
++
++/* Define to 1 if you have the <sys/xattr.h> header file. */
++#define HAVE_SYS_XATTR_H 1
++
++/* Define to 1 if you have the 'tcgetpgrp' function. */
++#define HAVE_TCGETPGRP 1
++
++/* true if you have Tru64 ACLs */
++/* #undef HAVE_TRU64_ACLS */
++
++/* Define to 1 if you have the <unistd.h> header file. */
++#define HAVE_UNISTD_H 1
++
++/* true if you have UnixWare ACLs */
++/* #undef HAVE_UNIXWARE_ACLS */
++
++/* Define to 1 if you have the 'unsetenv' function. */
++#define HAVE_UNSETENV 1
++
++/* Define to 1 if you have the 'usleep' function. */
++#define HAVE_USLEEP 1
++
++/* Define to 1 if you have the 'utime' function. */
++#define HAVE_UTIME 1
++
++/* Define to 1 if you have the 'utimensat' function. */
++#define HAVE_UTIMENSAT 1
++
++/* Define to 1 if you have the 'utimes' function. */
++#define HAVE_UTIMES 1
++
++/* Define to 1 if you have the <utime.h> header file. */
++#define HAVE_UTIME_H 1
++
++/* Define to 1 if 'utime(file, NULL)' sets file's timestamp to the present. */
++#define HAVE_UTIME_NULL 1
++
++/* Define to 1 if you have the 'vasprintf' function. */
++#define HAVE_VASPRINTF 1
++
++/* Define to 1 if you have the 'va_copy' function. */
++/* #undef HAVE_VA_COPY */
++
++/* Define to 1 if you have the 'vsnprintf' function. */
++#define HAVE_VSNPRINTF 1
++
++/* Define to 1 if you have the 'wait4' function. */
++#define HAVE_WAIT4 1
++
++/* Define to 1 if you have the 'waitpid' function. */
++#define HAVE_WAITPID 1
++
++/* Define to 1 if you have the <xxhash.h> header file. */
++#define HAVE_XXHASH_H 1
++
++/* Define to 1 if you have the <zlib.h> header file. */
++#define HAVE_ZLIB_H 1
++
++/* Define to 1 if you have the <zstd.h> header file. */
++#define HAVE_ZSTD_H 1
++
++/* Define to 1 if you have the '_acl' function. */
++/* #undef HAVE__ACL */
++
++/* Define to 1 if you have the '_facl' function. */
++/* #undef HAVE__FACL */
++
++/* Define to 1 if you have the '__acl' function. */
++/* #undef HAVE___ACL */
++
++/* Define to 1 if you have the '__facl' function. */
++/* #undef HAVE___FACL */
++
++/* Define to 1 if you have the '__va_copy' function. */
++/* #undef HAVE___VA_COPY */
++
++/* Define as const if the declaration of iconv() needs const. */
++#define ICONV_CONST 
++
++/* Define if you want the --iconv option. Specifying a value will set the
++   default iconv setting (a NULL means no --iconv processing by default). */
++#define ICONV_OPTION NULL
++
++/* true if you have IPv6 */
++#define INET6 1
++
++/* Define to 1 if `major', `minor', and `makedev' are declared in <mkdev.h>.
++   */
++/* #undef MAJOR_IN_MKDEV */
++
++/* Define to 1 if `major', `minor', and `makedev' are declared in
++   <sysmacros.h>. */
++/* #undef MAJOR_IN_SYSMACROS */
++
++/* Define to 1 if makedev() takes 3 args */
++/* #undef MAKEDEV_TAKES_3_ARGS */
++
++/* Define to 1 if mknod() can create FIFOs. */
++#define MKNOD_CREATES_FIFOS 1
++
++/* Define to 1 if mknod() can create sockets. */
++/* #undef MKNOD_CREATES_SOCKETS */
++
++/* unprivileged group for unprivileged user */
++#define NOBODY_GROUP "nobody"
++
++/* unprivileged user--e.g. nobody */
++#define NOBODY_USER "nobody"
++
++/* True if device files do not support xattrs */
++#define NO_DEVICE_XATTRS 1
++
++/* True if special files do not support xattrs */
++#define NO_SPECIAL_XATTRS 1
++
++/* True if symlinks do not support user xattrs */
++/* #undef NO_SYMLINK_USER_XATTRS */
++
++/* True if symlinks do not support xattrs */
++/* #undef NO_SYMLINK_XATTRS */
++
++/* package name for rsync */
++#define PACKAGE "rsync"
++
++/* Define to the address where bug reports for this package should be sent. */
++#define PACKAGE_BUGREPORT "https://rsync.samba.org/bug-tracking.html"
++
++/* Define to the full name of this package. */
++#define PACKAGE_NAME "rsync"
++
++/* Define to the full name and version of this package. */
++#define PACKAGE_STRING "rsync"
++
++/* Define to the one symbol short name of this package. */
++#define PACKAGE_TARNAME "rsync"
++
++/* Define to the home page for this package. */
++#define PACKAGE_URL ""
++
++/* Define to the version of this package. */
++#define PACKAGE_VERSION ""
++
++/* sysconfig dir for popt */
++#define POPT_SYSCONFDIR "/etc"
++
++/* location of configuration file for rsync server */
++#define RSYNCD_SYSCONF "/etc/rsyncd.conf"
++
++/* location of rsync on remote machine */
++#define RSYNC_PATH "rsync"
++
++/* default -e command */
++#define RSYNC_RSH "ssh"
++
++/* Define to 1 if --secluded-args should be the default */
++/* #undef RSYNC_USE_SECLUDED_ARGS */
++
++/* Define to 1 if sockets need to be shutdown */
++/* #undef SHUTDOWN_ALL_SOCKETS */
++
++/* Define to 1 if "signed char" is a valid type */
++#define SIGNED_CHAR_OK 1
++
++/* The size of 'char*', as computed by sizeof. */
++#define SIZEOF_CHARP 8
++
++/* The size of 'int', as computed by sizeof. */
++#define SIZEOF_INT 4
++
++/* The size of 'int16_t', as computed by sizeof. */
++#define SIZEOF_INT16_T 2
++
++/* The size of 'int32_t', as computed by sizeof. */
++#define SIZEOF_INT32_T 4
++
++/* The size of 'int64_t', as computed by sizeof. */
++#define SIZEOF_INT64_T 8
++
++/* The size of 'long', as computed by sizeof. */
++#define SIZEOF_LONG 8
++
++/* The size of 'long long', as computed by sizeof. */
++#define SIZEOF_LONG_LONG 8
++
++/* The size of 'off64_t', as computed by sizeof. */
++#define SIZEOF_OFF64_T 0
++
++/* The size of 'off_t', as computed by sizeof. */
++#define SIZEOF_OFF_T 8
++
++/* The size of 'short', as computed by sizeof. */
++#define SIZEOF_SHORT 2
++
++/* The size of 'time_t', as computed by sizeof. */
++#define SIZEOF_TIME_T 8
++
++/* The size of 'uint16_t', as computed by sizeof. */
++#define SIZEOF_UINT16_T 2
++
++/* The size of 'uint32_t', as computed by sizeof. */
++#define SIZEOF_UINT32_T 4
++
++/* If using the C implementation of alloca, define if you know the
++   direction of stack growth for your system; otherwise it will be
++   automatically deduced at runtime.
++	STACK_DIRECTION > 0 => grows toward higher addresses
++	STACK_DIRECTION < 0 => grows toward lower addresses
++	STACK_DIRECTION = 0 => direction of growth unknown */
++/* #undef STACK_DIRECTION */
++
++/* Define to 1 if all of the C89 standard headers exist (not just the ones
++   required in a freestanding environment). This macro is provided for
++   backward compatibility; new code need not use it. */
++#define STDC_HEADERS 1
++
++/* Define to 1 to add support for ACLs */
++#define SUPPORT_ACLS 1
++
++/* Undefine if you do not want LZ4 compression. By default this is defined. */
++#define SUPPORT_LZ4 1
++
++/* Define to 1 to add support for extended attributes */
++#define SUPPORT_XATTRS 1
++
++/* Undefine if you do not want xxhash checksums. By default this is defined.
++   */
++#define SUPPORT_XXHASH 1
++
++/* Undefine if you do not want zstd compression. By default this is defined.
++   */
++#define SUPPORT_ZSTD 1
++
++/* Define to 1 if you want rsync to make use of iconv_open() */
++#define USE_ICONV_OPEN 1
++
++/* Define to 1 to enable MD5 ASM optimizations */
++/* #undef USE_MD5_ASM */
++
++/* Undefine if you do not want to use openssl crypto library. By default this
++   is defined. */
++#ifndef RSYNC_NO_OPENSSL
++#define USE_OPENSSL 1
++#endif
++
++/* Define to 1 to enable rolling-checksum ASM optimizations (requires
++   --enable-roll-simd) */
++/* #undef USE_ROLL_ASM */
++
++/* Define to 1 to enable rolling-checksum SIMD optimizations */
++/* #undef USE_ROLL_SIMD */
++
++/* String to pass to iconv() for the UTF-8 charset. */
++#define UTF8_CHARSET "UTF-8"
++
++/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
++   significant byte first (like Motorola and SPARC, unlike Intel). */
++#if defined AC_APPLE_UNIVERSAL_BUILD
++# if defined __BIG_ENDIAN__
++#  define WORDS_BIGENDIAN 1
++# endif
++#else
++# ifndef WORDS_BIGENDIAN
++/* #  undef WORDS_BIGENDIAN */
++# endif
++#endif
++
++/* Number of bits in a file offset, on hosts where this is settable. */
++/* #undef _FILE_OFFSET_BITS */
++
++/* Define _GNU_SOURCE so that we get all necessary prototypes */
++#define _GNU_SOURCE 1
++
++/* Define to 1 on platforms where this makes off_t a 64-bit type. */
++/* #undef _LARGE_FILES */
++
++/* Number of bits in time_t, on hosts where this is settable. */
++/* #undef _TIME_BITS */
++
++/* Define to 1 on platforms where this makes time_t a 64-bit type. */
++/* #undef __MINGW_USE_VC2005_COMPAT */
++
++/* Define as 'int' if <sys/types.h> doesn't define. */
++/* #undef gid_t */
++
++/* Define to '__inline__' or '__inline' if that's what the C compiler
++   calls it, or to nothing if 'inline' is not supported under any name.  */
++#ifndef __cplusplus
++/* #undef inline */
++#endif
++
++/* Define as 'unsigned int' if <stddef.h> doesn't define. */
++/* #undef size_t */
++
++/* type to use in place of socklen_t if not defined */
++/* #undef socklen_t */
++
++/* Define as 'int' if <sys/types.h> doesn't define. */
++/* #undef uid_t */

--- a/modules/rsync/3.4.2/presubmit.yml
+++ b/modules/rsync/3.4.2/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - macos
+  - macos_arm64
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@rsync'

--- a/modules/rsync/3.4.2/source.json
+++ b/modules/rsync/3.4.2/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/RsyncProject/rsync/releases/download/v3.4.2/rsync-3.4.2.tar.gz",
+    "integrity": "sha256-/xCqLBUc1LLbvmE1Em28hUBGET0t+0lXKjSCMyZ+sxU=",
+    "strip_prefix": "rsync-3.4.2",
+    "patches": {
+        "add_config_h.patch": "sha256-HlyavSyp5G3TmMOsJHCgIDi7zkxhCgMNf927616NJsg=",
+        "add_build_file.patch": "sha256-BV4hLErXNM+EpiNM703u/wk1AYhU29lk9j3FaK+hWG4="
+    },
+    "patch_strip": 1
+}

--- a/modules/rsync/metadata.json
+++ b/modules/rsync/metadata.json
@@ -12,7 +12,8 @@
         "github:RsyncProject/rsync"
     ],
     "versions": [
-        "3.4.1"
+        "3.4.1",
+        "3.4.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Updates `rsync` to 3.4.2, its `openssl` dependency and adds bazel 9 to the matrix.