### PR TITLE
Add rules_node_addon 1.0.2

### DIFF
--- a/modules/rules_node_addon/1.0.2/MODULE.bazel
+++ b/modules/rules_node_addon/1.0.2/MODULE.bazel
@@ -1,0 +1,19 @@
+module(
+    name = "rules_node_addon",
+    version = "1.0.2",
+)
+
+bazel_dep(name = "aspect_rules_js", version = "3.2.2", dev_dependency = True)
+
+bazel_dep(name = "node_addon_api", version = "8.8.0.bcr.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.20")
+bazel_dep(name = "rules_nodejs", version = "6.7.4")
+
+node_addon_windows = use_extension("//node_addon:windows.bzl", "node_addon_windows")
+use_repo(node_addon_windows, "windows_node_api")
+
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+node.toolchain(include_headers = True)
+use_repo(node, "nodejs_toolchains")

--- a/modules/rules_node_addon/1.0.2/presubmit.yml
+++ b/modules/rules_node_addon/1.0.2/presubmit.yml
@@ -1,0 +1,24 @@
+bcr_test_module:
+  module_path: "examples/node_version_pin"
+  matrix:
+    platform: ["ubuntu2204", "macos", "windows"]
+    bazel: ["7.x", "8.x", "9.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."
+bcr_test_module_full:
+  module_path: "examples/full"
+  matrix:
+    platform: ["ubuntu2204", "macos"]
+    bazel: ["7.x", "8.x", "9.x"]
+  tasks:
+    run_tests:
+      name: "Run full test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_node_addon/1.0.2/source.json
+++ b/modules/rules_node_addon/1.0.2/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-9I1Jjq2dC8Yn2X4wqy+8b+r3OrK0FXtFVzeTvcWsd0M=",
+    "strip_prefix": "rules_node_addon-1.0.2",
+    "url": "https://github.com/BYVoid/rules_node_addon/releases/download/v1.0.2/rules_node_addon-1.0.2.tar.gz"
+}

--- a/modules/rules_node_addon/metadata.json
+++ b/modules/rules_node_addon/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/BYVoid/rules_node_addon",
+    "maintainers": [
+        {
+            "email": "byvoid@byvoid.com",
+            "github": "BYVoid",
+            "name": "Carbo Kuo",
+            "github_user_id": 245270
+        }
+    ],
+    "repository": [
+        "github:BYVoid/rules_node_addon"
+    ],
+    "versions": [
+        "1.0.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add a new module: `rules_node_addon` version `1.0.2`.

Bazel rules for building [Node-API](https://nodejs.org/api/n-api.html) native addons that work with Node.js and Bun.

- Presubmit tests `examples/node_version_pin` (Linux/macOS/Windows) and `examples/full` (Linux/macOS, TypeScript + Bun + js_test) on Bazel 7.x/8.x/9.x.
