### PR TITLE
Add Bazel 9.x build support for remotery module

### DIFF
--- a/modules/remotery/1.0.0.bcr.0/MODULE.bazel
+++ b/modules/remotery/1.0.0.bcr.0/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "remotery",
+    version = "1.0.0.bcr.0",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.18")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/remotery/1.0.0.bcr.0/overlay/BUILD.bazel
+++ b/modules/remotery/1.0.0.bcr.0/overlay/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+)
+
+license(
+    name = "license",
+    package_name = "remotery",
+)
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "remotery",
+    srcs = ["lib/Remotery.c"],
+    hdrs = ["lib/Remotery.h"],
+    includes = ["lib"],
+    copts = [
+        "-w",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/modules/remotery/1.0.0.bcr.0/presubmit.yml
+++ b/modules/remotery/1.0.0.bcr.0/presubmit.yml
@@ -1,14 +1,15 @@
 matrix:
   platform:
-  - debian11
-  - ubuntu2204
-  - macos
-  - macos_arm64
-  - windows
+    - ubuntu2404
+    - ubuntu2404_arm64
+    - macos
+    - macos_arm64
+    - windows
+    - windows_arm64
   bazel:
-  - 9.x
-  - 8.x
-  - 7.x
+    - 7.x
+    - 8.x
+    - 9.x
 tasks:
   verify_targets:
     name: Verify build targets

--- a/modules/remotery/1.0.0.bcr.0/presubmit.yml
+++ b/modules/remotery/1.0.0.bcr.0/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@remotery//:remotery'

--- a/modules/remotery/1.0.0.bcr.0/source.json
+++ b/modules/remotery/1.0.0.bcr.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/Celtoys/Remotery/archive/refs/tags/v1.0.0.tar.gz",
+    "integrity": "sha256-ZdbLrC0BnDX8odhXKc6LPSlNhfrHXFOSGZGhTR83m7g=",
+    "strip_prefix": "Remotery-1.0.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-dEqDMuLPxfN7HZQwuObGHfT8HPlRNzgr3FmjKlkNj08="
+    },
+    "patch_strip": 0
+}

--- a/modules/remotery/1.0.0.bcr.0/source.json
+++ b/modules/remotery/1.0.0.bcr.0/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-ZdbLrC0BnDX8odhXKc6LPSlNhfrHXFOSGZGhTR83m7g=",
     "strip_prefix": "Remotery-1.0.0",
     "overlay": {
-        "BUILD.bazel": "sha256-dEqDMuLPxfN7HZQwuObGHfT8HPlRNzgr3FmjKlkNj08="
+        "BUILD.bazel": "sha256-ykG7y+ZG/k7cNp0jqyq7StfPA3BaJkPMYX0ZeoUGs3g="
     },
     "patch_strip": 0
 }

--- a/modules/remotery/metadata.json
+++ b/modules/remotery/metadata.json
@@ -12,7 +12,8 @@
         "github:Celtoys/Remotery"
     ],
     "versions": [
-        "1.0.0"
+        "1.0.0",
+        "1.0.0.bcr.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Work towards 9.x support for Gazebo.