### PR TITLE
rules_itest@0.0.56

### DIFF
--- a/modules/rules_itest/0.0.56/MODULE.bazel
+++ b/modules/rules_itest/0.0.56/MODULE.bazel
@@ -1,0 +1,32 @@
+module(
+    name = "rules_itest",
+    version = "0.0.56",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "rules_cc", version = "0.1.5")
+bazel_dep(name = "rules_go", version = "0.61.0")
+bazel_dep(name = "gazelle", version = "0.41.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "org_golang_x_sys",
+)
+
+bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.2", dev_dependency = True)
+
+bazel_dep(name = "llvm", version = "0.8.4", dev_dependency = True)
+register_toolchains("@llvm//toolchain:all", dev_dependency = True)
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
+go_sdk.from_file(
+    name = "go_sdk",
+    go_mod = "//:go.mod",
+)
+use_repo(go_sdk, "go_sdk")

--- a/modules/rules_itest/0.0.56/attestations.json
+++ b/modules/rules_itest/0.0.56/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/hermeticbuild/rules_itest/releases/download/v0.0.56/source.json.intoto.jsonl",
+            "integrity": "sha256-Rm/Zn+pksO/uySjOAXwSCJtj+wHgKBe8t3vcecgZUh0="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/hermeticbuild/rules_itest/releases/download/v0.0.56/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-5TZ4X4iCY/H1MZ4QoTJ5+wx9ARayOQeFJnu1r7JSjyw="
+        },
+        "rules_itest-v0.0.56.tar.gz": {
+            "url": "https://github.com/hermeticbuild/rules_itest/releases/download/v0.0.56/rules_itest-v0.0.56.tar.gz.intoto.jsonl",
+            "integrity": "sha256-15xPagyQ0LHA1Frx/8fM6RFvrto3VbvAh17JEoIoMzI="
+        }
+    }
+}

--- a/modules/rules_itest/0.0.56/patches/module_dot_bazel_version.patch
+++ b/modules/rules_itest/0.0.56/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_itest",
+-    version = "0.0.1",
++    version = "0.0.56",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "bazel_lib", version = "3.0.0")

--- a/modules/rules_itest/0.0.56/presubmit.yml
+++ b/modules/rules_itest/0.0.56/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "tests"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [8.x, 9.x, rolling]
+  tasks:
+    run_tests:
+      name: "Run tests"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_itest/0.0.56/source.json
+++ b/modules/rules_itest/0.0.56/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-EqQr/8Is7UMl6wIrugypUQVxQtBfWSaIfGYJujEBX1Y=",
+    "strip_prefix": "rules_itest-0.0.56",
+    "url": "https://github.com/hermeticbuild/rules_itest/releases/download/v0.0.56/rules_itest-v0.0.56.tar.gz",
+    "docs_url": "https://github.com/hermeticbuild/rules_itest/releases/download/v0.0.56/rules_itest-v0.0.56.docs.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-oCmMhkN1c4TqXFG6GC3XZRpYsnFLKklyVS9ETBOV7U0="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_itest/metadata.json
+++ b/modules/rules_itest/metadata.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/dzbarsky/rules_itest/blob/master/docs/itest.md",
+    "homepage": "https://github.com/hermeticbuild/rules_itest/blob/master/docs/itest.md",
     "maintainers": [
         {
             "name": "David Zbarsky",
@@ -9,7 +9,7 @@
         }
     ],
     "repository": [
-        "github:dzbarsky/rules_itest"
+        "github:hermeticbuild/rules_itest"
     ],
     "versions": [
         "0.0.9",
@@ -29,7 +29,8 @@
         "0.0.49",
         "0.0.50",
         "0.0.51",
-        "0.0.52"
+        "0.0.52",
+        "0.0.56"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/hermeticbuild/rules_itest/releases/tag/v0.0.56

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_