### PR TITLE
safedi@2.0.0

### DIFF
--- a/modules/safedi/2.0.0/MODULE.bazel
+++ b/modules/safedi/2.0.0/MODULE.bazel
@@ -1,0 +1,36 @@
+"""Bazel module for SafeDI.
+
+Provides Bazel-native build targets for SafeDI's four source modules
+(SafeDI, SafeDICore, SafeDIMacros, SafeDITool) as an alternative to
+SPM. External dependencies (swift-syntax, swift-argument-parser) are
+translated from Package.swift via rules_swift_package_manager so the
+two build systems stay in sync.
+"""
+
+module(
+    name = "safedi",
+    version = "2.0.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_swift", version = "3.6.0", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_swift_package_manager", version = "1.15.0")
+bazel_dep(name = "apple_support", version = "1.24.2", repo_name = "build_bazel_apple_support")
+
+# Translate SPM dependencies into Bazel targets. The resulting
+# @swiftpkg_* repos are referenced from per-module BUILD.bazel files.
+swift_deps = use_extension(
+    "@rules_swift_package_manager//:extensions.bzl",
+    "swift_deps",
+)
+swift_deps.from_package(
+    resolved = "//:Package.resolved",
+    swift = "//:Package.swift",
+)
+use_repo(
+    swift_deps,
+    "swift_package",
+    "swiftpkg_swift_argument_parser",
+    "swiftpkg_swift_docc_plugin",
+    "swiftpkg_swift_syntax",
+)

--- a/modules/safedi/2.0.0/presubmit.yml
+++ b/modules/safedi/2.0.0/presubmit.yml
@@ -1,0 +1,67 @@
+# BCR presubmit configuration. Pattern adapted from swift-syntax
+# (modules/swift-syntax/603.0.1/presubmit.yml) and swift-index-store
+# (modules/swift-index-store/1.9.2/presubmit.yml) — same dep shape
+# (swift-syntax + rules_swift on Bazel 9.x with Xcode 26 SDK on an
+# older runner OS).
+#
+# `build_flags` per task:
+#   - --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+#       Stops Bazel from auto-detecting the host CC toolchain; without
+#       this, rules_swift's xcode_swift_toolchain falls through to
+#       `cc_toolchain.target_gnu_system_name` returning "local" on
+#       BCR's runner and analysis fails. Unanimous across the BCR
+#       Swift modules surveyed (swift-syntax, swift-index-store,
+#       swift-filename-matcher, asc_swift). Belt-and-suspenders with
+#       the `apple_support` bazel_dep we register in MODULE.bazel.
+#   - --host_macos_minimum_os=11.0
+#       Pins the deployment target for tools built under exec config
+#       (e.g. SafeDITool itself), so a binary built with the macOS 26
+#       SDK still runs on BCR's older runner OS. Without this, dyld
+#       refuses to load SafeDITool when the example task tries to
+#       execute it during code generation. 11.0 matches SafeDI's
+#       Package.swift declared platform — lowest reasonable value,
+#       and SafeDITool only needs to run, not exercise newer APIs.
+#   - --macos_minimum_os=<value>
+#       Target-config deployment target. Differs per task:
+#       * verify_safedi_build: 11.0 — matches Package.swift, what
+#         SafeDI as a library claims to support.
+#       * bcr_test_module.build_example: 14.0 — the example app
+#         uses macOS 14+ SwiftUI APIs (LoggedInView's onChange,
+#         NameEntryView's TextField init), so it can't compile
+#         lower. This is the example app's requirement, not SafeDI's.
+matrix:
+  platform: ["macos_arm64"]
+  bazel: ["9.x"]
+
+tasks:
+  verify_safedi_build:
+    name: "Build SafeDI targets (${{ platform }}, Bazel ${{ bazel }})"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
+      - "--host_macos_minimum_os=11.0"
+      - "--macos_minimum_os=11.0"
+    build_targets:
+      - "@safedi//Sources/SafeDI:SafeDI"
+      - "@safedi//Sources/SafeDICore:SafeDICore"
+      - "@safedi//Sources/SafeDIMacros:SafeDIMacros"
+      - "@safedi//Sources/SafeDITool:SafeDITool"
+
+bcr_test_module:
+  module_path: "Examples/ExampleBazelIntegration"
+  matrix:
+    platform: ["macos_arm64"]
+    bazel: ["9.x"]
+  tasks:
+    build_example:
+      name: "Build downstream example (${{ platform }}, Bazel ${{ bazel }})"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
+        - "--host_macos_minimum_os=11.0"
+        - "--macos_minimum_os=14.0"
+      build_targets:
+        - "//Subproject:Subproject"
+        - "//ExampleBazelIntegration:ExampleBazelIntegration"

--- a/modules/safedi/2.0.0/source.json
+++ b/modules/safedi/2.0.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-ifQgijJgTlipBGBARsqvWCW1JBJPY3U1JSKMJOXq/+Y=",
+    "strip_prefix": "SafeDI-2.0.0",
+    "url": "https://github.com/dfed/SafeDI/releases/download/2.0.0/SafeDI-2.0.0.tar.gz"
+}

--- a/modules/safedi/metadata.json
+++ b/modules/safedi/metadata.json
@@ -12,7 +12,8 @@
         "github:dfed/SafeDI"
     ],
     "versions": [
-        "2.0.0-rc-3"
+        "2.0.0-rc-3",
+        "2.0.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/dfed/SafeDI/releases/tag/2.0.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_