### PR TITLE
Add node_addon_api 8.8.0.bcr.1

### DIFF
--- a/modules/node_addon_api/8.8.0.bcr.1/MODULE.bazel
+++ b/modules/node_addon_api/8.8.0.bcr.1/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "node_addon_api",
+    version = "8.8.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+# node-addon-api is a header-only C++ wrapper over N-API.
+# :node_addon_api_headers_only exposes just the wrapper headers (napi.h /
+# napi-inl.h); :node_addon_api additionally pulls in the active Node toolchain's
+# C headers (node_api.h) via rules_nodejs.
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_nodejs", version = "6.7.4")

--- a/modules/node_addon_api/8.8.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/node_addon_api/8.8.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# node-addon-api's own header-only wrapper (napi.h + napi-inl.h), WITHOUT the
+# Node C headers. Depend on this if your build already provides node_api.h some
+# other way (e.g. node-api-headers, napi-rs, or building inside Node) and you
+# don't want a dependency on the rules_nodejs Node toolchain.
+cc_library(
+    name = "node_addon_api_headers_only",
+    hdrs = glob(["*.h"]),
+    includes = ["."],
+)
+
+# Full target: the wrapper headers above plus the Node C headers (node_api.h,
+# js_native_api.h) supplied cross-platform by the consumer's active Node
+# toolchain. The root module must opt in with node.toolchain(include_headers =
+# True).
+cc_library(
+    name = "node_addon_api",
+    deps = [
+        ":node_addon_api_headers_only",
+        "@rules_nodejs//nodejs/headers:current_node_cc_headers",
+    ],
+)
+
+# Expose the raw header files so targets that build outside the C++ toolchain
+# can reference them directly via $(location).
+exports_files(glob(["*.h"]))

--- a/modules/node_addon_api/8.8.0.bcr.1/overlay/test_module/BUILD.bazel
+++ b/modules/node_addon_api/8.8.0.bcr.1/overlay/test_module/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+# Build the N-API addon as a loadable shared library. napi_* symbols are
+# provided by the Node process at load time, so the shared object must tolerate
+# undefined symbols (only an issue on macOS; ELF shared libs allow this).
+cc_binary(
+    name = "hello.so",
+    srcs = ["hello.cc"],
+    copts = ["-std=c++17"],
+    linkshared = True,
+    linkopts = select({
+        # macOS ld errors on undefined symbols by default; tell it to resolve
+        # the napi_* symbols at load time (dlopen), like node-gyp does.
+        "@platforms//os:macos": ["-undefined", "dynamic_lookup"],
+        "//conditions:default": [],
+    }),
+    deps = ["@node_addon_api//:node_addon_api"],
+)
+
+# Node expects the addon to have a .node extension.
+genrule(
+    name = "hello_node",
+    srcs = [":hello.so"],
+    outs = ["hello.node"],
+    cmd = "cp $< $@",
+)
+
+# Loads hello.node from Node, calls into it, and asserts the returned value.
+js_test(
+    name = "addon_test",
+    data = [":hello.node"],
+    entry_point = "test.js",
+)

