### PR TITLE
registry: restrict download() URLs to http/https schemes

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -72,6 +72,13 @@ def download(url):
     opener = urllib.request.build_opener(Github404ErrorProcessor)
     urllib.request.install_opener(opener)
     parts = urllib.parse.urlparse(url)
+    # Module source/mirror URLs come from untrusted submissions. Restrict the
+    # scheme to http/https so that a submission cannot make the validation
+    # tooling read local files (file://) or use other urllib-supported schemes.
+    if parts.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Unsupported URL scheme '{parts.scheme}' in {url}; only http and https are allowed"
+        )
     headers = {"User-Agent": "curl/8.7.1"}  # Set the User-Agent header
     try:
         authenticators = netrc.netrc().authenticators(parts.netloc)


### PR DESCRIPTION
## Problem

`download()` in `tools/registry.py` is used by the validation tooling (`bcr_validation.py`) to fetch a module submission's `source.json` `url` and `mirror_urls`. These URLs come from untrusted fork-PR submissions, and `download()` passes them to `urllib.request.urlopen` without restricting the scheme. As a result a submission can use `file://` to make the tooling read a local file on the CI runner (the response hash is printed to the public CI log on integrity mismatch), or other urllib-supported schemes.

## Change

Restrict `download()` to `http`/`https` after parsing the URL; any other scheme raises a `ValueError`. Module source and mirror archives are always served over http(s), so this does not affect legitimate submissions, and it removes the `file://`/other-scheme vector from untrusted submission URLs.
