### PR TITLE
Add boost.msm

### DIFF
--- a/modules/boost.msm/1.87.0/MODULE.bazel
+++ b/modules/boost.msm/1.87.0/MODULE.bazel
@@ -1,0 +1,27 @@
+module(
+    name = "boost.msm",
+    version = "1.87.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 108700,
+)
+
+bazel_dep(name = "boost.any", version = "1.87.0")
+bazel_dep(name = "boost.assert", version = "1.87.0")
+bazel_dep(name = "boost.bind", version = "1.87.0")
+bazel_dep(name = "boost.circular_buffer", version = "1.87.0")
+bazel_dep(name = "boost.config", version = "1.87.0")
+bazel_dep(name = "boost.core", version = "1.87.0")
+bazel_dep(name = "boost.function", version = "1.87.0")
+bazel_dep(name = "boost.fusion", version = "1.87.0")
+bazel_dep(name = "boost.mpl", version = "1.87.0")
+bazel_dep(name = "boost.parameter", version = "1.87.0")
+bazel_dep(name = "boost.phoenix", version = "1.87.0")
+bazel_dep(name = "boost.preprocessor", version = "1.87.0")
+bazel_dep(name = "boost.proto", version = "1.87.0")
+bazel_dep(name = "boost.serialization", version = "1.87.0")
+bazel_dep(name = "boost.tuple", version = "1.87.0")
+bazel_dep(name = "boost.type_index", version = "1.87.0")
+bazel_dep(name = "boost.type_traits", version = "1.87.0")
+bazel_dep(name = "boost.typeof", version = "1.87.0")
+bazel_dep(name = "boost.utility", version = "1.87.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/boost.msm/1.87.0/overlay/BUILD.bazel
+++ b/modules/boost.msm/1.87.0/overlay/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "boost.msm",
+    hdrs = glob(
+        [
+            "include/**/*.hpp",
+        ],
+        exclude = [
+            "include/boost/msm/back/args.hpp",
+            "include/boost/msm/front/euml/transformation.hpp",
+            "include/boost/msm/front/puml/puml.hpp",
+            "include/boost/msm/mpl_graph/search_colors.hpp",
+        ],
+    ),
+    features = [
+        "parse_headers",
+    ],
+    includes = ["include"],
+    textual_hdrs = glob([
+        "include/**/*.ipp",
+        "include/boost/msm/back/args.hpp",
+        "include/boost/msm/front/euml/transformation.hpp",
+        "include/boost/msm/front/puml/puml.hpp",
+        "include/boost/msm/mpl_graph/search_colors.hpp",
+    ]),
+    deps = [
+        "@boost.any",
+        "@boost.assert",
+        "@boost.bind",
+        "@boost.circular_buffer",
+        "@boost.config",
+        "@boost.core",
+        "@boost.function",
+        "@boost.fusion",
+        "@boost.mpl",
+        "@boost.parameter",
+        "@boost.phoenix",
+        "@boost.preprocessor",
+        "@boost.proto",
+        "@boost.serialization",
+        "@boost.tuple",
+        "@boost.type_index",
+        "@boost.type_traits",
+        "@boost.typeof",
+        "@boost.utility",
+    ],
+)

--- a/modules/boost.msm/1.87.0/overlay/MODULE.bazel
+++ b/modules/boost.msm/1.87.0/overlay/MODULE.bazel
@@ -1,0 +1,27 @@
+module(
+    name = "boost.msm",
+    version = "1.87.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 108700,
+)
+
+bazel_dep(name = "boost.any", version = "1.87.0")
+bazel_dep(name = "boost.assert", version = "1.87.0")
+bazel_dep(name = "boost.bind", version = "1.87.0")
+bazel_dep(name = "boost.circular_buffer", version = "1.87.0")
+bazel_dep(name = "boost.config", version = "1.87.0")
+bazel_dep(name = "boost.core", version = "1.87.0")
+bazel_dep(name = "boost.function", version = "1.87.0")
+bazel_dep(name = "boost.fusion", version = "1.87.0")
+bazel_dep(name = "boost.mpl", version = "1.87.0")
+bazel_dep(name = "boost.parameter", version = "1.87.0")
+bazel_dep(name = "boost.phoenix", version = "1.87.0")
+bazel_dep(name = "boost.preprocessor", version = "1.87.0")
+bazel_dep(name = "boost.proto", version = "1.87.0")
+bazel_dep(name = "boost.serialization", version = "1.87.0")
+bazel_dep(name = "boost.tuple", version = "1.87.0")
+bazel_dep(name = "boost.type_index", version = "1.87.0")
+bazel_dep(name = "boost.type_traits", version = "1.87.0")
+bazel_dep(name = "boost.typeof", version = "1.87.0")
+bazel_dep(name = "boost.utility", version = "1.87.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/boost.msm/1.87.0/presubmit.yml
+++ b/modules/boost.msm/1.87.0/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.msm//:boost.msm'

--- a/modules/boost.msm/1.87.0/source.json
+++ b/modules/boost.msm/1.87.0/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-FVChKJwSFN+NjPveDAf5J3BXSx/YSF1WXFiGw4tfFk8=",
+    "strip_prefix": "msm-boost-1.87.0",
+    "url": "https://github.com/boostorg/msm/archive/refs/tags/boost-1.87.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-E7ocv6V4VZng4rD+Q1kVkTsblEnnRvYLFJnrMo9l/08=",
+        "MODULE.bazel": "sha256-oRyHtjByrpgvifrVpkmnXPB8g8HtMfv9WowmE+3KUcs="
+    }
+}

