### PR TITLE
Remove compatibility_level from add_module prompts

### DIFF
--- a/tools/add_module.py
+++ b/tools/add_module.py
@@ -25,7 +25,6 @@ What this script can do:
   - Generate MODULE.bazel file with given module information
     - module name
     - version
-    - compatibility level
     - dependencies
   - Generate the source.json file with given source information
     - The archive url
@@ -79,8 +78,7 @@ def ask_input(msg):
 def from_user_input():
     name = ask_input("Please enter the module name: ")
     version = ask_input("Please enter the module version: ")
-    compatibility = ask_input("Please enter the compatibility level [default is 0]: ") or "0"
-    module = Module(name, version, compatibility)
+    module = Module(name, version)
 
     url = ask_input("Please enter the URL of the source archive: ")
     strip_prefix = ask_input("Please enter the strip_prefix value of the archive [default None]: ") or None

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -173,10 +173,10 @@ class Version:
 class Module:
     """A class to represent all information of a Bazel module."""
 
-    def __init__(self, name=None, version=None, compatibility_level=1):
+    def __init__(self, name=None, version=None):
         self.name = name
         self.version = version
-        self.compatibility_level = compatibility_level
+        self.compatibility_level = None
         self.module_dot_bazel = None
         self.url = None
         self.strip_prefix = None
@@ -251,14 +251,6 @@ class RegistryException(Exception):
 
 class RegistryClient:
     """A class to help create a Bazel registry."""
-
-    _MODULE_BAZEL = """
-module(
-    name = "{0}",
-    version = "{1}",
-    compatibility_level = {2},
-)
-""".strip()
 
     def __init__(self, root):
         self.root = pathlib.Path(root)
@@ -387,13 +379,17 @@ module(
             #   - no override is used
             shutil.copy(module.module_dot_bazel, module_dot_bazel)
         else:
-            deps = "\n".join(f'bazel_dep(name = "{name}", version = "{version}")' for name, version in module.deps)
             with module_dot_bazel.open("w") as f:
-                f.write(self._MODULE_BAZEL.format(module.name, module.version, module.compatibility_level))
-                if deps:
+                f.write("module(\n")
+                f.write(f'    name = "{module.name}",\n')
+                f.write(f'    version = "{module.version}",\n')
+                if module.compatibility_level is not None:
+                    f.write(f"    compatibility_level = {module.compatibility_level},\n")
+                f.write(")\n")
+                if module.deps:
                     f.write("\n")
-                    f.write(deps)
-                f.write("\n")
+                    for name, version in module.deps:
+                        f.write(f'bazel_dep(name = "{name}", version = "{version}")\n')
 
         # Create source.json & copy patch files to the registry
         source = {


### PR DESCRIPTION
New modules should not specify a compatibility level; it is deprecated in current versions of Bazel.

Closes #1856.