### PR TITLE
Add Au 0.5.0

### DIFF
--- a/modules/au/0.5.0/MODULE.bazel
+++ b/modules/au/0.5.0/MODULE.bazel
@@ -1,0 +1,32 @@
+# Copyright 2025 Aurora Operations, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "au",
+    version = "0.5.0",
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.4")
+
+# GoogleTest is required for our publically available `//au:testing` target.  We
+# specify the current version we use here so this will participate in any users
+# BCR resolution, but it won't actually be pulled down to the users workspace if
+# they don't actually depend on a target that depends on `googletest`.
+bazel_dep(
+    name = "googletest",
+    # NOTE: if updating this version, also update the version numbers in
+    # `CMakelists.txt`.
+    version = "1.12.1",
+    repo_name = "com_google_googletest",
+)

--- a/modules/au/0.5.0/presubmit.yml
+++ b/modules/au/0.5.0/presubmit.yml
@@ -6,7 +6,6 @@ matrix:
   - macos_arm64
   - windows
   bazel:
-  - 9.x
   - 8.x
   - 7.x
 tasks:

--- a/modules/au/0.5.0/presubmit.yml
+++ b/modules/au/0.5.0/presubmit.yml
@@ -1,0 +1,22 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@au//au'
+    - '@au//au:au'
+    - '@au//au:io'
+    - '@au//au:std_format'
+    - '@au//au:testing'

--- a/modules/au/0.5.0/source.json
+++ b/modules/au/0.5.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/aurora-opensource/au/releases/download/0.5.0/au-0.5.0.tar.gz",
+    "integrity": "sha256-adNRDfeIDcWhCddRuK/Diyrb9K8ugptWmxnL3ZcP7l4=",
+    "strip_prefix": "au-0.5.0"
+}

--- a/modules/au/metadata.json
+++ b/modules/au/metadata.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://aurora-opensource.github.io/au",
+    "maintainers": [
+        {
+            "email": "hordijk@aurora.tech",
+            "github": "hoffbrinkle",
+            "github_user_id": 16811362,
+            "name": "Michael Hordijk"
+        },
+        {
+            "email": "chogg@aurora.tech",
+            "github": "chiphogg",
+            "github_user_id": 1819744,
+            "name": "Chip Hogg"
+        }
+    ],
+    "repository": [
+        "github:aurora-opensource/au"
+    ],
+    "versions": [
+        "0.5.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Initial add of [Au](https://aurora-opensource.github.io/au) to BCR.  Au is
the Aurora units library, a C++14 compatible units library.