### PR TITLE
Add re2 2025-11-05.bcr.2

### DIFF
--- a/modules/re2/2025-11-05.bcr.2/MODULE.bazel
+++ b/modules/re2/2025-11-05.bcr.2/MODULE.bazel
@@ -1,0 +1,29 @@
+# Copyright 2009 The RE2 Authors.  All Rights Reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Bazel (http://bazel.build/) MODULE file for RE2.
+
+module(
+    name = "re2",
+    version = "2025-11-05.bcr.2",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "apple_support", version = "1.23.1")
+bazel_dep(name = "rules_cc", version = "0.1.4")
+bazel_dep(name = "abseil-cpp", version = "20250512.1")
+bazel_dep(name = "rules_python", version = "1.5.1")
+bazel_dep(name = "pybind11_bazel", version = "2.13.6")
+
+# This is a temporary hack for `x64_x86_windows`.
+# TODO(junyer): Remove whenever no longer needed.
+cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension", dev_dependency = True)
+use_repo(cc_configure, "local_config_cc")
+
+# These dependencies will be ignored when the `re2` module is not
+# the root module (or when `--ignore_dev_dependency` is enabled).
+bazel_dep(name = "google_benchmark", version = "1.9.4", dev_dependency = True)
+bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)
+bazel_dep(name = "abseil-py", version = "2.1.0", dev_dependency = True)

--- a/modules/re2/2025-11-05.bcr.2/patches/module_version.patch
+++ b/modules/re2/2025-11-05.bcr.2/patches/module_version.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -6,7 +6,7 @@
+ 
+ module(
+     name = "re2",
+-    version = "2025-11-05",
++    version = "2025-11-05.bcr.2",
+     compatibility_level = 1,
+ )

--- a/modules/re2/2025-11-05.bcr.2/presubmit.yml
+++ b/modules/re2/2025-11-05.bcr.2/presubmit.yml
@@ -1,0 +1,58 @@
+matrix:
+  platform:
+  - rockylinux8
+  - debian10
+  - ubuntu2004
+  - macos
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.*
+
+tasks:
+  unix_build:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    build_targets:
+    - '@re2//:re2'
+    - '@re2//python:re2'
+  windows_build:
+    platform: windows
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=/std:c++17'
+    build_targets:
+    - '@re2//:re2'
+    - '@re2//python:re2'
+
+bcr_test_module:
+  module_path: '.'
+  matrix:
+    platform:
+    - rockylinux8
+    - debian10
+    - ubuntu2004
+    - macos
+    - windows
+    bazel:
+    - 7.x
+    - 8.x
+  tasks:
+    unix_test:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_flags:
+      - '--cxxopt=-std=c++17'
+      test_targets:
+      - '//:small_tests'
+      - '//python:all'
+    windows_test:
+      platform: windows
+      bazel: ${{ bazel }}
+      test_flags:
+      - '--cxxopt=/std:c++17'
+      test_targets:
+      - '//:small_tests'
+      - '//python:all'

--- a/modules/re2/2025-11-05.bcr.2/source.json
+++ b/modules/re2/2025-11-05.bcr.2/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-x7Gnp8aNLXz400PcVmVcG1qMiq3twBfbRT1MHYkTuEQ=",
+    "strip_prefix": "re2-2025-11-05",
+    "url": "https://github.com/google/re2/releases/download/2025-11-05/re2-2025-11-05.zip",
+    "patch_strip": 0,
+    "patches": {
+        "module_version.patch": "sha256-NbA644hChhzfTARpfcA0xd54LmzxZ9r7A67epf7SRU4="
+    }
+}

--- a/modules/re2/metadata.json
+++ b/modules/re2/metadata.json
@@ -29,7 +29,8 @@
         "2025-08-12",
         "2025-08-12.bcr.1",
         "2025-11-05",
-        "2025-11-05.bcr.1"
+        "2025-11-05.bcr.1",
+        "2025-11-05.bcr.2"
     ],
     "yanked_versions": {
         "2023-06-02": "bad compatibility_level, upgrade to 2023-09-01 or newer",


### PR DESCRIPTION
Minimal BCR entry for re2 2025-11-05.bcr.2 using the existing official 2025-11-05 source archive. This PR is intended to validate registry metadata and will be closed after CI observation if it is not needed.