--- a/modules/node_addon_api/8.8.0.bcr.1/overlay/test_module/MODULE.bazel
+++ b/modules/node_addon_api/8.8.0.bcr.1/overlay/test_module/MODULE.bazel
@@ -1,0 +1,16 @@
+module(
+    name = "node_addon_api_test",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "node_addon_api", version = "8.8.0.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_nodejs", version = "6.7.4")
+bazel_dep(name = "aspect_rules_js", version = "3.2.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+# node-addon-api needs the Node C headers, which rules_nodejs only emits when
+# the root toolchain opts in with include_headers = True.
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+node.toolchain(include_headers = True)
+use_repo(node, "nodejs_toolchains")

--- a/modules/node_addon_api/8.8.0.bcr.1/overlay/test_module/hello.cc
+++ b/modules/node_addon_api/8.8.0.bcr.1/overlay/test_module/hello.cc
@@ -1,0 +1,16 @@
+#include <napi.h>
+
+namespace {
+
+Napi::String Hello(const Napi::CallbackInfo& info) {
+  return Napi::String::New(info.Env(), "hello from node-addon-api");
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("hello", Napi::Function::New(env, Hello));
+  return exports;
+}
+
+}  // namespace
+
+NODE_API_MODULE(hello, Init)

--- a/modules/node_addon_api/8.8.0.bcr.1/overlay/test_module/test.js
+++ b/modules/node_addon_api/8.8.0.bcr.1/overlay/test_module/test.js
@@ -1,0 +1,17 @@
+const assert = require("assert");
+const path = require("path");
+
+// rules_js runs from the output tree, where hello.node (a generated file) sits
+// next to the copied entry point.
+const addon = require(path.join(__dirname, "hello.node"));
+
+const expected = "hello from node-addon-api";
+const actual = addon.hello();
+
+assert.strictEqual(
+  actual,
+  expected,
+  `addon.hello() returned "${actual}", expected "${expected}"`,
+);
+
+console.log("addon test passed:", actual);

--- a/modules/node_addon_api/8.8.0.bcr.1/presubmit.yml
+++ b/modules/node_addon_api/8.8.0.bcr.1/presubmit.yml
@@ -1,0 +1,18 @@
+bcr_test_module:
+  module_path: "test_module"
+  matrix:
+    platform:
+      - debian11
+      - ubuntu2204
+      - macos
+    bazel: [7.x, 8.x, 9.x, rolling]
+  tasks:
+    run_test:
+      name: Build and run N-API addon against node-addon-api
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "@node_addon_api//:node_addon_api_headers_only"
+        - "@node_addon_api//:node_addon_api"
+      test_targets:
+        - "//:addon_test"

--- a/modules/node_addon_api/8.8.0.bcr.1/source.json
+++ b/modules/node_addon_api/8.8.0.bcr.1/source.json
@@ -1,0 +1,12 @@
+{
+    "url": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+    "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+    "strip_prefix": "package",
+    "overlay": {
+        "BUILD.bazel": "sha256-ETt3S0cS/RKlwnNyl9gmCPMG5qYjFgQKU1LzbC40ZeU=",
+        "test_module/BUILD.bazel": "sha256-0kMvrXE/QQk+WlwHTXrX4VsfypzVUy1Mfrx0UCzaVy8=",
+        "test_module/MODULE.bazel": "sha256-y0hnxL9chUWaQViimkTMO1rtpLHS1meDQgHfOtJA/1o=",
+        "test_module/hello.cc": "sha256-gPH2o8UrZdgmsSAjyUeV+5VOoOJIOQ2KuEZdKH0OClY=",
+        "test_module/test.js": "sha256-w3nFbzKKOqar7Aw556vvsUOpD7PlFMuetRBa1bO+xyw="
+    }
+}

--- a/modules/node_addon_api/metadata.json
+++ b/modules/node_addon_api/metadata.json
@@ -13,7 +13,8 @@
         "https://registry.npmjs.org/node-addon-api"
     ],
     "versions": [
-        "8.8.0"
+        "8.8.0",
+        "8.8.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
## node_addon_api 8.8.0.bcr.1

A registry revision of [node-addon-api](https://github.com/nodejs/node-addon-api) 8.8.0 (the header-only C++ wrapper over N-API). Same npm source archive as 8.8.0; the BUILD is reworked for consumers that supply the Node C headers themselves or build addons outside Bazel's C++ toolchain.

### Why

8.8.0 exposed a single `:node_addon_api` `cc_library` that unconditionally depends on `@rules_nodejs//nodejs/headers:current_node_cc_headers`. That forces a registered Node toolchain — analysis fails without one — even for consumers that already obtain `node_api.h` another way. This revision splits the target and exposes the raw headers:

- **`:node_addon_api_headers_only`** — just the wrapper headers (`napi.h` / `napi-inl.h`), with no Node-toolchain dependency. For consumers that provide `node_api.h` themselves (e.g. a vendored copy, `node-api-headers`, or building inside Node), this lets them drop the rules_nodejs dependency entirely instead of patching it out.
- **`:node_addon_api`** — the above plus `current_node_cc_headers`, i.e. the original 8.8.0 behavior. Requires `node.toolchain(include_headers = True)`.
- **`exports_files(glob(["*.h"]))`** — so build steps that don't go through the C++ toolchain (e.g. a genrule invoking a compiler directly, or a cross-compilation wrapper) can reference the raw headers on disk via `$(location)`, instead of extracting them from `CcInfo`.
