### PR TITLE
Remove the registry's own compatibility_level

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,6 @@
 module(
     name = "bazel_central_registry",
     version = "0.0.0",
-    compatibility_level = 1,
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")


### PR DESCRIPTION
It is deprecated (with a warning) in current versions of Bazel: `WARNING: .../bazel-central-registry/MODULE.bazel:1:7: The attribute 'compatibility_level' in module() is a no-op and will be removed in a future Bazel release. Please remove it from your MODULE.bazel file.`

Amends #8550 FYI @Vertexwahn.