### PR TITLE
fix(security): validate @bazel-io comment commands before invoking privileged token action

### DIFF
--- a/.github/workflows/handle_comment.yml
+++ b/.github/workflows/handle_comment.yml
@@ -14,6 +14,26 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Validate comment command
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          # Security: validate that the comment matches only known safe @bazel-io commands
+          # before invoking the token-bearing action. Defense-in-depth in case new
+          # command types are added to the upstream action without workflow review.
+          STRIPPED="${COMMENT_BODY#@bazel-io }"
+          VALID=false
+          for cmd in "skip_check unstable_url" "skip_check compatibility_level" "skip_check incompatible_flags" "abandon"; do
+            if [ "$STRIPPED" = "$cmd" ]; then
+              VALID=true
+              break
+            fi
+          done
+          if [ "$VALID" = "false" ]; then
+            echo "Unknown or unrecognized @bazel-io command: '$STRIPPED' — skipping."
+            exit 1
+          fi
+
       - name: Handle @bazel-io commands
         uses: bazelbuild/continuous-integration/actions/bcr-pr-reviewer@3d8663cb5406076255c6865af23cb85d6eff5c35
         with:


### PR DESCRIPTION
## Summary

Adds explicit allowlist validation of `@bazel-io` comment commands at the workflow level before invoking the token-bearing `bcr-pr-reviewer` action.

## Details

Currently, any PR comment starting with `@bazel-io ` immediately invokes the `bazelbuild/continuous-integration/actions/bcr-pr-reviewer` action with `BCR_PR_REVIEW_HELPER_TOKEN`. The only input validation happens inside the action's JavaScript allowlist check.

This PR adds a **defense-in-depth** validation step that checks the comment against known commands (`skip_check unstable_url`, `skip_check compatibility_level`, `skip_check incompatible_flags`, `abandon`) at the **workflow level** before the action is invoked.

This ensures:
1. If new command types are added to the upstream action without a corresponding workflow review, they **cannot be triggered** by arbitrary user comments
2. The attack surface for `BCR_PR_REVIEW_HELPER_TOKEN` is explicitly documented and bounded in the workflow itself
3. Unknown commands fail loudly (exit 1) rather than silently invoking the action

## Impact

Without this check, any future expansion of the upstream action's command surface is automatically available to any GitHub user who can comment on PRs, before maintainers have a chance to review whether that exposure is intentional.

## Testing

Existing CI covers the action behavior. The allowlist logic mirrors what the action already does internally.