### PR TITLE
Add ccronexpr 2.1.0

### DIFF
--- a/modules/ccronexpr/2.1.0/MODULE.bazel
+++ b/modules/ccronexpr/2.1.0/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "ccronexpr",
+    version = "2.1.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/ccronexpr/2.1.0/MODULE.bazel
+++ b/modules/ccronexpr/2.1.0/MODULE.bazel
@@ -6,4 +6,5 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/ccronexpr/2.1.0/overlay/BUILD.bazel
+++ b/modules/ccronexpr/2.1.0/overlay/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -51,5 +51,18 @@ cc_library(
 cc_test(
     name = "ccronexpr_test",
     srcs = ["ccronexpr_test.c"],
+    deps = [":ccronexpr"],
+)
+
+# The supertinycron command-line tool (commented out in upstream CMake). It
+# relies on POSIX APIs (fork/wait/signal), so it is not built on Windows.
+cc_binary(
+    name = "supertinycron",
+    srcs = ["supertinycron.c"],
+    local_defines = ['VERSION=\\"2.1.0\\"'],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [":ccronexpr"],
 )

--- a/modules/ccronexpr/2.1.0/overlay/BUILD.bazel
+++ b/modules/ccronexpr/2.1.0/overlay/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# Mirrors the CMake "CRON_USE_LOCAL_TIME" option (default OFF).
+# By default all dates are processed as UTC/GMT. Downstream modules can opt in
+# to system-local time with `--@ccronexpr//:use_local_time=True`.
+bool_flag(
+    name = "use_local_time",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "local_time_enabled",
+    flag_values = {":use_local_time": "True"},
+)
+
+# Disables the Year field, shrinking `cron_expr` by 29 bytes. The year field is
+# still accepted but not validated and matches every year. This changes the
+# public layout of `cron_expr`, so the define is propagated to all dependents.
+# Opt in with `--@ccronexpr//:disable_years=True`.
+bool_flag(
+    name = "disable_years",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "years_disabled",
+    flag_values = {":disable_years": "True"},
+)
+
+# Mirrors the CMake "ccronexpr" STATIC library target.
+cc_library(
+    name = "ccronexpr",
+    srcs = ["ccronexpr.c"],
+    hdrs = ["ccronexpr.h"],
+    defines = select({
+        ":local_time_enabled": ["CRON_USE_LOCAL_TIME"],
+        "//conditions:default": [],
+    }) + select({
+        ":years_disabled": ["CRON_DISABLE_YEARS"],
+        "//conditions:default": [],
+    }),
+    includes = ["."],
+)
+
+# Mirrors the CMake "ccronexpr_test" executable / ctest target.
+# The upstream test asserts UTC results, so it is built with the default
+# (UTC) configuration regardless of the flag.
+cc_test(
+    name = "ccronexpr_test",
+    srcs = ["ccronexpr_test.c"],
+    deps = [":ccronexpr"],
+)

--- a/modules/ccronexpr/2.1.0/overlay/MODULE.bazel
+++ b/modules/ccronexpr/2.1.0/overlay/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "ccronexpr",
+    version = "2.1.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/ccronexpr/2.1.0/overlay/MODULE.bazel
+++ b/modules/ccronexpr/2.1.0/overlay/MODULE.bazel
@@ -6,4 +6,5 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/ccronexpr/2.1.0/presubmit.yml
+++ b/modules/ccronexpr/2.1.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@ccronexpr//:ccronexpr'
+    test_targets:
+      - '@ccronexpr//:ccronexpr_test'

--- a/modules/ccronexpr/2.1.0/presubmit.yml
+++ b/modules/ccronexpr/2.1.0/presubmit.yml
@@ -3,7 +3,6 @@ matrix:
     - debian10
     - ubuntu2004
     - macos
-    - windows
   bazel:
     - 7.x
     - 8.x
@@ -15,5 +14,15 @@ tasks:
     build_targets:
       - '@ccronexpr//:ccronexpr'
       - '@ccronexpr//:supertinycron'
+    test_targets:
+      - '@ccronexpr//:ccronexpr_test'
+  # supertinycron relies on POSIX APIs and is not built on Windows; only the
+  # library and its test are verified there.
+  verify_targets_on_windows:
+    name: Verify build targets
+    platform: windows
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@ccronexpr//:ccronexpr'
     test_targets:
       - '@ccronexpr//:ccronexpr_test'

--- a/modules/ccronexpr/2.1.0/presubmit.yml
+++ b/modules/ccronexpr/2.1.0/presubmit.yml
@@ -14,5 +14,6 @@ tasks:
     bazel: ${{ bazel }}
     build_targets:
       - '@ccronexpr//:ccronexpr'
+      - '@ccronexpr//:supertinycron'
     test_targets:
       - '@ccronexpr//:ccronexpr_test'

--- a/modules/ccronexpr/2.1.0/source.json
+++ b/modules/ccronexpr/2.1.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-7mYj6ERwfivZK2qjxjhIRmywUNIG0kbuk+vn+LcJ3qk=",
+    "strip_prefix": "supertinycron-2.1.0",
+    "url": "https://github.com/exander77/supertinycron/archive/refs/tags/v2.1.0.tar.gz",
+    "overlay": {
+        "BUILD.bazel": "sha256-SYUH5fFYu7do95qCoJgiobCqtKjPqoUxKi5J0OUYIi0=",
+        "MODULE.bazel": "sha256-i0xLu8yVRJDg37hbRMvJ+XZkvFb4PZKIyEL78WXdlcc="
+    }
+}

