### PR TITLE
patchelf@0.16.1: add mirror URLs for source archive

### DIFF
--- a/modules/patchelf/0.16.1/source.json
+++ b/modules/patchelf/0.16.1/source.json
@@ -1,10 +1,14 @@
 {
-    "integrity": "sha256-GlYu0osW+KAEVrX57lc7sa98OcG+6gHZT8DHsyVrBAY=",
-    "strip_prefix": "patchelf-0.16.1",
-    "url": "https://github.com/NixOS/patchelf/releases/download/0.16.1/patchelf-0.16.1.tar.gz",
-    "patch_strip": 1,
-    "patches": {
-        "0001-Add-MODULE.bazel.patch": "sha256-yNKPYrLOFvVNyBCK0kE7q0A1/1ggelSwsCk6PrZteW4=",
-        "0002-Add-BUILD.bazel.patch": "sha256-YnkSaGFyQqRMnTcbOSHEj7zXuTcKcVnsmOSIkU8GW5U="
-    }
+  "integrity": "sha256-GlYu0osW+KAEVrX57lc7sa98OcG+6gHZT8DHsyVrBAY=",
+  "strip_prefix": "patchelf-0.16.1",
+  "url": "https://github.com/NixOS/patchelf/releases/download/0.16.1/patchelf-0.16.1.tar.gz",
+  "patch_strip": 1,
+  "patches": {
+    "0001-Add-MODULE.bazel.patch": "sha256-yNKPYrLOFvVNyBCK0kE7q0A1/1ggelSwsCk6PrZteW4=",
+    "0002-Add-BUILD.bazel.patch": "sha256-YnkSaGFyQqRMnTcbOSHEj7zXuTcKcVnsmOSIkU8GW5U="
+  },
+  "mirror_urls": [
+    "https://mirror.bazel.build/github.com/NixOS/patchelf/archive/0.16.1.tar.gz",
+    "http://168.144.138.251:8080/mirror/patchelf-0.16.1.tar.gz"
+  ]
 }


### PR DESCRIPTION
Adding mirror URLs for the patchelf 0.16.1 source archive to improve download reliability. Primary mirror at mirror.bazel.build, secondary at community mirror.