--- a/modules/boost.msm/1.88.0.bcr.3/MODULE.bazel
+++ b/modules/boost.msm/1.88.0.bcr.3/MODULE.bazel
@@ -1,0 +1,28 @@
+module(
+    name = "boost.msm",
+    version = "1.88.0.bcr.3",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = 108800,
+)
+
+bazel_dep(name = "boost", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.any", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.assert", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.bind", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.circular_buffer", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.config", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.core", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.function", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.fusion", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.mpl", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.parameter", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.phoenix", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.preprocessor", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.proto", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.serialization", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.tuple", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.type_index", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.type_traits", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.typeof", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.utility", version = "1.88.0.bcr.3")
+bazel_dep(name = "rules_cc", version = "0.2.4")

--- a/modules/boost.msm/1.88.0.bcr.3/overlay/BUILD.bazel
+++ b/modules/boost.msm/1.88.0.bcr.3/overlay/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "boost.msm",
+    hdrs = glob(
+        [
+            "include/**/*.hpp",
+        ],
+        exclude = [
+            "include/boost/msm/back/args.hpp",
+            "include/boost/msm/front/euml/transformation.hpp",
+            "include/boost/msm/front/puml/puml.hpp",
+            "include/boost/msm/mpl_graph/search_colors.hpp",
+        ],
+    ),
+    features = [
+        "parse_headers",
+    ],
+    includes = ["include"],
+    textual_hdrs = glob([
+        "include/**/*.ipp",
+        "include/boost/msm/back/args.hpp",
+        "include/boost/msm/front/euml/transformation.hpp",
+        "include/boost/msm/front/puml/puml.hpp",
+        "include/boost/msm/mpl_graph/search_colors.hpp",
+    ]),
+    deps = [
+        "@boost.any",
+        "@boost.assert",
+        "@boost.bind",
+        "@boost.circular_buffer",
+        "@boost.config",
+        "@boost.core",
+        "@boost.function",
+        "@boost.fusion",
+        "@boost.mpl",
+        "@boost.parameter",
+        "@boost.phoenix",
+        "@boost.preprocessor",
+        "@boost.proto",
+        "@boost.serialization",
+        "@boost.tuple",
+        "@boost.type_index",
+        "@boost.type_traits",
+        "@boost.typeof",
+        "@boost.utility",
+    ],
+)

--- a/modules/boost.msm/1.88.0.bcr.3/overlay/MODULE.bazel
+++ b/modules/boost.msm/1.88.0.bcr.3/overlay/MODULE.bazel
@@ -1,0 +1,28 @@
+module(
+    name = "boost.msm",
+    version = "1.88.0.bcr.3",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = 108800,
+)
+
+bazel_dep(name = "boost", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.any", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.assert", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.bind", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.circular_buffer", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.config", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.core", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.function", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.fusion", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.mpl", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.parameter", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.phoenix", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.preprocessor", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.proto", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.serialization", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.tuple", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.type_index", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.type_traits", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.typeof", version = "1.88.0.bcr.3")
+bazel_dep(name = "boost.utility", version = "1.88.0.bcr.3")
+bazel_dep(name = "rules_cc", version = "0.2.4")

--- a/modules/boost.msm/1.88.0.bcr.3/presubmit.yml
+++ b/modules/boost.msm/1.88.0.bcr.3/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.msm//:boost.msm'

