### PR TITLE
fix(bcr_validation): apply PEP 706 extraction filter on the pinned Python 3.11 toolchain

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -497,10 +497,9 @@ class BcrValidator:
         if archive_type in ("tar.zst", "tzst"):
             with open(archive_file, "rb") as fh, zstandard.ZstdDecompressor().stream_reader(fh) as reader:
                 with tarfile.open(fileobj=reader, mode="r|") as tar:
-                    if sys.version_info >= (3, 12):
-                        tar.extractall(output_dir, filter="data")
-                    else:
-                        tar.extractall(output_dir)
+                    # The PEP 706 'data' filter rejects members that escape the
+                    # destination (absolute paths, '..', unsafe symlinks/links).
+                    tar.extractall(output_dir, filter="data")
             return
         format = {
             "tar.gz": "gztar",
@@ -513,11 +512,15 @@ class BcrValidator:
             "war": "zip",
             "aar": "zip",
         }.get(archive_type)
-        # Use PEP 706 safe extraction if available (Python 3.12+)
-        if sys.version_info >= (3, 12) and format != "zip":
+        # Apply the PEP 706 'data' filter to tar-based archives. The `filter`
+        # parameter was backported to tarfile.extractall / shutil.unpack_archive
+        # in 3.9.17, 3.10.12, 3.11.4 and 3.12, so it is available on the pinned
+        # 3.11 toolchain; gating it on `sys.version_info >= (3, 12)` left the
+        # safe path unreachable in production. zip archives are excluded because
+        # zipfile (which has no `filter` kwarg) already normalizes member paths.
+        if format != "zip":
             shutil.unpack_archive(str(archive_file), output_dir, format=format, filter="data")
         else:
-            # Fallback for older Python versions. Since CI is 3.12+, this handles local dev compatibility.
             shutil.unpack_archive(str(archive_file), output_dir, format=format)
 
     @staticmethod
@@ -924,10 +927,7 @@ class BcrValidator:
         if source_uri not in gh_source_uris:
             self.report(
                 BcrValidationResult.FAILED,
-                (
-                    f"{module_name}@{version}: Expected source URI {source_uri}, "
-                    f"but got {', '.join(gh_source_uris)}."
-                ),
+                (f"{module_name}@{version}: Expected source URI {source_uri}, but got {', '.join(gh_source_uris)}."),
             )
             return
 

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -497,10 +497,9 @@ class BcrValidator:
         if archive_type in ("tar.zst", "tzst"):
             with open(archive_file, "rb") as fh, zstandard.ZstdDecompressor().stream_reader(fh) as reader:
                 with tarfile.open(fileobj=reader, mode="r|") as tar:
-                    if sys.version_info >= (3, 12):
-                        tar.extractall(output_dir, filter="data")
-                    else:
-                        tar.extractall(output_dir)
+                    # The PEP 706 'data' filter rejects members that escape the
+                    # destination (absolute paths, '..', unsafe symlinks/links).
+                    tar.extractall(output_dir, filter="data")
             return
         format = {
             "tar.gz": "gztar",
@@ -513,11 +512,12 @@ class BcrValidator:
             "war": "zip",
             "aar": "zip",
         }.get(archive_type)
-        # Use PEP 706 safe extraction if available (Python 3.12+)
-        if sys.version_info >= (3, 12) and format != "zip":
+        # Apply the PEP 706 'data' filter to tar-based archives. zip is excluded
+        # because zipfile has no `filter` kwarg and already normalizes member
+        # paths.
+        if format != "zip":
             shutil.unpack_archive(str(archive_file), output_dir, format=format, filter="data")
         else:
-            # Fallback for older Python versions. Since CI is 3.12+, this handles local dev compatibility.
             shutil.unpack_archive(str(archive_file), output_dir, format=format)
 
     @staticmethod
@@ -924,10 +924,7 @@ class BcrValidator:
         if source_uri not in gh_source_uris:
             self.report(
                 BcrValidationResult.FAILED,
-                (
-                    f"{module_name}@{version}: Expected source URI {source_uri}, "
-                    f"but got {', '.join(gh_source_uris)}."
-                ),
+                (f"{module_name}@{version}: Expected source URI {source_uri}, but got {', '.join(gh_source_uris)}."),
             )
             return
 

--- a/tools/bcr_validation_test.py
+++ b/tools/bcr_validation_test.py
@@ -14,10 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
+import os
+import tarfile
+import tempfile
 import unittest
+
+import zstandard
+
 from registry import RegistryClient
+from tools import bcr_validation
 from tools.bcr_validation import BcrValidator, BcrValidationException, is_ref_in_original_repo
 
