### PR TITLE
aspect_tools_telemetry@0.4.2

### DIFF
--- a/modules/aspect_tools_telemetry/0.4.2/MODULE.bazel
+++ b/modules/aspect_tools_telemetry/0.4.2/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "aspect_tools_telemetry",
+    version = "0.4.2",
+)
+
+# Minimum version constraints, do not increase
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.0.3")
+
+tel = use_extension("//:extension.bzl", "telemetry")
+use_repo(tel, "aspect_tools_telemetry_report")

--- a/modules/aspect_tools_telemetry/0.4.2/attestations.json
+++ b/modules/aspect_tools_telemetry/0.4.2/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/aspect-build/tools_telemetry/releases/download/v0.4.2/source.json.intoto.jsonl",
+            "integrity": "sha256-f62dn6snTjXzkjiVPjDVlb15pqmjt8nIA0XcNKeUKKQ="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/aspect-build/tools_telemetry/releases/download/v0.4.2/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-Nogurc/alIpt3gIOnaETRyw86Mj+oAGbMLFJ5CBKCLc="
+        },
+        "tools_telemetry-v0.4.2.tar.gz": {
+            "url": "https://github.com/aspect-build/tools_telemetry/releases/download/v0.4.2/tools_telemetry-v0.4.2.tar.gz.intoto.jsonl",
+            "integrity": "sha256-lJHTJHFxo7BVyO96bQQ8mJxa3WD/3+ZBIqbTVUZ/tXw="
+        }
+    }
+}

--- a/modules/aspect_tools_telemetry/0.4.2/patches/module_dot_bazel_version.patch
+++ b/modules/aspect_tools_telemetry/0.4.2/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "aspect_tools_telemetry",
+-    version = "0.0.0",
++    version = "0.4.2",
+ )
+ 
+ # Minimum version constraints, do not increase
+ bazel_dep(name = "bazel_lib", version = "3.0.0")

--- a/modules/aspect_tools_telemetry/0.4.2/presubmit.yml
+++ b/modules/aspect_tools_telemetry/0.4.2/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+    - ubuntu2204
+  # We depend on a holdback version of `bazel-lib` to expand compatability. That
+  # ancient version is broken on Bazel 9/rolling. When presubmit runs in
+  # `--external` that dependency gets picked and is broken. Seem comments in
+  # MODULE.bazel. To unblock that we don't list `rolling` here.
+  bazel: [6.*, 7.*, 8.*]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@aspect_tools_telemetry//...'

--- a/modules/aspect_tools_telemetry/0.4.2/source.json
+++ b/modules/aspect_tools_telemetry/0.4.2/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-72svC+yABImjcdElCiKdv1HSa1Ix2j+nM7wlseDIa8M=",
+    "strip_prefix": "tools_telemetry-0.4.2",
+    "url": "https://github.com/aspect-build/tools_telemetry/releases/download/v0.4.2/tools_telemetry-v0.4.2.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-dpRBpLpXCcSpPH487lAs6LQcI5WuFe1XcsRuJjPo0Lo="
+    },
+    "patch_strip": 1
+}

--- a/modules/aspect_tools_telemetry/metadata.json
+++ b/modules/aspect_tools_telemetry/metadata.json
@@ -2,16 +2,22 @@
     "homepage": "https://registry.build/github/aspect-build/tools_telemetry",
     "maintainers": [
         {
-            "email": "alex@aspect.build",
-            "github": "alexeagle",
-            "name": "Alex Eagle",
-            "github_user_id": 47395
+            "email": "jason@aspect.build",
+            "github": "jbedard",
+            "name": "Jason Bedard",
+            "github_user_id": 89246
         },
         {
-            "email": "reid@aspect.build",
-            "github": "arrdem",
-            "name": "Reid D McKenzie",
-            "github_user_id": 704767
+            "email": "adamc@aspect.build",
+            "github": "acozzette",
+            "name": "Adam Cozzette",
+            "github_user_id": 1115459
+        },
+        {
+            "email": "greg@aspect.build",
+            "github": "gregmagolan",
+            "name": "Greg Magolan",
+            "github_user_id": 520826
         }
     ],
     "repository": [
@@ -32,7 +38,8 @@
         "0.3.0",
         "0.3.1",
         "0.3.2",
-        "0.3.3"
+        "0.3.3",
+        "0.4.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/aspect-build/tools_telemetry/releases/tag/v0.4.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_