### PR TITLE
Validate the strip prefix

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -58,6 +58,12 @@ py_binary(
     ],
 )
 
+py_test(
+    name = "bcr_validation_test",
+    srcs = ["bcr_validation_test.py"],
+    deps = [":bcr_validation"],
+)
+
 py_library(
     name = "verify_stable_archives",
     srcs = ["verify_stable_archives.py"],

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -531,6 +531,24 @@ class BcrValidator:
 
         tmp_dir = Path(tempfile.mkdtemp())
         output_dir = tmp_dir.joinpath("source_root")
+        # Validate the stripped output directory.
+        strip_prefix = source.get("strip_prefix", "")
+        if strip_prefix:
+            candidate = (output_dir / strip_prefix).resolve()
+            try:
+                candidate.relative_to(output_dir.resolve())
+            except ValueError:
+                error_msg = "CRITICAL FAILURE: " \
+                    f"strip_prefix '{strip_prefix}' resolves outside the " \
+                    f"extraction directory. Resolved to: {candidate}"
+                self.report(
+                    BcrValidationResult.FAILED,
+                    error_msg
+                )
+                shutil.rmtree(tmp_dir)
+                raise BcrValidationException(error_msg)
+        source_root = output_dir / strip_prefix
+
         self._download_source_archive(source, output_dir)
 
         module_file = self.registry.get_module_dot_bazel_path(module_name, version)

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -538,13 +538,12 @@ class BcrValidator:
             try:
                 candidate.relative_to(output_dir.resolve())
             except ValueError:
-                error_msg = "CRITICAL FAILURE: " \
-                    f"strip_prefix '{strip_prefix}' resolves outside the " \
+                error_msg = (
+                    "CRITICAL FAILURE: "
+                    f"strip_prefix '{strip_prefix}' resolves outside the "
                     f"extraction directory. Resolved to: {candidate}"
-                self.report(
-                    BcrValidationResult.FAILED,
-                    error_msg
                 )
+                self.report(BcrValidationResult.FAILED, error_msg)
                 shutil.rmtree(tmp_dir)
                 raise BcrValidationException(error_msg)
         source_root = output_dir / strip_prefix

--- a/tools/bcr_validation_test.py
+++ b/tools/bcr_validation_test.py
@@ -29,36 +29,22 @@ class TestBcrValidation(unittest.TestCase):
     def setUp(self):
         registry = RegistryClient("/fake")
 
-        self.bcr_validator = BcrValidator(
-            registry=registry, upstream=None, should_fix=False
-        )
+        self.bcr_validator = BcrValidator(registry=registry, upstream=None, should_fix=False)
 
     def test_fail_module_dot_bazel_source_is_not_archive(self):
-        self.bcr_validator.registry.get_source = MagicMock(
-            return_value=dict(type="not_archive")
-        )
+        self.bcr_validator.registry.get_source = MagicMock(return_value=dict(type="not_archive"))
         with self.assertRaises(BcrValidationException) as _:
-            self.bcr_validator.verify_module_dot_bazel(
-                module_name="foobar", version="0.0.0"
-            )
+            self.bcr_validator.verify_module_dot_bazel(module_name="foobar", version="0.0.0")
 
     def test_fail_module_dot_bazel_no_relative_strip_prefix_outside_module(self):
-        self.bcr_validator.registry.get_source = MagicMock(
-            return_value=dict(strip_prefix="..")
-        )
+        self.bcr_validator.registry.get_source = MagicMock(return_value=dict(strip_prefix=".."))
         with self.assertRaises(BcrValidationException) as _:
-            self.bcr_validator.verify_module_dot_bazel(
-                module_name="foobar", version="0.0.0"
-            )
+            self.bcr_validator.verify_module_dot_bazel(module_name="foobar", version="0.0.0")
 
     def test_fail_module_dot_bazel_no_absolute_strip_prefix(self):
-        self.bcr_validator.registry.get_source = MagicMock(
-            return_value=dict(strip_prefix="/fake2")
-        )
+        self.bcr_validator.registry.get_source = MagicMock(return_value=dict(strip_prefix="/fake2"))
         with self.assertRaises(BcrValidationException) as _:
-            self.bcr_validator.verify_module_dot_bazel(
-                module_name="foobar", version="0.0.0"
-            )
+            self.bcr_validator.verify_module_dot_bazel(module_name="foobar", version="0.0.0")
 
 
 if __name__ == "__main__":

--- a/tools/bcr_validation_test.py
+++ b/tools/bcr_validation_test.py
@@ -35,19 +35,25 @@ class TestBcrValidation(unittest.TestCase):
         self.bcr_validator.registry.get_source = MagicMock(return_value=dict(type="not_archive"))
         with self.assertRaises(BcrValidationException) as e:
             self.bcr_validator.verify_module_dot_bazel(module_name="foobar", version="0.0.0")
-        self.assertEqual("Module source \"type\" must be \"archive\" (the default)", str(e.exception))
+        self.assertEqual('Module source "type" must be "archive" (the default)', str(e.exception))
 
     def test_fail_module_dot_bazel_no_relative_strip_prefix_outside_module(self):
         self.bcr_validator.registry.get_source = MagicMock(return_value=dict(strip_prefix=".."))
         with self.assertRaises(BcrValidationException) as e:
             self.bcr_validator.verify_module_dot_bazel(module_name="foobar", version="0.0.0")
-        self.assertTrue("CRITICAL FAILURE: strip_prefix '..' resolves outside the extraction directory. Resolved to: /" in str(e.exception))
+        self.assertTrue(
+            "CRITICAL FAILURE: strip_prefix '..' resolves outside the extraction directory. Resolved to: /"
+            in str(e.exception)
+        )
 
     def test_fail_module_dot_bazel_no_absolute_strip_prefix(self):
         self.bcr_validator.registry.get_source = MagicMock(return_value=dict(strip_prefix="/fake2"))
         with self.assertRaises(BcrValidationException) as e:
             self.bcr_validator.verify_module_dot_bazel(module_name="foobar", version="0.0.0")
-        self.assertTrue("CRITICAL FAILURE: strip_prefix '/fake2' resolves outside the extraction directory. Resolved to: /" in str(e.exception))
+        self.assertTrue(
+            "CRITICAL FAILURE: strip_prefix '/fake2' resolves outside the extraction directory. Resolved to: /"
+            in str(e.exception)
+        )
 
 
 if __name__ == "__main__":

--- a/tools/bcr_validation_test.py
+++ b/tools/bcr_validation_test.py
@@ -16,10 +16,7 @@
 
 import unittest
 from registry import RegistryClient
-from tools.bcr_validation import (
-    BcrValidator,
-    BcrValidationException
-)
+from tools.bcr_validation import BcrValidator, BcrValidationException
 
 from unittest.mock import MagicMock
 

--- a/tools/bcr_validation_test.py
+++ b/tools/bcr_validation_test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from registry import RegistryClient
+from tools.bcr_validation import (
+    BcrValidator,
+    BcrValidationException,
+    UPSTREAM_MODULES_DIR_URL,
+)
+
+from unittest.mock import MagicMock
+
+
+class TestBcrValidation(unittest.TestCase):
+    def setUp(self):
+        registry = RegistryClient("/fake")
+
+        self.bcr_validator = BcrValidator(
+            registry=registry, upstream=None, should_fix=False
+        )
+
+    def test_fail_module_dot_bazel_source_is_not_archive(self):
+        self.bcr_validator.registry.get_source = MagicMock(
+            return_value=dict(type="not_archive")
+        )
+        with self.assertRaises(BcrValidationException) as _:
+            self.bcr_validator.verify_module_dot_bazel(
+                module_name="foobar", version="0.0.0"
+            )
+
+    def test_fail_module_dot_bazel_no_relative_strip_prefix_outside_module(self):
+        self.bcr_validator.registry.get_source = MagicMock(
+            return_value=dict(strip_prefix="..")
+        )
+        with self.assertRaises(BcrValidationException) as _:
+            self.bcr_validator.verify_module_dot_bazel(
+                module_name="foobar", version="0.0.0"
+            )
+
+    def test_fail_module_dot_bazel_no_absolute_strip_prefix(self):
+        self.bcr_validator.registry.get_source = MagicMock(
+            return_value=dict(strip_prefix="/fake2")
+        )
+        with self.assertRaises(BcrValidationException) as _:
+            self.bcr_validator.verify_module_dot_bazel(
+                module_name="foobar", version="0.0.0"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bcr_validation_test.py
+++ b/tools/bcr_validation_test.py
@@ -33,18 +33,21 @@ class TestBcrValidation(unittest.TestCase):
 
     def test_fail_module_dot_bazel_source_is_not_archive(self):
         self.bcr_validator.registry.get_source = MagicMock(return_value=dict(type="not_archive"))
-        with self.assertRaises(BcrValidationException) as _:
+        with self.assertRaises(BcrValidationException) as e:
             self.bcr_validator.verify_module_dot_bazel(module_name="foobar", version="0.0.0")
+        self.assertEqual("Module source \"type\" must be \"archive\" (the default)", str(e.exception))
 
     def test_fail_module_dot_bazel_no_relative_strip_prefix_outside_module(self):
         self.bcr_validator.registry.get_source = MagicMock(return_value=dict(strip_prefix=".."))
-        with self.assertRaises(BcrValidationException) as _:
+        with self.assertRaises(BcrValidationException) as e:
             self.bcr_validator.verify_module_dot_bazel(module_name="foobar", version="0.0.0")
+        self.assertTrue("CRITICAL FAILURE: strip_prefix '..' resolves outside the extraction directory. Resolved to: /" in str(e.exception))
 
     def test_fail_module_dot_bazel_no_absolute_strip_prefix(self):
         self.bcr_validator.registry.get_source = MagicMock(return_value=dict(strip_prefix="/fake2"))
-        with self.assertRaises(BcrValidationException) as _:
+        with self.assertRaises(BcrValidationException) as e:
             self.bcr_validator.verify_module_dot_bazel(module_name="foobar", version="0.0.0")
+        self.assertTrue("CRITICAL FAILURE: strip_prefix '/fake2' resolves outside the extraction directory. Resolved to: /" in str(e.exception))
 
 
 if __name__ == "__main__":

--- a/tools/bcr_validation_test.py
+++ b/tools/bcr_validation_test.py
@@ -18,8 +18,7 @@ import unittest
 from registry import RegistryClient
 from tools.bcr_validation import (
     BcrValidator,
-    BcrValidationException,
-    UPSTREAM_MODULES_DIR_URL,
+    BcrValidationException
 )
 
 from unittest.mock import MagicMock


### PR DESCRIPTION
Disallow upward-relative (outside of the sandbox directory) and absolute strip prefixes.

Also adds some unit tests for BcrValidator.verify_module_dot_bazel().

Supercedes #8375.