### PR TITLE
Disallow git_repository; all modules must use http_archive

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ The BCR follows the format of a regular [Bazel registry](https://bazel.build/ext
     - If the string has the format of `github:<org>/<repo>`, then source URLs from `https://github.com/<org>/<repo>` are allowed (see the [validations](#validations) section below).
     - If the string has the format of a regular URL (such as `https://foo.com/bar`), then source URLs beginning with the string are allowed. The string can optionally end in a slash (`/`), with no difference in the semantics (for example, `https://foo.com/bar/thing.zip` would be accepted, but `https://foo.com/barthing.zip` would not).
   - `deprecated`: a string. When set, this denotes that the module should not be used. Must be set if the module's latest version is [yanked](#yank-a-module-version).
-- The `source.json` file must be of the `type` `archive` (which is the default) or `git_repository`. Other types such as `local_path` are not allowed.
+- The `source.json` file must be of the `type` `archive` (which is the default). Other types such as `git_repository` or `local_path` are not allowed.
 - A presubmit.yml file. See [Presubmit](#presubmit) below.
 
 ## Contribute a Bazel module

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -135,16 +135,6 @@ def apply_patch(work_dir, patch_strip, patch_file):
     )
 
 
-def run_git(*args):
-    # Requires git to be installed
-    subprocess.run(
-        ["git", *args],
-        shell=False,
-        check=True,
-        env=os.environ,
-    )
-
-
 def fix_line_endings(lines):
     return [line.rstrip() + "\n" for line in lines]
 
@@ -317,23 +307,10 @@ class BcrValidator:
     def verify_source_archive_url_match_github_repo(self, module_name, version):
         """Verify the source archive URL matches the github repo. For now, we only support github repositories check."""
         source = self.registry.get_source(module_name, version)
-        if source.get("type", None) == "git_repository":
-            source_url = source["remote"]
-            # Preprocess the git URL to make the comparison easier.
-            if source_url.startswith("git@"):
-                source_url = source_url.removeprefix("git@")
-                source_netloc, source_parts = source_url.split(":")
-                source_url = "https://" + source_netloc + "/" + source_parts
-            if source_url.endswith(".git"):
-                source_url = source_url.removesuffix(".git")
-            # Make the commit look like a GitHub archive to unify the
-            # rest of this check. For non-GitHub repositories, the extra
-            # trailing parts are ignored.
-            commit = source["commit"]
-            source_url = source_url.rstrip("/")
-            source_url = f"{source_url}/archive/{commit}.zip"
-        else:
-            source_url = source["url"]
+        if source.get("type", "archive") != "archive":
+            raise BcrValidationException('Module source "type" must be "archive" (the default)')
+
+        source_url = source["url"]
         source_repositories = self.registry.get_metadata(module_name).get("repository", [])
         matched = not source_repositories
         for source_repository in source_repositories:
@@ -369,8 +346,6 @@ class BcrValidator:
 
     def verify_source_archive_url_stability(self, module_name, version):
         """Verify source archive URL is stable"""
-        if self.registry.get_source(module_name, version).get("type", None) == "git_repository":
-            return
         source_url = self.registry.get_source(module_name, version)["url"]
         if verify_stable_archive(source_url) == UrlStability.UNSTABLE:
             self.report(
@@ -390,9 +365,6 @@ class BcrValidator:
     def verify_source_archive_url_integrity(self, module_name, version):
         """Verify the integrity value of the URL and mirror URLs is correct."""
         source = self.registry.get_source(module_name, version)
-        if source.get("type", None) == "git_repository":
-            return
-
         expected_integrity = source["integrity"]
         urls_to_check = [(source["url"], "main source archive URL")]
 
@@ -423,45 +395,6 @@ class BcrValidator:
                 BcrValidationResult.GOOD,
                 "The source archive's integrity value matches all provided URLs.",
             )
-
-    def verify_git_repo_source_stability(self, module_name, version):
-        """Verify git repositories are specified in a stable way."""
-        if self.registry.get_source(module_name, version).get("type", None) != "git_repository":
-            return
-
-        # There's a handful of failure modes here, don't fail fast.
-        error_encountered = False
-        if self.registry.get_source(module_name, version).get("branch", None):
-            self.report(
-                BcrValidationResult.FAILED,
-                f"{module_name}@{version}'s source is a git_repository that is trying to track "
-                "a branch. Please use a specific commit instead, as branches are not stable sources.",
-            )
-            error_encountered = True
-        if self.registry.get_source(module_name, version).get("tag", None):
-            self.report(
-                BcrValidationResult.FAILED,
-                f"{module_name}@{version}'s source is a git_repository that is trying to track "
-                "a tag. Please use a specific commit instead, as tags are not stable sources.",
-            )
-            error_encountered = True
-        commit = self.registry.get_source(module_name, version)["commit"]
-        try:
-            commit_hash_bytes = bytes.fromhex(commit)
-            if len(commit_hash_bytes) != 20:
-                self.report(
-                    BcrValidationResult.FAILED,
-                    f"{module_name}@{version}'s git_repository commit hash is an unexpected length.",
-                )
-        except ValueError:
-            self.report(
-                BcrValidationResult.FAILED,
-                f"{module_name}@{version}'s source is a git_repository with an invalid commit hash format.",
-            )
-            error_encountered = True
-
-        if not error_encountered:
-            self.report(BcrValidationResult.GOOD, "The git_repository appears stable.")
 
     def verify_presubmit_yml_change(self, module_name, version):
         """Verify if the presubmit.yml is similar enough to the previous version."""
@@ -571,11 +504,6 @@ class BcrValidator:
             # Fallback for older Python versions. Since CI is 3.12+, this handles local dev compatibility.
             shutil.unpack_archive(str(archive_file), output_dir, format=format)
 
-    def _download_git_repo(self, source, output_dir):
-        run_git("clone", "--depth=1", source["remote"], output_dir)
-        run_git("-C", output_dir, "fetch", "--depth=1", "origin", source["commit"])
-        run_git("-C", output_dir, "checkout", source["commit"])
-
     @staticmethod
     def extract_attribute_from_module(module_dot_bazel_file, attribute, default=None):
         """Extract the value of the given attribute from `module()` call in the MODULE.bazel file content"""
@@ -598,15 +526,12 @@ class BcrValidator:
 
     def verify_module_dot_bazel(self, module_name, version, check_compatibility_level=True):
         source = self.registry.get_source(module_name, version)
+        if source.get("type", "archive") != "archive":
+            raise BcrValidationException('Module source "type" must be "archive" (the default)')
+
         tmp_dir = Path(tempfile.mkdtemp())
         output_dir = tmp_dir.joinpath("source_root")
-        source_type = source.get("type", "archive")
-        if source_type == "archive":
-            self._download_source_archive(source, output_dir)
-        elif source_type == "git_repository":
-            self._download_git_repo(source, output_dir)
-        else:
-            raise BcrValidationException("Unsupported repository type")
+        self._download_source_archive(source, output_dir)
 
         module_file = self.registry.get_module_dot_bazel_path(module_name, version)
         if module_file.is_symlink():
@@ -829,7 +754,6 @@ class BcrValidator:
     def validate_module(self, module_name, version, skipped_validations):
         print_expanded_group(f"Validating {module_name}@{version}")
         self.verify_module_existence(module_name, version)
-        self.verify_git_repo_source_stability(module_name, version)
         if "source_repo" not in skipped_validations:
             self.verify_source_archive_url_match_github_repo(module_name, version)
         if "url_stability" not in skipped_validations:

--- a/tools/bzlmod_migration_test_examples/py_extension/WORKSPACE
+++ b/tools/bzlmod_migration_test_examples/py_extension/WORKSPACE
@@ -1,7 +1,6 @@
 workspace(name="py_extension")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository") 
 
 
 # Python rule


### PR DESCRIPTION
To support a reliable ecosystem of mirrors, BCR will only accept http_archive modules from now on.

See https://github.com/bazelbuild/bazel/issues/23461#issuecomment-4230015227 for prior discussion / explanation.

Closes bazelbuild/bazel#23461.