+from unittest import mock
 from unittest.mock import MagicMock
 
 
@@ -64,6 +73,39 @@ class TestBcrValidation(unittest.TestCase):
             "pull/1234/merge",
         ):
             self.assertFalse(is_ref_in_original_repo("fake/repo", ref), ref)
+
+    def _make_malicious_tar(self, mode):
+        # A tar archive whose only member uses a '..' path-traversal name.
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode=mode) as tar:
+            info = tarfile.TarInfo("../escaped.txt")
+            data = b"owned"
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        return buf.getvalue()
+
+    def _assert_extraction_is_contained(self, filename, archive_bytes):
+        extraction_parent = tempfile.mkdtemp()
+        output_dir = os.path.join(extraction_parent, "source_root")
+        os.makedirs(output_dir)
+
+        def fake_download_file(url, dest):
+            with open(dest, "wb") as f:
+                f.write(archive_bytes)
+
+        with mock.patch.object(bcr_validation, "download_file", fake_download_file):
+            # The PEP 706 'data' filter must reject the traversing member.
+            with self.assertRaises(Exception):
+                self.bcr_validator._download_source_archive({"url": "https://example.com/%s" % filename}, output_dir)
+        # Nothing may be written outside the extraction directory.
+        self.assertFalse(os.path.exists(os.path.join(extraction_parent, "escaped.txt")))
+
+    def test_source_archive_extraction_rejects_traversal_tar_gz(self):
+        self._assert_extraction_is_contained("evil.tar.gz", self._make_malicious_tar("w:gz"))
+
+    def test_source_archive_extraction_rejects_traversal_tar_zst(self):
+        raw = self._make_malicious_tar("w")
+        self._assert_extraction_is_contained("evil.tar.zst", zstandard.ZstdCompressor().compress(raw))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`BcrValidator._download_source_archive` extracts an attacker-controlled module **source archive** (`.tar.gz`/`.tar.zst`/`.tar.xz`/…) but applies the PEP 706 safe-extraction `filter="data"` only when `sys.version_info >= (3, 12)`. The accompanying comment assumes "CI is 3.12+".

That assumption does not hold for this repository:

- `MODULE.bazel` pins the hermetic Python toolchain to 3.11: `python.toolchain(is_default=True, python_version="3.11")` / `use_repo(python, "python_3_11", ...)`.
- `tools/BUILD` loads `@python_versions//3.11`, and `requirements_lock.txt` is compiled with 3.11.
- Validation runs via `bazel run //tools:bcr_validation`, i.e. under that 3.11 interpreter.

So `sys.version_info < (3, 12)` in practice, and the **unfiltered** `tarfile.extractall(output_dir)` / `shutil.unpack_archive(...)` branch is the one that runs. A crafted source archive can then write outside the extraction directory via `..` path traversal or via a symlink member — the safe-extraction path the code intends to use is effectively dead.

The recent containment work (`strip_prefix` #9035, overlay) operates on the extracted tree and assumes extraction itself stayed within `output_dir`; this change closes that assumption at the extraction step.

## Fix

This PR removes the `sys.version_info >= (3, 12)` gate and applies `filter="data"` unconditionally for tar-based archives. `zip` is excluded because `zipfile` has no `filter` kwarg and already normalizes member paths.

### Why dropping the version gate is safe

The `filter` parameter was backported to `tarfile.extractall` and `shutil.unpack_archive` in **3.9.17, 3.10.12, 3.11.4 and 3.12** (PEP 706), so it is available on the pinned 3.11 toolchain — there is no interpreter this repository runs on where the unconditional call is unsupported. Gating it on `sys.version_info >= (3, 12)` is what left the safe path unreachable in production.

(Per review: this rationale used to sit in a code comment; it lives here instead, since it explains why the change was made rather than what the code does.)

## Testing Plan

Added `tools/bcr_validation_test.py` tests that drive `_download_source_archive` (with `download_file` mocked) on a `.tar.gz` and a `.tar.zst` source archive whose only member is a `../escaped.txt` traversal entry, asserting the member is rejected and nothing is written outside the extraction directory.

```text
$ python -m unittest tools.bcr_validation_test.TestBcrValidation \
    -k traversal -v        # run on Python 3.11.15
test_source_archive_extraction_rejects_traversal_tar_gz ... ok
test_source_archive_extraction_rejects_traversal_tar_zst ... ok
----------------------------------------------------------------------
Ran 2 tests in 0.005s
OK
```

Verified manually that without this change the same archives extract the traversing member outside `source_root` on Python 3.11, and that `filter="data"` blocks it with `tarfile.OutsideDestinationError`.

