### PR TITLE
Add Bazel 9.x support for ccd module.

### DIFF
--- a/modules/ccd/2.1.0.bcr.2/MODULE.bazel
+++ b/modules/ccd/2.1.0.bcr.2/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "ccd",
+    version = "2.1.0.bcr.2",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/ccd/2.1.0.bcr.2/overlay/BUILD.bazel
+++ b/modules/ccd/2.1.0.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,57 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+)
+
+license(
+    name = "license",
+    package_name = "ccd",
+    license_kinds = ["@rules_license//licenses/spdx:BSD-3-Clause"],
+    license_text = ":BSD-LICENSE",
+)
+
+ccd_sources = glob(
+    include = [
+        "src/*.c",
+    ],
+)
+
+ccd_headers = glob(
+    include = [
+        "src/*.h",
+    ],
+)
+
+ccd_public_headers = glob(
+    include = [
+        "src/ccd/*.h",
+    ],
+)
+
+expand_template(
+    name = "config",
+    out = "src/ccd/config.h",
+    substitutions = {"#cmakedefine": "// #undef"},
+    template = "src/ccd/config.h.cmake.in",
+)
+
+cc_library(
+    name = "ccd_single",
+    srcs = ccd_sources + ccd_headers,
+    hdrs = ccd_public_headers + ["src/ccd/config.h"],
+    defines = ["CCD_SINGLE"],
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ccd",
+    srcs = ccd_sources + ccd_headers,
+    hdrs = ccd_public_headers + ["src/ccd/config.h"],
+    defines = ["CCD_DOUBLE"],
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+)

--- a/modules/ccd/2.1.0.bcr.2/presubmit.yml
+++ b/modules/ccd/2.1.0.bcr.2/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform:
+    - ubuntu2404
+    - ubuntu2404_arm64
+    - macos
+    - macos_arm64
+    - windows
+    - windows_arm64
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@ccd//:ccd'
+    - '@ccd//:ccd_single'

--- a/modules/ccd/2.1.0.bcr.2/source.json
+++ b/modules/ccd/2.1.0.bcr.2/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/danfis/libccd/archive/refs/tags/v2.1.tar.gz",
+    "integrity": "sha256-VCtsR/Ui1YH7855R3zLH0SVqwMYm58K0HxBA1LnVDR4=",
+    "strip_prefix": "libccd-2.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-YX+r20unJD0qy+iD5YYYcU/dXYOusCJu5LECcMtj0JQ="
+    }
+}

--- a/modules/ccd/metadata.json
+++ b/modules/ccd/metadata.json
@@ -13,7 +13,8 @@
     ],
     "versions": [
         "2.1.0",
-        "2.1.0.bcr.1"
+        "2.1.0.bcr.1",
+        "2.1.0.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Work towards 9.x support for Gazebo. The compatibility_level argument to module is [deprecated and discouraged](https://bazel.build/external/faq), and so I have removed it from the module.