### PR TITLE
feat(toolchains_musl): add version 0.1.27.bcr.1 with Bazel 9 fix

### DIFF
--- a/modules/toolchains_musl/0.1.27.bcr.1/MODULE.bazel
+++ b/modules/toolchains_musl/0.1.27.bcr.1/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "toolchains_musl",
+    version = "0.1.27.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_features", version = "1.9.0")
+bazel_dep(name = "platforms", version = "0.0.9")
+bazel_dep(name = "rules_cc", version = "0.2.18")
+
+toolchains_musl = use_extension("//:toolchains_musl.bzl", "toolchains_musl")
+use_repo(toolchains_musl, "musl_toolchains_hub")
+
+register_toolchains("@musl_toolchains_hub//:all")

--- a/modules/toolchains_musl/0.1.27.bcr.1/overlay/MODULE.bazel
+++ b/modules/toolchains_musl/0.1.27.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "toolchains_musl",
+    version = "0.1.27.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_features", version = "1.9.0")
+bazel_dep(name = "platforms", version = "0.0.9")
+bazel_dep(name = "rules_cc", version = "0.2.18")
+
+toolchains_musl = use_extension("//:toolchains_musl.bzl", "toolchains_musl")
+use_repo(toolchains_musl, "musl_toolchains_hub")
+
+register_toolchains("@musl_toolchains_hub//:all")

