### PR TITLE
Add cpu_features 0.11.0

### DIFF
--- a/modules/cpu_features/0.11.0/MODULE.bazel
+++ b/modules/cpu_features/0.11.0/MODULE.bazel
@@ -1,0 +1,19 @@
+###############################################################################
+# Bazel now uses Bzlmod by default to manage external dependencies.
+# Please consider migrating your external dependencies from WORKSPACE to MODULE.bazel.
+#
+# For more details, please check https://github.com/bazelbuild/bazel/issues/18958
+###############################################################################
+
+CPU_FEATURES_VERSION = "0.11.0"
+
+module(
+    name = "cpu_features",
+    repo_name = "com_google_cpufeatures",
+    version = "0.11.0",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+bazel_dep(name = "platforms", version = "1.0.0")

--- a/modules/cpu_features/0.11.0/patches/module_dot_bazel.patch
+++ b/modules/cpu_features/0.11.0/patches/module_dot_bazel.patch
@@ -1,0 +1,11 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -10,7 +10,7 @@
+ module(
+     name = "cpu_features",
+     repo_name = "com_google_cpufeatures",
+-    version = CPU_FEATURES_VERSION,
++    version = "0.11.0",
+ )
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/modules/cpu_features/0.11.0/presubmit.yml
+++ b/modules/cpu_features/0.11.0/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@cpu_features//:cpuinfo'
+    - '@cpu_features//:list_cpu_features'

--- a/modules/cpu_features/0.11.0/source.json
+++ b/modules/cpu_features/0.11.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/google/cpu_features/archive/refs/tags/v0.11.0.tar.gz",
+    "integrity": "sha256-qyRj8tOPyv8c6Aa+jkyRMzRJkx9eAgCdVDslaaP6Rxo=",
+    "strip_prefix": "cpu_features-0.11.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-0tOSqhmKnmTmNhmLFrUxRZBiF7BlZj5xDiIzQpqmdOo="
+    }
+}

--- a/modules/cpu_features/metadata.json
+++ b/modules/cpu_features/metadata.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://github.com/google/cpu_features",
+    "maintainers": [],
+    "repository": [
+        "github:google/cpu_features"
+    ],
+    "versions": [
+        "0.11.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds the initial Bazel Central Registry entry for [google/cpu_features](https://github.com/google/cpu_features) at its latest release, [v0.11.0](https://github.com/google/cpu_features/releases/tag/v0.11.0).

### Notes
- **Source archive**: cpu_features does not publish a release tarball, so this uses the auto-generated GitHub tag archive (`.../archive/refs/tags/v0.11.0.tar.gz`). The `unstable_url` check is therefore expected to fail; see the `@bazel-io skip_check unstable_url` comment below.
- **MODULE.bazel patch**: Upstream sets `version` via a Starlark constant (`version = CPU_FEATURES_VERSION`). A small `module_dot_bazel.patch` inlines the literal version (`version = "0.11.0"`) so the checked-in MODULE.bazel passes the BCR version check while still matching the patched source.
- **Maintainers**: none listed (this entry is not submitted by the upstream project).
- **Build targets** exercised by presubmit: `@cpu_features//:cpuinfo` (core library) and `@cpu_features//:list_cpu_features` (CLI binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)