### PR TITLE
Replace centos7 with rockylinux8

### DIFF
--- a/modules/ofiuco/0.5.0/presubmit.yml
+++ b/modules/ofiuco/0.5.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.5.1/presubmit.yml
+++ b/modules/ofiuco/0.5.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.5.2/presubmit.yml
+++ b/modules/ofiuco/0.5.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.5.3/presubmit.yml
+++ b/modules/ofiuco/0.5.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.6.2/presubmit.yml
+++ b/modules/ofiuco/0.6.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.6.3/presubmit.yml
+++ b/modules/ofiuco/0.6.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.6.4/presubmit.yml
+++ b/modules/ofiuco/0.6.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.7.0/presubmit.yml
+++ b/modules/ofiuco/0.7.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.7.1/presubmit.yml
+++ b/modules/ofiuco/0.7.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.7.2/presubmit.yml
+++ b/modules/ofiuco/0.7.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.8.0/presubmit.yml
+++ b/modules/ofiuco/0.8.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.8.1/presubmit.yml
+++ b/modules/ofiuco/0.8.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.8.2/presubmit.yml
+++ b/modules/ofiuco/0.8.2/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.8.3/presubmit.yml
+++ b/modules/ofiuco/0.8.3/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.8.4/presubmit.yml
+++ b/modules/ofiuco/0.8.4/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.8.5/presubmit.yml
+++ b/modules/ofiuco/0.8.5/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.9.0/presubmit.yml
+++ b/modules/ofiuco/0.9.0/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/ofiuco/0.9.1/presubmit.yml
+++ b/modules/ofiuco/0.9.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform:
-    - centos7
+    - rockylinux8
     - debian10
     - ubuntu2004
     - macos

--- a/modules/rules_cc/0.1.2/presubmit.yml
+++ b/modules/rules_cc/0.1.2/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel:
   - 7.x
   - 8.x

--- a/modules/rules_foreign_cc/0.15.0/presubmit.yml
+++ b/modules/rules_foreign_cc/0.15.0/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ["7.x"]
 
 tasks:

--- a/modules/rules_foreign_cc/0.15.1/presubmit.yml
+++ b/modules/rules_foreign_cc/0.15.1/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
   bazel: ["7.x"]
 
 tasks:

--- a/modules/rules_jni/0.11.1/presubmit.yml
+++ b/modules/rules_jni/0.11.1/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   bazel: [7.x, 8.x]
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["rockylinux8", "debian10", "macos", "ubuntu2004", "windows"]
 
 tasks:
   build_targets:
@@ -22,12 +22,12 @@ bcr_test_module:
       platform: ${{ platform }}
       test_targets:
         - "//..."
-    # The CentOS image does not set JAVA_HOME. To make the tests work, we set it
+    # The Rocky Linux image does not set JAVA_HOME. To make the tests work, we set it
     # manually.
-    run_tests_centos7:
+    run_tests_rockylinux8:
       name: "Run test module"
       bazel: ${{ bazel }}
-      platform: centos7
+      platform: rockylinux8
       environment:
         JAVA_HOME: /usr/lib/jvm/zulu21
       test_targets:

--- a/modules/rules_sh/0.2.0/patches/add_module_extension.patch
+++ b/modules/rules_sh/0.2.0/patches/add_module_extension.patch
@@ -5,7 +5,7 @@ index 0000000..8b8cbda
 +++ b/.bazelci/presubmit.yml
 @@ -0,0 +1,16 @@
 +platforms:
-+  centos7:
++  rockylinux8:
 +    build_targets:
 +    - '@rules_sh//...'
 +  debian10:

--- a/modules/rules_sh/0.2.0/patches/add_module_extension.patch
+++ b/modules/rules_sh/0.2.0/patches/add_module_extension.patch
@@ -5,7 +5,7 @@ index 0000000..8b8cbda
 +++ b/.bazelci/presubmit.yml
 @@ -0,0 +1,16 @@
 +platforms:
-+  rockylinux8:
++  centos7:
 +    build_targets:
 +    - '@rules_sh//...'
 +  debian10:


### PR DESCRIPTION
https://github.com/bazelbuild/continuous-integration/pull/2630 removed the CI hack that replaced centos7 with rockylinux8, thus breaking BCR Bazel Compatibility Test: https://buildkite.com/bazel/bcr-bazel-compatibility-test/builds/1041/canvas?sid=019e86eb-11d2-4bc9-9d77-9ae9855fe285&tab=output