### PR TITLE
Add rules_opensbi@0.1.0

### DIFF
--- a/modules/rules_opensbi/0.1.0/MODULE.bazel
+++ b/modules/rules_opensbi/0.1.0/MODULE.bazel
@@ -1,0 +1,34 @@
+module(
+    name = "rules_opensbi",
+    version = "0.1.0",
+    bazel_compatibility = [">=8.0.0"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+
+# Hermetic device tree compiler. Provides @dtc//:dtc, built from source with
+# hermetic flex/bison; used by the `dtb` rule.
+bazel_dep(name = "dtc", version = "1.7.2.bcr.1")
+
+# Documentation and formatting tooling. These are only needed when developing
+# this module, so they are dev dependencies and are stripped for downstream
+# consumers (and BCR presubmit).
+bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)
+
+# Pin protobuf (pulled in by stardoc) so the prebuilt protoc toolchain is used
+# instead of compiling protoc from source. See the matching flags in .bazelrc.
+bazel_dep(name = "protobuf", version = "35.1", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.5", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
+
+# Hermetic RISC-V bare-metal GCC toolchain (xPack riscv-none-elf-gcc). The
+# extension downloads a relocatable prebuilt toolchain and exposes it as the
+# @opensbi_riscv_toolchain repository. The OpenSBI rules drive this compiler
+# directly, so no cc_toolchain registration or platform flags are required.
+riscv_toolchain = use_extension("//internal/toolchain:extensions.bzl", "riscv_toolchain")
+use_repo(riscv_toolchain, "opensbi_riscv_toolchain")
+
+# Hermetic QEMU (xPack qemu-riscv) for opensbi_qemu_test.
+qemu = use_extension("//internal/toolchain:extensions.bzl", "qemu")
+use_repo(qemu, "opensbi_qemu")

--- a/modules/rules_opensbi/0.1.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_opensbi/0.1.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 4fdf8ee..b899c09 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "rules_opensbi",
+-    version = "0.0.0",
++    version = "0.1.0",
+     bazel_compatibility = [">=8.0.0"],
+ )
+ 

--- a/modules/rules_opensbi/0.1.0/presubmit.yml
+++ b/modules/rules_opensbi/0.1.0/presubmit.yml
@@ -1,0 +1,18 @@
+bcr_test_module:
+  module_path: "integration"
+  matrix:
+    platform: ["ubuntu2204"]
+    bazel: ["8.x", "9.x"]
+  tasks:
+    build_firmware:
+      name: "Build OpenSBI firmware images"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      # Build-only: these need the hermetic toolchain but neither dtc nor QEMU,
+      # which BCR presubmit does not provide. The QEMU boot tests run in the
+      # project's own CI (see .github/workflows/test.yml).
+      build_targets:
+        - "@opensbi//:fw_dynamic"
+        - "@opensbi//:fw_jump"
+        - "//examples/firmware:fw_dynamic_reloc"
+        - "//examples/firmware:fw_payload_loop"

--- a/modules/rules_opensbi/0.1.0/source.json
+++ b/modules/rules_opensbi/0.1.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-k5UN6Y3jLi11kQ2ISREAbvj3rDIe1iGFjYdWusJ2z8w=",
+    "patch_strip": 1,
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-meS9EBfHiCHjQBiuu3cn4PPSsZlqMohsdn4QanqbieM="
+    },
+    "strip_prefix": "",
+    "url": "https://github.com/filmil/bazel_rules_opensbi/releases/download/v0.1.0/bazel_rules_opensbi-v0.1.0.zip"
+}

--- a/modules/rules_opensbi/metadata.json
+++ b/modules/rules_opensbi/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/filmil/bazel_rules_opensbi",
+    "maintainers": [
+        {
+            "email": "246576+filmil@users.noreply.github.com",
+            "github": "filmil",
+            "github_user_id": 246576,
+            "name": "Filip Filmar"
+        }
+    ],
+    "repository": [
+        "github:filmil/bazel_rules_opensbi"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Bazel-native build rules for [OpenSBI](https://github.com/riscv-software-src/opensbi)
(RISC-V Supervisor Binary Interface firmware). Every compile/link/objcopy is a
native Bazel action — no `make`/`Kconfig`. Drives a hermetic riscv64 GCC
toolchain, the hermetic `dtc` module, and a hermetic QEMU for boot tests.

Source is a stable GitHub release asset; the MODULE.bazel version is applied via
patch. Validated with `tools/bcr_validation.py` (all GOOD; only the expected
new-`presubmit.yml` maintainer-review flag).