### PR TITLE
rules_elide@0.6.0

### DIFF
--- a/modules/rules_elide/0.6.0/MODULE.bazel
+++ b/modules/rules_elide/0.6.0/MODULE.bazel
@@ -1,0 +1,54 @@
+# protobuf 35.x, a transitive proto dep, is Bazel 8+ only, so require >=8.0.0.
+# Keep this note above the module directive and free of parentheses: BCR's
+# version stamper inserts the version at the first close-paren after the
+# directive opens, so a stray paren here corrupts the published MODULE.bazel.
+# v0.5.0 failed BCR this way: a parenthesis in this comment broke the stamp.
+module(
+    name = "rules_elide",
+    bazel_compatibility = [">=8.0.0"],
+    version = "0.6.0",
+)
+
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_java", version = "9.6.1")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "protobuf", version = "35.1")
+
+# Needed by //elide/kotlin:toolchain.bzl, which wraps a stock rules_kotlin
+# toolchain (via define_kt_toolchain) and swaps in the Elide KotlinBuilder shim.
+bazel_dep(name = "rules_kotlin", version = "2.4.0")
+
+bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)
+bazel_dep(name = "rules_jvm_external", version = "7.0", dev_dependency = True)
+
+# Transitively loaded by rules_java/rules_kotlin .bzl; declared so the Stardoc
+# `starlark_doc_extract` targets in //docs can cover it with a bzl_library.
+bazel_dep(name = "bazel_features", version = "1.50.0", dev_dependency = True)
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
+maven.install(
+    name = "kt_test_deps",
+    artifacts = [
+        "org.jetbrains.kotlin:kotlin-test:2.4.0",
+        "org.jetbrains.kotlin:kotlin-test-junit5:2.4.0",
+        "org.junit.jupiter:junit-jupiter:5.11.3",
+        "org.junit.platform:junit-platform-console-standalone:1.11.3",
+        "org.junit.platform:junit-platform-launcher:1.11.3",
+    ],
+)
+use_repo(maven, "kt_test_deps")
+
+elide = use_extension("//elide:extensions.bzl", "elide", dev_dependency = True)
+elide.install()
+use_repo(elide, "elide_toolchains")
+
+register_toolchains(
+    "@elide_toolchains//:all",
+    dev_dependency = True,
+)
+
+register_toolchains(
+    "//tests:_test_elide_toolchain",
+    dev_dependency = True,
+)

--- a/modules/rules_elide/0.6.0/attestations.json
+++ b/modules/rules_elide/0.6.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/elide-dev/rules_elide/releases/download/v0.6.0/source.json.intoto.jsonl",
+            "integrity": "sha256-0q3fC4GXazG8SBJyp9n+y0WPkNzFFE7MvRQQ3+xZR+w="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/elide-dev/rules_elide/releases/download/v0.6.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-ukwJL2VSEYTlZ5wvGYe5O92HHCJ1IsWonPhzWPaA3AE="
+        },
+        "rules_elide-v0.6.0.tar.gz": {
+            "url": "https://github.com/elide-dev/rules_elide/releases/download/v0.6.0/rules_elide-v0.6.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-PDm+ZdcWVw6Q7UXuQfUNADo/BjNjfaLuNLOaIfQ6+YM="
+        }
+    }
+}

--- a/modules/rules_elide/0.6.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_elide/0.6.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -5,8 +5,9 @@
+ # v0.5.0 failed BCR this way: a parenthesis in this comment broke the stamp.
+ module(
+     name = "rules_elide",
+     bazel_compatibility = [">=8.0.0"],
++    version = "0.6.0",
+ )
+ 
+ bazel_dep(name = "platforms", version = "1.1.0")
+ bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/modules/rules_elide/0.6.0/presubmit.yml
+++ b/modules/rules_elide/0.6.0/presubmit.yml
@@ -1,0 +1,29 @@
+# NOTE: there is intentionally no top-level `tasks:` building `@rules_elide//...`.
+# rules_elide is toolchain-based: a bare consumer (one that only declares
+# `bazel_dep(rules_elide)` without calling the `elide` module extension's
+# `install`/`use` tags) registers no `@rules_elide//elide:toolchain_type`, and
+# `@rules_elide//...` includes the ruleset's own self-hosted Kotlin builder
+# (`//elide/kotlin/builder:lib`, an `elide_kotlin_library`) which needs that
+# toolchain at analysis time. So `@rules_elide//...` can never analyze from a
+# bare consumer. Real consumer verification is the `bcr_test_module` below,
+# which registers a stub toolchain and exercises every `elide_*` rule.
+bcr_test_module:
+  module_path: e2e/smoke
+  matrix:
+    platform:
+      - ubuntu2204
+      - macos
+    # rules_elide declares `bazel_compatibility = [">=8.0.0"]` in MODULE.bazel,
+    # so 7.x is intentionally excluded (it would fail the compatibility check).
+    bazel:
+      - "8.x"
+      - "9.x"
+  tasks:
+    smoke_analysis:
+      name: e2e smoke build (analysis)
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_flags:
+        - "--nobuild"
+      build_targets:
+        - "//..."

--- a/modules/rules_elide/0.6.0/source.json
+++ b/modules/rules_elide/0.6.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-CYHPqTSLrav5bdB383jTXuJabwQKdwBA7Pwbykkgq9U=",
+    "strip_prefix": "rules_elide-0.6.0",
+    "url": "https://github.com/elide-dev/rules_elide/releases/download/v0.6.0/rules_elide-v0.6.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-btW/qwwy19tQzsld1rr05X19TCoskkCfM6ieYcUngaY="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_elide/metadata.json
+++ b/modules/rules_elide/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/elide-dev/rules_elide",
+    "maintainers": [
+        {
+            "email": "oss@elide.dev",
+            "name": "The Elide Authors"
+        }
+    ],
+    "repository": [
+        "github:elide-dev/rules_elide"
+    ],
+    "versions": [
+        "0.6.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/elide-dev/rules_elide/releases/tag/v0.6.0

_Filed by the rules_elide release workflow under @sgammon; entry pushed by elidebot._