### PR TITLE
rules_latex@0.2.0

### DIFF
--- a/modules/rules_latex/0.2.0/MODULE.bazel
+++ b/modules/rules_latex/0.2.0/MODULE.bazel
@@ -1,0 +1,44 @@
+"""rules_latex - Bazel rules for building LaTeX documents with Tectonic.
+
+See https://github.com/nicklambourne/rules_latex for details.
+"""
+
+module(
+    name = "rules_latex",
+    version = "0.2.0",
+    compatibility_level = 1,
+)
+
+# Standard dependencies.
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+
+# Stardoc generates the Markdown that backs the user guide at
+# https://nicklambourne.github.io/rules_latex/. Marked as a dev-only
+# dependency because consumers of rules_latex don't need it; only
+# our own //docs:* targets do.
+bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.5.0", dev_dependency = True)
+
+# Module extension that registers the tectonic toolchain repos.
+tectonic = use_extension("//latex/toolchain:extensions.bzl", "tectonic")
+tectonic.toolchain()
+use_repo(
+    tectonic,
+    "rules_latex_tectonic_toolchains",
+    # Per-platform repos that hold the downloaded tectonic binaries.
+    "rules_latex_tectonic_linux_aarch64",
+    "rules_latex_tectonic_linux_x86_64",
+    "rules_latex_tectonic_macos_aarch64",
+    "rules_latex_tectonic_macos_x86_64",
+)
+
+register_toolchains("@rules_latex_tectonic_toolchains//:all")
+
+# Module extension that vendors PDF.js for latex_serve_web. Always
+# materialised so the rule's default _pdfjs_lib / _pdfjs_worker
+# attributes resolve cleanly; the actual ~10 MB download only happens
+# when something in the build graph references the @rules_latex_pdfjs
+# repo (i.e. when a latex_serve_web target is built).
+pdfjs = use_extension("//latex/web:extensions.bzl", "pdfjs")
+use_repo(pdfjs, "rules_latex_pdfjs")

--- a/modules/rules_latex/0.2.0/attestations.json
+++ b/modules/rules_latex/0.2.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/nicklambourne/rules_latex/releases/download/v0.2.0/source.json.intoto.jsonl",
+            "integrity": "sha256-e+OQ+6CFThfcDUXh6gTzmStwXEaC33+gvbMUB+tj368="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/nicklambourne/rules_latex/releases/download/v0.2.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-QM2t2K+TMwwuYHOtKUWwj1ikvyW+0azaSp9tE7o/sB4="
+        },
+        "rules_latex-0.2.0.tar.gz": {
+            "url": "https://github.com/nicklambourne/rules_latex/releases/download/v0.2.0/rules_latex-0.2.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-dkTQuGzEdqvhnjhx1Z3ZFAbF5RS0Fv5owqS1TNfbIho="
+        }
+    }
+}

--- a/modules/rules_latex/0.2.0/presubmit.yml
+++ b/modules/rules_latex/0.2.0/presubmit.yml
@@ -1,0 +1,34 @@
+# BCR presubmit configuration.
+#
+# When the BCR receives our submission PR, it runs this presubmit
+# against a copy of our test module. The test module exercises the
+# rules through Bzlmod against the published version of rules_latex
+# being submitted. If the test module fails, the PR is blocked.
+#
+# Our test module is `examples/` — a Bzlmod workspace that consumes
+# rules_latex via bazel_dep. It contains six sub-packages (hello,
+# letter, cv, paper, thesis, beamer) covering the main document
+# shapes. We exercise the smallest ones in presubmit; the rest are
+# covered in the project's own CI.
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["ubuntu2204", "macos"]
+    # The pinned tectonic / biber / bundle versions don't change with
+    # Bazel, so we exercise across just one Bazel major (8.x). When
+    # we add Bazel-version-specific behaviour we should expand the
+    # matrix.
+    bazel: [8.x]
+  tasks:
+    run_tests:
+      name: "Build and test hello example"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//hello:hello"
+        - "//hello:hello_offline"
+        - "//letter:letter"
+      test_targets:
+        - "//hello:hello_compiles"
+        - "//letter:letter_compiles"

--- a/modules/rules_latex/0.2.0/source.json
+++ b/modules/rules_latex/0.2.0/source.json
@@ -1,0 +1,6 @@
+{
+    "integrity": "sha256-KCPxsITAeLRblsiEw1VJAwIGFmtgHBzdxM22FniOI3A=",
+    "strip_prefix": "rules_latex-0.2.0",
+    "url": "https://github.com/nicklambourne/rules_latex/releases/download/v0.2.0/rules_latex-0.2.0.tar.gz",
+    "docs_url": "https://github.com/nicklambourne/rules_latex/releases/download/v0.2.0/rules_latex-0.2.0.docs.tar.gz"
+}

--- a/modules/rules_latex/metadata.json
+++ b/modules/rules_latex/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/nicklambourne/rules_latex",
+    "maintainers": [
+        {
+            "name": "Nicholas Lambourne",
+            "email": "dev@ndl.au",
+            "github": "nicklambourne",
+            "github_user_id": 9084563
+        }
+    ],
+    "repository": [
+        "github:nicklambourne/rules_latex"
+    ],
+    "versions": [
+        "0.2.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/nicklambourne/rules_latex/releases/tag/v0.2.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_