### PR TITLE
Add node_addon_api 8.8.0

### DIFF
--- a/modules/node_addon_api/8.8.0/MODULE.bazel
+++ b/modules/node_addon_api/8.8.0/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "node_addon_api",
+    version = "8.8.0",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+# node-addon-api is a header-only C++ wrapper over N-API. Its headers
+# (napi.h / napi-inl.h) #include <node_api.h>, which is provided by the
+# active Node toolchain's headers via rules_nodejs.
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_nodejs", version = "6.7.4")

--- a/modules/node_addon_api/8.8.0/overlay/BUILD.bazel
+++ b/modules/node_addon_api/8.8.0/overlay/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# node-addon-api is header-only (napi.h + napi-inl.h). It sits on top of the
+# Node C headers, which are supplied cross-platform by the consumer's active
+# Node toolchain through rules_nodejs' current_node_cc_headers target.
+#
+# NOTE: the consuming (root) module must enable header output on its Node
+# toolchain, otherwise current_node_cc_headers resolves to nothing:
+#
+#   node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+#   node.toolchain(include_headers = True)
+cc_library(
+    name = "node_addon_api",
+    hdrs = glob(["*.h"]),
+    includes = ["."],
+    visibility = ["//visibility:public"],
+    deps = ["@rules_nodejs//nodejs/headers:current_node_cc_headers"],
+)

--- a/modules/node_addon_api/8.8.0/overlay/test_module/BUILD.bazel
+++ b/modules/node_addon_api/8.8.0/overlay/test_module/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+# Build the N-API addon as a loadable shared library. napi_* symbols are
+# provided by the Node process at load time, so the shared object must tolerate
+# undefined symbols (only an issue on macOS; ELF shared libs allow this).
+cc_binary(
+    name = "hello.so",
+    srcs = ["hello.cc"],
+    copts = ["-std=c++17"],
+    linkshared = True,
+    linkopts = select({
+        # macOS ld errors on undefined symbols by default; tell it to resolve
+        # the napi_* symbols at load time (dlopen), like node-gyp does.
+        "@platforms//os:macos": ["-undefined", "dynamic_lookup"],
+        "//conditions:default": [],
+    }),
+    deps = ["@node_addon_api//:node_addon_api"],
+)
+
+# Node expects the addon to have a .node extension.
+genrule(
+    name = "hello_node",
+    srcs = [":hello.so"],
+    outs = ["hello.node"],
+    cmd = "cp $< $@",
+)
+
+# Loads hello.node from Node, calls into it, and asserts the returned value.
+js_test(
+    name = "addon_test",
+    data = [":hello.node"],
+    entry_point = "test.js",
+)

