### PR TITLE
aspect_rules_lint_rust@0.0.2

### DIFF
--- a/modules/aspect_rules_lint_rust/0.0.2/MODULE.bazel
+++ b/modules/aspect_rules_lint_rust/0.0.2/MODULE.bazel
@@ -1,0 +1,33 @@
+"Bazel dependencies for Rust lint support"
+
+module(
+    name = "aspect_rules_lint_rust",
+    version = "0.0.2",
+    bazel_compatibility = [">=8.0.0"],
+)
+
+bazel_dep(name = "aspect_rules_lint", version = "2.6.0")
+bazel_dep(name = "aspect_rules_js", version = "1.40.0")
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "llvm", version = "0.7.5")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# aspect_rules_lint 2.6.0 selects rules_go 0.57.0, which uses the global CcInfo symbol removed in Bazel 9.
+bazel_dep(name = "rules_go", version = "0.59.0", dev_dependency = True, repo_name = None)
+
+bazel_dep(name = "rules_rs", version = "0.0.83")
+
+rules_rust = use_extension("@rules_rs//rs:rules_rust.bzl", "rules_rust")
+use_repo(rules_rust, "rules_rust")
+
+toolchains = use_extension("@rules_rs//rs/toolchains:module_extension.bzl", "toolchains")
+toolchains.toolchain(
+    edition = "2021",
+    version = "1.92.0",
+)
+use_repo(toolchains, "default_rust_toolchains")
+
+register_toolchains(
+    "@default_rust_toolchains//:all",
+    "@llvm//toolchain:all",
+)

--- a/modules/aspect_rules_lint_rust/0.0.2/attestations.json
+++ b/modules/aspect_rules_lint_rust/0.0.2/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/aspect-build/rules_lint/releases/download/rust-v0.0.2/source.json.intoto.jsonl",
+            "integrity": "sha256-d8W3VYnjq6IMwLzIGYDvKvjNNwTAOHIJp/BrSLj3bGE="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/aspect-build/rules_lint/releases/download/rust-v0.0.2/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-NI/VN+6/nmC59uu6vP82GSmZlCmBnA5haTDyKKEyBE4="
+        },
+        "rules_lint-rust-v0.0.2.tar.gz": {
+            "url": "https://github.com/aspect-build/rules_lint/releases/download/rust-v0.0.2/rules_lint-rust-v0.0.2.tar.gz.intoto.jsonl",
+            "integrity": "sha256-gj21QAYajFMXRD4SJ6xFD2VVLcadOV/ibejDDWfisio="
+        }
+    }
+}

--- a/modules/aspect_rules_lint_rust/0.0.2/presubmit.yml
+++ b/modules/aspect_rules_lint_rust/0.0.2/presubmit.yml
@@ -1,0 +1,12 @@
+matrix:
+  platform:
+    - ubuntu2204
+    - macos
+  bazel: [8.x, 9.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@aspect_rules_lint_rust//:all"

--- a/modules/aspect_rules_lint_rust/0.0.2/presubmit.yml
+++ b/modules/aspect_rules_lint_rust/0.0.2/presubmit.yml
@@ -2,7 +2,7 @@ matrix:
   platform:
     - ubuntu2204
     - macos
-  bazel: [8.x, 9.x]
+  bazel: [8.x, 9.0.0]
 tasks:
   verify_targets:
     name: Verify build targets

--- a/modules/aspect_rules_lint_rust/0.0.2/source.json
+++ b/modules/aspect_rules_lint_rust/0.0.2/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-xu9tbG0AThaPGyRxqpAAZkRVzQJTPhNRF7yVTfJdFAA=",
+    "strip_prefix": "rules_lint-rust-v0.0.2",
+    "url": "https://github.com/aspect-build/rules_lint/releases/download/rust-v0.0.2/rules_lint-rust-v0.0.2.tar.gz"
+}

--- a/modules/aspect_rules_lint_rust/metadata.json
+++ b/modules/aspect_rules_lint_rust/metadata.json
@@ -1,0 +1,30 @@
+{
+    "homepage": "https://github.com/aspect-build/rules_lint",
+    "maintainers": [
+        {
+            "email": "jesse@aspect.build",
+            "github": "JesseTatasciore",
+            "name": "Jesse Tatasciore",
+            "github_user_id": 11635434
+        },
+        {
+            "email": "jason@aspect.build",
+            "github": "jbedard",
+            "name": "Jason Bedard",
+            "github_user_id": 89246
+        },
+        {
+            "email": "dzbarsky@gmail.com",
+            "github": "dzbarsky",
+            "name": "David Zbarsky",
+            "github_user_id": 1565842
+        }
+    ],
+    "repository": [
+        "github:aspect-build/rules_lint"
+    ],
+    "versions": [
+        "0.0.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/aspect-build/rules_lint/releases/tag/rust-v0.0.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_