### PR TITLE
rules_elide@0.4.0

### DIFF
--- a/modules/rules_elide/0.4.0/MODULE.bazel
+++ b/modules/rules_elide/0.4.0/MODULE.bazel
@@ -1,0 +1,51 @@
+module(
+    name = "rules_elide",
+    # Bazel 8+ only: protobuf 35.x (a transitive proto dep,
+    version = "0.4.0",
+) requires >=8.0.0.
+    bazel_compatibility = [">=8.0.0"],
+)
+
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_java", version = "9.6.1")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "protobuf", version = "35.1")
+
+# Needed by //elide/kotlin:toolchain.bzl, which wraps a stock rules_kotlin
+# toolchain (via define_kt_toolchain) and swaps in the Elide KotlinBuilder shim.
+bazel_dep(name = "rules_kotlin", version = "2.4.0")
+
+bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)
+bazel_dep(name = "rules_jvm_external", version = "7.0", dev_dependency = True)
+
+# Transitively loaded by rules_java/rules_kotlin .bzl; declared so the Stardoc
+# `starlark_doc_extract` targets in //docs can cover it with a bzl_library.
+bazel_dep(name = "bazel_features", version = "1.50.0", dev_dependency = True)
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
+maven.install(
+    name = "kt_test_deps",
+    artifacts = [
+        "org.jetbrains.kotlin:kotlin-test:2.4.0",
+        "org.jetbrains.kotlin:kotlin-test-junit5:2.4.0",
+        "org.junit.jupiter:junit-jupiter:5.11.3",
+        "org.junit.platform:junit-platform-console-standalone:1.11.3",
+        "org.junit.platform:junit-platform-launcher:1.11.3",
+    ],
+)
+use_repo(maven, "kt_test_deps")
+
+elide = use_extension("//elide:extensions.bzl", "elide", dev_dependency = True)
+elide.install()
+use_repo(elide, "elide_toolchains")
+
+register_toolchains(
+    "@elide_toolchains//:all",
+    dev_dependency = True,
+)
+
+register_toolchains(
+    "//tests:_test_elide_toolchain",
+    dev_dependency = True,
+)

--- a/modules/rules_elide/0.4.0/attestations.json
+++ b/modules/rules_elide/0.4.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/elide-dev/rules_elide/releases/download/v0.4.0/source.json.intoto.jsonl",
+            "integrity": "sha256-ezksOsQmJQFtiaCs0GOwaVXWzctHKYK8A1qypjglIUQ="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/elide-dev/rules_elide/releases/download/v0.4.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-4h0wjiJYrvJSmbR4U5LSj+YtJqRy8l/gtY3BXd2BqiI="
+        },
+        "rules_elide-v0.4.0.tar.gz": {
+            "url": "https://github.com/elide-dev/rules_elide/releases/download/v0.4.0/rules_elide-v0.4.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-pcwQ8kyc1QOdoZXURHrYcqSrdSU/SZZnpSMDfG2Tl6M="
+        }
+    }
+}

--- a/modules/rules_elide/0.4.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_elide/0.4.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,9 @@
+ module(
+     name = "rules_elide",
+-    # Bazel 8+ only: protobuf 35.x (a transitive proto dep) requires >=8.0.0.
++    # Bazel 8+ only: protobuf 35.x (a transitive proto dep,
++    version = "0.4.0",
++) requires >=8.0.0.
+     bazel_compatibility = [">=8.0.0"],
+ )
+ 
+ bazel_dep(name = "platforms", version = "1.1.0")

--- a/modules/rules_elide/0.4.0/presubmit.yml
+++ b/modules/rules_elide/0.4.0/presubmit.yml
@@ -1,0 +1,39 @@
+matrix:
+  platform:
+    - ubuntu2204
+    - macos
+  bazel:
+    - "7.x"
+    - "8.x"
+    - "9.x"
+
+tasks:
+  verify_consumer_build:
+    name: Verify consumer build
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@rules_elide//..."
+
+# A separate consumer module under e2e/smoke exercises the rules end-to-end.
+# BCR resolves it via `bcr_test_module` so a published version is verified
+# against the same downstream scenario as `bazel build` in the source repo.
+bcr_test_module:
+  module_path: e2e/smoke
+  matrix:
+    platform:
+      - ubuntu2204
+      - macos
+    bazel:
+      - "7.x"
+      - "8.x"
+      - "9.x"
+  tasks:
+    smoke_analysis:
+      name: e2e smoke build (analysis)
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--nobuild"
+      build_targets:
+        - "//..."

--- a/modules/rules_elide/0.4.0/source.json
+++ b/modules/rules_elide/0.4.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-5hneamZ+EIaQPcIW2qP3qbNG5MnSLBXbnXlVN2saoig=",
+    "strip_prefix": "rules_elide-0.4.0",
+    "url": "https://github.com/elide-dev/rules_elide/releases/download/v0.4.0/rules_elide-v0.4.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-GAwiUPGKHHP64WJq2YEgn0j9cjI0ghp4MNewpaCQ/ug="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_elide/metadata.json
+++ b/modules/rules_elide/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/elide-dev/rules_elide",
+    "maintainers": [
+        {
+            "email": "oss@elide.dev",
+            "name": "The Elide Authors"
+        }
+    ],
+    "repository": [
+        "github:elide-dev/rules_elide"
+    ],
+    "versions": [
+        "0.4.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/elide-dev/rules_elide/releases/tag/v0.4.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_