### PR TITLE
proxy-wasm-rust-sdk@0.2.5

### DIFF
--- a/modules/proxy-wasm-rust-sdk/0.2.5/MODULE.bazel
+++ b/modules/proxy-wasm-rust-sdk/0.2.5/MODULE.bazel
@@ -1,0 +1,44 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "proxy-wasm-rust-sdk",
+    version = "0.2.5",
+    repo_name = "proxy_wasm_rust_sdk",
+)
+
+# Regular dependencies (sorted alphabetically).
+bazel_dep(name = "bazel_features", version = "1.38.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "rules_cc", version = "0.2.14")
+bazel_dep(name = "rules_rust", version = "0.70.0")
+
+# Configure Rust toolchain.
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust.toolchain(
+    edition = "2018",
+    versions = ["1.95.0"],
+)
+use_repo(rust, "rust_toolchains")
+
+register_toolchains("@rust_toolchains//:all")
+
+# Cargo dependencies.
+crates_deps = use_extension("//bazel:extensions.bzl", "crates_deps")
+use_repo(
+    crates_deps,
+    "crates_vendor",
+    "crates_vendor__hashbrown-0.16.1",
+    "crates_vendor__log-0.4.29",
+)

--- a/modules/proxy-wasm-rust-sdk/0.2.5/presubmit.yml
+++ b/modules/proxy-wasm-rust-sdk/0.2.5/presubmit.yml
@@ -1,0 +1,30 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004
+    - ubuntu2004_arm64
+    - macos
+    - macos_arm64
+  bazel: [7.x, 8.x, 9.x]
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@proxy-wasm-rust-sdk//:proxy_wasm"

--- a/modules/proxy-wasm-rust-sdk/0.2.5/source.json
+++ b/modules/proxy-wasm-rust-sdk/0.2.5/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-Dr+LXVOdKCHHLQhi9GDu5jQZY/e7RCq8plHxvpBuqxo=",
+    "strip_prefix": "proxy-wasm-rust-sdk-0.2.5",
+    "url": "https://github.com/proxy-wasm/proxy-wasm-rust-sdk/archive/refs/tags/v0.2.5.tar.gz"
+}

--- a/modules/proxy-wasm-rust-sdk/metadata.json
+++ b/modules/proxy-wasm-rust-sdk/metadata.json
@@ -11,7 +11,8 @@
         "github:proxy-wasm/proxy-wasm-rust-sdk"
     ],
     "versions": [
-        "0.2.4"
+        "0.2.4",
+        "0.2.5"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/proxy-wasm/proxy-wasm-rust-sdk/releases/tag/v0.2.5

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_
