### PR TITLE
Rename clickhouse-cpp-client to clickhouse-cpp

### DIFF
--- a/modules/clickhouse-cpp/2.6.1/MODULE.bazel
+++ b/modules/clickhouse-cpp/2.6.1/MODULE.bazel
@@ -1,0 +1,20 @@
+module(
+    name = "clickhouse-cpp",
+    version = "2.6.1",
+    # Overlay-only modules must declare a Bazel floor; >=7.2.1 is the
+    # minimum required by the BCR for overlay-based source archives.
+    bazel_compatibility = [">=7.2.1"],
+)
+
+# Pinned to 20260107.1, the last version that declares
+# `compatibility_level = 1`, so that the module remains importable on
+# Bazel < 9.1 whose bazel_tools also depends on a level-1 abseil-cpp.
+# See PR discussion; the attribute is a no-op from Bazel 9.1.0 onwards.
+bazel_dep(name = "abseil-cpp", version = "20260107.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "boringssl", version = "0.20260526.0")
+bazel_dep(name = "lz4", version = "1.10.0.bcr.1")
+bazel_dep(name = "openssl", version = "3.5.5.bcr.4")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "zstd", version = "1.5.7.bcr.1")

--- a/modules/clickhouse-cpp/2.6.1/overlay/BUILD.bazel
+++ b/modules/clickhouse-cpp/2.6.1/overlay/BUILD.bazel
@@ -1,0 +1,167 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# Bazel build for clickhouse-cpp. The canonical build is CMake
+# (top-level CMakeLists.txt); this file mirrors the same library as
+# a bzlmod target so downstream Bazel projects can depend on it via
+# the Bazel Central Registry without standing up CMake.
+#
+# Differences from the CMake build that callers should be aware of:
+#   * TLS links against BoringSSL (`@boringssl`) by default; pass
+#     `--@clickhouse-cpp//:tls=openssl` to use the BCR OpenSSL module
+#     instead, or `--@clickhouse-cpp//:tls=no` to disable TLS
+#     entirely. `USE_BORINGSSL` ifdef-guards the two OpenSSL-only
+#     surfaces (`SSL_CONF_*` command API and `SSL_read_ex`) that
+#     BoringSSL doesn't provide; see clickhouse/base/sslsocket.cpp.
+#   * lz4 / zstd / abseil come from BCR modules instead of contrib/.
+#     cityhash is the exception: it is built from contrib/ because the
+#     wire protocol needs ClickHouse's frozen CityHash variant, which
+#     differs from the stock BCR module (see the :cityhash target).
+
+# Selects the TLS implementation: `--@clickhouse-cpp//:tls=boringssl`
+# (default), `--@clickhouse-cpp//:tls=openssl`, or
+# `--@clickhouse-cpp//:tls=no` to disable TLS entirely (matching
+# CMake's `WITH_OPENSSL=OFF` default). The two TLS libraries come from
+# BCR modules and are linked statically, keeping the build hermetic.
+string_flag(
+    name = "tls",
+    build_setting_default = "boringssl",
+    values = [
+        "boringssl",
+        "openssl",
+        "no",
+    ],
+)
+
+config_setting(
+    name = "tls_boringssl",
+    flag_values = {":tls": "boringssl"},
+)
+
+config_setting(
+    name = "tls_openssl",
+    flag_values = {":tls": "openssl"},
+)
+
+config_setting(
+    name = "tls_no",
+    flag_values = {":tls": "no"},
+)
+
+# OpenSSL on Windows pulls in Win32 system libraries (the cert store via
+# crypt32, plus user32) that BoringSSL bundles itself. Used to gate the
+# extra linkopts below.
+selects.config_setting_group(
+    name = "tls_openssl_on_windows",
+    match_all = [
+        ":tls_openssl",
+        "@platforms//os:windows",
+    ],
+)
+
+# Vendored CityHash from contrib/, NOT the BCR `@cityhash` module.
+# ClickHouse's wire protocol checksums compressed blocks with a specific
+# frozen CityHash128 variant (see clickhouse/base/compressed.cpp); the
+# stock Google CityHash 1.0.2 that BCR packages produces *different*
+# hashes, so a server rejects compressed blocks with "Checksum doesn't
+# match: corrupted data". This is the exact copy the CMake build uses,
+# guaranteeing byte-identical hashing and wire compatibility.
+cc_library(
+    name = "cityhash",
+    srcs = [
+        "contrib/cityhash/cityhash/city.cc",
+        "contrib/cityhash/cityhash/config.h",
+    ],
+    hdrs = [
+        "contrib/cityhash/cityhash/city.h",
+        "contrib/cityhash/cityhash/citycrc.h",
+    ],
+    # config.h gates __builtin_expect off with `#if WIN32 || WIN64`, but
+    # MSVC only predefines `_WIN32`/`_WIN64`. Under CMake it's CMake that
+    # defines WIN32, which Bazel's MSVC toolchain doesn't. Define it here
+    # so the GCC/Clang-only builtin isn't used on MSVC.
+    copts = select({
+        "@platforms//os:windows": ["/DWIN32"],
+        "//conditions:default": [],
+    }),
+    strip_include_prefix = "contrib/cityhash/cityhash",
+)
+
+# The main clickhouse-cpp library. Downstream callers use
+# `#include <clickhouse/client.h>` and link `@clickhouse-cpp//:clickhouse`.
+cc_library(
+    name = "clickhouse",
+    srcs = glob(
+        [
+            "clickhouse/*.cpp",
+            "clickhouse/base/*.cpp",
+            "clickhouse/columns/*.cpp",
+            "clickhouse/types/*.cpp",
+        ],
+        # Only compiled when TLS is enabled, mirroring CMake's
+        # `IF (WITH_OPENSSL)` source-list append.
+        exclude = ["clickhouse/base/sslsocket.cpp"],
+    ) + select({
+        ":tls_no": [],
+        "//conditions:default": ["clickhouse/base/sslsocket.cpp"],
+    }),
+    hdrs = glob([
+        "clickhouse/*.h",
+        "clickhouse/base/*.h",
+        "clickhouse/columns/*.h",
+        "clickhouse/types/*.h",
+    ]),
+    defines = select({
+        # `WITH_OPENSSL` enables the TLS code paths in client.cpp /
+        # sslsocket.cpp (same macro as the CMake option). `USE_BORINGSSL`
+        # takes the BoringSSL-compatible branches in sslsocket.cpp.
+        ":tls_boringssl": [
+            "WITH_OPENSSL",
+            "USE_BORINGSSL",
+        ],
+        ":tls_openssl": ["WITH_OPENSSL"],
+        ":tls_no": [],
+    }),
+    # Winsock, required by base/socket.cpp et al. Mirrors CMake's
+    # `IF (WIN32 OR MINGW)` link block. (The BoringSSL backend already
+    # propagates ws2_32 itself; declare it explicitly so the openssl
+    # and no-TLS configurations link too.)
+    linkopts = select({
+        "@platforms//os:windows": [
+            "-DEFAULTLIB:ws2_32.lib",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        # OpenSSL references the Win32 cert store and user32; declare
+        # them so downstream executables link without each consumer
+        # having to repeat it. Mirrors CMake's MSVC `Crypt32` link.
+        ":tls_openssl_on_windows": [
+            "-DEFAULTLIB:crypt32.lib",
+            "-DEFAULTLIB:user32.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    # Expose headers at their workspace path so both internal
+    # (`#include "client.h"` from clickhouse/*.cpp via quote-form
+    # source-dir search) and external (`#include <clickhouse/client.h>`)
+    # include forms resolve.
+    strip_include_prefix = "/",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@abseil-cpp//absl/numeric:int128",
+        ":cityhash",
+        "@lz4//:lz4",
+        "@zstd//:zstd",
+    ] + select({
+        ":tls_boringssl": [
+            "@boringssl//:crypto",
+            "@boringssl//:ssl",
+        ],
+        ":tls_openssl": [
+            "@openssl//:crypto",
+            "@openssl//:ssl",
+        ],
+        ":tls_no": [],
+    }),
+)

--- a/modules/clickhouse-cpp/2.6.1/overlay/MODULE.bazel
+++ b/modules/clickhouse-cpp/2.6.1/overlay/MODULE.bazel
@@ -1,0 +1,20 @@
+module(
+    name = "clickhouse-cpp",
+    version = "2.6.1",
+    # Overlay-only modules must declare a Bazel floor; >=7.2.1 is the
+    # minimum required by the BCR for overlay-based source archives.
+    bazel_compatibility = [">=7.2.1"],
+)
+
+# Pinned to 20260107.1, the last version that declares
+# `compatibility_level = 1`, so that the module remains importable on
+# Bazel < 9.1 whose bazel_tools also depends on a level-1 abseil-cpp.
+# See PR discussion; the attribute is a no-op from Bazel 9.1.0 onwards.
+bazel_dep(name = "abseil-cpp", version = "20260107.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "boringssl", version = "0.20260526.0")
+bazel_dep(name = "lz4", version = "1.10.0.bcr.1")
+bazel_dep(name = "openssl", version = "3.5.5.bcr.4")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "zstd", version = "1.5.7.bcr.1")

--- a/modules/clickhouse-cpp/2.6.1/patches/sslsocket.patch
+++ b/modules/clickhouse-cpp/2.6.1/patches/sslsocket.patch
@@ -1,0 +1,57 @@
+--- a/clickhouse/base/sslsocket.cpp
++++ b/clickhouse/base/sslsocket.cpp
+@@ -2,6 +2,7 @@
+ #include "../client.h"
+ #include "../exceptions.h"
+ 
++#include <iostream>
+ #include <stdexcept>
+ 
+ #include <openssl/ssl.h>
+@@ -50,6 +51,19 @@ void throwSSLError(SSL * ssl, int error, const char * /*location*/, const char *
+ }
+ 
+ void configureSSL(const clickhouse::SSLParams::ConfigurationType & configuration, SSL * ssl, SSL_CTX * context = nullptr) {
++#ifdef USE_BORINGSSL
++    // BoringSSL doesn't ship the SSL_CONF_* command API, so the
++    // configuration vector cannot be applied. Users who rely on
++    // SSL_CONF commands should build against
++    // OpenSSL (e.g. --@clickhouse-cpp-client//:tls=openssl with Bazel).
++    (void)ssl;
++    (void)context;
++    if (!configuration.empty()) {
++        throw clickhouse::OpenSSLError(
++            "SSLParams::configuration cannot be used when the library is built against BoringSSL "
++            "To apply these settings, build against OpenSSL by using the `tls=openssl` option in Bazel.");
++    }
++#else
+     std::unique_ptr<SSL_CONF_CTX, decltype(&SSL_CONF_CTX_free)> conf_ctx_holder(SSL_CONF_CTX_new(), SSL_CONF_CTX_free);
+     auto conf_ctx = conf_ctx_holder.get();
+ 
+@@ -84,6 +98,7 @@ void configureSSL(const clickhouse::SSLParams::ConfigurationType & configuration
+         else
+             throw clickhouse::OpenSSLError("Failed to configure OpenSSL: command '" + kv.first + "' unknown error: " + std::to_string(err));
+     }
++#endif
+ }
+ 
+ #define STRINGIFY_HELPER(x) #x
+@@ -285,9 +300,18 @@ SSLSocketInput::SSLSocketInput(SSL *ssl)
+ {}
+ 
+ size_t SSLSocketInput::DoRead(void* buf, size_t len) {
++#ifdef USE_BORINGSSL
++    // BoringSSL doesn't have SSL_read_ex (OpenSSL 3.0+ API); fall back to
++    // SSL_read with the length clamped to INT_MAX.
++    const int max_read = static_cast<int>(
++        std::min<std::size_t>(len, std::numeric_limits<int>::max()));
++    return static_cast<size_t>(
++        HANDLE_SSL_ERROR(ssl_, SSL_read(ssl_, buf, max_read)));
++#else
+     size_t actually_read;
+     HANDLE_SSL_ERROR(ssl_, SSL_read_ex(ssl_, buf, len, &actually_read));
+     return actually_read;
++#endif
+ }
+ 
+ SSLSocketOutput::SSLSocketOutput(SSL *ssl)

--- a/modules/clickhouse-cpp/2.6.1/presubmit.yml
+++ b/modules/clickhouse-cpp/2.6.1/presubmit.yml
@@ -1,0 +1,32 @@
+matrix:
+  unix_platform:
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+  windows_platform:
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets_unix:
+    name: Unix
+    platform: ${{ unix_platform }}
+    bazel: ${{ bazel }}
+    # abseil-cpp (a dependency) requires C++17; Bazel 7.x defaults to
+    # -std=c++14 on the Linux/GCC autodetected toolchain, so force the
+    # standard explicitly. Mirrors abseil-cpp's own BCR presubmit.
+    build_flags:
+      - "--cxxopt=-std=c++17"
+    build_targets:
+      - "@clickhouse-cpp//:clickhouse"
+  verify_targets_windows:
+    name: Windows
+    platform: ${{ windows_platform }}
+    bazel: ${{ bazel }}
+    # MSVC spelling of the same C++17 requirement (see Unix task).
+    build_flags:
+      - "--cxxopt=/std:c++17"
+    build_targets:
+      - "@clickhouse-cpp//:clickhouse"

--- a/modules/clickhouse-cpp/2.6.1/source.json
+++ b/modules/clickhouse-cpp/2.6.1/source.json
@@ -1,0 +1,13 @@
+{
+    "integrity": "sha256-UblZL0s0jXqg5bWY7XXHge6ePdb2cebRmN2jpsWnsiI=",
+    "strip_prefix": "clickhouse-cpp-2.6.1",
+    "url": "https://github.com/ClickHouse/clickhouse-cpp/archive/refs/tags/v2.6.1.tar.gz",
+    "overlay": {
+        "BUILD.bazel": "sha256-CkQHz7nAmenufqb/58W4cIOZQCnmsEH1jkolgKdDMQk=",
+        "MODULE.bazel": "sha256-1Ne9R33ezLabUvDuERJnvYnCRqhgdpdio8zNcC3/1oc="
+    },
+    "patches": {
+        "sslsocket.patch": "sha256-wF712d++OT0XTmblXgeohkNFPrS3Fj9/yezraYjMqf4="
+    },
+    "patch_strip": 1
+}

--- a/modules/clickhouse-cpp/2.6.2/MODULE.bazel
+++ b/modules/clickhouse-cpp/2.6.2/MODULE.bazel
@@ -1,0 +1,17 @@
+module(name = "clickhouse-cpp", version = "2.6.2")
+
+# Pinned to 20260107.1, the last version that declares
+# `compatibility_level = 1`, so that the module remains importable on
+# Bazel < 9.1 whose bazel_tools also depends on a level-1 abseil-cpp.
+# See PR discussion; the attribute is a no-op from Bazel 9.1.0 onwards.
+bazel_dep(name = "abseil-cpp", version = "20260107.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "boringssl", version = "0.20260526.0")
+bazel_dep(name = "lz4", version = "1.10.0.bcr.1")
+bazel_dep(name = "openssl", version = "3.5.5.bcr.4")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "zstd", version = "1.5.7.bcr.1")
+
+# Test-only dependencies; not pulled in by consumers of the library.
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)

--- a/modules/clickhouse-cpp/2.6.2/patches/config_setting_visibility.patch
+++ b/modules/clickhouse-cpp/2.6.2/patches/config_setting_visibility.patch
@@ -1,0 +1,22 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -37,16 +37,19 @@
+ config_setting(
+     name = "tls_boringssl",
+     flag_values = {":tls": "boringssl"},
++    visibility = ["//visibility:public"],
+ )
+ 
+ config_setting(
+     name = "tls_openssl",
+     flag_values = {":tls": "openssl"},
++    visibility = ["//visibility:public"],
+ )
+ 
+ config_setting(
+     name = "tls_no",
+     flag_values = {":tls": "no"},
++    visibility = ["//visibility:public"],
+ )
+ 
+ # OpenSSL on Windows pulls in Win32 system libraries (the cert store via

--- a/modules/clickhouse-cpp/2.6.2/patches/module_name.patch
+++ b/modules/clickhouse-cpp/2.6.2/patches/module_name.patch
@@ -1,0 +1,8 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,4 +1,4 @@
+-module(name = "clickhouse-cpp-client", version = "2.6.2")
++module(name = "clickhouse-cpp", version = "2.6.2")
+ 
+ # Pinned to 20260107.1, the last version that declares
+ # `compatibility_level = 1`, so that the module remains importable on

--- a/modules/clickhouse-cpp/2.6.2/presubmit.yml
+++ b/modules/clickhouse-cpp/2.6.2/presubmit.yml
@@ -1,0 +1,73 @@
+matrix:
+  unix_platform:
+    - debian11
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+  windows_platform:
+    - windows
+  bazel: [7.x, 8.x, 9.x, rolling]
+tasks:
+  verify_targets_unix:
+    name: Unix
+    platform: ${{ unix_platform }}
+    bazel: ${{ bazel }}
+    # abseil-cpp (a dependency) requires C++17; Bazel 7.x defaults to
+    # -std=c++14 on the Linux/GCC autodetected toolchain, so force the
+    # standard explicitly. Mirrors abseil-cpp's own BCR presubmit.
+    build_flags:
+      - "--cxxopt=-std=c++17"
+    build_targets:
+      - "@clickhouse-cpp//:clickhouse"
+  verify_targets_windows:
+    name: Windows
+    platform: ${{ windows_platform }}
+    bazel: ${{ bazel }}
+    # MSVC spelling of the same C++17 requirement (see Unix task).
+    build_flags:
+      - "--cxxopt=/std:c++17"
+    build_targets:
+      - "@clickhouse-cpp//:clickhouse"
+# Build the module as the root workspace so its dev-only googletest
+# dependency is available, and run the hermetic unit test suite.
+# //ut:e2e_tests is intentionally excluded: it needs a live ClickHouse
+# server (it is tagged manual/external upstream).
+bcr_test_module:
+  module_path: ""
+  matrix:
+    unix_platform:
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - ubuntu2404
+      - macos
+      - macos_arm64
+    windows_platform:
+      - windows
+    bazel: [7.x, 8.x, 9.x, rolling]
+  tasks:
+    unit_tests_unix:
+      name: Unit tests (Unix)
+      platform: ${{ unix_platform }}
+      bazel: ${{ bazel }}
+      # Socketcase.connecttimeout connects to an IPv6 discard address and
+      # asserts a connect timeout / unreachable error. It is non-hermetic
+      # (depends on the sandbox's IPv6 routing, which varies across Bazel
+      # versions' sandboxes), so exclude it from the registry run.
+      test_flags:
+        - "--cxxopt=-std=c++17"
+        - "--test_filter=-Socketcase.connecttimeout"
+      test_targets:
+        - "//ut:unit_tests"
+    unit_tests_windows:
+      name: Unit tests (Windows)
+      platform: ${{ windows_platform }}
+      bazel: ${{ bazel }}
+      # See the Unix task: Socketcase.connecttimeout is non-hermetic.
+      test_flags:
+        - "--cxxopt=/std:c++17"
+        - "--test_filter=-Socketcase.connecttimeout"
+      test_targets:
+        - "//ut:unit_tests"

--- a/modules/clickhouse-cpp/2.6.2/source.json
+++ b/modules/clickhouse-cpp/2.6.2/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-usSXhXdZ6ZH6ThY4vM+TbLNtEK15JzaVpXAnLMSJFCg=",
+    "strip_prefix": "clickhouse-cpp-2.6.2",
+    "url": "https://github.com/ClickHouse/clickhouse-cpp/archive/refs/tags/v2.6.2.tar.gz",
+    "patches": {
+        "config_setting_visibility.patch": "sha256-yZ9dr2PD0G0DTbbTIpphzxU7VrOpvNPgJZDS1f1j/qg=",
+        "module_name.patch": "sha256-4ZBcCNi0d/1uvnOKUAg7tNIMvIHE50of8+pvWr8Ldrg="
+    },
+    "patch_strip": 1
+}

--- a/modules/clickhouse-cpp/metadata.json
+++ b/modules/clickhouse-cpp/metadata.json
@@ -8,7 +8,6 @@
             "name": "Andrew Slabko"
         }
     ],
