### PR TITLE
gazelle_py@0.8.7

### DIFF
--- a/modules/gazelle_py/0.8.7/MODULE.bazel
+++ b/modules/gazelle_py/0.8.7/MODULE.bazel
@@ -1,0 +1,90 @@
+module(
+    name = "gazelle_py",
+    version = "0.8.7",
+    # rules_rs 0.0.73 requires Bazel >=8.5.0; we don't use anything beyond
+    # what rules_rs requires, so match its floor.
+    bazel_compatibility = [">=8.5.0"],
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_rs", version = "0.0.73")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "protobuf", version = "34.0.bcr.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_go", version = "0.60.0")
+bazel_dep(name = "gazelle", version = "0.50.0")
+bazel_dep(name = "with_cfg.bzl", version = "0.14.6")
+
+# Source of @llvm//constraints/libc:gnu.2.28 — the libc constraint that
+# rules_rs's Linux toolchains pin via target_compatible_with, applied to our
+# host platform at //platforms:local_gnu.
+bazel_dep(name = "llvm", version = "0.7.3")
+
+# Hermetic clang toolchain. Replaces Bazel's autodetected `@local_config_cc`
+# so APPLE_SDK_PLATFORM never reaches the action env on macOS, avoiding
+# XcodeLocalEnvProvider's duplicate-SDKROOT crash with rules_rust's hermetic
+# SDKROOT injection.
+register_toolchains("@llvm//toolchain:all")
+
+# rules_rust facade — exposes @rules_rust so .bazelrc's --config=opt and
+# the with_cfg wrapper in //crates/import_extractor:opt.bzl can reference
+# @rules_rust//:extra_rustc_flags. Also keeps rules_rs's internal loads
+# resolving against the same canonical repo for toolchain_type matching.
+rules_rust = use_extension("@rules_rs//rs:rules_rust.bzl", "rules_rust")
+use_repo(rules_rust, "rules_rust")
+
+# Rust toolchain — propagates to consumers because their gazelle_binary
+# links our staticlib via cgo and needs to build the rust crate.
+toolchains = use_extension(
+    "@rules_rs//rs/toolchains:module_extension.bzl",
+    "toolchains",
+)
+toolchains.toolchain(
+    edition = "2024",
+    version = "1.95.0",
+)
+use_repo(toolchains, "default_rust_toolchains")
+
+register_toolchains("@default_rust_toolchains//:all")
+
+# Crate resolution: rules_rs reads Cargo.toml/Cargo.lock directly (no
+# repinning). Propagates to consumers along with the rust toolchain above.
+#
+# The hub name is namespaced (`gazelle_py_crates` rather than the generic
+# `crates`) so it doesn't collide with consumers' own crate.from_cargo
+# invocations — rules_rs merges hubs by name, and a collision would pair
+# our Cargo.lock against the consumer's Cargo.toml.
+crate = use_extension(
+    "@rules_rs//rs:extensions.bzl",
+    "crate",
+)
+crate.from_cargo(
+    name = "gazelle_py_crates",
+    cargo_lock = "//:Cargo.lock",
+    cargo_toml = "//:Cargo.toml",
+    platform_triples = [
+        "aarch64-apple-darwin",
+        "aarch64-unknown-linux-gnu",
+        "x86_64-apple-darwin",
+        "x86_64-unknown-linux-gnu",
+    ],
+)
+use_repo(crate, "gazelle_py_crates")
+
+# Prost/tonic codegen toolchains for rust_prost_library.
+rules_rust_prost = use_extension("@rules_rs//rs:rules_rust_prost.bzl", "rules_rust_prost")
+use_repo(rules_rust_prost, "rules_rust_prost")
+
+register_toolchains("@rules_rust_prost//:default_prost_toolchain")
+
+# Go toolchain + module deps for the gazelle plugin.
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.24.12")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bmatcuk_doublestar_v4",
+    "com_github_burntsushi_toml",
+    "org_golang_google_protobuf",
+)

--- a/modules/gazelle_py/0.8.7/attestations.json
+++ b/modules/gazelle_py/0.8.7/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/perplexityai/gazelle_py/releases/download/v0.8.7/source.json.intoto.jsonl",
+            "integrity": "sha256-2r1nv+HNX2EsbDhtw9fI885lMNdQDRmzS2SQHNfZn3k="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/perplexityai/gazelle_py/releases/download/v0.8.7/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-IICuPMwM+Dh+8AJ+JZiGLmIu+fmCRrZ3ukyn6eMGweQ="
+        },
+        "gazelle_py-v0.8.7.tar.gz": {
+            "url": "https://github.com/perplexityai/gazelle_py/releases/download/v0.8.7/gazelle_py-v0.8.7.tar.gz.intoto.jsonl",
+            "integrity": "sha256-mDoNQ9xFS5raV3MJVshoj2hGPkz2bhCXkiHLfKBtLD4="
+        }
+    }
+}

--- a/modules/gazelle_py/0.8.7/patches/module_dot_bazel_version.patch
+++ b/modules/gazelle_py/0.8.7/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "gazelle_py",
+-    version = "0.0.0",
++    version = "0.8.7",
+     # rules_rs 0.0.73 requires Bazel >=8.5.0; we don't use anything beyond
+     # what rules_rs requires, so match its floor.
+     bazel_compatibility = [">=8.5.0"],
+ )