--- a/modules/node_addon_api/8.8.0/overlay/test_module/MODULE.bazel
+++ b/modules/node_addon_api/8.8.0/overlay/test_module/MODULE.bazel
@@ -1,0 +1,16 @@
+module(
+    name = "node_addon_api_test",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "node_addon_api", version = "8.8.0")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_nodejs", version = "6.7.4")
+bazel_dep(name = "aspect_rules_js", version = "3.2.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# node-addon-api needs the Node C headers, which rules_nodejs only emits when
+# the root toolchain opts in with include_headers = True.
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+node.toolchain(include_headers = True)
+use_repo(node, "nodejs_toolchains")

--- a/modules/node_addon_api/8.8.0/overlay/test_module/hello.cc
+++ b/modules/node_addon_api/8.8.0/overlay/test_module/hello.cc
@@ -1,0 +1,16 @@
+#include <napi.h>
+
+namespace {
+
+Napi::String Hello(const Napi::CallbackInfo& info) {
+  return Napi::String::New(info.Env(), "hello from node-addon-api");
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("hello", Napi::Function::New(env, Hello));
+  return exports;
+}
+
+}  // namespace
+
+NODE_API_MODULE(hello, Init)

--- a/modules/node_addon_api/8.8.0/overlay/test_module/test.js
+++ b/modules/node_addon_api/8.8.0/overlay/test_module/test.js
@@ -1,0 +1,17 @@
+const assert = require("assert");
+const path = require("path");
+
+// rules_js runs from the output tree, where hello.node (a generated file) sits
+// next to the copied entry point.
+const addon = require(path.join(__dirname, "hello.node"));
+
+const expected = "hello from node-addon-api";
+const actual = addon.hello();
+
+assert.strictEqual(
+  actual,
+  expected,
+  `addon.hello() returned "${actual}", expected "${expected}"`,
+);
+
+console.log("addon test passed:", actual);

--- a/modules/node_addon_api/8.8.0/presubmit.yml
+++ b/modules/node_addon_api/8.8.0/presubmit.yml
@@ -1,0 +1,17 @@
+bcr_test_module:
+  module_path: "test_module"
+  matrix:
+    platform:
+      - debian11
+      - ubuntu2204
+      - macos
+    bazel: [7.x, 8.x, 9.x, rolling]
+  tasks:
+    run_test:
+      name: Build and run N-API addon against node-addon-api
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "@node_addon_api//:node_addon_api"
+      test_targets:
+        - "//:addon_test"

--- a/modules/node_addon_api/8.8.0/source.json
+++ b/modules/node_addon_api/8.8.0/source.json
@@ -1,0 +1,12 @@
+{
+    "url": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+    "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+    "strip_prefix": "package",
+    "overlay": {
+        "BUILD.bazel": "sha256-pRPh8IIY5y9XNzGOoLpl7R3Cq63CGLDrYGlQGa41J9Q=",
+        "test_module/BUILD.bazel": "sha256-0kMvrXE/QQk+WlwHTXrX4VsfypzVUy1Mfrx0UCzaVy8=",
+        "test_module/MODULE.bazel": "sha256-MEKU4yUxVRDez18ujdFl0WZkgjlzHVfcILeoc0q2fs0=",
+        "test_module/hello.cc": "sha256-gPH2o8UrZdgmsSAjyUeV+5VOoOJIOQ2KuEZdKH0OClY=",
+        "test_module/test.js": "sha256-w3nFbzKKOqar7Aw556vvsUOpD7PlFMuetRBa1bO+xyw="
+    }
+}

--- a/modules/node_addon_api/metadata.json
+++ b/modules/node_addon_api/metadata.json
@@ -1,0 +1,19 @@
+{
+    "homepage": "https://github.com/nodejs/node-addon-api",
+    "maintainers": [
+        {
+            "email": "byvoid@byvoid.com",
+            "github": "BYVoid",
+            "name": "Carbo Kuo",
+            "github_user_id": 245270
+        }
+    ],
+    "repository": [
+        "github:nodejs/node-addon-api",
+        "https://registry.npmjs.org/node-addon-api"
+    ],
+    "versions": [
+        "8.8.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
## node_addon_api 8.8.0

Adds [node-addon-api](https://github.com/nodejs/node-addon-api) — the header-only C++ wrapper over Node-API (N-API), providing `Napi::` classes such as `Napi::Object`, `Napi::Function`, and `Napi::AsyncWorker` instead of the raw C API.

### Source

The archive is the official npm tarball (`registry.npmjs.org`). node-addon-api is not published as a GitHub release archive, so this uses the npm registry URL. The package is header-only; a BUILD file is supplied via `source.json` `overlay`.

> Because the npm registry URL is not a GitHub release archive, the `unstable_url` check does not apply here:
>
> @bazel-io skip_check unstable_url

### Node headers

node-addon-api's headers (`napi.h` / `napi-inl.h`) `#include <node_api.h>`, which is part of the Node C headers rather than this package. Those are provided cross-platform by the consumer's **active Node toolchain** through rules_nodejs:

```starlark
deps = ["@rules_nodejs//nodejs/headers:current_node_cc_headers"]
```

`current_node_cc_headers` resolves the Node toolchain and forwards its headers `CcInfo`, so consumers don't need to hardcode a platform-specific repo. The one requirement is that the root module opt in to header output:

```starlark
node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
node.toolchain(include_headers = True)
```

The published module itself depends only on `rules_cc` and `rules_nodejs`.

### Usage

```starlark
bazel_dep(name = "node_addon_api", version = "8.8.0")

node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
node.toolchain(include_headers = True)
```
```starlark
cc_binary(
    name = "my_addon.node",
    srcs = ["addon.cc"],
    copts = ["-std=c++17"],  # node-addon-api 8.x requires C++17
    linkshared = True,
    deps = ["@node_addon_api"],
)
```

### Test module

`test_module` is more than a compile check: it builds a real loadable addon and exercises it from Node.

1. Compiles a minimal N-API addon (`hello.cc`) into a shared library and renames it to `hello.node`.
2. A `js_test` (aspect_rules_js) runs the Node toolchain on `test.js`, which `require()`s `hello.node`, calls into it, and asserts the returned value.

Verified locally on macOS (arm64) and Linux (x86_64, GCC).

### Notes

- node-addon-api 8.x effectively requires **C++17** (`std::string_view`, `if constexpr`); building at C++14 fails on GCC.
- Windows is not supported by the built-in rules_nodejs toolchains, since Node's Windows releases do not ship the C headers that `current_node_cc_headers` forwards.