-    "deprecated": "Renamed to module `clickhouse-cpp`. Use clickhouse-cpp instead (identical content and versions).",
     "repository": [
         "github:ClickHouse/clickhouse-cpp"
     ],
@@ -16,8 +15,5 @@
         "2.6.1",
         "2.6.2"
     ],
-    "yanked_versions": {
-        "2.6.1": "Renamed to module `clickhouse-cpp`; depend on clickhouse-cpp 2.6.1 instead.",
-        "2.6.2": "Renamed to module `clickhouse-cpp`; depend on clickhouse-cpp 2.6.2 instead."
-    }
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Few days ago, we published our library, `clickhouse-cpp`, to the Bazel Central Registry under the name `clickhouse-cpp-client`, as it seemed like a clearer name that would avoid conflicts with the ClickHouse server itself. However, after gathering private feedback from our users, we realized that this was a significant mistake:

* `clickhouse-cpp` is already the established name of the library, and it is the name used by other package managers.
* While we tried to avoid confusion with the ClickHouse server, we ended up creating even more confusion because a ClickHouse client CLI tool also exists. In fact, most users looking to install the `clickhouse-cpp` library would likely avoid `clickhouse-cpp-client`, assuming it refers to the CLI tool or an add-on for it.

Taking this into account, we believe we should acknowledge the mistake and perform the rename now, before it is too late. However, this is where I would appreciate some guidance, as I understand package renames are relatively uncommon in the Bazel Central Registry. The package has never been publicly announced and was published only few days ago. Additionally, we have consistently communicated that the package is experimental and may undergo breaking changes before it stabilizes. As a result, very few (if any) users are likely to be affected.
