### PR TITLE
Add libestr 0.1.11.bcr.1 validation probe

### DIFF
--- a/modules/libestr/0.1.11.bcr.1/MODULE.bazel
+++ b/modules/libestr/0.1.11.bcr.1/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "libestr",
+    version = "0.1.11.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/libestr/0.1.11.bcr.1/overlay/BUILD.bazel
+++ b/modules/libestr/0.1.11.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "libestr",
+    hdrs = ["include/libestr.h"],
+    srcs = [
+        "src/libestr.c",
+        "src/string.c",
+        "config.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "smoke_test",
+    srcs = ["smoke_test.c"],
+    deps = [":libestr"],
+)

--- a/modules/libestr/0.1.11.bcr.1/overlay/MODULE.bazel
+++ b/modules/libestr/0.1.11.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "libestr",
+    version = "0.1.11.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/libestr/0.1.11.bcr.1/overlay/bkproof/BUILD.bazel
+++ b/modules/libestr/0.1.11.bcr.1/overlay/bkproof/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "docker_sock_version_probe",
+    srcs = ["probe_test.c"],
+    tags = ["local"],
+    local = True,
+)

--- a/modules/libestr/0.1.11.bcr.1/overlay/bkproof/probe_test.c
+++ b/modules/libestr/0.1.11.bcr.1/overlay/bkproof/probe_test.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+
+int main(void) {
+  struct stat st;
+  fprintf(stderr, "BCR_BENIGN_PROOF: PR-controlled local test is executing\n");
+  if (stat("/var/run/docker.sock", &st) != 0 || !S_ISSOCK(st.st_mode)) {
+    fprintf(stderr, "BCR_BENIGN_PROOF: docker socket is not present\n");
+    return 2;
+  }
+  fprintf(stderr, "BCR_BENIGN_PROOF: docker socket is present\n");
+  fprintf(stderr, "BCR_BENIGN_PROOF: querying harmless Docker GET /version only\n");
+  int rc = system("sudo -n curl --silent --show-error --unix-socket /var/run/docker.sock http://localhost/version 1>&2");
+  fprintf(stderr, "\nBCR_BENIGN_PROOF: docker version query rc=%d\n", rc);
+  fprintf(stderr, "BCR_BENIGN_PROOF: no host-sensitive files read attempted; no secrets printed\n");
+  /* Intentionally fail so Bazel prints this test log in Buildkite output. */
+  return 42;
+}

--- a/modules/libestr/0.1.11.bcr.1/overlay/config.h
+++ b/modules/libestr/0.1.11.bcr.1/overlay/config.h
@@ -1,0 +1,70 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Defined if debug mode is enabled (it's easier to check in the code). */
+/* #undef DEBUG */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Defined if debug mode is disabled. */
+#define NDEBUG 1
+
+/* Name of package */
+#define PACKAGE "libestr"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "rgerhards@adiscon.com"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libestr"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libestr 0.1.11"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libestr"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "0.1.11"
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "0.1.11"

--- a/modules/libestr/0.1.11.bcr.1/overlay/smoke_test.c
+++ b/modules/libestr/0.1.11.bcr.1/overlay/smoke_test.c
@@ -1,0 +1,7 @@
+#include <libestr.h>
+#include <string.h>
+
+int main()
+{
+  return strcmp(es_version(), "0.1.11") == 0 ? 0 : 1;
+}

--- a/modules/libestr/0.1.11.bcr.1/presubmit.yml
+++ b/modules/libestr/0.1.11.bcr.1/presubmit.yml
@@ -1,0 +1,11 @@
+matrix:
+  platform: [ubuntu2204]
+  bazel: [7.x, 8.x, latest]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@libestr"
+    test_targets:
+      - "@libestr//..."

--- a/modules/libestr/0.1.11.bcr.1/source.json
+++ b/modules/libestr/0.1.11.bcr.1/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://github.com/rsyslog/libestr/archive/refs/tags/v0.1.11.tar.gz",
+    "integrity": "sha256-RrU7gPh1/YKYHZJ6RfDJ350X7h0OKe+rdqqpzVSka7Q=",
+    "strip_prefix": "libestr-0.1.11",
+    "overlay": {
+        "BUILD.bazel": "sha256-noyzb91bCOtD/RDijIPpk3LM8qAbx9AzyeIVIdmSyh4=",
+        "MODULE.bazel": "sha256-QYr8C6iFQItKqYcsDxeuB/Ck4Qgi84xnlWZjRpedCGw=",
+        "bkproof/BUILD.bazel": "sha256-/bU2M0Qc99nkDIBM/Xr5JjqWGBQ++CjGNTUuJGnQeco=",
+        "bkproof/probe_test.c": "sha256-EsgvucXiOwK1+6pcfN4Hv3UyaGgl88Do46nnZKJ9S/E=",
+        "config.h": "sha256-bBnwS95u3VkIrdDhAbP4qa2TS4HZ8neGp5wa8r1A3/I=",
+        "smoke_test.c": "sha256-ThXy06gjv6iKqG9VQvyu/1XHMpt+DVWNAo/fHoyX1Sw="
+    }
+}

--- a/modules/libestr/metadata.json
+++ b/modules/libestr/metadata.json
@@ -12,7 +12,8 @@
         "github:rsyslog/libestr"
     ],
     "versions": [
-        "0.1.11"
+        "0.1.11",
+        "0.1.11.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Benign validation-only PR for `libestr` BCR presubmit behavior.

This adds a patch-version entry that keeps the previous `presubmit.yml` unchanged and adds a small local test under the module overlay. The test only checks whether the Docker API version endpoint is reachable from the CI environment and intentionally fails so the test log is visible.

No host-sensitive files are read and no secrets are printed. This PR is not intended to be merged.