--- a/modules/gazelle_py/0.8.7/presubmit.yml
+++ b/modules/gazelle_py/0.8.7/presubmit.yml
@@ -1,0 +1,76 @@
+# Run inside bcr_test/ rather than against the published module's own root.
+# Two reasons the consumer workspace has to be ours, not BCR's auto-generated
+# one:
+#
+# 1. `--@llvm//config:experimental_stub_libgcc_s=True` (a flag rules_rust's
+#    `-lgcc_s` link spec needs on Linux) names the @llvm repo. BCR's auto-
+#    generated workspace declares only @gazelle_py as a direct bazel_dep, so
+#    @llvm isn't visible in its main repo mapping and Bazel errors out at
+#    "Computing main repo mapping". bcr_test/MODULE.bazel adds @llvm as a
+#    direct bazel_dep, making the flag resolvable.
+#
+# 2. `--host_platform=@gazelle_py//platforms:local_gnu` names @gazelle_py.
+#    Same visibility rule — bcr_test/ has gazelle_py as a direct dep via
+#    local_path_override, so the flag resolves.
+#
+# Crucially, bcr_test/ ships NO `.bazelrc` of its own — BCR's `bazel info`
+# pre-flight reads any rc in scope before bzlmod resolves deps, and parsing
+# repo-qualified flags at that point fails (see #21 for the prior debugging).
+# Every flag below lives in `build_flags:`, which only applies during
+# `bazel build`, by which time bzlmod has resolved.
+bcr_test_module:
+  module_path: "bcr_test"
+  matrix:
+    # bazelisk wildcard syntax accepts `<major>.x` / `<major>.*`, not
+    # `<major>.<minor>.x` — `8.5.x` errors out with "invalid version".
+    # The supported floor (rules_rs's) is 8.5.0; bazelisk's `8.x` resolves
+    # to the latest 8.y, which currently is comfortably above.
+    bazel:
+      - 9.x
+      - 8.x
+  tasks:
+    # Two tasks (not a `platform:` matrix entry) because the host_platform
+    # pin only applies on Linux. `local_gnu` parents `@platforms//host` and
+    # adds `@llvm//constraints/libc:gnu.2.28`; on a darwin host that double-
+    # tags the platform with both `os:macos` and `libc:gnu`, which collides
+    # in rules_rust's compiler-rt select() (`Illegal ambiguous match …`).
+    # macOS doesn't need any platform pin — Bazel's default host config
+    # already satisfies rules_rs's macOS toolchains.
+    verify_linux:
+      name: Build the gazelle_py plugin (Linux)
+      platform: ubuntu2204
+      bazel: ${{ bazel }}
+      # Mirrors //.bazelrc's hermetic @llvm toolchain flags. See that file
+      # for per-flag rationale. Lives here (not in bcr_test/.bazelrc)
+      # because BCR's `bazel info` pre-flight runs before bzlmod resolves,
+      # and any rc-level flag referencing @llvm or @gazelle_py would fail
+      # to parse at that point.
+      build_flags:
+        - "--host_platform=@gazelle_py//platforms:local_gnu"
+        - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
+        - "--repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1"
+        - "--@llvm//config:experimental_stub_libgcc_s=True"
+        - "--linkopt=-no-pie"
+      build_targets:
+        # Go gazelle plugin (transitively cgo-links the Rust staticlib).
+        - "@gazelle_py//py/..."
+        # Rust crate — also exercised via py/, but listed explicitly so the
+        # rlib variant + the proto codegen are covered on every platform.
+        - "@gazelle_py//crates/import_extractor/..."
+    verify_macos:
+      name: Build the gazelle_py plugin (macOS)
+      # `macos_arm64` (not bare `macos`, which still points at Intel
+      # runners) since rules_rs's macOS Rust toolchains target arm64.
+      platform: macos_arm64
+      bazel: ${{ bazel }}
+      build_flags:
+        # No `--host_platform` on macOS (see comment above). The libgcc_s
+        # stub flag stays — it's a no-op on darwin but @llvm needs to be
+        # visible in the repo mapping regardless of platform; it lives in
+        # bcr_test/MODULE.bazel as a direct bazel_dep, so the flag parses.
+        - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
+        - "--repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1"
+        - "--@llvm//config:experimental_stub_libgcc_s=True"
+      build_targets:
+        - "@gazelle_py//py/..."
+        - "@gazelle_py//crates/import_extractor/..."

--- a/modules/gazelle_py/0.8.7/source.json
+++ b/modules/gazelle_py/0.8.7/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-oL6nF4DO4LjNMjiHJ+H62FUr3y65sq2CJ+DxO4EtL1w=",
+    "strip_prefix": "gazelle_py-0.8.7",
+    "url": "https://github.com/perplexityai/gazelle_py/releases/download/v0.8.7/gazelle_py-v0.8.7.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-Ea6qR8HhVsU9UOw/WlycOdJ4QyDtnCZ/VpekY0PDl5c="
+    },
+    "patch_strip": 1
+}

--- a/modules/gazelle_py/metadata.json
+++ b/modules/gazelle_py/metadata.json
@@ -24,6 +24,11 @@
             "email": "ryansiu@perplexity.ai",
             "github": "ryansiu-pplx",
             "github_user_id": 181008231
+        },
+        {
+            "email": "ossmaintainers@perplexity.ai",
+            "github": "pplx-oss",
+            "github_user_id": 287052873
         }
     ],
     "repository": [
@@ -38,7 +43,8 @@
         "0.8.0",
         "0.8.1",
         "0.8.2",
-        "0.8.6"
+        "0.8.6",
+        "0.8.7"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/perplexityai/gazelle_py/releases/tag/v0.8.7

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_