### PR TITLE
Add libcircllhist@0.3.2.bcr.1

### DIFF
--- a/modules/libcircllhist/0.3.2.bcr.1/MODULE.bazel
+++ b/modules/libcircllhist/0.3.2.bcr.1/MODULE.bazel
@@ -1,0 +1,16 @@
+module(
+    name = "libcircllhist",
+    version = "0.3.2.bcr.1",
+    compatibility_level = 1,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(
+    name = "platforms",
+    version = "1.1.0",
+)
+
+bazel_dep(
+    name = "rules_cc",
+    version = "0.2.17",
+)

--- a/modules/libcircllhist/0.3.2.bcr.1/patches/0001-fix-printing-warning.patch
+++ b/modules/libcircllhist/0.3.2.bcr.1/patches/0001-fix-printing-warning.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shantanu Gontia <gontia.shantanu@gmail.com>
+Date: Fri, 29 May 2026 08:13:40 +0530
+Subject: fix printing warning
+
+
+diff --git src/circllhist_print.c src/circllhist_print.c
+index bce97d2..46a614c 100644
+--- src/circllhist_print.c
++++ src/circllhist_print.c
+@@ -106,7 +106,7 @@ void print(const histogram_t *hist) {
+     for(i=0; i<invquantiles.cnt; i++) {
+       printf("\"invq(%f)\":%g,", invquantiles.elements[i], qvals[i]);
+     }
+-    printf("\"count\":%zu}\n", hist_sample_count(hist));
++    printf("\"count\":%" PRIu64 "}\n", hist_sample_count(hist));
+   }
+   else print_hist(hist);
+ }
+-- 
+2.54.0

--- a/modules/libcircllhist/0.3.2.bcr.1/patches/0002-add-module.bazel.patch
+++ b/modules/libcircllhist/0.3.2.bcr.1/patches/0002-add-module.bazel.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shantanu Gontia <gontia.shantanu@gmail.com>
+Date: Fri, 29 May 2026 08:14:07 +0530
+Subject: add module.bazel
+
+
+diff --git MODULE.bazel MODULE.bazel
+new file mode 100644
+index 0000000..da9c01b
+--- /dev/null
++++ MODULE.bazel
+@@ -0,0 +1,16 @@
++module(
++    name = "libcircllhist",
++    version = "0.3.2.bcr.1",
++    compatibility_level = 1,
++    bazel_compatibility = [">=7.2.1"],
++)
++
++bazel_dep(
++    name = "platforms",
++    version = "1.1.0",
++)
++
++bazel_dep(
++    name = "rules_cc",
++    version = "0.2.17",
++)
+-- 
+2.54.0

--- a/modules/libcircllhist/0.3.2.bcr.1/patches/0003-add-build-file.patch
+++ b/modules/libcircllhist/0.3.2.bcr.1/patches/0003-add-build-file.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shantanu Gontia <gontia.shantanu@gmail.com>
+Date: Fri, 29 May 2026 08:15:13 +0530
+Subject: add build file
+
+
+diff --git BUILD.bazel BUILD.bazel
+new file mode 100644
+index 0000000..765743f
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,40 @@
++load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
++
++licenses(["notice"])  # Apache 2
++
++config_setting(
++    name = "windows_x86_64",
++    constraint_values = [
++        "@platforms//os:windows",
++        "@platforms//cpu:x86_64",
++    ],
++)
++
++cc_library(
++    name = "circlhist",
++    srcs = ["src/circllhist.c"],
++    hdrs = [
++        "src/circllhist.h",
++    ],
++    copts = select({
++        "//:windows_x86_64": ["-DWIN32"],
++        "//conditions:default": [],
++    }),
++    strip_include_prefix = "src",
++    visibility = ["//visibility:public"],
++)
++
++alias(
++    name = "libcirclhist",
++    actual = "//:circlhist",
++    visibility = ["//visibility:public"],
++)
++
++cc_binary(
++    name = "circlhist_print",
++    srcs = ["src/circllhist_print.c"],
++    deps = [
++        ":circlhist",
++    ],
++    visibility = ["//visibility:public"],
++)
+-- 
+2.54.0

--- a/modules/libcircllhist/0.3.2.bcr.1/presubmit.yml
+++ b/modules/libcircllhist/0.3.2.bcr.1/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@libcircllhist//:circlhist'

--- a/modules/libcircllhist/0.3.2.bcr.1/source.json
+++ b/modules/libcircllhist/0.3.2.bcr.1/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/openhistogram/libcircllhist/archive/refs/tags/py-0.3.2.tar.gz",
+    "integrity": "sha256-bfvWSf3jgPeiJW3vQ7nGN0xtb+doF4sJ457t+HSxOfQ=",
+    "strip_prefix": "libcircllhist-py-0.3.2",
+    "patches": {
+        "0001-fix-printing-warning.patch": "sha256-UQt4L0kYWFRn0ulwVsXJqb2QiwWsx9E+wQr+yV7Geps=",
+        "0002-add-module.bazel.patch": "sha256-V4RIDw5irmV7GETGiepek1weMG83lBkM4di/ReCY4BA=",
+        "0003-add-build-file.patch": "sha256-Hxg1h6E4y5rKogqZZW8mDaV8V2yGGp9CCiKwh7aEG8Y="
+    },
+    "patch_strip": 0
+}

--- a/modules/libcircllhist/metadata.json
+++ b/modules/libcircllhist/metadata.json
@@ -10,7 +10,8 @@
         "github:openhistogram/libcircllhist"
     ],
     "versions": [
-        "0.3.2"
+        "0.3.2",
+        "0.3.2.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Revision for the `libcircllhist` library to add Bazel 9 support