### PR TITLE
gazelle_d@0.1.0

### DIFF
--- a/modules/gazelle_d/0.1.0/MODULE.bazel
+++ b/modules/gazelle_d/0.1.0/MODULE.bazel
@@ -1,0 +1,15 @@
+module(
+    name = "gazelle_d",
+    version = "0.1.0",
+)
+
+bazel_dep(name = "gazelle", version = "0.51.0")
+bazel_dep(name = "rules_d", version = "0.10.1")
+bazel_dep(name = "rules_go", version = "0.59.0")
+
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.9.2", dev_dependency = True)
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(
+    version = "1.25.9",
+)

--- a/modules/gazelle_d/0.1.0/attestations.json
+++ b/modules/gazelle_d/0.1.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/dcarp/gazelle_d/releases/download/v0.1.0/source.json.intoto.jsonl",
+            "integrity": "sha256-Wk6pihlbbFVjW6daNT4qT4Z3VXb2m9nyDWGf3wnbd2M="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/dcarp/gazelle_d/releases/download/v0.1.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-5FgDRuK6/qqVAdb78g+eQNqd2qQ5jpiGPF+hKC3W8Pg="
+        },
+        "gazelle_d-v0.1.0.tar.gz": {
+            "url": "https://github.com/dcarp/gazelle_d/releases/download/v0.1.0/gazelle_d-v0.1.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-k7lPST6/lrFWSZRljde2jEn2idmxcuVKeVoJL0lvc8g="
+        }
+    }
+}

--- a/modules/gazelle_d/0.1.0/presubmit.yml
+++ b/modules/gazelle_d/0.1.0/presubmit.yml
@@ -1,0 +1,10 @@
+matrix:
+  platform: ["debian13", "ubuntu2404"]
+  bazel: ["7.x", "8.x", "9.x"]
+tasks:
+  verify_targets:
+    name: "Build and test"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "//..."

--- a/modules/gazelle_d/0.1.0/source.json
+++ b/modules/gazelle_d/0.1.0/source.json
@@ -1,0 +1,6 @@
+{
+    "integrity": "sha256-l/U7s4gx37b7E2tobkAeUiSY8LkvP68QFnSHGdMQT2A=",
+    "strip_prefix": "gazelle_d-0.1.0",
+    "docs_url": "https://github.com/dcarp/gazelle_d/releases/download/v0.1.0/gazelle_d-v0.1.0.docs.tar.gz",
+    "url": "https://github.com/dcarp/gazelle_d/releases/download/v0.1.0/gazelle_d-v0.1.0.tar.gz"
+}

--- a/modules/gazelle_d/metadata.json
+++ b/modules/gazelle_d/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/dcarp/gazelle_d",
+    "maintainers": [
+        {
+            "name": "Dragos Carp",
+            "email": "dragoscarp@gmail.com",
+            "github": "dcarp",
+            "github_user_id": 1738497
+        }
+    ],
+    "repository": [
+        "github:dcarp/gazelle_d"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/dcarp/gazelle_d/releases/tag/v0.1.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_