### PR TITLE
Added module: trlc@2.0.5 to BCR

### DIFF
--- a/modules/trlc/2.0.5/MODULE.bazel
+++ b/modules/trlc/2.0.5/MODULE.bazel
@@ -1,0 +1,115 @@
+module(
+    name = "trlc",
+    compatibility_level = 1,
+    version = "2.0.5",
+)
+
+bazel_dep(
+    name = "rules_python",
+    version = "1.1.0",
+)
+
+bazel_dep(
+    name = "buildifier_prebuilt",
+    version = "8.2.1.1",
+    dev_dependency = True,
+)
+
+bazel_dep(
+    name = "aspect_rules_lint",
+    version = "2.2.0",
+    dev_dependency = True,
+)
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+
+python.toolchain(python_version = "3.9")
+python.toolchain(python_version = "3.10")
+python.toolchain(python_version = "3.11")
+python.toolchain(
+    is_default = True,
+    python_version = "3.12",
+    configure_coverage_tool = True,
+)
+
+use_repo(python, "python_versions")
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
+[
+    pip.parse(
+        hub_name = "trlc_dependencies",
+        python_version = python_version,
+        requirements_lock = "//:requirements_lock.txt",
+    )
+    for python_version in [
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+    ]
+]
+
+use_repo(pip, "trlc_dependencies")
+
+[
+    pip.parse(
+        hub_name = "trlc_sphinx_dependencies",
+        python_version = python_version,
+        requirements_lock = "//tools/sphinx:requirements.txt",
+    )
+    for python_version in [
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+    ]
+]
+
+use_repo(pip, "trlc_sphinx_dependencies")
+
+# Dev-only pip hub: tools required for linting, static analysis, etc.
+pip_dev = use_extension(
+    "@rules_python//python/extensions:pip.bzl",
+    "pip",
+    dev_dependency = True,
+)
+
+pip_dev.parse(
+    hub_name = "trlc_dev_dependencies",
+    python_version = "3.12",
+    requirements_lock = "//:requirements_dev_lock.txt",
+)
+
+use_repo(pip_dev, "trlc_dev_dependencies")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# ---------------------------------------------------------------------------
+# CVC5 binary archives
+# Keep in synch with CVC5_DEFAULT_VERSION in util/fetch_cvc5.py
+# and requirements.txt / requirements_dev.txt
+# ---------------------------------------------------------------------------
+http_archive(
+    name = "cvc5_linux",
+    build_file = "@trlc//:cvc5.BUILD",
+    sha256 = "30abf22d8042f3c4d3eb1120c595abd461f92f276a6d1264895fb4403b5fb3fd",
+    strip_prefix = "cvc5-Linux-x86_64-static-gpl",
+    url = "https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.2/cvc5-Linux-x86_64-static-gpl.zip",
+)
+
+http_archive(
+    name = "cvc5_mac",
+    build_file = "@trlc//:cvc5.BUILD",
+    sha256 = "6c63ba3bd174d026be161be75f64df8d200c8a284012c49e91807f3ede5afc44",
+    strip_prefix = "cvc5-macOS-arm64-static-gpl",
+    url = "https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.2/cvc5-macOS-arm64-static-gpl.zip",
+)
+
+http_archive(
+    name = "cvc5_windows",
+    build_file = "@trlc//:cvc5.BUILD",
+    sha256 = "206d55380f9a0ccf43541756b5ce2be487efcbbf322b93dc1de662856c70e5cc",
+    strip_prefix = "cvc5-Win64-x86_64-static",
+    url = "https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.2/cvc5-Win64-x86_64-static.zip",
+)

--- a/modules/trlc/2.0.5/patches/module_dot_bazel_version.patch
+++ b/modules/trlc/2.0.5/patches/module_dot_bazel_version.patch
@@ -1,0 +1,15 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,11 +1,11 @@
+ module(
+     name = "trlc",
+     compatibility_level = 1,
+-    version = "0.0.0",
++    version = "2.0.5",
+ )
+ 
+ bazel_dep(
+     name = "rules_python",
+     version = "1.1.0",
+ )
+ 

--- a/modules/trlc/2.0.5/presubmit.yml
+++ b/modules/trlc/2.0.5/presubmit.yml
@@ -1,0 +1,24 @@
+incompatible_flags:
+  "--incompatible_config_setting_private_default_visibility":
+    - 8.x
+  "--incompatible_disable_starlark_host_transitions":
+    - 8.x
+  "--incompatible_disable_native_repo_rules":
+    - 8.x
+  "--incompatible_strict_action_env":
+    - 8.x
+matrix:
+  platform:
+  - ubuntu2204
+  - windows
+  bazel:
+  - 8.x
+tasks:
+  verify_api_examples:
+    name: "Verify api-examples"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_flags:
+    - "--@@rules_python+//python/config_settings:python_version=3.12"
+    test_targets:
+    - "@trlc//api-examples/..."

--- a/modules/trlc/2.0.5/source.json
+++ b/modules/trlc/2.0.5/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-peb24kiTmQEeOOXl3PaxuSMVRf4DAf5fI4QYIqm878k=",
+    "strip_prefix": "trlc-trlc-2.0.5",
+    "url": "https://github.com/bmw-software-engineering/trlc/archive/refs/tags/trlc-2.0.5.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-MdmSuDCa8Tm3cDS0hA8PF2Yxchg12J/MRukLjg6p1zA="
+    },
+    "patch_strip": 1
+}

--- a/modules/trlc/metadata.json
+++ b/modules/trlc/metadata.json
@@ -18,7 +18,8 @@
         "github:bmw-software-engineering/trlc"
     ],
     "versions": [
-        "2.0.4"
+        "2.0.4",
+        "2.0.5"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Added trlc version 2.0.5 (release tag trlc-2.0.5)
MODULE.bazel with dependencies on rules_python and cvc5. Maintainer: Ambuj Singh Kushwaha [ambujsingh7566180876@gmail.com]