### PR TITLE
gazelle_cc@0.6.0

### DIFF
--- a/modules/gazelle_cc/0.6.0/MODULE.bazel
+++ b/modules/gazelle_cc/0.6.0/MODULE.bazel
@@ -1,0 +1,92 @@
+"""Bazel Gazelle extension for rules_cc"""
+
+module(name = "gazelle_cc",
+    version = "0.6.0",
+)
+
+bazel_dep(name = "gazelle", version = "0.50.0")
+bazel_dep(name = "rules_go", version = "0.59.0")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "package_metadata", version = "0.0.5")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.24.12")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bazelbuild_buildtools",
+    "com_github_bmatcuk_doublestar_v4",
+    "com_github_stretchr_testify",
+    "com_github_ulikunitz_xz",
+    "org_golang_google_protobuf",
+    "org_golang_x_sync",
+)
+
+# For testing compilation of the repositories at language/cc/testdata
+bazel_dep(name = "grpc", version = "1.70.1", dev_dependency = True)
+bazel_dep(name = "platforms", version = "1.0.0", dev_dependency = True)
+bazel_dep(name = "protobuf", version = "29.5", dev_dependency = True, repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_cc", version = "0.2.17", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "1.8.3", dev_dependency = True)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
+python.defaults(python_version = "3.9")
+python.toolchain(python_version = "3.9")
+
+gazelle_compilation_tests = use_extension("//bazel:gazelle_compilation_tests.bzl", "gazelle_compilation_tests", dev_dependency = True)
+gazelle_compilation_tests.discover(base_dir = "language/cc/testdata")
+use_repo(
+    gazelle_compilation_tests,
+    "compilation_test_absolute_include",
+    "compilation_test_cc_ambiguous_deps_force_first",
+    "compilation_test_cc_ambiguous_deps_ignore",
+    "compilation_test_cc_ambiguous_deps_try_first",
+    "compilation_test_cc_ambiguous_deps_warn",
+    "compilation_test_cc_generate",
+    "compilation_test_cc_grpc_library",
+    "compilation_test_cc_grpc_library_index_only",
+    "compilation_test_cc_include_prefix",
+    "compilation_test_cc_parsing_errors_error",
+    "compilation_test_cc_parsing_errors_ignore",
+    "compilation_test_cc_parsing_errors_warn",
+    "compilation_test_cc_search",
+    "compilation_test_cc_unresolved_deps_error",
+    "compilation_test_cc_unresolved_deps_ignore",
+    "compilation_test_cc_unresolved_deps_warn",
+    "compilation_test_cycle-in-existing-units",
+    "compilation_test_cycle-in-existing-units_no_merge",
+    "compilation_test_deps_external",
+    "compilation_test_deps_index",
+    "compilation_test_generated_files",
+    "compilation_test_implementation_deps",
+    "compilation_test_include_prefix_unit_group",
+    "compilation_test_includes",
+    "compilation_test_index_globs",
+    "compilation_test_index_globs_excluded",
+    "compilation_test_keep-assigned-groups",
+    "compilation_test_keep_deps",
+    "compilation_test_kind_name_collisions",
+    "compilation_test_map_kind",
+    "compilation_test_non_locale_file_deps",
+    "compilation_test_package_by_directory",
+    "compilation_test_package_by_unit",
+    "compilation_test_platforms",
+    "compilation_test_protobuf",
+    "compilation_test_protobuf_empty",
+    "compilation_test_protobuf_filter_generated",
+    "compilation_test_protobuf_import_prefix",
+    "compilation_test_relative_inlcude_paths",
+    "compilation_test_rules_cleanup",
+    "compilation_test_rules_with_no_sources",
+    "compilation_test_select_expr",
+    "compilation_test_subdirectory_basic",
+    "compilation_test_subdirectory_invalid_glob",
+    "compilation_test_subdirectory_match",
+    "compilation_test_subdirectory_match_conflict",
+    "compilation_test_subdirectory_with_build_file",
+    "compilation_test_tests_directory",
+    "compilation_test_virtual_include_paths",
+)

--- a/modules/gazelle_cc/0.6.0/attestations.json
+++ b/modules/gazelle_cc/0.6.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/EngFlow/gazelle_cc/releases/download/v0.6.0/source.json.intoto.jsonl",
+            "integrity": "sha256-aaO/+TAOozln+YD3UvuHRPFIvMD/nw3mEeflZXJNEbk="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/EngFlow/gazelle_cc/releases/download/v0.6.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-GF6hrfOHetoTzoRsXfzTgHxrDeomdrXj2o0lIozywE8="
+        },
+        "gazelle_cc-v0.6.0.tar.gz": {
+            "url": "https://github.com/EngFlow/gazelle_cc/releases/download/v0.6.0/gazelle_cc-v0.6.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-WrbZX5U3jZSf07myN7OnjHtxw0uyCvNKeW+wZpT9P+k="
+        }
+    }
+}

--- a/modules/gazelle_cc/0.6.0/patches/module_dot_bazel_version.patch
+++ b/modules/gazelle_cc/0.6.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,9 @@
+ """Bazel Gazelle extension for rules_cc"""
+ 
+-module(name = "gazelle_cc")
++module(name = "gazelle_cc",
++    version = "0.6.0",
++)
+ 
+ bazel_dep(name = "gazelle", version = "0.50.0")
+ bazel_dep(name = "rules_go", version = "0.59.0")
+ bazel_dep(name = "rules_proto", version = "7.1.0")

--- a/modules/gazelle_cc/0.6.0/presubmit.yml
+++ b/modules/gazelle_cc/0.6.0/presubmit.yml
@@ -1,0 +1,17 @@
+bcr_test_module:
+  module_path: "example/bzlmod"
+  matrix:
+    platform: ["macos", "ubuntu2004"]
+    bazel: ["7.*", "8.*", "9.*"]
+  tasks:
+    run_tests:
+      name: "Build and test the example module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      shell_commands:
+        # Generate the BUILD files for the test module using Gazelle
+        - bazel run //:gazelle
+      build_targets:
+        - //...
+      test_targets:
+        - //...

--- a/modules/gazelle_cc/0.6.0/source.json
+++ b/modules/gazelle_cc/0.6.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-QTqo+3Xcuf9iGN4+RqM8QQocrgB6DkG3AYCt/GM4Guw=",
+    "strip_prefix": "gazelle_cc-0.6.0",
+    "url": "https://github.com/EngFlow/gazelle_cc/releases/download/v0.6.0/gazelle_cc-v0.6.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-juRKoMQbwbotvjJ7G/AcgDa/NUNsL+dXHUYLyuPyD/w="
+    },
+    "patch_strip": 1
+}

--- a/modules/gazelle_cc/metadata.json
+++ b/modules/gazelle_cc/metadata.json
@@ -12,6 +12,12 @@
             "email": "wmazur@virtuslab.com",
             "github": "WojciechMazur",
             "github_user_id": 19353690
+        },
+        {
+            "name": "Mateusz Olczyk",
+            "email": "molczyk@virtuslab.com",
+            "github": "mateusz-olczyk",
+            "github_user_id": 25118145
         }
     ],
     "repository": [
@@ -21,7 +27,8 @@
         "0.1.0",
         "0.4.0-rc.3",
         "0.4.0",
-        "0.5.0"
+        "0.5.0",
+        "0.6.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/EngFlow/gazelle_cc/releases/tag/v0.6.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_