### PR TITLE
Add systemd@260.1.bcr.2 exporting libsystemd cc_library

### DIFF
--- a/modules/systemd/260.1.bcr.2/MODULE.bazel
+++ b/modules/systemd/260.1.bcr.2/MODULE.bazel
@@ -1,0 +1,13 @@
+module(
+    name = "systemd",
+    version = "260.1.bcr.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "gawk", version = "5.3.2.bcr.7")
+bazel_dep(name = "gperf", version = "3.1.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.2.8")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "2.0.1")

--- a/modules/systemd/260.1.bcr.2/overlay/BUILD.bazel
+++ b/modules/systemd/260.1.bcr.2/overlay/BUILD.bazel
@@ -134,7 +134,7 @@ ISYSTEM = [
     "src/include/uapi",
 ]
 
-INCLUDES = ISYSTEM + [
+INCLUDES = [
     ".",
     "src/basic",
     "src/fundamental",
@@ -307,7 +307,18 @@ filegroup(
     ),
 )
 
-# --- The libraries ---
+cc_library(
+    name = "uapi_headers",
+    hdrs = glob(["src/include/uapi/**/*.h"]),
+    strip_include_prefix = "src/include/uapi",
+)
+
+cc_library(
+    name = "override_headers_library",
+    hdrs = glob(["src/include/override/**/*.h"]),
+    strip_include_prefix = "src/include/override",
+    deps = [":uapi_headers"],
+)
 
 # The object library underlying both libudev and libsystemd. It compiles
 # every .c file the two share (basic, fundamental, libc, all of
@@ -351,6 +362,7 @@ cc_library(
         ":override_headers",
     ],
     copts = COPTS,
+    features = ["-external_include_paths"],
     includes = INCLUDES,
     textual_hdrs = [
         ":gen_af_from_name_inc",
@@ -366,8 +378,11 @@ cc_library(
         ":gen_statx_attribute_to_name_inc",
         ":gen_statx_mask_to_name_inc",
     ],
+    deps = [":override_headers_library"],
     alwayslink = True,
 )
+
+# --- The libraries ---
 
 cc_shared_library(
     name = "libsystemd_so",

--- a/modules/systemd/260.1.bcr.2/overlay/BUILD.bazel
+++ b/modules/systemd/260.1.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,419 @@
+"""Rules for building systemd, exposing libudev and libsystemd.
+
+systemd generally builds with meson/ninja and is buildable under
+rules_foreign_cc with some patching. But since we only need libudev
+and libsystemd it's relatively elementary to use native rules_cc.
+
+Both libraries sit on top of systemd's sd-device / sd-netlink /
+sd-id128 / basic utility code, so the object library includes ~218 .c
+files spanning src/basic, src/fundamental, src/libc, src/libsystemd/sd-*
+and src/libudev. They all live in a single `cc_library`
+(`systemd_objects`) here, and each `.so` scopes its own exports through
+its respective version script (libudev.sym / libsystemd.sym).
+"""
+
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+load("@rules_license//rules:license.bzl", "license")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("//:codegen.bzl", "cc_macro_list")
+
+package(default_applicable_licenses = [":license"])
+
+license(
+    name = "license",
+    package_name = "systemd",
+    license_kinds = ["@rules_license//licenses/spdx:LGPL-2.1-or-later"],
+    license_text = "LICENSE.LGPL2.1",
+    package_url = "https://github.com/systemd/systemd",
+)
+
+# Things Bazel can't infer the way meson does: feature-test setup and
+# the inclusion of the hand-curated config.h.
+BAZEL_COPTS = [
+    "-D_FILE_OFFSET_BITS=64",
+    "-include",
+    "$(execpath :config.h)",
+]
+
+# Cross-compat between gcc and clang. UPSTREAM_MESON_COPTS below contains
+# both gcc-only (`-Wlogical-op`, `-Wsuggest-attribute=noreturn`, ...) and
+# clang-only (`-Wno-string-plus-int`, `-Wno-error=#warnings`) -W flags;
+# -Wno-unknown-warning-option lets each compiler silently drop the others.
+CROSS_COMPILER_COPTS = [
+    "-Wno-unknown-warning-option",
+]
+
+# Verbatim from systemd's meson.build: basic_disabled_warnings +
+# possible_common_cc_flags + possible_cc_flags. Meson filters each through
+# cc.get_supported_arguments() at configure time; Bazel has no equivalent,
+# so we curate by hand and rely on -Wno-unknown-warning-option above to
+# absorb the rest — but only for clang. gcc errors on unknown *positive*
+# -W flags regardless (it silently accepts unknown -Wno-X to allow forward
+# compat, but unknown -Wfoo is a hard error), and gcc also errors on
+# -Werror=foo when foo isn't a known warning. So flags newer than the
+# gcc we're willing to require have to be dropped here. Dropped vs.
+# upstream:
+#   -fstrict-flex-arrays={1,3}              needs gcc >= 13 / clang >= 16
+#   -Werror=flex-array-member-not-at-end    needs gcc >= 14.1
+#   -Werror=missing-parameter-name          needs gcc >= 14.1
+#   -Werror=strict-flex-arrays              needs gcc >= 13
+#   -Wunterminated-string-initialization    needs gcc >= 15
+#   -Wno-error=#warnings                    clang-only (gcc has no `#warnings`
+#                                           category)
+#   -Wzero-as-null-pointer-constant         gcc warns it's C++-only every
+#                                           compile; we are C-only
+#   -Wno-unknown-warning-option             hoisted to CROSS_COMPILER_COPTS
+#   -fvisibility=hidden                     replaced by OVERRIDE_COPTS below
+UPSTREAM_MESON_COPTS = [
+    "-Wno-missing-field-initializers",
+    "-Wno-unused-parameter",
+    "-Wno-nonnull-compare",
+    "-Warray-bounds",
+    "-Warray-bounds=2",
+    "-Wdate-time",
+    "-Wendif-labels",
+    "-Werror=bool-compare",
+    "-Werror=discarded-qualifiers",
+    "-Werror=format=2",
+    "-Werror=format-signedness",
+    "-Werror=implicit-function-declaration",
+    "-Werror=implicit-int",
+    "-Werror=incompatible-pointer-types",
+    "-Werror=int-conversion",
+    "-Werror=missing-declarations",
+    "-Werror=missing-prototypes",
+    "-Werror=overflow",
+    "-Werror=override-init",
+    "-Werror=pointer-sign",
+    "-Werror=return-type",
+    "-Werror=sequence-point",
+    "-Werror=shift-count-overflow",
+    "-Werror=shift-overflow=2",
+    "-Werror=undef",
+    "-Wfloat-equal",
+    "-Wimplicit-fallthrough=5",
+    "-Winit-self",
+    "-Wlogical-op",
+    "-Wmissing-include-dirs",
+    "-Wmissing-noreturn",
+    "-Wnested-externs",
+    "-Wold-style-definition",
+    "-Wpointer-arith",
+    "-Wredundant-decls",
+    "-Wshadow",
+    "-Wstrict-aliasing=2",
+    "-Wstrict-prototypes",
+    "-Wsuggest-attribute=noreturn",
+    "-Wunused-function",
+    "-Wwrite-strings",
+    "-Wzero-length-bounds",
+    "-Wno-string-plus-int",
+    "-fdiagnostics-show-option",
+    "-fno-common",
+    "-fstack-protector",
+    "-fstack-protector-strong",
+    "--param=ssp-buffer-size=4",
+    # systemd does type punning, so -fno-strict-aliasing is load-bearing.
+    "-fno-strict-aliasing",
+]
+
+# Overrides — must follow UPSTREAM_MESON_COPTS so they win.
+OVERRIDE_COPTS = [
+    # libudev.sym scopes the .so's exports but only if the symbols aren't
+    # hidden first; counters -fvisibility=hidden in possible_cc_flags.
+    "-fvisibility=default",
+]
+
+COPTS = BAZEL_COPTS + CROSS_COMPILER_COPTS + UPSTREAM_MESON_COPTS + OVERRIDE_COPTS
+
+# Override and uapi go via -isystem so override headers (which use
+# `#include_next`) take precedence over the sysroot's.
+ISYSTEM = [
+    "src/include/override",
+    "src/include/uapi",
+]
+
+INCLUDES = ISYSTEM + [
+    ".",
+    "src/basic",
+    "src/fundamental",
+    "src/libsystemd/sd-bus",
+    "src/libsystemd/sd-common",
+    "src/libsystemd/sd-device",
+    "src/libsystemd/sd-event",
+    "src/libsystemd/sd-hwdb",
+    "src/libsystemd/sd-id128",
+    "src/libsystemd/sd-journal",
+    "src/libsystemd/sd-json",
+    "src/libsystemd/sd-netlink",
+    "src/libsystemd/sd-network",
+    "src/libsystemd/sd-path",
+    "src/libsystemd/sd-resolve",
+    "src/libsystemd/sd-varlink",
+    "src/libudev",
+    "src/shared",
+    "src/systemd",
+    "src/version",
+]
+
+# --- Generated sources ---
+
+expand_template(
+    name = "gen_version_h",
+    out = "src/version/version.h",
+    substitutions = {"@VCS_TAG@": ""},
+    template = "src/version/version.h.in",
+)
+
+# A handful of source files `#include` gperf-generated tables for
+# kernel UAPI constants (AF_*, ARPHRD_*, errno, STATX_*, ...). The
+# `cc_macro_list` rule in codegen.bzl runs the configured cross
+# compiler with `cpp -dM` to enumerate those constants from the
+# target's headers, then awk/python/gperf turn the lists into
+# `.inc` files included by the .c files.
+[
+    cc_macro_list(
+        name = family + "_list_txt",
+        out = "src/basic/{0}-list.txt".format(family.replace("_", "-")),
+        headers = [":override_headers"],
+        script = "src/basic/generate-{0}-list.sh".format(family.replace("_", "-")),
+        system_includes = ISYSTEM,
+    )
+    for family in [
+        "af",
+        "arphrd",
+        "capability",
+        "errno",
+        "statx_attribute",
+        "statx_mask",
+    ]
+]
+
+# `lookup_<f>` and `hash_<f>_name` are derivable from the family name.
+# `--ignore-case` is a per-family policy: capability macros
+# (CAP_SYS_ADMIN etc.) are case-sensitive; the others aren't.
+GPERF_FAMILIES = [
+    # (name, macro-prefix, include-string, ignore-case)
+    ("af", "", "<sys/socket.h>", True),
+    ("arphrd", "ARPHRD_", "<linux/if_arp.h>", True),
+    ("capability", "", "<linux/capability.h>", False),
+    ("errno", "", "<errno.h>", True),
+]
+
+[
+    genrule(
+        name = "gen_{0}_from_name_gperf".format(name),
+        srcs = ["src/basic/{0}-list.txt".format(name)],
+        outs = ["src/basic/{0}-from-name.gperf".format(name)],
+        cmd = "$(execpath :generate_gperfs) {0} '{1}' $< '{2}' > $@".format(
+            name,
+            prefix,
+            header,
+        ),
+        tools = [":generate_gperfs"],
+    )
+    for name, prefix, header, _ in GPERF_FAMILIES
+]
+
+[
+    genrule(
+        name = "gen_{0}_from_name_inc".format(name),
+        srcs = ["src/basic/{0}-from-name.gperf".format(name)],
+        outs = ["src/basic/{0}-from-name.inc".format(name)],
+        cmd = "$(execpath @gperf) -L ANSI-C -t {ic}-N lookup_{n} -H hash_{n}_name -p -C < $< > $@".format(
+            ic = "--ignore-case " if ignore_case else "",
+            n = name,
+        ),
+        tools = ["@gperf"],
+    )
+    for name, _, _, ignore_case in GPERF_FAMILIES
+]
+
+# awk-driven to-name reverse lookups. Input list and awk script share
+# the family name as a basename.
+[
+    genrule(
+        name = "gen_{0}_to_name_inc".format(family.replace("-", "_")),
+        srcs = [
+            "src/basic/{0}-to-name.awk".format(family),
+            "src/basic/{0}-list.txt".format(family),
+        ],
+        outs = ["src/basic/{0}-to-name.inc".format(family)],
+        cmd = "$(execpath @gawk//:gawk) -f $(execpath src/basic/{0}-to-name.awk) $(execpath src/basic/{0}-list.txt) > $@".format(family),
+        tools = ["@gawk"],
+    )
+    for family in [
+        "af",
+        "arphrd",
+        "capability",
+        "errno",
+        "statx-attribute",
+        "statx-mask",
+    ]
+]
+
+# Audit-type names live in the awk script itself; feed /dev/null and
+# capture stdout.
+genrule(
+    name = "gen_audit_type_to_name_inc",
+    srcs = ["src/libsystemd/sd-journal/audit_type-to-name.awk"],
+    outs = ["src/libsystemd/sd-journal/audit_type-to-name.inc"],
+    cmd = "$(execpath @gawk//:gawk) -f $< /dev/null > $@",
+    tools = ["@gawk"],
+)
+
+genrule(
+    name = "gen_filesystem_sets_c",
+    outs = ["src/basic/filesystem-sets.c"],
+    cmd = "$(execpath :filesystem_sets) fs-type-to-string filesystem-sets fs-in-group > $@",
+    tools = [":filesystem_sets"],
+)
+
+genrule(
+    name = "gen_filesystems_gperf_gperf",
+    outs = ["src/basic/filesystems-gperf.gperf"],
+    cmd = "$(execpath :filesystem_sets) gperf > $@",
+    tools = [":filesystem_sets"],
+)
+
+genrule(
+    name = "gen_filesystems_gperf_h",
+    srcs = ["src/basic/filesystems-gperf.gperf"],
+    outs = ["src/basic/filesystems-gperf.h"],
+    cmd = "$(execpath @gperf) $< --output-file $@",
+    tools = ["@gperf"],
+)
+
+py_binary(
+    name = "filesystem_sets",
+    srcs = ["src/basic/filesystem-sets.py"],
+    main = "src/basic/filesystem-sets.py",
+)
+
+py_binary(
+    name = "generate_gperfs",
+    srcs = ["tools/generate-gperfs.py"],
+    main = "tools/generate-gperfs.py",
+)
+
+filegroup(
+    name = "override_headers",
+    srcs = glob(
+        [
+            "src/include/override/**/*.h",
+            "src/include/uapi/**/*.h",
+        ],
+    ),
+)
+
+# --- The libraries ---
+
+# The object library underlying both libudev and libsystemd. It compiles
+# every .c file the two share (basic, fundamental, libc, all of
+# libsystemd's sd-*, and libudev). Including libudev's sources in the
+# libsystemd link is harmless: each .so's version script (libudev.sym /
+# libsystemd.sym) decides what is actually exported.
+cc_library(
+    name = "systemd_objects",
+    srcs = glob(
+        [
+            "src/basic/*.c",
+            "src/fundamental/*.c",
+            "src/libc/*.c",
+            "src/libsystemd/sd-*/*.c",
+            "src/libudev/libudev*.c",
+        ],
+        exclude = [
+            "src/basic/fuzz-*.c",
+            "src/basic/test-*.c",
+            "src/fundamental/fuzz-*.c",
+            "src/fundamental/test-*.c",
+            "src/libsystemd/sd-*/fuzz-*.c",
+            "src/libsystemd/sd-*/test-*.c",
+            "src/libudev/test-*.c",
+            # Generated, added explicitly below.
+            "src/basic/filesystem-sets.c",
+        ],
+    ) + [
+        "config.h",
+        ":gen_filesystem_sets_c",
+    ],
+    hdrs = glob([
+        "src/basic/*.h",
+        "src/fundamental/*.h",
+        "src/libsystemd/sd-*/*.h",
+        "src/libudev/*.h",
+        "src/shared/*.h",
+        "src/systemd/*.h",
+    ]) + [
+        ":gen_version_h",
+        ":override_headers",
+    ],
+    copts = COPTS,
+    includes = INCLUDES,
+    textual_hdrs = [
+        ":gen_af_from_name_inc",
+        ":gen_af_to_name_inc",
+        ":gen_arphrd_from_name_inc",
+        ":gen_arphrd_to_name_inc",
+        ":gen_audit_type_to_name_inc",
+        ":gen_capability_from_name_inc",
+        ":gen_capability_to_name_inc",
+        ":gen_errno_from_name_inc",
+        ":gen_errno_to_name_inc",
+        ":gen_filesystems_gperf_h",
+        ":gen_statx_attribute_to_name_inc",
+        ":gen_statx_mask_to_name_inc",
+    ],
+    alwayslink = True,
+)
+
+cc_shared_library(
+    name = "libsystemd_so",
+    additional_linker_inputs = ["src/libsystemd/libsystemd.sym"],
+    shared_lib_name = "libsystemd.so.0",
+    user_link_flags = [
+        "-Wl,-soname,libsystemd.so.0",
+        "-Wl,--version-script,$(execpath src/libsystemd/libsystemd.sym)",
+        "-Wl,-z,nodelete",
+        "-ldl",
+        "-lrt",
+        "-lpthread",
+        "-lm",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":systemd_objects"],
+)
+
+cc_library(
+    name = "libsystemd",
+    srcs = [":libsystemd_so"],
+    hdrs = glob(["src/systemd/*.h"]),
+    strip_include_prefix = "src",
+    visibility = ["//visibility:public"],
+)
+
+cc_shared_library(
+    name = "libudev_so",
+    additional_linker_inputs = ["src/libudev/libudev.sym"],
+    shared_lib_name = "libudev.so.1",
+    user_link_flags = [
+        "-Wl,-soname,libudev.so.1",
+        "-Wl,--version-script,$(execpath src/libudev/libudev.sym)",
+        "-ldl",
+        "-lrt",
+        "-lpthread",
+        "-lm",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":systemd_objects"],
+)
+
+cc_library(
+    name = "libudev",
+    srcs = [":libudev_so"],
+    hdrs = ["src/libudev/libudev.h"],
+    strip_include_prefix = "src/libudev",
+    visibility = ["//visibility:public"],
+)

--- a/modules/systemd/260.1.bcr.2/overlay/codegen.bzl
+++ b/modules/systemd/260.1.bcr.2/overlay/codegen.bzl
@@ -1,0 +1,97 @@
+"""Code-generation rules for systemd.
+
+`cc_macro_list` runs a small bash script through the configured C compiler
+(cc_toolchain) to enumerate UAPI macros from a target header (e.g. AF_*,
+ARPHRD_*, CAP_*, errno, STATX_*). The generator scripts are vendored
+as-is from upstream systemd; they expect `$CC -E -dM -include <header>`
+followed by extra include flags. We forward `-isystem` for the systemd
+override + uapi dirs so that override headers (e.g. linux/capability.h)
+take precedence over the sysroot's, matching upstream meson's behaviour.
+
+The output is a plain text file with one identifier per line; downstream
+genrules feed it to gperf or awk.
+"""
+
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain", "use_cc_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+
+def _cc_macro_list_impl(ctx):
+    cc_toolchain = find_cc_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+    compiler = cc_common.get_tool_for_action(
+        feature_configuration = feature_configuration,
+        action_name = "c-compile",
+    )
+
+    out = ctx.outputs.out
+    workspace_root = ctx.label.workspace_root
+    prefix = (workspace_root + "/") if workspace_root else ""
+
+    # Ask the C++ toolchain for the real compile command line instead of
+    # reconstructing target/sysroot/include flags by hand. This keeps this
+    # generator aligned with whatever C toolchain Bazel selected, including
+    # cross toolchains that encode the target in features rather than in
+    # cc_toolchain fields.
+    #
+    # `-E -x c` is still needed because some upstream generate-*-list.sh
+    # scripts invoke `$CC -dM -include <header> - </dev/null` without `-E`,
+    # relying on gcc's behaviour where `-dM` implies `-E`. clang is stricter.
+    compile_variables = cc_common.create_compile_variables(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        system_include_directories = depset(
+            direct = [prefix + d for d in ctx.attr.system_includes],
+        ),
+        user_compile_flags = ["-E", "-x", "c"],
+    )
+    flags = list(cc_common.get_memory_inefficient_command_line(
+        feature_configuration = feature_configuration,
+        action_name = ACTION_NAMES.c_compile,
+        variables = compile_variables,
+    ))
+    for d in ctx.attr.system_includes:
+        flags += ["-isystem", prefix + d]
+
+    ctx.actions.run_shell(
+        outputs = [out],
+        inputs = depset(
+            direct = [ctx.file.script] + ctx.files.headers,
+            transitive = [cc_toolchain.all_files],
+        ),
+        arguments = [out.path, ctx.file.script.path, compiler] + flags,
+        command = 'out="$1"; shift; bash "$@" > "$out"',
+        mnemonic = "GenMacroList",
+        progress_message = "Generating %s" % out.short_path,
+    )
+
+    return [DefaultInfo(files = depset([out]))]
+
+cc_macro_list = rule(
+    implementation = _cc_macro_list_impl,
+    attrs = {
+        "script": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "The generate-<name>-list.sh script.",
+        ),
+        "headers": attr.label_list(
+            allow_files = True,
+            doc = "Override headers that need to be visible to the cpp run.",
+        ),
+        "system_includes": attr.string_list(
+            doc = "Paths passed as -isystem after the compiler.",
+        ),
+        "out": attr.output(
+            mandatory = True,
+            doc = "Path of the generated text file (relative to package).",
+        ),
+    },
+    fragments = ["cpp"],
+    toolchains = use_cc_toolchain(),
+)

--- a/modules/systemd/260.1.bcr.2/overlay/config.h
+++ b/modules/systemd/260.1.bcr.2/overlay/config.h
@@ -1,0 +1,176 @@
+// libudev needs the config.h that meson normally generates. This is a
+// hand-curated minimum of the upstream output, kept down to these
+// categories:
+//
+//  - feature-test macros (consumed by glibc/kernel headers, not by the
+//    systemd source itself; kept defensively)
+//  - ABI assumptions: GPERF_LEN_TYPE + SIZEOF_*
+//  - module identity (PROJECT_VERSION + VERSION_TAG)
+//  - HAVE_* / ENABLE_* probe results that gate #if blocks
+//  - cosmetic strings/numerics referenced by code that libudev's
+//    exported symbols don't transitively reach. Set to "" / 0 to make
+//    their irrelevance obvious. (TTY_MODE is the exception: it has
+//    assert_cc bit-pattern checks in src/basic/terminal-util.h.)
+//
+// Roughly 225 macros from the upstream config.h are omitted entirely
+// because nothing in the compile set even references them. To
+// regenerate after a systemd bump: `meson setup`, dump config.h, and
+// cross-reference against the .c/.h files matched by the BUILD globs.
+
+#pragma once
+
+/* Visible to glibc/kernel headers; absent from systemd source. */
+#define _GNU_SOURCE 1
+#define _LARGEFILE64_SOURCE 1
+#define __SANE_USERSPACE_TYPES__
+
+/* Target ABI / typedef expansion — must be accurate. */
+#define GPERF_LEN_TYPE size_t
+#define SIZEOF_DEV_T 8
+#define SIZEOF_INO_T 8
+#define SIZEOF_RLIM_T 8
+#define SIZEOF_TIME_T 8
+#define SIZEOF_TIMEX_MEMBER 8
+
+// Module identity. Matches the source tarball and overlay directory name.
+#define PROJECT_VERSION 260
+#define PROJECT_VERSION_FULL "260.1"
+#define VERSION_TAG "260.1"
+
+// HAVE_* / ENABLE_* probe results.
+#define BPF_FRAMEWORK 0
+#define BUILD_MODE_DEVELOPER 0
+#define ENABLE_COMPAT_MUTABLE_UID_BOUNDARIES 0
+#define ENABLE_DEBUG_HASHMAP 0
+#define ENABLE_DEBUG_MMAP_CACHE 0
+#define ENABLE_DEBUG_SIPHASH 0
+#define ENABLE_EFI 0
+#define ENABLE_GSHADOW 0
+#define ENABLE_IDN 0
+#define ENABLE_IMA 0
+#define ENABLE_IPE 0
+#define ENABLE_LOGIND 0
+#define ENABLE_SMACK 0
+#define ENABLE_UTMP 0
+#define HAVE_ACL 0
+#define HAVE_ADD_KEY 0
+#define HAVE_APPARMOR 0
+#define HAVE_ARCHIVE_ENTRY_GID_IS_SET 0
+#define HAVE_ARCHIVE_ENTRY_HARDLINK_IS_SET 0
+#define HAVE_ARCHIVE_ENTRY_UID_IS_SET 0
+#define HAVE_AUDIT 0
+#define HAVE_BLKID 0
+#define HAVE_BPF 0
+#define HAVE_BZIP2 0
+#define HAVE_COMPRESSION 0
+#define HAVE_CRYPT_TOKEN_SET_EXTERNAL_PATH 0
+#define HAVE_ELFUTILS 0
+#define HAVE_EPOLL_PWAIT2 1
+#define HAVE_FCHMODAT2 0
+#define HAVE_FSCONFIG 1
+#define HAVE_FSMOUNT 1
+#define HAVE_FSOPEN 1
+#define HAVE_GCRYPT 0
+#define HAVE_GET_MEMPOLICY 0
+#define HAVE_GNUTLS 0
+#define HAVE_IOPRIO_GET 0
+#define HAVE_IOPRIO_SET 0
+#define HAVE_KCMP 0
+#define HAVE_KEYCTL 0
+#define HAVE_KMOD 0
+#define HAVE_LIBARCHIVE 0
+#define HAVE_LIBBPF 0
+#define HAVE_LIBCRYPT 0
+#define HAVE_LIBCRYPTSETUP 0
+#define HAVE_LIBCRYPTSETUP_PLUGINS 0
+#define HAVE_LIBCURL 0
+#define HAVE_LIBFDISK 0
+#define HAVE_LIBFIDO2 0
+#define HAVE_LIBIDN2 0
+#define HAVE_LIBMOUNT 0
+#define HAVE_LZ4 0
+#define HAVE_MOUNT_SETATTR 1
+#define HAVE_MOVE_MOUNT 1
+#define HAVE_OPEN_TREE 1
+#define HAVE_OPEN_TREE_ATTR 0
+#define HAVE_OPENSSL 0
+#define HAVE_P11KIT 0
+#define HAVE_PAM 0
+#define HAVE_PASSWDQC 0
+#define HAVE_PCRE2 0
+#define HAVE_PIDFD_OPEN 0
+#define HAVE_PIDFD_SEND_SIGNAL 0
+#define HAVE_PIDFD_SPAWN 0
+#define HAVE_PIVOT_ROOT 0
+#define HAVE_PWQUALITY 0
+#define HAVE_QRENCODE 0
+#define HAVE_QUOTACTL_FD 0
+#define HAVE_REMOVEXATTRAT 0
+#define HAVE_REQUEST_KEY 0
+#define HAVE_RT_TGSIGQUEUEINFO 0
+#define HAVE_SCHED_SETATTR 1
+#define HAVE_SECCOMP 0
+#define HAVE_SELINUX 0
+#define HAVE_SET_MEMPOLICY 0
+#define HAVE_SETXATTRAT 0
+#define HAVE_SPLIT_BIN 1
+#define HAVE_TPM2 0
+#define HAVE_VALGRIND_VALGRIND_H 0
+#define HAVE_VMLINUX_H 0
+#define HAVE_WARNING_ZERO_AS_NULL_POINTER_CONSTANT 1
+#define HAVE_WARNING_ZERO_LENGTH_BOUNDS 0
+#define HAVE_XKBCOMMON 0
+#define HAVE_XZ 0
+#define HAVE_ZLIB 0
+#define HAVE_ZSTD 0
+#define LOG_MESSAGE_VERIFICATION 1
+#define LOG_TRACE 0
+#define SD_BOOT 0
+
+/* TTY_MODE has assert_cc bit-pattern checks; can't be 0. */
+#define TTY_MODE 0600
+
+/* Cosmetic — only reached by compiled code that libudev's exports
+ * don't transitively call. UID-base assert_cc constraints check
+ * low-bits-clear, which 0 satisfies. */
+#define CATALOG_DATABASE ""
+#define COMPRESSION_PRIORITY_LZ4 ""
+#define COMPRESSION_PRIORITY_XZ ""
+#define COMPRESSION_PRIORITY_ZSTD ""
+#define CONTAINER_UID_BASE_MAX 0
+#define CONTAINER_UID_BASE_MIN 0
+#define DEFAULT_COMPRESSION 0
+#define DEFAULT_TIMEOUT_SEC 0
+#define DEFAULT_USER_SHELL ""
+#define DEFAULT_USER_TIMEOUT_SEC 0
+#define DYNAMIC_UID_MAX 0
+#define DYNAMIC_UID_MIN 0
+#define EXTRA_NET_NAMING_SCHEMES
+#define FALLBACK_HOSTNAME ""
+#define FOREIGN_UID_BASE 0
+#define GETTEXT_PACKAGE ""
+#define GREETER_UID_MAX 0
+#define GREETER_UID_MIN 0
+#define KMOD ""
+#define LIBDIR ""
+#define LIBEXECDIR ""
+#define NOBODY_GROUP_NAME ""
+#define NOBODY_USER_NAME ""
+#define NOLOGIN ""
+#define PREFIX_NOSLASH ""
+#define PROJECT_URL ""
+#define RELATIVE_SOURCE_PATH ""
+#define SYSTEM_ALLOC_GID_MIN 0
+#define SYSTEM_ALLOC_UID_MIN 0
+#define SYSTEM_CONFIG_UNIT_DIR ""
+#define SYSTEM_DATA_UNIT_DIR ""
+#define SYSTEM_ENV_GENERATOR_DIR ""
+#define SYSTEM_GENERATOR_DIR ""
+#define SYSTEM_GID_MAX 0
+#define SYSTEM_UID_MAX 0
+#define UDEVLIBEXECDIR ""
+#define USER_CONFIG_UNIT_DIR ""
+#define USER_DATA_UNIT_DIR ""
+#define USER_ENV_GENERATOR_DIR ""
+#define USER_GENERATOR_DIR ""
+#define VARLINK_BRIDGES_DIR ""

--- a/modules/systemd/260.1.bcr.2/presubmit.yml
+++ b/modules/systemd/260.1.bcr.2/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian12
+  - debian13
+  - ubuntu2204
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@systemd//:libsystemd'
+    - '@systemd//:libudev'

--- a/modules/systemd/260.1.bcr.2/source.json
+++ b/modules/systemd/260.1.bcr.2/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-EbmCGJK3XRmveyHw9/TlNjZjgUf68+ak3teLQMs4mT8=",
     "strip_prefix": "systemd-260.1",
     "overlay": {
-        "BUILD.bazel": "sha256-9LGMGyFe/9WdsF0pGvwFV+WoF9JEKnrlyu0nY4yI2Jc=",
+        "BUILD.bazel": "sha256-QsYYewpIyeaHMea535sj84WrlwAedq3lvcaFyedjjSE=",
         "codegen.bzl": "sha256-dL4+3Qxivuc1KyAIiiAryJ8Y0vZtOrIyqAl6wnpHpbw=",
         "config.h": "sha256-upyusTwcDUIZ+ihkTKHeApKeMOmpsh/sB+UO1ODeTSI="
     }

--- a/modules/systemd/260.1.bcr.2/source.json
+++ b/modules/systemd/260.1.bcr.2/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/systemd/systemd/archive/refs/tags/v260.1.tar.gz",
+    "integrity": "sha256-EbmCGJK3XRmveyHw9/TlNjZjgUf68+ak3teLQMs4mT8=",
+    "strip_prefix": "systemd-260.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-9LGMGyFe/9WdsF0pGvwFV+WoF9JEKnrlyu0nY4yI2Jc=",
+        "codegen.bzl": "sha256-dL4+3Qxivuc1KyAIiiAryJ8Y0vZtOrIyqAl6wnpHpbw=",
+        "config.h": "sha256-upyusTwcDUIZ+ihkTKHeApKeMOmpsh/sB+UO1ODeTSI="
+    }
+}

