### PR TITLE
Add cppoptlib 2.0.0

### DIFF
--- a/modules/cppoptlib/2.0.0/MODULE.bazel
+++ b/modules/cppoptlib/2.0.0/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "cppoptlib",
+    version = "2.0.0",
+    compatibility_level = 2,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)

--- a/modules/cppoptlib/2.0.0/presubmit.yml
+++ b/modules/cppoptlib/2.0.0/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004
+    - macos_arm64
+  bazel:
+    - 7.x
+    - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@cppoptlib//include:cppoptlib'

--- a/modules/cppoptlib/2.0.0/source.json
+++ b/modules/cppoptlib/2.0.0/source.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "sha256-quDRU6YQfdu9Ff+z/GME1xhKjCdbUcpBfrAjUbEi3AU=",
+  "strip_prefix": "CppNumericalSolvers-2.0.0",
+  "url": "https://github.com/PatWie/CppNumericalSolvers/releases/download/v2.0.0/CppNumericalSolvers-2.0.0.tar.gz"
+}

--- a/modules/cppoptlib/metadata.json
+++ b/modules/cppoptlib/metadata.json
@@ -1,0 +1,13 @@
+{
+  "homepage": "https://github.com/PatWie/CppNumericalSolvers",
+  "maintainers": [
+    {
+      "github": "PatWie",
+      "github_user_id": 6756603,
+      "name": "Patrick Wieschollek"
+    }
+  ],
+  "repository": ["github:PatWie/CppNumericalSolvers"],
+  "versions": ["2.0.0"],
+  "yanked_versions": {}
+}


### PR DESCRIPTION
  New module: cppoptlib 2.0.0

  A header-only C++17 numerical optimization library with the only
  dependency being Eigen3.

  On a 376-problem benchmark against Nocedal's Fortran L-BFGS, libLBFGS,
  LBFGSpp, and LBFGS-Lite, CppNumericalSolvers achieves the highest
  reliability (95% converged), the most first-place wins (230/376, 2x the
  next library), and the lowest mean function evaluations of any solver
  tested. Full results: https://patwie.github.io/CppNumericalSolversBenchmark/

  Solvers included:
  - Gradient Descent, Conjugate Gradient, L-BFGS, BFGS (1st order)
  - Newton, Trust-Region Newton (2nd order)
  - Nelder-Mead (derivative-free)
  - L-BFGS-B (box constraints)
  - Augmented Lagrangian (equality/inequality constraints)

  Features expression templates for composing objectives without
  boilerplate (e.g. ridge regression as SquaredError + lambda * L2Reg).

  Homepage: https://github.com/PatWie/CppNumericalSolvers

Actively maintained since 2014 (11 years).