### PR TITLE
robin-map@1.4.1

### DIFF
--- a/modules/robin-map/1.4.1/MODULE.bazel
+++ b/modules/robin-map/1.4.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "robin-map",
+    version = "1.4.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/robin-map/1.4.1/overlay/BUILD.bazel
+++ b/modules/robin-map/1.4.1/overlay/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "robin-map",
+    hdrs = glob(["include/tsl/*.h"]),
+    strip_include_prefix = "include/",
+    visibility = ["//visibility:public"],
+)

--- a/modules/robin-map/1.4.1/presubmit.yml
+++ b/modules/robin-map/1.4.1/presubmit.yml
@@ -1,0 +1,46 @@
+matrix:
+  platform:
+  - debian12
+  - debian13
+  - ubuntu2204
+  - ubuntu2404
+  - macos_arm64
+  - windows
+  platform_non_windows:
+  - debian12
+  - debian13
+  - ubuntu2204
+  - ubuntu2404
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags: &build_flags
+    - '--process_headers_in_dependencies'
+    - '--features=parse_headers'
+    build_targets: &build_targets
+    - '@robin-map//:robin-map'
+  verify_targets_bazel_7_windows:
+    name: Verify build targets (Bazel 7, Windows)
+    platform: windows
+    bazel: 7.x
+    build_flags: *build_flags
+    build_targets: *build_targets
+  verify_targets_bazel_7_non_windows:
+    name: Verify build targets (Bazel 7, non-Windows)
+    platform: ${{ platform_non_windows }}
+    bazel: 7.x
+    build_flags:
+    - '--process_headers_in_dependencies'
+    - '--features=parse_headers'
+    # When using Bazel 7.x, unless the root module loads rules_cc (of any
+    # version) then Bazel ignores robin-map's MVS rules_cc version that
+    # guarantees C++17 support, so for the anonymous module test we need
+    # to force the standard version.
+    - '--cxxopt=--std=c++17'
+    build_targets: *build_targets

--- a/modules/robin-map/1.4.1/source.json
+++ b/modules/robin-map/1.4.1/source.json
@@ -1,0 +1,8 @@
+{
+    "integrity": "sha256-Dj9To3f9zcX5/tekwNT5noK7tkF1IzvRNCf++adx9KE=",
+    "strip_prefix": "robin-map-1.4.1",
+    "url": "https://github.com/Tessil/robin-map/archive/refs/tags/v1.4.1.tar.gz",
+    "overlay": {
+        "BUILD.bazel": "sha256-VveSYAtND5x4jD+hCv9tIlfW5yAZnullq3aZMP3t+H4="
+    }
+}

--- a/modules/robin-map/metadata.json
+++ b/modules/robin-map/metadata.json
@@ -2,8 +2,10 @@
     "homepage": "https://github.com/Tessil/robin-map",
     "maintainers": [
         {
-            "email": "bcr-maintainers@bazel.build",
-            "name": "No Maintainer Specified"
+            "email": "jeremy.nimmer@tri.global",
+            "github": "jwnimmer-tri",
+            "github_user_id": 17596505,
+            "name": "Jeremy Nimmer"
         }
     ],
     "repository": [
@@ -12,7 +14,8 @@
     "versions": [
         "1.2.1",
         "1.3.0",
-        "1.4.0"
+        "1.4.0",
+        "1.4.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adopt this unmaintained module.

Modernize CI matrix.

Remove copts; this is a header-only library. For parse_headers testing in presubmit, the rules_cc toolchain already defaults to C++17 once we bump rules_cc to 0.1.1.

Export LICENSE file.