### PR TITLE
aspect_rules_terser@2.1.2

### DIFF
--- a/modules/aspect_rules_terser/2.1.2/MODULE.bazel
+++ b/modules/aspect_rules_terser/2.1.2/MODULE.bazel
@@ -1,0 +1,41 @@
+"aspect-build/rules_terser"
+
+module(
+    name = "aspect_rules_terser",
+    bazel_compatibility = [">=7.0.0"],
+    compatibility_level = 1,
+    version = "2.1.2",
+)
+
+# Lower-bounds (minimum) versions for direct runtime dependencies
+bazel_dep(name = "aspect_bazel_lib", version = "2.19.3")
+bazel_dep(name = "aspect_rules_js", version = "2.0.0")
+bazel_dep(name = "aspect_tools_telemetry", version = "0.2.8")
+bazel_dep(name = "platforms", version = "0.0.5")
+
+tel = use_extension("@aspect_tools_telemetry//:extension.bzl", "telemetry")
+use_repo(tel, "aspect_tools_telemetry_report")
+
+####### Dev dependencies ########
+
+bazel_dep(name = "aspect_gazelle_prebuilt", version = "0.0.20", dev_dependency = True)
+bazel_dep(name = "aspect_rules_lint", version = "2.6.0", dev_dependency = True)
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.9.2", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
+
+# Transitive dep of aspect_rules_js; older versions resolved by the 2.0.0
+# lower-bound fail on Bazel 9 (removed `incompatible_use_toolchain_transition`).
+bazel_dep(name = "rules_nodejs", version = "6.7.4", dev_dependency = True)
+
+# Transitive dep of aspect_rules_lint's gazelle; the 0.42.0 it resolves
+# fails on Bazel 9 (native CcInfo symbol removed).
+bazel_dep(name = "rules_go", version = "0.61.1", dev_dependency = True)
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
+npm.npm_translate_lock(
+    name = "npm",
+    npmrc = "//:.npmrc",
+    pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+use_repo(npm, "npm")

--- a/modules/aspect_rules_terser/2.1.2/attestations.json
+++ b/modules/aspect_rules_terser/2.1.2/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/aspect-build/rules_terser/releases/download/v2.1.2/source.json.intoto.jsonl",
+            "integrity": "sha256-dextGDxlmsbR9eDf0ZCx4Lj5AYae6INARn600t0JSgg="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/aspect-build/rules_terser/releases/download/v2.1.2/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-8z8oAwXLzzhCmqAcd5cGqG8puJSKq8J7hw3o9igoklM="
+        },
+        "rules_terser-v2.1.2.tar.gz": {
+            "url": "https://github.com/aspect-build/rules_terser/releases/download/v2.1.2/rules_terser-v2.1.2.tar.gz.intoto.jsonl",
+            "integrity": "sha256-PtH24T/YWSPCAYrbTvxIppFPNymCupzYCXOBhePZG/w="
+        }
+    }
+}

--- a/modules/aspect_rules_terser/2.1.2/patches/module_dot_bazel_version.patch
+++ b/modules/aspect_rules_terser/2.1.2/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -3,8 +3,9 @@
+ module(
+     name = "aspect_rules_terser",
+     bazel_compatibility = [">=7.0.0"],
+     compatibility_level = 1,
++    version = "2.1.2",
+ )
+ 
+ # Lower-bounds (minimum) versions for direct runtime dependencies
+ bazel_dep(name = "aspect_bazel_lib", version = "2.19.3")

--- a/modules/aspect_rules_terser/2.1.2/presubmit.yml
+++ b/modules/aspect_rules_terser/2.1.2/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: 'e2e/smoke'
+  matrix:
+    bazel: ['7.x', '8.x', '9.x']
+    platform: ['debian10', 'macos', 'ubuntu2004', 'windows']
+  tasks:
+    run_tests:
+      name: 'Run test module'
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - '//...'

--- a/modules/aspect_rules_terser/2.1.2/presubmit.yml
+++ b/modules/aspect_rules_terser/2.1.2/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: 'e2e/smoke'
   matrix:
     bazel: ['7.x', '8.x', '9.x']
-    platform: ['debian10', 'macos', 'ubuntu2004', 'windows']
+    platform: ['debian10', 'macos', 'ubuntu2004']
   tasks:
     run_tests:
       name: 'Run test module'

--- a/modules/aspect_rules_terser/2.1.2/source.json
+++ b/modules/aspect_rules_terser/2.1.2/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-IUQXwKwCjON1bIIrSllxZiNkOwwmCKYsDnw6EgRGpYI=",
+    "strip_prefix": "rules_terser-2.1.2",
+    "docs_url": "https://github.com/aspect-build/rules_terser/releases/download/v2.1.2/rules_terser-v2.1.2.docs.tar.gz",
+    "url": "https://github.com/aspect-build/rules_terser/releases/download/v2.1.2/rules_terser-v2.1.2.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-husqH8ZmuKHhcNInVhH48t6/DK22z0bFqdBFuNbfcow="
+    },
+    "patch_strip": 1
+}

--- a/modules/aspect_rules_terser/metadata.json
+++ b/modules/aspect_rules_terser/metadata.json
@@ -1,11 +1,11 @@
 {
-    "homepage": "https://docs.aspect.build/rules/aspect_rules_terser",
+    "homepage": "https://docs.aspect.build/bazel/javascript",
     "maintainers": [
         {
-            "email": "alex@aspect.build",
-            "github": "alexeagle",
-            "name": "Alex Eagle",
-            "github_user_id": 47395
+            "email": "jason@aspect.build",
+            "github": "jbedard",
+            "name": "Jason Bedard",
+            "github_user_id": 89246
         }
     ],
     "repository": [
@@ -19,7 +19,8 @@
         "2.0.0-rc0",
         "2.0.0",
         "2.0.1",
-        "2.1.0"
+        "2.1.0",
+        "2.1.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/aspect-build/rules_terser/releases/tag/v2.1.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_