### PR TITLE
gperf: add mirror URL for the source.

### DIFF
--- a/modules/gperf/3.1.bcr.2/MODULE.bazel
+++ b/modules/gperf/3.1.bcr.2/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "gperf",
+    version = "3.1.bcr.2",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/gperf/3.1.bcr.2/patches/add_build_file.patch
+++ b/modules/gperf/3.1.bcr.2/patches/add_build_file.patch
@@ -1,0 +1,33 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,29 @@
++""" Builds gperf.
++"""
++
++load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
++
++cc_library(
++    name = "gperf_c_lib",
++    srcs = glob([
++        "lib/*.c",
++        "lib/*.h",
++    ]),
++    includes = ["lib"],
++    visibility = ["//visibility:private"],
++)
++
++cc_binary(
++    name = "gperf",
++    srcs = glob([
++        "src/*.inc",
++        "src/*.cc",
++        "src/*.h",
++        "lib/*.cc",
++        "lib/*.h",
++    ]) + ["config.h"],
++    includes = ["lib", "src"],
++    copts = ["-std=c++11","-w"],
++    deps = ["gperf_c_lib"],
++    visibility = ["//visibility:public"],
++)
++

--- a/modules/gperf/3.1.bcr.2/patches/gperf.patch
+++ b/modules/gperf/3.1.bcr.2/patches/gperf.patch
@@ -1,0 +1,190 @@
+From 6c073922a7b04fe520d8350ab4da03d6c8207703 Mon Sep 17 00:00:00 2001
+From: Dmitry Mikhin <dmikhin@webmonitorx.ru>
+Date: Fri, 26 Jul 2024 18:12:25 +0300
+Subject: [PATCH] gperf
+
+---
+ config.h                                   | 1 +
+ src/bool-array.cc                          | 2 +-
+ src/bool-array.h                           | 2 +-
+ src/{bool-array.icc => bool-array.inc}     | 0
+ src/keyword-list.cc                        | 2 +-
+ src/keyword-list.h                         | 2 +-
+ src/{keyword-list.icc => keyword-list.inc} | 0
+ src/keyword.cc                             | 2 +-
+ src/keyword.h                              | 2 +-
+ src/{keyword.icc => keyword.inc}           | 0
+ src/options.cc                             | 2 +-
+ src/options.h                              | 2 +-
+ src/{options.icc => options.inc}           | 0
+ src/positions.cc                           | 2 +-
+ src/positions.h                            | 2 +-
+ src/{positions.icc => positions.inc}       | 0
+ 16 files changed, 11 insertions(+), 10 deletions(-)
+ create mode 100644 config.h
+ rename src/{bool-array.icc => bool-array.inc} (100%)
+ rename src/{keyword-list.icc => keyword-list.inc} (100%)
+ rename src/{keyword.icc => keyword.inc} (100%)
+ rename src/{options.icc => options.inc} (100%)
+ rename src/{positions.icc => positions.inc} (100%)
+
+diff --git config.h config.h
+new file mode 100644
+index 0000000..8b13789
+--- /dev/null
++++ config.h
+@@ -0,0 +1 @@
++
+diff --git src/bool-array.cc src/bool-array.cc
+index d0e3364..e1c27a5 100644
+--- src/bool-array.cc
++++ src/bool-array.cc
+@@ -39,7 +39,7 @@ Bool_Array::~Bool_Array ()
+ #ifndef __OPTIMIZE__
+ 
+ #define INLINE /* not inline */
+-#include "bool-array.icc"
++#include "bool-array.inc"
+ #undef INLINE
+ 
+ #endif /* not defined __OPTIMIZE__ */
+diff --git src/bool-array.h src/bool-array.h
+index 33472fe..0a9d824 100644
+--- src/bool-array.h
++++ src/bool-array.h
+@@ -69,7 +69,7 @@ private:
+ #include <string.h>
+ #include "options.h"
+ #define INLINE inline
+-#include "bool-array.icc"
++#include "bool-array.inc"
+ #undef INLINE
+ 
+ #endif
+diff --git src/bool-array.icc src/bool-array.inc
+similarity index 100%
+rename from src/bool-array.icc
+rename to src/bool-array.inc
+diff --git src/keyword-list.cc src/keyword-list.cc
+index 235edd5..abca269 100644
+--- src/keyword-list.cc
++++ src/keyword-list.cc
+@@ -167,7 +167,7 @@ mergesort_list (KeywordExt_List *list,
+ #ifndef __OPTIMIZE__
+ 
+ #define INLINE /* not inline */
+-#include "keyword-list.icc"
++#include "keyword-list.inc"
+ #undef INLINE
+ 
+ #endif /* not defined __OPTIMIZE__ */
+diff --git src/keyword-list.h src/keyword-list.h
+index ca2ada6..8a9bfde 100644
+--- src/keyword-list.h
++++ src/keyword-list.h
+@@ -75,7 +75,7 @@ extern KeywordExt_List * mergesort_list (KeywordExt_List *list,
+ #ifdef __OPTIMIZE__
+ 
+ #define INLINE inline
+-#include "keyword-list.icc"
++#include "keyword-list.inc"
+ #undef INLINE
+ 
+ #endif
+diff --git src/keyword-list.icc src/keyword-list.inc
+similarity index 100%
+rename from src/keyword-list.icc
+rename to src/keyword-list.inc
+diff --git src/keyword.cc src/keyword.cc
+index 82f1077..fd67dc1 100644
+--- src/keyword.cc
++++ src/keyword.cc
+@@ -153,7 +153,7 @@ char empty_string[1] = "";
+ #ifndef __OPTIMIZE__
+ 
+ #define INLINE /* not inline */
+-#include "keyword.icc"
++#include "keyword.inc"
+ #undef INLINE
+ 
+ #endif /* not defined __OPTIMIZE__ */
+diff --git src/keyword.h src/keyword.h
+index e4421cf..02fda31 100644
+--- src/keyword.h
++++ src/keyword.h
+@@ -106,7 +106,7 @@ extern char empty_string[1];
+ #ifdef __OPTIMIZE__
+ 
+ #define INLINE inline
+-#include "keyword.icc"
++#include "keyword.inc"
+ #undef INLINE
+ 
+ #endif
+diff --git src/keyword.icc src/keyword.inc
+similarity index 100%
+rename from src/keyword.icc
+rename to src/keyword.inc
+diff --git src/options.cc src/options.cc
+index ec5cd5f..85c9f02 100644
+--- src/options.cc
++++ src/options.cc
+@@ -1088,7 +1088,7 @@ There is NO WARRANTY, to the extent permitted by law.\n\
+ #ifndef __OPTIMIZE__
+ 
+ #define INLINE /* not inline */
+-#include "options.icc"
++#include "options.inc"
+ #undef INLINE
+ 
+ #endif /* not defined __OPTIMIZE__ */
+diff --git src/options.h src/options.h
+index 2ac53b8..09df009 100644
+--- src/options.h
++++ src/options.h
+@@ -295,7 +295,7 @@ extern Options option;
+ #ifdef __OPTIMIZE__
+ 
+ #define INLINE inline
+-#include "options.icc"
++#include "options.inc"
+ #undef INLINE
+ 
+ #endif
+diff --git src/options.icc src/options.inc
+similarity index 100%
+rename from src/options.icc
+rename to src/options.inc
+diff --git src/positions.cc src/positions.cc
+index 1fb6883..064d269 100644
+--- src/positions.cc
++++ src/positions.cc
+@@ -169,7 +169,7 @@ Positions::print () const
+ #ifndef __OPTIMIZE__
+ 
+ #define INLINE /* not inline */
+-#include "positions.icc"
++#include "positions.inc"
+ #undef INLINE
+ 
+ #endif /* not defined __OPTIMIZE__ */
+diff --git src/positions.h src/positions.h
+index 05c3cf3..bfd25da 100644
+--- src/positions.h
++++ src/positions.h
+@@ -165,7 +165,7 @@ private:
+ 
+ #include <string.h>
+ #define INLINE inline
+-#include "positions.icc"
++#include "positions.inc"
+ #undef INLINE
+ 
+ #endif
+diff --git src/positions.icc src/positions.inc
+similarity index 100%
+rename from src/positions.icc
+rename to src/positions.inc
+-- 
+2.45.2
+

--- a/modules/gperf/3.1.bcr.2/patches/module_dot_bazel.patch
+++ b/modules/gperf/3.1.bcr.2/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "gperf",
++    version = "3.1.bcr.2",
++    compatibility_level = 1,
++)
++
++bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/modules/gperf/3.1.bcr.2/presubmit.yml
+++ b/modules/gperf/3.1.bcr.2/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@gperf//:gperf'

--- a/modules/gperf/3.1.bcr.2/source.json
+++ b/modules/gperf/3.1.bcr.2/source.json
@@ -1,0 +1,14 @@
+{
+    "url": "https://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz",
+    "mirror_urls": [
+        "https://mirror.bazel.build/ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"
+    ],
+    "integrity": "sha256-WIVGuUW7pLcLajphboC0q0ZuPzMCSjUvwhmBEs27OuI=",
+    "strip_prefix": "gperf-3.1",
+    "patches": {
+        "gperf.patch": "sha256-OC0fk8s9GVp8ptxl6KvTiOuyvt3MdhiVUsshepFUcs0=",
+        "add_build_file.patch": "sha256-W00W2vT9KeapzxXi5QxoVrWZgJgNve8vTV07OdZBZck=",
+        "module_dot_bazel.patch": "sha256-vFRzXsX9WbnBZR+PuC/lBMXZqPcdC8r2wIIOLsC4czc="
+    },
+    "patch_strip": 0
+}

--- a/modules/gperf/metadata.json
+++ b/modules/gperf/metadata.json
@@ -14,7 +14,8 @@
     ],
     "versions": [
         "3.1",
-        "3.1.bcr.1"
+        "3.1.bcr.1",
+        "3.1.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
ftp.gnu.org is notoriously overloaded, so having a mirror available is reducing random timeouts.