--- a/modules/systemd/metadata.json
+++ b/modules/systemd/metadata.json
@@ -12,7 +12,8 @@
     ],
     "versions": [
         "260.1",
-        "260.1.bcr.1"
+        "260.1.bcr.1",
+        "260.1.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
 Exports a new `libsystemd` `cc_library` alongside the existing `libudev`. Both share the same upstream `v260.1` archive — this version only adds Bazel targets, no source/integrity change.

 ### What's new

 - `@systemd//:libsystemd` — a `cc_shared_library` (`libsystemd_so`) wrapped in a `cc_library`. Public headers are exposed as `<systemd/sd-bus.h>`, `<systemd/sd-journal.h>`, etc. (via `strip_include_prefix = "src"`).

 ### Implementation notes

 - The object library that backed `libudev` (`libudev_objects`) already compiled everything `libsystemd` needs — all of `src/basic`, `src/fundamental`, `src/libc`, and `src/libsystemd/sd-*`. It's renamed to `systemd_objects` and now backs both shared libraries. Including libudev's sources in the libsystemd link is harmless: each `.so` scopes its own exports through its version script.
- `libsystemd_so` uses upstream's `src/libsystemd/libsystemd.sym` version script, soname `libsystemd.so.0` (matching `libsystemd_version = 0.43.0`), and `-z nodelete` to mirror upstream's link flags.
- `presubmit.yml` now builds `@systemd//:libsystemd` in addition to `@systemd//:libudev`.

### Verification

Built against a local registry checkout:

- `@systemd//:libsystemd` compiles and links. The resulting `libsystemd.so.0` has soname `libsystemd.so.0`, versioned `sd_*` exports (`@@LIBSYSTEMD_*`), and no `udev_` symbols leaked.
- `@systemd//:libudev` still builds and produces `libudev.so.1` with its `udev_` exports — the rename is non-breaking.
- `tools/bcr_validation.py --check systemd@260.1.bcr.2` passes.

The source archive uses the GitHub auto-generated tarball URL (unchanged from `260.1`/`260.1.bcr.1`), so this PR needs:

@bazel-io skip_check unstable_url