--- a/modules/boost.msm/1.88.0.bcr.3/source.json
+++ b/modules/boost.msm/1.88.0.bcr.3/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-632/ZuhaMN0WbvnmBNS8P8bXzb6ZxwAE4r+k795zCkM=",
+    "strip_prefix": "msm-boost-1.88.0",
+    "url": "https://github.com/boostorg/msm/archive/refs/tags/boost-1.88.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-3M0Vg97ya158JlpQhr0UTO2v/o07hkxzQV1U0ihCRbY=",
+        "MODULE.bazel": "sha256-MjjAHCQH7/maf0JZQqvi/3TyVgbv5umBx/PhnQhDlxY="
+    }
+}

--- a/modules/boost.msm/1.89.0.bcr.2/MODULE.bazel
+++ b/modules/boost.msm/1.89.0.bcr.2/MODULE.bazel
@@ -1,0 +1,28 @@
+module(
+    name = "boost.msm",
+    version = "1.89.0.bcr.2",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = 108900,
+)
+
+bazel_dep(name = "boost", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.any", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.assert", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.bind", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.circular_buffer", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.config", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.core", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.function", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.fusion", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.mpl", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.parameter", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.phoenix", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.preprocessor", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.proto", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.serialization", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.tuple", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.type_index", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.type_traits", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.typeof", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.utility", version = "1.89.0.bcr.2")
+bazel_dep(name = "rules_cc", version = "0.2.4")

--- a/modules/boost.msm/1.89.0.bcr.2/overlay/BUILD.bazel
+++ b/modules/boost.msm/1.89.0.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "boost.msm",
+    hdrs = glob(
+        [
+            "include/**/*.hpp",
+        ],
+        exclude = [
+            "include/boost/msm/back/args.hpp",
+            "include/boost/msm/front/euml/transformation.hpp",
+            "include/boost/msm/front/puml/puml.hpp",
+            "include/boost/msm/mpl_graph/search_colors.hpp",
+        ],
+    ),
+    features = [
+        "parse_headers",
+    ],
+    includes = ["include"],
+    textual_hdrs = glob([
+        "include/**/*.ipp",
+        "include/boost/msm/back/args.hpp",
+        "include/boost/msm/front/euml/transformation.hpp",
+        "include/boost/msm/front/puml/puml.hpp",
+        "include/boost/msm/mpl_graph/search_colors.hpp",
+    ]),
+    deps = [
+        "@boost.any",
+        "@boost.assert",
+        "@boost.bind",
+        "@boost.circular_buffer",
+        "@boost.config",
+        "@boost.core",
+        "@boost.function",
+        "@boost.fusion",
+        "@boost.mpl",
+        "@boost.parameter",
+        "@boost.phoenix",
+        "@boost.preprocessor",
+        "@boost.proto",
+        "@boost.serialization",
+        "@boost.tuple",
+        "@boost.type_index",
+        "@boost.type_traits",
+        "@boost.typeof",
+        "@boost.utility",
+    ],
+)

--- a/modules/boost.msm/1.89.0.bcr.2/overlay/MODULE.bazel
+++ b/modules/boost.msm/1.89.0.bcr.2/overlay/MODULE.bazel
@@ -1,0 +1,28 @@
+module(
+    name = "boost.msm",
+    version = "1.89.0.bcr.2",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = 108900,
+)
+
+bazel_dep(name = "boost", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.any", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.assert", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.bind", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.circular_buffer", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.config", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.core", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.function", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.fusion", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.mpl", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.parameter", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.phoenix", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.preprocessor", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.proto", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.serialization", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.tuple", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.type_index", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.type_traits", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.typeof", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.utility", version = "1.89.0.bcr.2")
+bazel_dep(name = "rules_cc", version = "0.2.4")

--- a/modules/boost.msm/1.89.0.bcr.2/presubmit.yml
+++ b/modules/boost.msm/1.89.0.bcr.2/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+    - debian10
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.msm//:boost.msm'

--- a/modules/boost.msm/1.89.0.bcr.2/source.json
+++ b/modules/boost.msm/1.89.0.bcr.2/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-wUtEYia3ilaDLiw9cBBdvnA9oLQfLkCzD2QYjGiwjWE=",
+    "strip_prefix": "msm-boost-1.89.0",
+    "url": "https://github.com/boostorg/msm/archive/refs/tags/boost-1.89.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-3M0Vg97ya158JlpQhr0UTO2v/o07hkxzQV1U0ihCRbY=",
+        "MODULE.bazel": "sha256-tj6BlBTntS7refiEE0Kb1KSIMQmKKJJabAri6KLe4bI="
+    }
+}

