### PR TITLE
tar.bzl@0.10.5

### DIFF
--- a/modules/tar.bzl/0.10.5/MODULE.bazel
+++ b/modules/tar.bzl/0.10.5/MODULE.bazel
@@ -1,0 +1,22 @@
+"Bazel dependencies"
+
+module(
+    name = "tar.bzl",
+    compatibility_level = 1,
+    version = "0.10.5",
+)
+
+bazel_dep(name = "bazel_features", version = "1.34.0")
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "gawk", version = "5.3.2.bcr.3")
+bazel_dep(name = "platforms", version = "0.0.11")
+
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.2.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.0.3", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
+
+toolchains = use_extension("//tar:extensions.bzl", "toolchains")
+use_repo(toolchains, "bsd_tar_toolchains")
+
+register_toolchains("@bsd_tar_toolchains//:all")

--- a/modules/tar.bzl/0.10.5/attestations.json
+++ b/modules/tar.bzl/0.10.5/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.5/source.json.intoto.jsonl",
+            "integrity": "sha256-0nNosCqoXcDIGLq1U9HCk1q03gugH1VxGUKrtxIfiD4="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.5/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-IMrga9bCVFOBdJrLVlI5In1KdVAz4oJYGOX2kquvHFU="
+        },
+        "tar.bzl-v0.10.5.tar.gz": {
+            "url": "https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.5/tar.bzl-v0.10.5.tar.gz.intoto.jsonl",
+            "integrity": "sha256-Zzal781aqedmt1qbgYDB0B71y/uh4LINHUTZossVBAY="
+        }
+    }
+}

--- a/modules/tar.bzl/0.10.5/patches/module_dot_bazel_version.patch
+++ b/modules/tar.bzl/0.10.5/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -2,8 +2,9 @@
+ 
+ module(
+     name = "tar.bzl",
+     compatibility_level = 1,
++    version = "0.10.5",
+ )
+ 
+ bazel_dep(name = "bazel_features", version = "1.34.0")
+ bazel_dep(name = "bazel_lib", version = "3.0.0")

--- a/modules/tar.bzl/0.10.5/presubmit.yml
+++ b/modules/tar.bzl/0.10.5/presubmit.yml
@@ -1,0 +1,14 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    # TODO(alex): add windows.
+    # bazel-lib was only testing e2e/smoke on windows, which is missing tar coverage
+    platform: ["debian11", "macos", "ubuntu2204"]
+    bazel: ["rolling", "8.x", "7.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/tar.bzl/0.10.5/source.json
+++ b/modules/tar.bzl/0.10.5/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-J5nf1DEx6HLI+f7UGlR6jFr9Vxxd9rgJ6rYhnURAOHI=",
+    "strip_prefix": "tar.bzl-0.10.5",
+    "docs_url": "https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.5/tar.bzl-v0.10.5.docs.tar.gz",
+    "url": "https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.5/tar.bzl-v0.10.5.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-9cNWnWVP/Vpd1qH+6XVp1q+EUKyvR0KOqrVkP6+68Vs="
+    },
+    "patch_strip": 1
+}

--- a/modules/tar.bzl/metadata.json
+++ b/modules/tar.bzl/metadata.json
@@ -12,6 +12,18 @@
             "github": "thesayyn",
             "name": "Şahin Yort",
             "github_user_id": 20563340
+        },
+        {
+            "email": "dzbarsky@gmail.com",
+            "github": "dzbarsky",
+            "name": "David Zbarsky",
+            "github_user_id": 1565842
+        },
+        {
+            "email": "jason@aspect.build",
+            "github": "jbedard",
+            "name": "Jason Bedard",
+            "github_user_id": 89246
         }
     ],
     "repository": [
@@ -35,7 +47,8 @@
         "0.9.0",
         "0.10.1",
         "0.10.2",
-        "0.10.4"
+        "0.10.4",
+        "0.10.5"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/bazel-contrib/tar.bzl/releases/tag/v0.10.5

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_