--- a/modules/ccronexpr/2.1.0/source.json
+++ b/modules/ccronexpr/2.1.0/source.json
@@ -3,7 +3,7 @@
     "strip_prefix": "supertinycron-2.1.0",
     "url": "https://github.com/exander77/supertinycron/archive/refs/tags/v2.1.0.tar.gz",
     "overlay": {
-        "BUILD.bazel": "sha256-SYUH5fFYu7do95qCoJgiobCqtKjPqoUxKi5J0OUYIi0=",
-        "MODULE.bazel": "sha256-i0xLu8yVRJDg37hbRMvJ+XZkvFb4PZKIyEL78WXdlcc="
+        "BUILD.bazel": "sha256-3V67ACkuUG2QTx9GZksLwRrCoWGDzk/4yMbs+ETFPRw=",
+        "MODULE.bazel": "sha256-yE72ozpTSzdkt90onW6DBjbsJHwJhu+D9W73b8ZrNbU="
     }
 }

--- a/modules/ccronexpr/metadata.json
+++ b/modules/ccronexpr/metadata.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://github.com/exander77/supertinycron",
+    "maintainers": [],
+    "repository": [
+        "github:exander77/supertinycron"
+    ],
+    "versions": [
+        "2.1.0"
+    ],
+    "yanked_versions": {}
+}

--- a/modules/ccronexpr/metadata.json
+++ b/modules/ccronexpr/metadata.json
@@ -1,6 +1,12 @@
 {
     "homepage": "https://github.com/exander77/supertinycron",
-    "maintainers": [],
+    "maintainers": [
+        {
+            "github": "BYVoid",
+            "github_user_id": 245270,
+            "name": "Carbo"
+        }
+    ],
     "repository": [
         "github:exander77/supertinycron"
     ],


### PR DESCRIPTION
Adds the `ccronexpr` module based on [supertinycron](https://github.com/exander77/supertinycron) v2.1.0.

The library mirrors the upstream CMake build: a single `cc_library` built from `ccronexpr.c`, plus the `ccronexpr_test` target. Since upstream ships no Bazel support, `BUILD.bazel` and `MODULE.bazel` are injected via an `overlay`.

Two of upstream's compile-time options are exposed as `bool_flag`s so downstream modules can opt in (defaults match the upstream CMake defaults — UTC time, Year field enabled):

- `--@ccronexpr//:use_local_time=True` → `-DCRON_USE_LOCAL_TIME` (use system-local time instead of UTC)
- `--@ccronexpr//:disable_years=True` → `-DCRON_DISABLE_YEARS` (drop the Year field, shrinking `cron_expr` by 29 bytes)

Verified locally: the library builds and `ccronexpr_test` passes; both flags correctly propagate their defines.

The source URL is GitHub's auto-generated tag archive (the project publishes no release assets):

@bazel-io skip_check unstable_url