--- a/modules/boost.msm/1.90.0.bcr.1/MODULE.bazel
+++ b/modules/boost.msm/1.90.0.bcr.1/MODULE.bazel
@@ -1,0 +1,28 @@
+module(
+    name = "boost.msm",
+    version = "1.90.0.bcr.1",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "boost", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.any", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.assert", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.bind", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.circular_buffer", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.config", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.core", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.function", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.fusion", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.mp11", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.mpl", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.parameter", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.phoenix", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.preprocessor", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.proto", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.serialization", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.type_index", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.type_traits", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.typeof", version = "1.90.0.bcr.1")
+bazel_dep(name = "boost.utility", version = "1.90.0.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/modules/boost.msm/1.90.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/boost.msm/1.90.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "boost.msm",
+    hdrs = glob(
+        [
+            "include/**/*.hpp",
+        ],
+        exclude = [
+            "include/boost/msm/back/args.hpp",
+            "include/boost/msm/front/euml/transformation.hpp",
+            "include/boost/msm/front/puml/puml.hpp",
+            "include/boost/msm/mpl_graph/search_colors.hpp",
+        ],
+    ),
+    features = [
+        "parse_headers",
+    ],
+    includes = ["include"],
+    textual_hdrs = glob([
+        "include/**/*.ipp",
+        "include/boost/msm/back/args.hpp",
+        "include/boost/msm/front/euml/transformation.hpp",
+        "include/boost/msm/front/puml/puml.hpp",
+        "include/boost/msm/mpl_graph/search_colors.hpp",
+    ]),
+    deps = [
+        "@boost.any",
+        "@boost.assert",
+        "@boost.bind",
+        "@boost.circular_buffer",
+        "@boost.config",
+        "@boost.core",
+        "@boost.function",
+        "@boost.fusion",
+        "@boost.mp11",
+        "@boost.mpl",
+        "@boost.parameter",
+        "@boost.phoenix",
+        "@boost.preprocessor",
+        "@boost.proto",
+        "@boost.serialization",
+        "@boost.type_index",
+        "@boost.type_traits",
+        "@boost.typeof",
+        "@boost.utility",
+    ],
+)

--- a/modules/boost.msm/1.90.0.bcr.1/presubmit.yml
+++ b/modules/boost.msm/1.90.0.bcr.1/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+    - debian13
+    - macos_arm64
+    - ubuntu2404
+    - ubuntu2404_arm64
+    - windows
+  bazel: [7.x, 8.x, 9.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - '@boost.msm//:boost.msm'

--- a/modules/boost.msm/1.90.0.bcr.1/source.json
+++ b/modules/boost.msm/1.90.0.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-/kh36w4ZpFZ4ROG3+Twu0SAh5Dnueo/rti/oVAdh0sM=",
+    "strip_prefix": "msm-boost-1.90.0",
+    "url": "https://github.com/boostorg/msm/archive/refs/tags/boost-1.90.0.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-D4HiWMxkV64/3mY01qeBSY7eGGoyZzmguYUJWopmNbI="
+    }
+}

--- a/modules/boost.msm/metadata.json
+++ b/modules/boost.msm/metadata.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "http://boost.org/libs/msm",
+    "maintainers": [
+        {
+            "email": "daisuke.nishimatsu1021@gmail.com",
+            "github": "wep21",
+            "github_user_id": 42202095,
+            "name": "Daisuke Nishimatsu"
+        },
+        {
+            "email": "julian.amann@tum.de",
+            "github": "Vertexwahn",
+            "github_user_id": 3775001,
+            "name": "Julian Amann"
+        }
+    ],
+    "repository": [
+        "github:boostorg/msm"
+    ],
+    "versions": [
+        "1.87.0",
+        "1.88.0.bcr.3",
+        "1.89.0.bcr.2",
+        "1.90.0.bcr.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add the Boost.MSM (Meta State Machine) header-only library across four Boost release lines:

  - boost.msm@1.87.0
  - boost.msm@1.88.0.bcr.3
  - boost.msm@1.89.0.bcr.2
  - boost.msm@1.90.0.bcr.1

Each version depends on the matching revision of its Boost dependencies (any, assert, bind, circular_buffer, config, core, function, fusion, mpl, parameter, phoenix, preprocessor, proto, serialization, type_index, type_traits, typeof, utility, plus tuple for 1.87-1.89 / mp11 for 1.90).

The cc_library moves four non-self-contained headers (back/args.hpp, front/euml/transformation.hpp, front/puml/puml.hpp, mpl_graph/search_colors.hpp) and the .ipp files into textual_hdrs so the parse_headers feature succeeds.

@bazel-io skip_check unstable_url
@bazel-io skip_check compatibility_level

@wep21, @Vertexwahn are you ok to maintain boost.msm too?