### PR TITLE
package_metadata@0.0.11

### DIFF
--- a/modules/package_metadata/0.0.11/MODULE.bazel
+++ b/modules/package_metadata/0.0.11/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "package_metadata",
+    version = "0.0.11",  # Automatically updated by release pipeline.
+)
+
+# This is a fundamental module that's depended on by virtually every bazel
+# module and **MUST NOT** have any dependencies.

--- a/modules/package_metadata/0.0.11/attestations.json
+++ b/modules/package_metadata/0.0.11/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/bazel-contrib/supply-chain/releases/download/package_metadata-0.0.11/source.json.intoto.jsonl",
+            "integrity": "sha256-SJXuO5uqLBF/B/ZvehYekRz8TbGuJ3Vlgi2ElbiV+vg="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/bazel-contrib/supply-chain/releases/download/package_metadata-0.0.11/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-XqYGf1Ktu02xBZtHu+FjFwoXG0aDAYq9RH2OJGQiw5o="
+        },
+        "package_metadata-0.0.11.tar.gz": {
+            "url": "https://github.com/bazel-contrib/supply-chain/releases/download/package_metadata-0.0.11/package_metadata-0.0.11.tar.gz.intoto.jsonl",
+            "integrity": "sha256-aX2WNmde/XMznZsnSxS+EUP5PQklW975dS5mkjIdZY8="
+        }
+    }
+}

--- a/modules/package_metadata/0.0.11/presubmit.yml
+++ b/modules/package_metadata/0.0.11/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@package_metadata//...'

--- a/modules/package_metadata/0.0.11/source.json
+++ b/modules/package_metadata/0.0.11/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-KoJg6aI+UXZ1qj+3sPxaI2Jk2/VTCUCL993numziKA4=",
+    "strip_prefix": "package_metadata-0.0.11/metadata",
+    "url": "https://github.com/bazel-contrib/supply-chain/releases/download/package_metadata-0.0.11/package_metadata-0.0.11.tar.gz"
+}

--- a/modules/package_metadata/metadata.json
+++ b/modules/package_metadata/metadata.json
@@ -2,6 +2,12 @@
     "homepage": "https://github.com/bazel-contrib/supply-chain",
     "maintainers": [
         {
+            "email": "aiuto@datadoghq.com",
+            "github": "aiuto",
+            "name": "Tony Aiuto",
+            "github_user_id": 3044252
+        },
+        {
             "email": "antonio@engflow.com",
             "github": "TheGrizzlyDev",
             "name": "Antonio Di Stefano",
@@ -31,7 +37,8 @@
         "0.0.5",
         "0.0.6",
         "0.0.7",
-        "0.0.10"
+        "0.0.10",
+        "0.0.11"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/bazel-contrib/supply-chain/releases/tag/package_metadata-0.0.11

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_