### PR TITLE
helly25_bzl@0.5.0

### DIFF
--- a/modules/helly25_bzl/0.5.0/MODULE.bazel
+++ b/modules/helly25_bzl/0.5.0/MODULE.bazel
@@ -1,0 +1,22 @@
+# Copyright 2025 The Helly25 Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module helly25_bzl."""
+
+module(
+    name = "helly25_bzl",
+    version = "0.5.0",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/modules/helly25_bzl/0.5.0/presubmit.yml
+++ b/modules/helly25_bzl/0.5.0/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+  platform:
+    - ubuntu2404
+    - macos_arm64
+    - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@helly25_bzl//bzl/..."

--- a/modules/helly25_bzl/0.5.0/source.json
+++ b/modules/helly25_bzl/0.5.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-X4F/PwMu03dnVWRxa9DFnGx+W85YV84QBBEvo0ybM5Q=",
+    "strip_prefix": "bzl-0.5.0",
+    "url": "https://github.com/helly25/bzl/releases/download/0.5.0/bzl-0.5.0.tar.gz"
+}

--- a/modules/helly25_bzl/metadata.json
+++ b/modules/helly25_bzl/metadata.json
@@ -22,7 +22,8 @@
         "0.4.1",
         "0.4.2",
         "0.4.3",
-        "0.4.4"
+        "0.4.4",
+        "0.5.0"
     ],
     "yanked_versions": {
         "0.4.0": "Packaging inconsistencies that break external version management; upgrade to 0.4.2.",


### PR DESCRIPTION
Release: https://github.com/helly25/bzl/releases/tag/0.5.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_