--- a/modules/toolchains_musl/0.1.27.bcr.1/patches/0001-fix-bazel-9-compatibility-67.patch
+++ b/modules/toolchains_musl/0.1.27.bcr.1/patches/0001-fix-bazel-9-compatibility-67.patch
@@ -1,0 +1,108 @@
+diff --git a/patches/0001-fix-bazel-9-compatibility-67.patch b/patches/0001-fix-bazel-9-compatibility-67.patch
+new file mode 100644
+index 0000000..85ab09f
+--- /dev/null
++++ b/patches/0001-fix-bazel-9-compatibility-67.patch
+@@ -0,0 +1,41 @@
++From c5e495c5907f57e8080be8eeb059982a94073442 Mon Sep 17 00:00:00 2001
++From: Mathieu Olivari <molivari@apple.com>
++Date: Sun, 3 May 2026 08:57:43 +0100
++Subject: [PATCH] fix: bazel 9 compatibility (#67)
++
++This fixes an error when the ruleset is used in a bazel 9 project.
++CcToolchainConfigInfo isn't defined in bazel 9 anymore. It must be
++imported from rules_cc.
++---
++ BUILD.bazel                  | 1 +
++ musl_cc_toolchain_config.bzl | 5 +++++
++ 2 files changed, 6 insertions(+)
++
++diff --git BUILD.bazel BUILD.bazel
++index 1fd40c4..22164f3 100644
++--- BUILD.bazel
+++++ BUILD.bazel
++@@ -1,3 +1,4 @@
+++load("@rules_cc//cc:defs.bzl", "cc_toolchain")
++ load("//:musl_cc_toolchain_config.bzl", "musl_cc_test_toolchain", "musl_cc_toolchain_config")
++ 
++ package(default_visibility = ["//visibility:public"])
++diff --git musl_cc_toolchain_config.bzl musl_cc_toolchain_config.bzl
++index 3c3d06c..413076e 100644
++--- musl_cc_toolchain_config.bzl
+++++ musl_cc_toolchain_config.bzl
++@@ -25,6 +25,11 @@ load(
++     "tool_path",
++     "with_feature_set",
++ )
+++load(
+++    "@rules_cc//cc:defs.bzl",
+++    "CcToolchainConfigInfo",
+++    "cc_common",
+++)
++ 
++ _CcTestInfo = provider(
++     doc = "Toolchain implementation for @bazel_tools//tools/cpp:test_runner_toolchain_type",
++-- 
++2.50.1 (Apple Git-155)
++
+diff --git a/repositories.bzl b/repositories.bzl
+index acdc63e..b6dca37 100644
+--- a/repositories.bzl
++++ b/repositories.bzl
+@@ -242,48 +242,56 @@ toolchain_repo = repository_rule(
+ def load_musl_toolchains(extra_exec_compatible_with=[], extra_target_compatible_with=[], target_settings=[]):
+     http_archive(
+         name = "musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl",
++        patches = ["patches/0001-fix-bazel-9-compatibility-67.patch"],
+         sha256 = "51e59d21ea780c830c0e2a38a3a4278126bbd9ea6fbbaac421861c631ab3f122",
+         url = "https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz",
+     )
+ 
+     http_archive(
+         name = "musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl",
++        patches = ["patches/0001-fix-bazel-9-compatibility-67.patch"],
+         sha256 = "c052e4b05653cf6f378c55bf600ddb02fa84f43a9bc4faba6764e870fa708627",
+         url = "https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz",
+     )
+ 
+     http_archive(
+         name = "musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl",
++        patches = ["patches/0001-fix-bazel-9-compatibility-67.patch"],
+         sha256 = "748575629934f5c75091baffb2b93fa2a18bab0d9dc61c364936d209c464bc29",
+         url = "https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz",
+     )
+ 
+     http_archive(
+         name = "musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl",
++        patches = ["patches/0001-fix-bazel-9-compatibility-67.patch"],
+         sha256 = "46d2384102425c99c1a7b03119055a39eb3e9743ac667a8c9617f503040901e9",
+         url = "https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz",
+     )
+ 
+     http_archive(
+         name = "musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl",
++        patches = ["patches/0001-fix-bazel-9-compatibility-67.patch"],
+         sha256 = "709df48b5830d8426f4a74d5a6dad46d84f30345c17bb37d504d101509a66104",
+         url = "https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz",
+     )
+ 
+     http_archive(
+         name = "musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl",
++        patches = ["patches/0001-fix-bazel-9-compatibility-67.patch"],
+         sha256 = "9a9d2d9af7e34e9740cd45249df1bdced19b003305ee4e7ed9f3eca96de68a0a",
+         url = "https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz",
+     )
+ 
+     http_archive(
+         name = "musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl",
++        patches = ["patches/0001-fix-bazel-9-compatibility-67.patch"],
+         sha256 = "99d444759a52764b118359a2f97abcd1a98b7fd74afd068f6c9d7b6d7a4240ea",
+         url = "https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz",
+     )
+ 
+     http_archive(
+         name = "musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl",
++        patches = ["patches/0001-fix-bazel-9-compatibility-67.patch"],
+         sha256 = "158300e91e672607b9521d80d653afb63e364d909d50f979d20ded684bb83e57",
+         url = "https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz",
+     )

--- a/modules/toolchains_musl/0.1.27.bcr.1/presubmit.yml
+++ b/modules/toolchains_musl/0.1.27.bcr.1/presubmit.yml
@@ -1,0 +1,27 @@
+bcr_test_module:
+  module_path: "bcr_test"
+  matrix:
+    platform:
+      - "debian10"
+      - "macos"
+      - "macos_arm64"
+      - "rockylinux8"
+      - "rockylinux8_arm64"
+      - "ubuntu2004"
+      - "ubuntu2404"
+    bazel: [ 7.*, 8.*, 9.* ]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."
+      build_flags:
+        # Required by sh_test with Bazel 7 and earlier
+        - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0"
+      test_targets:
+        - "//..."
+      test_flags:
+        # Required by sh_test with Bazel 7 and earlier
+        - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0"

--- a/modules/toolchains_musl/0.1.27.bcr.1/source.json
+++ b/modules/toolchains_musl/0.1.27.bcr.1/source.json
@@ -1,0 +1,11 @@
+{
+    "integrity": "sha256-WB0oD+m3+iU30ANZgHRih1pRU9Z9Kvo4ilh/KUOr7G0=",
+    "overlay": {
+        "MODULE.bazel": "sha256-xdH164cwX+/skBRMi1Z3yRej5cIS4EX9kX4WN+Wd854="
+    },
+    "patches": {
+        "0001-fix-bazel-9-compatibility-67.patch": "sha256-Q0QghMJamGm5f9A1s8otXE6EvCZw1HI1CsbST5HXrVQ="
+    },
+    "patch_strip": 1,
+    "url": "https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl_toolchain-v0.1.27.tar.gz"
+}

--- a/modules/toolchains_musl/metadata.json
+++ b/modules/toolchains_musl/metadata.json
@@ -4,14 +4,14 @@
         {
             "email": "dawagner@gmail.com",
             "github": "illicitonion",
-            "name": "Daniel Wagner-Hall",
-            "github_user_id": 1131704
+            "github_user_id": 1131704,
+            "name": "Daniel Wagner-Hall"
         },
         {
             "email": "fabian@meumertzhe.im",
             "github": "fmeum",
-            "name": "Fabian Meumertzheim",
-            "github_user_id": 4312191
+            "github_user_id": 4312191,
+            "name": "Fabian Meumertzheim"
         }
     ],
     "repository": [
@@ -27,7 +27,8 @@
         "0.1.20",
         "0.1.25",
         "0.1.26",
-        "0.1.27"
+        "0.1.27",
+        "0.1.27.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Add new BCR version 0.1.27.bcr.1 of toolchains_musl that includes a patch to fix Bazel 9 compatibility. The patch addresses an issue where CcToolchainConfigInfo must be imported from rules_cc in Bazel 9.

The patch has been merged into the upstream repo, but there are difficulties in releasing it. So we're applying it to the BCR in the meantime.