### PR TITLE
rules_itest@0.0.55

### DIFF
--- a/modules/rules_itest/0.0.55/MODULE.bazel
+++ b/modules/rules_itest/0.0.55/MODULE.bazel
@@ -1,0 +1,32 @@
+module(
+    name = "rules_itest",
+    version = "0.0.55",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "rules_cc", version = "0.1.5")
+bazel_dep(name = "rules_go", version = "0.61.0")
+bazel_dep(name = "gazelle", version = "0.41.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "org_golang_x_sys",
+)
+
+bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.2", dev_dependency = True)
+
+bazel_dep(name = "llvm", version = "0.8.4", dev_dependency = True)
+register_toolchains("@llvm//toolchain:all", dev_dependency = True)
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
+go_sdk.from_file(
+    name = "go_sdk",
+    go_mod = "//:go.mod",
+)
+use_repo(go_sdk, "go_sdk")

--- a/modules/rules_itest/0.0.55/attestations.json
+++ b/modules/rules_itest/0.0.55/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/hermeticbuild/rules_itest/releases/download/v0.0.55/source.json.intoto.jsonl",
+            "integrity": "sha256-HLBcF2DsqI1QtRgrhl2pMA0pIJsfQm1lCrMOOWhoO+I="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/hermeticbuild/rules_itest/releases/download/v0.0.55/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-ESyDEbWVDprOfvdPHyng6hTCSHk6r52bqoyBZi++4CQ="
+        },
+        "rules_itest-v0.0.55.tar.gz": {
+            "url": "https://github.com/hermeticbuild/rules_itest/releases/download/v0.0.55/rules_itest-v0.0.55.tar.gz.intoto.jsonl",
+            "integrity": "sha256-ADrAKsSSDbdLmzlDyLj91XrGGbm3Ce/xIeum6ruNmG8="
+        }
+    }
+}

--- a/modules/rules_itest/0.0.55/patches/module_dot_bazel_version.patch
+++ b/modules/rules_itest/0.0.55/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_itest",
+-    version = "0.0.1",
++    version = "0.0.55",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "bazel_lib", version = "3.0.0")

--- a/modules/rules_itest/0.0.55/presubmit.yml
+++ b/modules/rules_itest/0.0.55/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "tests"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x, 8.x, 9.x, rolling]
+  tasks:
+    run_tests:
+      name: "Run tests"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_itest/0.0.55/source.json
+++ b/modules/rules_itest/0.0.55/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-fpfbnhRJXtppfuOkRpSsDDIPE3OGbMz3I7ofz4bxpTo=",
+    "strip_prefix": "rules_itest-0.0.55",
+    "url": "https://github.com/hermeticbuild/rules_itest/releases/download/v0.0.55/rules_itest-v0.0.55.tar.gz",
+    "docs_url": "https://github.com/hermeticbuild/rules_itest/releases/download/v0.0.55/rules_itest-v0.0.55.docs.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-dipS7DqXqK4ynuxFk3QVMDmh83KweCtUgbadQvYJHNQ="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_itest/metadata.json
+++ b/modules/rules_itest/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/dzbarsky/rules_itest/blob/master/docs/itest.md",
+    "homepage": "https://github.com/hermeticbuild/rules_itest/blob/master/docs/itest.md",
     "maintainers": [
         {
             "name": "David Zbarsky",
@@ -9,7 +9,7 @@
         }
     ],
     "repository": [
-        "github:dzbarsky/rules_itest"
+        "github:hermeticbuild/rules_itest"
     ],
     "versions": [
         "0.0.9",
@@ -29,7 +29,8 @@
         "0.0.49",
         "0.0.50",
         "0.0.51",
-        "0.0.52"
+        "0.0.52",
+        "0.0.55"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/hermeticbuild/rules_itest/releases/tag/v0.0.55

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_