### PR TITLE
Harden BCR skip-check workflow

### DIFF
--- a/.github/workflows/skip_check.yml
+++ b/.github/workflows/skip_check.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   comment_bot:
-    if: startsWith(github.event.comment.body, '@bazel-io skip_check ')
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '@bazel-io skip_check ')
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,16 +72,18 @@ Validations performed in the scripts are:
 
 - Verify the module version exists in the `metadata.json` of the module.
 - Verify the source archive URL matches the source repository specified in `metadata.json`.
-- Verify the source archive URL is stable if it comes from GitHub. (See [this discussion](https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1029861300)). Comment `@bazel-io skip_check unstable_url` to skip this check.
+- Verify the source archive URL is stable if it comes from GitHub. (See [this discussion](https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1029861300)). An authorized PR participant can comment `@bazel-io skip_check unstable_url` to skip this check.
 - Verify the integrity values of the source archive and patch files (if any) are correct.
 - Verify the checked-in `MODULE.bazel` file matches the one in the extracted and patched source tree.
-- Verify the `compatibility_level` in `MODULE.bazel` matches the previous version. If the bump is intentional, you can comment `@bazel-io skip_check compatibility_level` in the PR to skip this check.
+- Verify the `compatibility_level` in `MODULE.bazel` matches the previous version. If the bump is intentional, an authorized PR participant can comment `@bazel-io skip_check compatibility_level` in the PR to skip this check.
 - Check if the module is new or the `presubmit.yml` file is too different compared to the last version, if so a BCR maintainer review will be required to run jobs specified in `presubmit.yml`.
 
 Additional validations implemented in the [bcr_presubmit.py](https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazel-central-registry/bcr_presubmit.py) script:
 
 - The checked-in `MODULE.bazel`, `source.json`, patches files are not modified in the PR.
 - The files outside of `modules/` directory are not modified in the pull request if the PR is adding a new module version.
+
+For skip-check comments, an authorized PR participant is the PR author, a repository collaborator, or a maintainer for all modules modified by the PR.
 
 ### Anonymous module test
 
@@ -190,7 +192,7 @@ incompatible_flags:
 
 During presubmit jobs, flags matching the current Bazel version in use will be tested. This applies to both the [anonymous module](#anonymous-module-test) and the [test module](#test-module).
 
-If you need to temporarily skip incompatible flags testing, you can comment `@bazel-io skip_check incompatible_flags` in your PR. This will automatically add the `skip-incompatible-flags-test` label to the PR, bypassing incompatible flags testing for all presubmit jobs. You can migrate for those breaking changes at a later time.
+If you need to temporarily skip incompatible flags testing, an authorized PR participant can comment `@bazel-io skip_check incompatible_flags` in the PR. This will automatically add the `skip-incompatible-flags-test` label to the PR, bypassing incompatible flags testing for all presubmit jobs. You can migrate for those breaking changes at a later time.
 
 For an overview result of testing top BCR modules with incompatible flags, you can check the nightly build of [BCR Bazel Compatibility Test](https://buildkite.com/bazel/bcr-bazel-compatibility-test).
 


### PR DESCRIPTION
## Summary
- only run the skip-check workflow for pull request comments
- update documentation so skip-check commands are described as restricted to authorized PR participants
- define authorized PR participants as the PR author, repository collaborators, or maintainers for all modified modules

## Why
This is the BCR-side companion to bazelbuild/continuous-integration#2658. The action PR enforces the authorization checks before adding validation-bypass labels. This PR narrows the workflow trigger surface and keeps public docs aligned with the hardened behavior.

## Validation
- reviewed workflow/docs diff
- action-side tests are in bazelbuild/continuous-integration#2658

## Follow-up
After bazelbuild/continuous-integration#2658 is merged, update the pinned bcr-pr-reviewer action SHA in BCR workflows to the fixed commit.