### PR TITLE
Add node_headers 24.14.0

### DIFF
--- a/modules/node_headers/24.14.0/MODULE.bazel
+++ b/modules/node_headers/24.14.0/MODULE.bazel
@@ -1,0 +1,10 @@
+"""Node.js C/C++ addon headers (include/node)"""
+
+module(
+    name = "node_headers",
+    version = "24.14.0",
+    compatibility_level = 24,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.20")

--- a/modules/node_headers/24.14.0/overlay/BUILD.bazel
+++ b/modules/node_headers/24.14.0/overlay/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "headers",
+    hdrs = glob(["*.h"]),
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/modules/node_headers/24.14.0/overlay/MODULE.bazel
+++ b/modules/node_headers/24.14.0/overlay/MODULE.bazel
@@ -1,0 +1,10 @@
+"""Node.js C/C++ addon headers (include/node)"""
+
+module(
+    name = "node_headers",
+    version = "24.14.0",
+    compatibility_level = 24,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.20")

--- a/modules/node_headers/24.14.0/presubmit.yml
+++ b/modules/node_headers/24.14.0/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform: ["debian10", "ubuntu2004", "macos", "windows"]
+    bazel: ["7.x", "8.x", "9.x"]
+  tasks:
+    verify_targets:
+      name: "Verify build targets"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - "//:headers"

--- a/modules/node_headers/24.14.0/source.json
+++ b/modules/node_headers/24.14.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://nodejs.org/dist/v24.14.0/node-v24.14.0-headers.tar.gz",
+    "strip_prefix": "node-v24.14.0/include/node",
+    "integrity": "sha256-vBUFyOKysfe3zzgIv1NpHl0RDIFtG8GkgHUZXF3K/gU=",
+    "overlay": {
+        "BUILD.bazel": "sha256-eaMipcfSRG8J4ndZK6DHrptMYTJP0vGu1SklhRedoyM=",
+        "MODULE.bazel": "sha256-eGwHHcpT2GlkPC3zmjRX2vf+SYcD64E6Esr/LzSCBUI="
+    }
+}

--- a/modules/node_headers/metadata.json
+++ b/modules/node_headers/metadata.json
@@ -1,0 +1,19 @@
+{
+    "homepage": "https://nodejs.org",
+    "maintainers": [
+        {
+            "email": "anthropicclaude@byvoid.com",
+            "github": "BYVoid",
+            "github_user_id": 245270,
+            "name": "Carbo Kuo"
+        }
+    ],
+    "repository": [
+        "github:nodejs/node",
+        "https://nodejs.org/dist"
+    ],
+    "versions": [
+        "24.14.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add `node_headers` 24.14.0 — Node.js C/C++ addon headers (`include/node`), packaged from the official `node-v24.14.0-headers.tar.gz` distribution with an overlay `cc_library` exposing `@node_headers//:headers`.

@bazel-io skip_check unstable_url
