### PR TITLE
pthreadpool@0.0.0-20260119-9003ee6

### DIFF
--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/MODULE.bazel
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/MODULE.bazel
@@ -1,0 +1,38 @@
+module(
+    name = "pthreadpool",
+    version = "0.0.0-20260119-9003ee6",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "cpuinfo",
+    version = "0.0.0-20260312-7607ca5",
+)
+bazel_dep(
+    name = "fxdiv",
+    version = "0.0.0-20201209-63058ef",
+    repo_name = "FXdiv",
+)
+bazel_dep(
+    name = "google_benchmark",
+    version = "1.9.5",
+    repo_name = "com_google_benchmark",
+)
+bazel_dep(
+    name = "googletest",
+    version = "1.17.0.bcr.2",
+    repo_name = "com_google_googletest",
+)
+bazel_dep(
+    name = "rules_cc",
+    version = "0.2.17",
+)
+bazel_dep(
+    name = "rules_license",
+    version = "1.0.0",
+)
+bazel_dep(
+    name = "platforms",
+    version = "1.0.0",
+)

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/overlay/tests/BUILD.bazel
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/overlay/tests/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "pthreadpool_smoke",
+    srcs = ["pthreadpool_smoke.cc"],
+    deps = ["@pthreadpool//:pthreadpool"],
+)

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/overlay/tests/MODULE.bazel
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/overlay/tests/MODULE.bazel
@@ -1,0 +1,7 @@
+bazel_dep(name = "pthreadpool")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+
+local_path_override(
+    module_name = "pthreadpool",
+    path = "..",
+)

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/overlay/tests/pthreadpool_smoke.cc
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/overlay/tests/pthreadpool_smoke.cc
@@ -1,0 +1,10 @@
+#include <pthreadpool.h>
+
+int main() {
+  pthreadpool_t pool = pthreadpool_create(1);
+  if (pool == nullptr) {
+    return 1;
+  }
+  pthreadpool_destroy(pool);
+  return 0;
+}

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/patches/module_dot_bazel.patch
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/patches/module_dot_bazel.patch
@@ -1,0 +1,104 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,72 +1,38 @@
+-## MODULE.bazel
+ module(
+     name = "pthreadpool",
++    version = "0.0.0-20260119-9003ee6",
++    bazel_compatibility = [">=7.2.1"],
++    compatibility_level = 1,
+ )
+ 
+-# Bazel rule definitions
+-bazel_dep(name = "rules_cc", version = "0.1.1")
+-bazel_dep(name = "rules_python", version = "1.0.0")
+-
+-pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+-pip.parse(
+-    hub_name = "pip",
+-    python_version = "3.11",
+-    requirements_lock = "//:requirements_lock.txt",
++bazel_dep(
++    name = "cpuinfo",
++    version = "0.0.0-20260312-7607ca5",
+ )
+-use_repo(pip, "pip")
+-
+-# Bazel Skylib.
+-bazel_dep(name = "bazel_skylib", version = "1.7.1")
+-
+-# Bazel Platforms
+-bazel_dep(name = "platforms", version = "0.0.10")
+-
+-# TODO: some (most? all?) of the http_archive() calls below could become bazel_dep() calls,
+-# but it would require verifying that the semver provided by the Bazel registry matches the hash
+-# that we expect in CMake; it's not clear that it is a big win to do so given the modest
+-# complexity of our deps, so I'm leaving it like this for now to ensure that the Bazel and CMake
+-# builds are using identical dependencies.
+-
+-http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+-
+-# LINT.IfChange(googletest)
+-# Google Test framework, used by most unit-tests.
+-http_archive(
+-    name = "com_google_googletest",
+-    sha256 = "ce7366fe57eb49928311189cb0e40e0a8bf3d3682fca89af30d884c25e983786",
+-    strip_prefix = "googletest-release-1.12.0",
+-    urls = ["https://github.com/google/googletest/archive/release-1.12.0.zip"],
++bazel_dep(
++    name = "fxdiv",
++    version = "0.0.0-20201209-63058ef",
++    repo_name = "FXdiv",
+ )
+-# LINT.ThenChange(cmake/DownloadGoogleTest.cmake,WORKSPACE:googletest)
+-
+-# LINT.IfChange(benchmark)
+-# Google Benchmark library, used in micro-benchmarks.
+-http_archive(
+-    name = "com_google_benchmark",
+-    sha256 = "28c7cac12cc25d87d3dcc8cbdefa4b03c32d1a27bd50e37ca466d8127c1688d834800c38f3c587a396188ee5fb7d1bd0971b41a599a5c4787f8742cb39ca47db",
+-    strip_prefix = "benchmark-1.5.3",
+-    urls = ["https://github.com/google/benchmark/archive/v1.5.3.zip"],
++bazel_dep(
++    name = "google_benchmark",
++    version = "1.9.5",
++    repo_name = "com_google_benchmark",
+ )
+-# LINT.ThenChange(cmake/DownloadGoogleBenchmark.cmake,WORKSPACE:benchmark)
+-
+-# LINT.IfChange
+-# FXdiv library, used for repeated integer division by the same factor
+-http_archive(
+-    name = "FXdiv",
+-    sha256 = "ab7dfb08829bee33dca38405d647868fb214ac685e379ec7ef2bebcd234cd44d",
+-    strip_prefix = "FXdiv-b408327ac2a15ec3e43352421954f5b1967701d1",
+-    urls = ["https://github.com/Maratyszcza/FXdiv/archive/b408327ac2a15ec3e43352421954f5b1967701d1.zip"],
++bazel_dep(
++    name = "googletest",
++    version = "1.17.0.bcr.2",
++    repo_name = "com_google_googletest",
+ )
+-# LINT.ThenChange(cmake/DownloadFXdiv.cmake)
+-
+-# LINT.IfChange
+-# cpuinfo library, used for detecting processor characteristics
+-http_archive(
+-    name = "cpuinfo",
+-    sha256 = "52e0ffd7998d8cb3a927d8a6e1145763744d866d2be09c4eccea27fc157b6bb0",
+-    strip_prefix = "cpuinfo-cebb0933058d7f181c979afd50601dc311e1bf8c",
+-    urls = [
+-        "https://github.com/pytorch/cpuinfo/archive/cebb0933058d7f181c979afd50601dc311e1bf8c.zip",
+-    ],
++bazel_dep(
++    name = "rules_cc",
++    version = "0.2.17",
+ )
+-# LINT.ThenChange(cmake/DownloadCpuinfo.cmake)
++bazel_dep(
++    name = "rules_license",
++    version = "1.0.0",
++)
++bazel_dep(
++    name = "platforms",
++    version = "1.0.0",
++)

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/patches/pthreadpool.patch
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/patches/pthreadpool.patch
@@ -1,8 +1,29 @@
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 0033f4d..0e9a7ef 100644
+index 0033f4d..5a306f7 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
-@@ -59,12 +59,18 @@ cc_library(
+@@ -10,9 +10,20 @@
+ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
++load("@rules_license//rules:license.bzl", "license")
++
++package(
++    default_applicable_licenses = [":license"],
++)
+
+ licenses(["notice"])
+
+ exports_files(["LICENSE"])
+
++license(
++    name = "license",
++    license_kinds = ["@rules_license//licenses/spdx:BSD-2-Clause"],
++    license_text = "LICENSE",
++)
++
+ ############################## pthreadpool library #############################
+
+ INTERNAL_HDRS = [
+@@ -59,12 +70,18 @@ cc_library(
      hdrs = [
          "include/pthreadpool.h",
      ],
@@ -24,7 +45,7 @@ index 0033f4d..0e9a7ef 100644
      defines = select({
          ":linux_arm": ["PTHREADPOOL_USE_CPUINFO=1"],
          ":linux_armeabi": ["PTHREADPOOL_USE_CPUINFO=1"],
-@@ -108,6 +114,12 @@ cc_library(
+@@ -108,6 +125,12 @@ cc_library(
              "-s ALLOW_BLOCKING_ON_MAIN_THREAD=1",
              "-s PTHREAD_POOL_SIZE=8",
          ],
@@ -37,7 +58,7 @@ index 0033f4d..0e9a7ef 100644
          "//conditions:default": [],
      }),
      strip_include_prefix = "include",
-@@ -223,6 +235,18 @@ config_setting(
+@@ -223,6 +246,18 @@ config_setting(
      },
  )
  

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/patches/pthreadpool.patch
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/patches/pthreadpool.patch
@@ -1,5 +1,5 @@
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 0033f4d..5a306f7 100644
+index 0033f4d..f07bac3 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -10,9 +10,20 @@
@@ -58,7 +58,7 @@ index 0033f4d..5a306f7 100644
          "//conditions:default": [],
      }),
      strip_include_prefix = "include",
-@@ -223,6 +246,18 @@ config_setting(
+@@ -223,66 +246,94 @@ config_setting(
      },
  )
  
@@ -76,4 +76,276 @@ index 0033f4d..5a306f7 100644
 +
  config_setting(
      name = "linux_x86_64",
-     values = {"cpu": "k8"},
+-    values = {"cpu": "k8"},
++    constraint_values = [
++        "@platforms//cpu:x86_64",
++        "@platforms//os:linux",
++    ],
+ )
+
+ config_setting(
+     name = "linux_arm",
+-    values = {"cpu": "arm"},
++    constraint_values = [
++        "@platforms//cpu:arm",
++        "@platforms//os:linux",
++    ],
+ )
+
+-config_setting(
++alias(
+     name = "linux_armeabi",
+-    values = {"cpu": "armeabi"},
++    actual = ":linux_arm",
+ )
+
+-config_setting(
++alias(
+     name = "linux_armhf",
+-    values = {"cpu": "armhf"},
++    actual = ":linux_arm",
+ )
+
+ config_setting(
+     name = "linux_armv7a",
+-    values = {"cpu": "armv7a"},
++    constraint_values = [
++        "@platforms//cpu:armv7",
++        "@platforms//os:linux",
++    ],
+ )
+
+ config_setting(
+     name = "linux_aarch64",
+-    values = {"cpu": "aarch64"},
++    constraint_values = [
++        "@platforms//os:linux",
++        "@platforms//cpu:aarch64",
++    ],
+ )
+
+ config_setting(
+     name = "android_x86",
+-    values = {
+-        "crosstool_top": "//external:android/crosstool",
+-        "cpu": "x86",
+-    },
++    constraint_values = [
++        "@platforms//os:android",
++        "@platforms//cpu:x86_32",
++    ],
++    visibility = ["//visibility:public"],
+ )
+
+ config_setting(
+     name = "android_x86_64",
+-    values = {
+-        "crosstool_top": "//external:android/crosstool",
+-        "cpu": "x86_64",
+-    },
++    constraint_values = [
++        "@platforms//os:android",
++        "@platforms//cpu:x86_64",
++    ],
++    visibility = ["//visibility:public"],
+ )
+
+ config_setting(
+     name = "android_armv7",
+-    values = {
+-        "crosstool_top": "//external:android/crosstool",
+-        "cpu": "armeabi-v7a",
+-    },
++    constraint_values = [
++        "@platforms//os:android",
++        "@platforms//cpu:armv7",
++    ],
++    visibility = ["//visibility:public"],
+ )
+
+ config_setting(
+     name = "android_arm64",
+-    values = {
+-        "crosstool_top": "//external:android/crosstool",
+-        "cpu": "arm64-v8a",
+-    },
++    constraint_values = [
++        "@platforms//os:android",
++        "@platforms//cpu:arm64",
++    ],
++    visibility = ["//visibility:public"],
+ )
+
+ # Note: we need to individually match x86 and x86-64 macOS rather than use
+@@ -290,114 +341,118 @@ config_setting(
+ # "macos" even when building on Linux!
+ config_setting(
+     name = "macos_x86",
+-    values = {
+-        "apple_platform_type": "macos",
+-        "cpu": "darwin",
+-    },
++    constraint_values = [
++        "@platforms//os:macos",
++        "@platforms//cpu:x86_32",
++    ],
+ )
+
+ config_setting(
+     name = "macos_x86_64",
+-    values = {
+-        "apple_platform_type": "macos",
+-        "cpu": "darwin_x86_64",
+-    },
++    constraint_values = [
++        "@platforms//os:macos",
++        "@platforms//cpu:x86_64",
++    ],
+ )
+
+ config_setting(
+     name = "macos_arm64",
+-    values = {
+-        "apple_platform_type": "macos",
+-        "cpu": "darwin_arm64",
+-    },
++    constraint_values = [
++        "@platforms//cpu:arm64",
++        "@platforms//os:macos",
++    ],
+ )
+
+ config_setting(
+     name = "ios",
+-    values = {
+-        "apple_platform_type": "ios",
+-    },
++    constraint_values = [
++        "@platforms//os:ios",
++    ],
+ )
+
+ config_setting(
+     name = "ios_x86",
+-    values = {
+-        "apple_platform_type": "ios",
+-        "cpu": "ios_i386",
+-    },
++    constraint_values = [
++        "@platforms//cpu:x86_32",
++        "@platforms//os:ios",
++    ],
+ )
+
+ config_setting(
+     name = "ios_x86_64",
+-    values = {
+-        "apple_platform_type": "ios",
+-        "cpu": "ios_x86_64",
+-    },
++    constraint_values = [
++        "@platforms//cpu:x86_64",
++        "@platforms//os:ios",
++    ],
+ )
+
+ config_setting(
+     name = "watchos",
+-    values = {
+-        "apple_platform_type": "watchos",
+-    },
++    constraint_values = [
++        "@platforms//os:watchos",
++    ],
+ )
+
+ config_setting(
+     name = "watchos_x86",
+-    values = {
+-        "apple_platform_type": "watchos",
+-        "cpu": "watchos_i386",
+-    },
++    constraint_values = [
++        "@platforms//os:watchos",
++        "@platforms//cpu:x86_32",
++    ],
+ )
+
+ config_setting(
+     name = "watchos_x86_64",
+-    values = {
+-        "apple_platform_type": "watchos",
+-        "cpu": "watchos_x86_64",
+-    },
++    constraint_values = [
++        "@platforms//os:watchos",
++        "@platforms//cpu:x86_64",
++    ],
+ )
+
+ config_setting(
+     name = "tvos",
+-    values = {
+-        "apple_platform_type": "tvos",
+-    },
++    constraint_values = [
++        "@platforms//os:tvos",
++    ],
+ )
+
+ config_setting(
+     name = "tvos_x86_64",
+-    values = {
+-        "apple_platform_type": "tvos",
+-        "cpu": "tvos_x86_64",
+-    },
++    constraint_values = [
++        "@platforms//cpu:x86_64",
++        "@platforms//os:tvos",
++    ],
+ )
+
+ config_setting(
+     name = "windows_x86_64",
+-    values = {
+-        "cpu": "x64_windows",
+-    },
++    constraint_values = [
++        "@platforms//os:windows",
++        "@platforms//cpu:x86_64",
++    ],
+ )
+
+ config_setting(
+     name = "windows_arm64",
+-    values = {
+-        "cpu": "arm64_windows",
+-    },
++    constraint_values = [
++        "@platforms//os:windows",
++        "@platforms//cpu:arm64",
++    ],
+ )
+
+ config_setting(
+     name = "emscripten",
+-    values = {
+-        "crosstool_top": "//toolchain:emscripten",
+-    },
++    constraint_values = [
++        "@platforms//os:emscripten",
++    ],
+ )
+
+ config_setting(
+     name = "emscripten_with_threads",
++    constraint_values = [
++        "@platforms//os:emscripten",
++    ],
+     values = {
+-        "crosstool_top": "//toolchain:emscripten",
+-        "copt": "-pthread",
++        "features": "use_pthreads",
+     },
+-)
++)

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/patches/pthreadpool.patch
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/patches/pthreadpool.patch
@@ -1,0 +1,45 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 0033f4d..896c368 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -59,12 +59,18 @@ cc_library(
+     hdrs = [
+         "include/pthreadpool.h",
+     ],
+-    copts = [
+-        "-std=c11",
+-    ] + select({
++    copts = select({
+         ":optimized_build": ["-O2"],
+         "//conditions:default": [],
+     }),
++    conlyopts = select({
++        ":windows_clang_cl": ["/std:c11"],
++        ":windows_msvc": [
++            "/std:c11",
++            "/experimental:c11atomics",
++        ],
++        "//conditions:default": ["-std=c11"],
++    }),
+     defines = select({
+         ":linux_arm": ["PTHREADPOOL_USE_CPUINFO=1"],
+         ":linux_armeabi": ["PTHREADPOOL_USE_CPUINFO=1"],
+@@ -223,6 +229,18 @@ config_setting(
+     },
+ )
+ 
++config_setting(
++    name = "windows_clang_cl",
++    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang-cl"},
++    constraint_values = ["@platforms//os:windows"],
++)
++
++config_setting(
++    name = "windows_msvc",
++    flag_values = {"@bazel_tools//tools/cpp:compiler": "msvc-cl"},
++    constraint_values = ["@platforms//os:windows"],
++)
++
+ config_setting(
+     name = "linux_x86_64",
+     values = {"cpu": "k8"},

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/patches/pthreadpool.patch
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/patches/pthreadpool.patch
@@ -1,5 +1,5 @@
 diff --git a/BUILD.bazel b/BUILD.bazel
-index 0033f4d..896c368 100644
+index 0033f4d..0e9a7ef 100644
 --- a/BUILD.bazel
 +++ b/BUILD.bazel
 @@ -59,12 +59,18 @@ cc_library(
@@ -24,7 +24,20 @@ index 0033f4d..896c368 100644
      defines = select({
          ":linux_arm": ["PTHREADPOOL_USE_CPUINFO=1"],
          ":linux_armeabi": ["PTHREADPOOL_USE_CPUINFO=1"],
-@@ -223,6 +229,18 @@ config_setting(
+@@ -108,6 +114,12 @@ cc_library(
+             "-s ALLOW_BLOCKING_ON_MAIN_THREAD=1",
+             "-s PTHREAD_POOL_SIZE=8",
+         ],
++        ":linux_x86_64": ["-pthread"],
++        ":linux_arm": ["-pthread"],
++        ":linux_armeabi": ["-pthread"],
++        ":linux_armhf": ["-pthread"],
++        ":linux_armv7a": ["-pthread"],
++        ":linux_aarch64": ["-pthread"],
+         "//conditions:default": [],
+     }),
+     strip_include_prefix = "include",
+@@ -223,6 +235,18 @@ config_setting(
      },
  )
  

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/presubmit.yml
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/presubmit.yml
@@ -5,7 +5,6 @@ matrix:
     - ubuntu2404
     - macos
     - macos_arm64
-    - windows
   bazel:
     - 7.x
     - 8.x
@@ -21,6 +20,15 @@ tasks:
       - "--host_cxxopt=-std=c++17"
     build_targets:
       - "@pthreadpool//..."
+  verify_targets_on_windows:
+    name: Verify build targets
+    platform: windows
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--cxxopt=/std:c++17"
+      - "--host_cxxopt=/std:c++17"
+    build_targets:
+      - "@pthreadpool//..."
 
 bcr_test_module:
   module_path: tests
@@ -31,7 +39,6 @@ bcr_test_module:
       - ubuntu2404
       - macos
       - macos_arm64
-      - windows
     bazel:
       - 7.x
       - 8.x
@@ -47,5 +54,19 @@ bcr_test_module:
         - "--host_cxxopt=-std=c++17"
       build_targets:
         - //...
+      test_targets:
+        - //...
+    run_test_module_on_windows:
+      name: Run test module
+      platform: windows
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--cxxopt=/std:c++17"
+        - "--host_cxxopt=/std:c++17"
+      build_targets:
+        - //...
+      test_flags:
+        - "--cxxopt=/std:c++17"
+        - "--host_cxxopt=/std:c++17"
       test_targets:
         - //...

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/presubmit.yml
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/presubmit.yml
@@ -1,0 +1,51 @@
+matrix:
+  platform:
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+    - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--cxxopt=-std=c++17"
+      - "--host_cxxopt=-std=c++17"
+    build_targets:
+      - "@pthreadpool//..."
+
+bcr_test_module:
+  module_path: tests
+  matrix:
+    platform:
+      - ubuntu2004
+      - ubuntu2204
+      - ubuntu2404
+      - macos
+      - macos_arm64
+      - windows
+    bazel:
+      - 7.x
+      - 8.x
+      - 9.x
+      - rolling
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--cxxopt=-std=c++17"
+        - "--host_cxxopt=-std=c++17"
+      build_targets:
+        - //...
+      test_targets:
+        - //...

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/source.json
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/source.json
@@ -3,7 +3,8 @@
     "integrity": "sha256-AKmhxjP2IpCiLqHbQsRAHf/p8FZF+2bWYJrkagUzOio=",
     "strip_prefix": "pthreadpool-9003ee6c137cea3b94161bd5c614fb43be523ee1",
     "patches": {
-        "module_dot_bazel.patch": "sha256-yebgwlhcwTP1xrpKGbnmwbjVR0szES4SGfV+oamkdn4="
+        "module_dot_bazel.patch": "sha256-yebgwlhcwTP1xrpKGbnmwbjVR0szES4SGfV+oamkdn4=",
+        "pthreadpool.patch": "sha256-9lkw/04WkTlcCIeEkv5V3CugmK+eaWSlSpilLzw1kCc="
     },
     "overlay": {
         "tests/BUILD.bazel": "sha256-qaJybxpICNbOkpidxpKA829RBkuFqlwnGmJsZjv4tvQ=",

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/source.json
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "pthreadpool-9003ee6c137cea3b94161bd5c614fb43be523ee1",
     "patches": {
         "module_dot_bazel.patch": "sha256-yebgwlhcwTP1xrpKGbnmwbjVR0szES4SGfV+oamkdn4=",
-        "pthreadpool.patch": "sha256-Dj3tpt1aXoIwKWHEfFDlPktZw/rt67jhj5OdKq1iOHk="
+        "pthreadpool.patch": "sha256-STxyTf6CngJzQ1JfB3PRRvuMMvQVoPBcoDBEq1AgXVg="
     },
     "overlay": {
         "tests/BUILD.bazel": "sha256-qaJybxpICNbOkpidxpKA829RBkuFqlwnGmJsZjv4tvQ=",

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/source.json
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/source.json
@@ -1,0 +1,14 @@
+{
+    "url": "https://github.com/google/pthreadpool/archive/9003ee6c137cea3b94161bd5c614fb43be523ee1.zip",
+    "integrity": "sha256-AKmhxjP2IpCiLqHbQsRAHf/p8FZF+2bWYJrkagUzOio=",
+    "strip_prefix": "pthreadpool-9003ee6c137cea3b94161bd5c614fb43be523ee1",
+    "patches": {
+        "module_dot_bazel.patch": "sha256-yebgwlhcwTP1xrpKGbnmwbjVR0szES4SGfV+oamkdn4="
+    },
+    "overlay": {
+        "tests/BUILD.bazel": "sha256-qaJybxpICNbOkpidxpKA829RBkuFqlwnGmJsZjv4tvQ=",
+        "tests/MODULE.bazel": "sha256-kw8mvRTqw5IC15Z2UOgwu+jIDw/5dDrjqeNPQM/wj8Q=",
+        "tests/pthreadpool_smoke.cc": "sha256-wrsjnNJKxtr4vOzx/X+MW2pbj4J0+qW/tjklF3LRT/A="
+    },
+    "patch_strip": 1
+}

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/source.json
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "pthreadpool-9003ee6c137cea3b94161bd5c614fb43be523ee1",
     "patches": {
         "module_dot_bazel.patch": "sha256-yebgwlhcwTP1xrpKGbnmwbjVR0szES4SGfV+oamkdn4=",
-        "pthreadpool.patch": "sha256-STxyTf6CngJzQ1JfB3PRRvuMMvQVoPBcoDBEq1AgXVg="
+        "pthreadpool.patch": "sha256-wHtqQbV2ljuYlv46ohXWxskOMLreQl16zzFmo9F2Fis="
     },
     "overlay": {
         "tests/BUILD.bazel": "sha256-qaJybxpICNbOkpidxpKA829RBkuFqlwnGmJsZjv4tvQ=",

--- a/modules/pthreadpool/0.0.0-20260119-9003ee6/source.json
+++ b/modules/pthreadpool/0.0.0-20260119-9003ee6/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "pthreadpool-9003ee6c137cea3b94161bd5c614fb43be523ee1",
     "patches": {
         "module_dot_bazel.patch": "sha256-yebgwlhcwTP1xrpKGbnmwbjVR0szES4SGfV+oamkdn4=",
-        "pthreadpool.patch": "sha256-9lkw/04WkTlcCIeEkv5V3CugmK+eaWSlSpilLzw1kCc="
+        "pthreadpool.patch": "sha256-Dj3tpt1aXoIwKWHEfFDlPktZw/rt67jhj5OdKq1iOHk="
     },
     "overlay": {
         "tests/BUILD.bazel": "sha256-qaJybxpICNbOkpidxpKA829RBkuFqlwnGmJsZjv4tvQ=",

--- a/modules/pthreadpool/metadata.json
+++ b/modules/pthreadpool/metadata.json
@@ -7,11 +7,13 @@
         }
     ],
     "repository": [
+        "github:google/pthreadpool",
         "github:Maratyszcza/pthreadpool"
     ],
     "versions": [
         "0.0.0-20230829-4fe0e1e",
-        "0.0.0-20250926-560c60d"
+        "0.0.0-20250926-560c60d",
+        "0.0.0-20260119-9003ee6"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Update pthreadpool to a newer upstream snapshot from the google repository. The new source no longer needs the extra pthreadpool patch carried by the previous BCR version.

Expand presubmit coverage to Bazel 9.x and rolling, enable the Windows matrix, and add a small bcr_test_module that compiles and runs a public pthreadpool header smoke test.