### PR TITLE
coin-or: use glpk with ftp mirror URL

### DIFF
--- a/modules/coin-or-lemon/1.3.1.bcr.1/MODULE.bazel
+++ b/modules/coin-or-lemon/1.3.1.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "coin-or-lemon",
+    version = "1.3.1.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.2")
+bazel_dep(name = "glpk", version = "5.0.bcr.5")

--- a/modules/coin-or-lemon/1.3.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/coin-or-lemon/1.3.1.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,627 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+# Description:
+# LEMON is an open source C++ library of graph and optimization algorithms.
+package(
+    features = [
+        "-layering_check",
+        "-parse_headers",
+    ],
+)
+
+filegroup(
+    name = "headers",
+    srcs = glob(["lemon/**/*.h"]),
+)
+
+cc_library(
+    name = "lemon",
+    srcs = [
+        "lemon/arg_parser.cc",
+        "lemon/base.cc",
+        "lemon/color.cc",
+        "lemon/glpk.cc",
+        "lemon/lp_base.cc",
+        "lemon/lp_skeleton.cc",
+        "lemon/random.cc",
+    ],
+    hdrs = [
+        "lemon/config.h",
+        ":headers",
+    ],
+    copts = [
+        "-fexceptions",
+    ],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = ["@glpk"],
+)
+
+cc_library(
+    name = "test_tools",
+    hdrs = [
+        "test/graph_test.h",
+        "test/test_tools.h",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    visibility = ["//visibility:private"],
+)
+
+cc_binary(
+    name = "arg_parser_demo",
+    srcs = ["demo/arg_parser_demo.cc"],
+    deps = [
+        ":lemon",
+    ],
+)
+
+cc_binary(
+    name = "dimacs-solver",
+    srcs = ["tools/dimacs-solver.cc"],
+    copts = [
+        "-fexceptions",
+        "-Wno-implicit-fallthrough",
+    ],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+    ],
+)
+
+cc_binary(
+    name = "dimacs-to-lgf",
+    srcs = ["tools/dimacs-to-lgf.cc"],
+    copts = [
+        "-fexceptions",
+        "-Wno-implicit-fallthrough",
+    ],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [":lemon"],
+)
+
+cc_binary(
+    name = "lgf-gen",
+    srcs = ["tools/lgf-gen.cc"],
+    deps = [":lemon"],
+)
+
+cc_binary(
+    name = "graph_to_eps_demo",
+    srcs = ["demo/graph_to_eps_demo.cc"],
+    deps = [":lemon"],
+)
+
+cc_binary(
+    name = "lgf_demo",
+    srcs = ["demo/lgf_demo.cc"],
+    copts = ["-fexceptions"],
+    data = ["demo/digraph.lgf"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [":lemon"],
+)
+
+cc_test(
+    name = "adaptors_test",
+    srcs = ["test/adaptors_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "arc_look_up_test",
+    srcs = ["test/arc_look_up_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "bellman_ford_test",
+    srcs = ["test/bellman_ford_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "bfs_test",
+    srcs = ["test/bfs_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "bpgraph_test",
+    srcs = ["test/bpgraph_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "circulation_test",
+    srcs = ["test/circulation_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "connectivity_test",
+    srcs = ["test/connectivity_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "counter_test",
+    srcs = ["test/counter_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "dfs_test",
+    srcs = ["test/dfs_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "dim_test",
+    srcs = ["test/dim_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "edge_set_test",
+    srcs = ["test/edge_set_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "error_test",
+    srcs = ["test/error_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "euler_test",
+    srcs = ["test/euler_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "dijkstra_test",
+    srcs = ["test/dijkstra_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "digraph_test",
+    srcs = ["test/digraph_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "fractional_matching_test",
+    srcs = ["test/fractional_matching_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "gomory_hu_test",
+    srcs = [
+        "lemon/gomory_hu.h",
+        "test/gomory_hu_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "graph_test",
+    srcs = [
+        "lemon/hypercube_graph.h",
+        "test/graph_test.cc",
+        "test/graph_test.h",
+    ],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "graph_copy_test",
+    srcs = ["test/graph_copy_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "graph_utils_test",
+    srcs = ["test/graph_utils_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "hao_orlin_test",
+    srcs = [
+        "lemon/hao_orlin.h",
+        "test/hao_orlin_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "heap_test",
+    srcs = [
+        "lemon/binomial_heap.h",
+        "lemon/dheap.h",
+        "lemon/fib_heap.h",
+        "lemon/pairing_heap.h",
+        "lemon/quad_heap.h",
+        "lemon/radix_heap.h",
+        "test/heap_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "kruskal_test",
+    srcs = ["test/kruskal_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "lgf_reader_writer_test",
+    srcs = ["test/lgf_reader_writer_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "lgf_test",
+    srcs = ["test/lgf_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "lp_test",
+    srcs = ["test/lp_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "maps_test",
+    srcs = ["test/maps_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "matching_test",
+    srcs = ["test/matching_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "max_cardinality_search_test",
+    srcs = [
+        "lemon/max_cardinality_search.h",
+        "test/max_cardinality_search_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "max_clique_test",
+    srcs = [
+        "lemon/grosso_locatelli_pullan_mc.h",
+        "test/max_clique_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "max_flow_test",
+    srcs = [
+        "lemon/edmonds_karp.h",
+        "test/max_flow_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "min_cost_arborescence_test",
+    srcs = [
+        "lemon/min_cost_arborescence.h",
+        "test/min_cost_arborescence_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "min_cost_flow_test",
+    srcs = [
+        "lemon/capacity_scaling.h",
+        "lemon/cost_scaling.h",
+        "lemon/cycle_canceling.h",
+        "test/min_cost_flow_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "min_mean_cycle_test",
+    srcs = [
+        "lemon/karp_mmc.h",
+        "test/min_mean_cycle_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "mip_test",
+    srcs = ["test/mip_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "nagamochi_ibaraki_test",
+    srcs = [
+        "lemon/nagamochi_ibaraki.h",
+        "test/nagamochi_ibaraki_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "path_test",
+    srcs = ["test/path_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "planarity_test",
+    srcs = [
+        "lemon/planarity.h",
+        "test/planarity_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "radix_sort_test",
+    srcs = ["test/radix_sort_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "random_test",
+    srcs = ["test/random_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "suurballe_test",
+    srcs = ["test/suurballe_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexception.
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "test_tools_pass",
+    srcs = [
+        "test/test_tools.h",
+        "test/test_tools_pass.cc",
+    ],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "time_measure_test",
+    srcs = ["test/time_measure_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "tsp_test",
+    srcs = [
+        "lemon/christofides_tsp.h",
+        "lemon/greedy_tsp.h",
+        "lemon/insertion_tsp.h",
+        "lemon/nearest_neighbor_tsp.h",
+        "lemon/opt2_tsp.h",
+        "test/tsp_test.cc",
+    ],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)
+
+cc_test(
+    name = "unionfind_test",
+    srcs = ["test/unionfind_test.cc"],
+    deps = [
+        ":lemon",
+        ":test_tools",
+    ],
+)

--- a/modules/coin-or-lemon/1.3.1.bcr.1/overlay/MODULE.bazel
+++ b/modules/coin-or-lemon/1.3.1.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "coin-or-lemon",
+    version = "1.3.1.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.2")
+bazel_dep(name = "glpk", version = "5.0.bcr.5")

--- a/modules/coin-or-lemon/1.3.1.bcr.1/overlay/lemon/config.h
+++ b/modules/coin-or-lemon/1.3.1.bcr.1/overlay/lemon/config.h
@@ -1,0 +1,38 @@
+// # Copyright 2021 Google LLC
+// #
+// # Licensed under the Apache License, Version 2.0 (the "License");
+// # you may not use this file except in compliance with the License.
+// # You may obtain a copy of the License at
+// #
+// #      http://www.apache.org/licenses/LICENSE-2.0
+// #
+// # Unless required by applicable law or agreed to in writing, software
+// # distributed under the License is distributed on an "AS IS" BASIS,
+// # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// # See the License for the specific language governing permissions and
+// # limitations under the License.
+
+#define LEMON_VERSION "1.3.1"
+#define LEMON_HAVE_LONG_LONG 1
+
+/* #undef LEMON_HAVE_LP */
+/* #undef LEMON_HAVE_MIP */
+#define LEMON_HAVE_GLPK 1
+/* #undef LEMON_HAVE_CPLEX */
+/* #undef LEMON_HAVE_SOPLEX */
+/* #undef LEMON_HAVE_CLP */
+/* #undef LEMON_HAVE_CBC */
+
+#define _LEMON_CPLEX 1
+#define _LEMON_CLP 2
+#define _LEMON_GLPK 3
+#define _LEMON_SOPLEX 4
+#define _LEMON_CBC 5
+
+/* #undef LEMON_DEFAULT_LP */
+/* #undef LEMON_DEFAULT_MIP */
+#define LEMON_DEFAULT_LP _LEMON_GLPK
+#define LEMON_DEFAULT_MIP _LEMON_GLPK
+
+#define LEMON_USE_PTHREAD 1
+/* #undef LEMON_USE_WIN32_THREADS */

--- a/modules/coin-or-lemon/1.3.1.bcr.1/patches/allocator-patch.patch
+++ b/modules/coin-or-lemon/1.3.1.bcr.1/patches/allocator-patch.patch
@@ -1,0 +1,337 @@
+diff --git a/lemon/bits/array_map.h b/lemon/bits/array_map.h
+index 355ee00..42aded6 100644
+--- a/lemon/bits/array_map.h
++++ b/lemon/bits/array_map.h
+@@ -75,6 +75,7 @@ namespace lemon {
+     typedef typename Notifier::ObserverBase Parent;
+ 
+     typedef std::allocator<Value> Allocator;
++    typedef std::allocator_traits<std::allocator<Value>> AllocatorTraits;
+ 
+   public:
+ 
+@@ -87,8 +88,8 @@ namespace lemon {
+       Notifier* nf = Parent::notifier();
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+-        int id = nf->id(it);;
+-        allocator.construct(&(values[id]), Value());
++        int id = nf->id(it);
++        AllocatorTraits::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -101,8 +102,8 @@ namespace lemon {
+       Notifier* nf = Parent::notifier();
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+-        int id = nf->id(it);;
+-        allocator.construct(&(values[id]), value);
++        int id = nf->id(it);
++        AllocatorTraits::construct(allocator, &(values[id]), value);
+       }
+     }
+ 
+@@ -120,8 +121,8 @@ namespace lemon {
+       Notifier* nf = Parent::notifier();
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+-        int id = nf->id(it);;
+-        allocator.construct(&(values[id]), copy.values[id]);
++        int id = nf->id(it);
++        AllocatorTraits::construct(allocator, &(values[id]), copy.values[id]);
+       }
+     }
+ 
+@@ -216,17 +217,17 @@ namespace lemon {
+         Value* new_values = allocator.allocate(new_capacity);
+         Item it;
+         for (nf->first(it); it != INVALID; nf->next(it)) {
+-          int jd = nf->id(it);;
++          int jd = nf->id(it);
+           if (id != jd) {
+-            allocator.construct(&(new_values[jd]), values[jd]);
+-            allocator.destroy(&(values[jd]));
++            AllocatorTraits::construct(allocator, &(new_values[jd]), values[jd]);
++            AllocatorTraits::destroy(allocator, &(values[jd]));
+           }
+         }
+         if (capacity != 0) allocator.deallocate(values, capacity);
+         values = new_values;
+         capacity = new_capacity;
+       }
+-      allocator.construct(&(values[id]), Value());
++      AllocatorTraits::construct(allocator, &(values[id]), Value());
+     }
+ 
+     // \brief Adds more new keys to the map.
+@@ -260,8 +261,8 @@ namespace lemon {
+             }
+           }
+           if (found) continue;
+-          allocator.construct(&(new_values[id]), values[id]);
+-          allocator.destroy(&(values[id]));
++          AllocatorTraits::construct(allocator, &(new_values[id]), values[id]);
++          AllocatorTraits::destroy(allocator, &(values[id]));
+         }
+         if (capacity != 0) allocator.deallocate(values, capacity);
+         values = new_values;
+@@ -269,7 +270,7 @@ namespace lemon {
+       }
+       for (int i = 0; i < int(keys.size()); ++i) {
+         int id = nf->id(keys[i]);
+-        allocator.construct(&(values[id]), Value());
++        AllocatorTraits::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -279,7 +280,7 @@ namespace lemon {
+     // and it overrides the erase() member function of the observer base.
+     virtual void erase(const Key& key) {
+       int id = Parent::notifier()->id(key);
+-      allocator.destroy(&(values[id]));
++      AllocatorTraits::destroy(allocator, &(values[id]));
+     }
+ 
+     // \brief Erase more keys from the map.
+@@ -289,7 +290,7 @@ namespace lemon {
+     virtual void erase(const std::vector<Key>& keys) {
+       for (int i = 0; i < int(keys.size()); ++i) {
+         int id = Parent::notifier()->id(keys[i]);
+-        allocator.destroy(&(values[id]));
++        AllocatorTraits::destroy(allocator, &(values[id]));
+       }
+     }
+ 
+@@ -302,8 +303,8 @@ namespace lemon {
+       allocate_memory();
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+-        int id = nf->id(it);;
+-        allocator.construct(&(values[id]), Value());
++        int id = nf->id(it);
++        AllocatorTraits::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -317,7 +318,7 @@ namespace lemon {
+         Item it;
+         for (nf->first(it); it != INVALID; nf->next(it)) {
+           int id = nf->id(it);
+-          allocator.destroy(&(values[id]));
++          AllocatorTraits::destroy(allocator, &(values[id]));
+         }
+         allocator.deallocate(values, capacity);
+         capacity = 0;
+diff --git a/lemon/path.h b/lemon/path.h
+index baa92c4..c3a1722 100644
+--- a/lemon/path.h
++++ b/lemon/path.h
+@@ -393,7 +393,7 @@ namespace lemon {
+       data.resize(len);
+       int index = 0;
+       for (typename CPath::ArcIt it(path); it != INVALID; ++it) {
+-        data[index] = it;;
++        data[index] = it;
+         ++index;
+       }
+     }
+@@ -405,7 +405,7 @@ namespace lemon {
+       int index = len;
+       for (typename CPath::RevArcIt it(path); it != INVALID; ++it) {
+         --index;
+-        data[index] = it;;
++        data[index] = it;
+       }
+     }
+ 
+@@ -448,7 +448,9 @@ namespace lemon {
+ 
+     Node *first, *last;
+ 
+-    std::allocator<Node> alloc;
++  private:
++    typedef std::allocator<Node> Allocator;
++    typedef std::allocator_traits<std::allocator<Node>> AllocatorTraits;
+ 
+   public:
+ 
+@@ -582,8 +584,8 @@ namespace lemon {
+     void clear() {
+       while (first != 0) {
+         last = first->next;
+-        alloc.destroy(first);
+-        alloc.deallocate(first, 1);
++        AllocatorTraits::destroy(_allocator, first);
++        _allocator.deallocate(first, 1);
+         first = last;
+       }
+     }
+@@ -595,8 +597,8 @@ namespace lemon {
+ 
+     /// \brief Add a new arc before the current path
+     void addFront(const Arc& arc) {
+-      Node *node = alloc.allocate(1);
+-      alloc.construct(node, Node());
++      Node *node = _allocator.allocate(1);
++      AllocatorTraits::construct(_allocator, node, Node());
+       node->prev = 0;
+       node->next = first;
+       node->arc = arc;
+@@ -617,8 +619,8 @@ namespace lemon {
+       } else {
+         last = 0;
+       }
+-      alloc.destroy(node);
+-      alloc.deallocate(node, 1);
++      AllocatorTraits::destroy(_allocator, node);
++      _allocator.deallocate(node, 1);
+     }
+ 
+     /// \brief The last arc of the path.
+@@ -628,8 +630,8 @@ namespace lemon {
+ 
+     /// \brief Add a new arc behind the current path.
+     void addBack(const Arc& arc) {
+-      Node *node = alloc.allocate(1);
+-      alloc.construct(node, Node());
++      Node *node = _allocator.allocate(1);
++      AllocatorTraits::construct(_allocator, node, Node());
+       node->next = 0;
+       node->prev = last;
+       node->arc = arc;
+@@ -650,8 +652,8 @@ namespace lemon {
+       } else {
+         first = 0;
+       }
+-      alloc.destroy(node);
+-      alloc.deallocate(node, 1);
++      AllocatorTraits::destroy(_allocator, node);
++      _allocator.deallocate(node, 1);
+     }
+ 
+     /// \brief Splice a path to the back of the current path.
+@@ -766,6 +768,9 @@ namespace lemon {
+       }
+     }
+ 
++  private:
++    Allocator _allocator;
++
+   };
+ 
+   /// \brief A structure for representing directed paths in a digraph.
+@@ -795,11 +800,11 @@ namespace lemon {
+     /// \brief Default constructor
+     ///
+     /// Default constructor
+-    StaticPath() : len(0), arcs(0) {}
++    StaticPath() : _len(0), _arcs(0) {}
+ 
+     /// \brief Copy constructor
+     ///
+-    StaticPath(const StaticPath& cpath) : arcs(0) {
++    StaticPath(const StaticPath& cpath) : _arcs(0) {
+       pathCopy(cpath, *this);
+     }
+ 
+@@ -807,7 +812,7 @@ namespace lemon {
+     ///
+     /// This path can be initialized from any other path type.
+     template <typename CPath>
+-    StaticPath(const CPath& cpath) : arcs(0) {
++    StaticPath(const CPath& cpath) : _arcs(0) {
+       pathCopy(cpath, *this);
+     }
+ 
+@@ -815,7 +820,7 @@ namespace lemon {
+     ///
+     /// Destructor of the path
+     ~StaticPath() {
+-      if (arcs) delete[] arcs;
++      if (_arcs) delete[] _arcs;
+     }
+ 
+     /// \brief Copy assignment
+@@ -887,7 +892,7 @@ namespace lemon {
+     ///
+     /// \pre \c n is in the <tt>[0..length() - 1]</tt> range.
+     const Arc& nth(int n) const {
+-      return arcs[n];
++      return _arcs[n];
+     }
+ 
+     /// \brief The arc iterator pointing to the n-th arc.
+@@ -896,26 +901,26 @@ namespace lemon {
+     }
+ 
+     /// \brief The length of the path.
+-    int length() const { return len; }
++    int length() const { return _len; }
+ 
+     /// \brief Return true when the path is empty.
+-    int empty() const { return len == 0; }
++    int empty() const { return _len == 0; }
+ 
+     /// \brief Erase all arcs in the digraph.
+     void clear() {
+-      len = 0;
+-      if (arcs) delete[] arcs;
+-      arcs = 0;
++      _len = 0;
++      if (_arcs) delete[] _arcs;
++      _arcs = 0;
+     }
+ 
+     /// \brief The first arc of the path.
+     const Arc& front() const {
+-      return arcs[0];
++      return _arcs[0];
+     }
+ 
+     /// \brief The last arc of the path.
+     const Arc& back() const {
+-      return arcs[len - 1];
++      return _arcs[_len - 1];
+     }
+ 
+ 
+@@ -923,29 +928,29 @@ namespace lemon {
+ 
+     template <typename CPath>
+     void build(const CPath& path) {
+-      len = path.length();
+-      arcs = new Arc[len];
++      _len = path.length();
++      _arcs = new Arc[_len];
+       int index = 0;
+       for (typename CPath::ArcIt it(path); it != INVALID; ++it) {
+-        arcs[index] = it;
++        _arcs[index] = it;
+         ++index;
+       }
+     }
+ 
+     template <typename CPath>
+     void buildRev(const CPath& path) {
+-      len = path.length();
+-      arcs = new Arc[len];
+-      int index = len;
++      _len = path.length();
++      _arcs = new Arc[_len];
++      int index = _len;
+       for (typename CPath::RevArcIt it(path); it != INVALID; ++it) {
+         --index;
+-        arcs[index] = it;
++        _arcs[index] = it;
+       }
+     }
+ 
+   private:
+-    int len;
+-    Arc* arcs;
++    int _len;
++    Arc* _arcs;
+   };
+ 
+   ///////////////////////////////////////////////////////////////////////

--- a/modules/coin-or-lemon/1.3.1.bcr.1/patches/lemon.patch
+++ b/modules/coin-or-lemon/1.3.1.bcr.1/patches/lemon.patch
@@ -1,0 +1,2945 @@
+diff --git a/demo/arg_parser_demo.cc b/demo/arg_parser_demo.cc
+index 1bafac0..c8e16e5 100644
+--- a/demo/arg_parser_demo.cc
++++ b/demo/arg_parser_demo.cc
+@@ -24,7 +24,7 @@
+ ///
+ /// \include arg_parser_demo.cc
+ 
+-#include <lemon/arg_parser.h>
++#include "lemon/arg_parser.h"
+ 
+ using namespace lemon;
+ int main(int argc, char **argv)
+diff --git a/demo/graph_to_eps_demo.cc b/demo/graph_to_eps_demo.cc
+index f2f55a9..99932b2 100644
+--- a/demo/graph_to_eps_demo.cc
++++ b/demo/graph_to_eps_demo.cc
+@@ -30,9 +30,9 @@
+ ///
+ /// \include graph_to_eps_demo.cc
+ 
+-#include<lemon/list_graph.h>
+-#include<lemon/graph_to_eps.h>
+-#include<lemon/math.h>
++#include "lemon/list_graph.h"
++#include "lemon/graph_to_eps.h"
++#include "lemon/math.h"
+ 
+ using namespace std;
+ using namespace lemon;
+diff --git a/demo/lgf_demo.cc b/demo/lgf_demo.cc
+index e2d31cd..1ae36ea 100644
+--- a/demo/lgf_demo.cc
++++ b/demo/lgf_demo.cc
+@@ -32,9 +32,9 @@
+ /// \include lgf_demo.cc
+ 
+ #include <iostream>
+-#include <lemon/smart_graph.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/lgf_writer.h>
++#include "lemon/smart_graph.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/lgf_writer.h"
+ 
+ using namespace lemon;
+ 
+diff --git a/doc/coding_style.dox b/doc/coding_style.dox
+index 80f1050..90ad6b6 100644
+--- a/doc/coding_style.dox
++++ b/doc/coding_style.dox
+@@ -54,7 +54,7 @@ Note that all standard LEMON headers are located in the \c lemon subdirectory,
+ so you should include them from C++ source like this:
+ 
+ \code
+-#include <lemon/header_file.h>
++#include "lemon/header_file.h"
+ \endcode
+ 
+ The source code files use the same style and they have '.cc' extension.
+diff --git a/doc/dirs.dox b/doc/dirs.dox
+index 8139060..e18c2e0 100644
+--- a/doc/dirs.dox
++++ b/doc/dirs.dox
+@@ -67,8 +67,8 @@ This directory contains the sources of some useful complete executables.
+ This is the base directory of LEMON includes, so each include file must be
+ prefixed with this, e.g.
+ \code
+-#include<lemon/list_graph.h>
+-#include<lemon/dijkstra.h>
++#include "lemon/list_graph.h"
++#include "lemon/dijkstra.h"
+ \endcode
+ */
+ 
+diff --git a/lemon/adaptors.h b/lemon/adaptors.h
+index 1a40f8e..b1dfd36 100644
+--- a/lemon/adaptors.h
++++ b/lemon/adaptors.h
+@@ -25,13 +25,13 @@
+ ///
+ /// This file contains several useful adaptors for digraphs and graphs.
+ 
+-#include <lemon/core.h>
+-#include <lemon/maps.h>
+-#include <lemon/bits/variant.h>
++#include "lemon/core.h"
++#include "lemon/maps.h"
++#include "lemon/bits/variant.h"
+ 
+-#include <lemon/bits/graph_adaptor_extender.h>
+-#include <lemon/bits/map_extender.h>
+-#include <lemon/tolerance.h>
++#include "lemon/bits/graph_adaptor_extender.h"
++#include "lemon/bits/map_extender.h"
++#include "lemon/tolerance.h"
+ 
+ #include <algorithm>
+ 
+diff --git a/lemon/arg_parser.cc b/lemon/arg_parser.cc
+index 35a73d9..db8a0b3 100644
+--- a/lemon/arg_parser.cc
++++ b/lemon/arg_parser.cc
+@@ -16,7 +16,7 @@
+  *
+  */
+ 
+-#include <lemon/arg_parser.h>
++#include "lemon/arg_parser.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/arg_parser.h b/lemon/arg_parser.h
+index 3fbe75c..2fa7089 100644
+--- a/lemon/arg_parser.h
++++ b/lemon/arg_parser.h
+@@ -26,7 +26,7 @@
+ #include <iostream>
+ #include <sstream>
+ #include <algorithm>
+-#include <lemon/assert.h>
++#include "lemon/assert.h"
+ 
+ ///\ingroup misc
+ ///\file
+diff --git a/lemon/assert.h b/lemon/assert.h
+index f6c1dfc..6694a27 100644
+--- a/lemon/assert.h
++++ b/lemon/assert.h
+@@ -23,7 +23,7 @@
+ /// \file
+ /// \brief Extended assertion handling
+ 
+-#include <lemon/error.h>
++#include "lemon/error.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/base.cc b/lemon/base.cc
+index a057b41..d066fb7 100644
+--- a/lemon/base.cc
++++ b/lemon/base.cc
+@@ -19,9 +19,9 @@
+ ///\file
+ ///\brief Some basic non-inline functions and static global data.
+ 
+-#include<lemon/tolerance.h>
+-#include<lemon/core.h>
+-#include<lemon/time_measure.h>
++#include "lemon/tolerance.h"
++#include "lemon/core.h"
++#include "lemon/time_measure.h"
+ namespace lemon {
+ 
+   float Tolerance<float>::def_epsilon = static_cast<float>(1e-4);
+diff --git a/lemon/bellman_ford.h b/lemon/bellman_ford.h
+index 310758e..0900ea3 100644
+--- a/lemon/bellman_ford.h
++++ b/lemon/bellman_ford.h
+@@ -23,12 +23,12 @@
+ /// \file
+ /// \brief Bellman-Ford algorithm.
+ 
+-#include <lemon/list_graph.h>
+-#include <lemon/bits/path_dump.h>
+-#include <lemon/core.h>
+-#include <lemon/error.h>
+-#include <lemon/maps.h>
+-#include <lemon/path.h>
++#include "lemon/list_graph.h"
++#include "lemon/bits/path_dump.h"
++#include "lemon/core.h"
++#include "lemon/error.h"
++#include "lemon/maps.h"
++#include "lemon/path.h"
+ 
+ #include <limits>
+ 
+diff --git a/lemon/bfs.h b/lemon/bfs.h
+index e5f4e5c..2506348 100644
+--- a/lemon/bfs.h
++++ b/lemon/bfs.h
+@@ -23,12 +23,12 @@
+ ///\file
+ ///\brief BFS algorithm.
+ 
+-#include <lemon/list_graph.h>
+-#include <lemon/bits/path_dump.h>
+-#include <lemon/core.h>
+-#include <lemon/error.h>
+-#include <lemon/maps.h>
+-#include <lemon/path.h>
++#include "lemon/list_graph.h"
++#include "lemon/bits/path_dump.h"
++#include "lemon/core.h"
++#include "lemon/error.h"
++#include "lemon/maps.h"
++#include "lemon/path.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/binomial_heap.h b/lemon/binomial_heap.h
+index 5bc1378..e8a7ac8 100644
+--- a/lemon/binomial_heap.h
++++ b/lemon/binomial_heap.h
+@@ -26,8 +26,8 @@
+ #include <vector>
+ #include <utility>
+ #include <functional>
+-#include <lemon/math.h>
+-#include <lemon/counter.h>
++#include "lemon/math.h"
++#include "lemon/counter.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/bits/alteration_notifier.h b/lemon/bits/alteration_notifier.h
+index d14fe36..f0effca 100644
+--- a/lemon/bits/alteration_notifier.h
++++ b/lemon/bits/alteration_notifier.h
+@@ -22,8 +22,8 @@
+ #include <vector>
+ #include <list>
+ 
+-#include <lemon/core.h>
+-#include <lemon/bits/lock.h>
++#include "lemon/core.h"
++#include "lemon/bits/lock.h"
+ 
+ //\ingroup graphbits
+ //\file
+diff --git a/lemon/bits/array_map.h b/lemon/bits/array_map.h
+index 355ee00..06e1bb8 100644
+--- a/lemon/bits/array_map.h
++++ b/lemon/bits/array_map.h
+@@ -21,10 +21,10 @@
+ 
+ #include <memory>
+ 
+-#include <lemon/bits/traits.h>
+-#include <lemon/bits/alteration_notifier.h>
+-#include <lemon/concept_check.h>
+-#include <lemon/concepts/maps.h>
++#include "lemon/bits/traits.h"
++#include "lemon/bits/alteration_notifier.h"
++#include "lemon/concept_check.h"
++#include "lemon/concepts/maps.h"
+ 
+ // \ingroup graphbits
+ // \file
+diff --git a/lemon/bits/bezier.h b/lemon/bits/bezier.h
+index 9d8d141..7f5f486 100644
+--- a/lemon/bits/bezier.h
++++ b/lemon/bits/bezier.h
+@@ -25,7 +25,7 @@
+ //
+ //Up to now this file is used internally by \ref graph_to_eps.h
+ 
+-#include<lemon/dim2.h>
++#include "lemon/dim2.h"
+ 
+ namespace lemon {
+   namespace dim2 {
+diff --git a/lemon/bits/default_map.h b/lemon/bits/default_map.h
+index 23728e4..9edffcf 100644
+--- a/lemon/bits/default_map.h
++++ b/lemon/bits/default_map.h
+@@ -19,10 +19,10 @@
+ #ifndef LEMON_BITS_DEFAULT_MAP_H
+ #define LEMON_BITS_DEFAULT_MAP_H
+ 
+-#include <lemon/config.h>
+-#include <lemon/bits/array_map.h>
+-#include <lemon/bits/vector_map.h>
+-//#include <lemon/bits/debug_map.h>
++#include "lemon/config.h"
++#include "lemon/bits/array_map.h"
++#include "lemon/bits/vector_map.h"
++//#include "lemon/bits/debug_map.h"
+ 
+ //\ingroup graphbits
+ //\file
+diff --git a/lemon/bits/edge_set_extender.h b/lemon/bits/edge_set_extender.h
+index 364ca2e..11e99ea 100644
+--- a/lemon/bits/edge_set_extender.h
++++ b/lemon/bits/edge_set_extender.h
+@@ -19,10 +19,10 @@
+ #ifndef LEMON_BITS_EDGE_SET_EXTENDER_H
+ #define LEMON_BITS_EDGE_SET_EXTENDER_H
+ 
+-#include <lemon/core.h>
+-#include <lemon/error.h>
+-#include <lemon/bits/default_map.h>
+-#include <lemon/bits/map_extender.h>
++#include "lemon/core.h"
++#include "lemon/error.h"
++#include "lemon/bits/default_map.h"
++#include "lemon/bits/map_extender.h"
+ 
+ //\ingroup digraphbits
+ //\file
+diff --git a/lemon/bits/graph_adaptor_extender.h b/lemon/bits/graph_adaptor_extender.h
+index c38c8e1..41f4254 100644
+--- a/lemon/bits/graph_adaptor_extender.h
++++ b/lemon/bits/graph_adaptor_extender.h
+@@ -19,8 +19,8 @@
+ #ifndef LEMON_BITS_GRAPH_ADAPTOR_EXTENDER_H
+ #define LEMON_BITS_GRAPH_ADAPTOR_EXTENDER_H
+ 
+-#include <lemon/core.h>
+-#include <lemon/error.h>
++#include "lemon/core.h"
++#include "lemon/error.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/bits/graph_extender.h b/lemon/bits/graph_extender.h
+index 755a890..752bf21 100644
+--- a/lemon/bits/graph_extender.h
++++ b/lemon/bits/graph_extender.h
+@@ -19,13 +19,13 @@
+ #ifndef LEMON_BITS_GRAPH_EXTENDER_H
+ #define LEMON_BITS_GRAPH_EXTENDER_H
+ 
+-#include <lemon/core.h>
++#include "lemon/core.h"
+ 
+-#include <lemon/bits/map_extender.h>
+-#include <lemon/bits/default_map.h>
++#include "lemon/bits/map_extender.h"
++#include "lemon/bits/default_map.h"
+ 
+-#include <lemon/concept_check.h>
+-#include <lemon/concepts/maps.h>
++#include "lemon/concept_check.h"
++#include "lemon/concepts/maps.h"
+ 
+ //\ingroup graphbits
+ //\file
+diff --git a/lemon/bits/lock.h b/lemon/bits/lock.h
+index 0906999..f768761 100644
+--- a/lemon/bits/lock.h
++++ b/lemon/bits/lock.h
+@@ -19,11 +19,11 @@
+ #ifndef LEMON_BITS_LOCK_H
+ #define LEMON_BITS_LOCK_H
+ 
+-#include <lemon/config.h>
++#include "lemon/config.h"
+ #if defined(LEMON_USE_PTHREAD)
+ #include <pthread.h>
+ #elif defined(LEMON_USE_WIN32_THREADS)
+-#include <lemon/bits/windows.h>
++#include "lemon/bits/windows.h"
+ #endif
+ 
+ namespace lemon {
+diff --git a/lemon/bits/map_extender.h b/lemon/bits/map_extender.h
+index f32403e..187c1e7 100644
+--- a/lemon/bits/map_extender.h
++++ b/lemon/bits/map_extender.h
+@@ -21,10 +21,10 @@
+ 
+ #include <iterator>
+ 
+-#include <lemon/bits/traits.h>
++#include "lemon/bits/traits.h"
+ 
+-#include <lemon/concept_check.h>
+-#include <lemon/concepts/maps.h>
++#include "lemon/concept_check.h"
++#include "lemon/concepts/maps.h"
+ 
+ //\file
+ //\brief Extenders for iterable maps.
+diff --git a/lemon/bits/path_dump.h b/lemon/bits/path_dump.h
+index 3e8cb8d..41be5a0 100644
+--- a/lemon/bits/path_dump.h
++++ b/lemon/bits/path_dump.h
+@@ -19,8 +19,8 @@
+ #ifndef LEMON_BITS_PATH_DUMP_H
+ #define LEMON_BITS_PATH_DUMP_H
+ 
+-#include <lemon/core.h>
+-#include <lemon/concept_check.h>
++#include "lemon/core.h"
++#include "lemon/concept_check.h"
+ 
+ namespace lemon {
+ 
+@@ -61,6 +61,10 @@ namespace lemon {
+         if (path->predMap[current] == INVALID) current = INVALID;
+       }
+ 
++      const typename Digraph::Arc arc() const {
++        return path->predMap[current];
++      }
++
+       operator const typename Digraph::Arc() const {
+         return path->predMap[current];
+       }
+diff --git a/lemon/bits/traits.h b/lemon/bits/traits.h
+index 53fbd45..cb2f039 100644
+--- a/lemon/bits/traits.h
++++ b/lemon/bits/traits.h
+@@ -23,7 +23,7 @@
+ //\brief Traits for graphs and maps
+ //
+ 
+-#include <lemon/bits/enable_if.h>
++#include "lemon/bits/enable_if.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/bits/variant.h b/lemon/bits/variant.h
+index b830189..d9ec7c2 100644
+--- a/lemon/bits/variant.h
++++ b/lemon/bits/variant.h
+@@ -19,7 +19,7 @@
+ #ifndef LEMON_BITS_VARIANT_H
+ #define LEMON_BITS_VARIANT_H
+ 
+-#include <lemon/assert.h>
++#include "lemon/assert.h"
+ 
+ // \file
+ // \brief Variant types
+diff --git a/lemon/bits/vector_map.h b/lemon/bits/vector_map.h
+index d60841d..2bce34b 100644
+--- a/lemon/bits/vector_map.h
++++ b/lemon/bits/vector_map.h
+@@ -22,11 +22,11 @@
+ #include <vector>
+ #include <algorithm>
+ 
+-#include <lemon/core.h>
+-#include <lemon/bits/alteration_notifier.h>
++#include "lemon/core.h"
++#include "lemon/bits/alteration_notifier.h"
+ 
+-#include <lemon/concept_check.h>
+-#include <lemon/concepts/maps.h>
++#include "lemon/concept_check.h"
++#include "lemon/concepts/maps.h"
+ 
+ //\ingroup graphbits
+ //
+diff --git a/lemon/bits/windows.cc b/lemon/bits/windows.cc
+index 7ad901c..4ce474d 100644
+--- a/lemon/bits/windows.cc
++++ b/lemon/bits/windows.cc
+@@ -19,7 +19,7 @@
+ ///\file
+ ///\brief Some basic non-inline functions and static global data.
+ 
+-#include<lemon/bits/windows.h>
++#include "lemon/bits/windows.h"
+ 
+ #ifdef WIN32
+ #ifndef WIN32_LEAN_AND_MEAN
+diff --git a/lemon/capacity_scaling.h b/lemon/capacity_scaling.h
+index ca64b56..691a023 100644
+--- a/lemon/capacity_scaling.h
++++ b/lemon/capacity_scaling.h
+@@ -26,8 +26,8 @@
+ 
+ #include <vector>
+ #include <limits>
+-#include <lemon/core.h>
+-#include <lemon/bin_heap.h>
++#include "lemon/core.h"
++#include "lemon/bin_heap.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/cbc.h b/lemon/cbc.h
+index 968e504..a9e6e0e 100644
+--- a/lemon/cbc.h
++++ b/lemon/cbc.h
+@@ -23,7 +23,7 @@
+ ///\brief Header of the LEMON-CBC mip solver interface.
+ ///\ingroup lp_group
+ 
+-#include <lemon/lp_base.h>
++#include "lemon/lp_base.h"
+ 
+ class CoinModel;
+ class OsiSolverInterface;
+diff --git a/lemon/christofides_tsp.h b/lemon/christofides_tsp.h
+index 2997567..53b38a2 100644
+--- a/lemon/christofides_tsp.h
++++ b/lemon/christofides_tsp.h
+@@ -23,11 +23,11 @@
+ /// \file
+ /// \brief Christofides algorithm for symmetric TSP
+ 
+-#include <lemon/full_graph.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/kruskal.h>
+-#include <lemon/matching.h>
+-#include <lemon/euler.h>
++#include "lemon/full_graph.h"
++#include "lemon/smart_graph.h"
++#include "lemon/kruskal.h"
++#include "lemon/matching.h"
++#include "lemon/euler.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/circulation.h b/lemon/circulation.h
+index b0f717b..f946578 100644
+--- a/lemon/circulation.h
++++ b/lemon/circulation.h
+@@ -19,8 +19,8 @@
+ #ifndef LEMON_CIRCULATION_H
+ #define LEMON_CIRCULATION_H
+ 
+-#include <lemon/tolerance.h>
+-#include <lemon/elevator.h>
++#include "lemon/tolerance.h"
++#include "lemon/elevator.h"
+ #include <limits>
+ 
+ ///\ingroup max_flow
+diff --git a/lemon/clp.cc b/lemon/clp.cc
+index 7c0ea74..59f74aa 100644
+--- a/lemon/clp.cc
++++ b/lemon/clp.cc
+@@ -16,7 +16,7 @@
+  *
+  */
+ 
+-#include <lemon/clp.h>
++#include "lemon/clp.h"
+ #include <coin/ClpSimplex.hpp>
+ 
+ namespace lemon {
+diff --git a/lemon/clp.h b/lemon/clp.h
+index fd331ac..e66ecc7 100644
+--- a/lemon/clp.h
++++ b/lemon/clp.h
+@@ -25,7 +25,7 @@
+ #include <vector>
+ #include <string>
+ 
+-#include <lemon/lp_base.h>
++#include "lemon/lp_base.h"
+ 
+ class ClpSimplex;
+ 
+diff --git a/lemon/color.cc b/lemon/color.cc
+index a49167b..154cbda 100644
+--- a/lemon/color.cc
++++ b/lemon/color.cc
+@@ -19,7 +19,7 @@
+ ///\file
+ ///\brief Color constants
+ 
+-#include<lemon/color.h>
++#include "lemon/color.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/color.h b/lemon/color.h
+index 0235791..0823387 100644
+--- a/lemon/color.h
++++ b/lemon/color.h
+@@ -20,8 +20,8 @@
+ #define LEMON_COLOR_H
+ 
+ #include<vector>
+-#include<lemon/math.h>
+-#include<lemon/maps.h>
++#include "lemon/math.h"
++#include "lemon/maps.h"
+ 
+ 
+ ///\ingroup misc
+diff --git a/lemon/concepts/bpgraph.h b/lemon/concepts/bpgraph.h
+index 2ebdeaf..64844a2 100644
+--- a/lemon/concepts/bpgraph.h
++++ b/lemon/concepts/bpgraph.h
+@@ -23,10 +23,10 @@
+ #ifndef LEMON_CONCEPTS_BPGRAPH_H
+ #define LEMON_CONCEPTS_BPGRAPH_H
+ 
+-#include <lemon/concepts/graph_components.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/concept_check.h>
+-#include <lemon/core.h>
++#include "lemon/concepts/graph_components.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/concept_check.h"
++#include "lemon/core.h"
+ 
+ namespace lemon {
+   namespace concepts {
+diff --git a/lemon/concepts/digraph.h b/lemon/concepts/digraph.h
+index dc3c36b..c04a171 100644
+--- a/lemon/concepts/digraph.h
++++ b/lemon/concepts/digraph.h
+@@ -23,10 +23,10 @@
+ ///\file
+ ///\brief The concept of directed graphs.
+ 
+-#include <lemon/core.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/concept_check.h>
+-#include <lemon/concepts/graph_components.h>
++#include "lemon/core.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/concept_check.h"
++#include "lemon/concepts/graph_components.h"
+ 
+ namespace lemon {
+   namespace concepts {
+diff --git a/lemon/concepts/graph.h b/lemon/concepts/graph.h
+index 76e43da..d4fa335 100644
+--- a/lemon/concepts/graph.h
++++ b/lemon/concepts/graph.h
+@@ -23,10 +23,10 @@
+ #ifndef LEMON_CONCEPTS_GRAPH_H
+ #define LEMON_CONCEPTS_GRAPH_H
+ 
+-#include <lemon/concepts/graph_components.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/concept_check.h>
+-#include <lemon/core.h>
++#include "lemon/concepts/graph_components.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/concept_check.h"
++#include "lemon/core.h"
+ 
+ namespace lemon {
+   namespace concepts {
+diff --git a/lemon/concepts/graph_components.h b/lemon/concepts/graph_components.h
+index 9df28f3..f33106b 100644
+--- a/lemon/concepts/graph_components.h
++++ b/lemon/concepts/graph_components.h
+@@ -23,10 +23,10 @@
+ #ifndef LEMON_CONCEPTS_GRAPH_COMPONENTS_H
+ #define LEMON_CONCEPTS_GRAPH_COMPONENTS_H
+ 
+-#include <lemon/core.h>
+-#include <lemon/concepts/maps.h>
++#include "lemon/core.h"
++#include "lemon/concepts/maps.h"
+ 
+-#include <lemon/bits/alteration_notifier.h>
++#include "lemon/bits/alteration_notifier.h"
+ 
+ namespace lemon {
+   namespace concepts {
+diff --git a/lemon/concepts/heap.h b/lemon/concepts/heap.h
+index 8c7a251..ef96a9e 100644
+--- a/lemon/concepts/heap.h
++++ b/lemon/concepts/heap.h
+@@ -23,8 +23,8 @@
+ ///\file
+ ///\brief The concept of heaps.
+ 
+-#include <lemon/core.h>
+-#include <lemon/concept_check.h>
++#include "lemon/core.h"
++#include "lemon/concept_check.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/concepts/maps.h b/lemon/concepts/maps.h
+index 88b66b5..bc06331 100644
+--- a/lemon/concepts/maps.h
++++ b/lemon/concepts/maps.h
+@@ -19,8 +19,8 @@
+ #ifndef LEMON_CONCEPTS_MAPS_H
+ #define LEMON_CONCEPTS_MAPS_H
+ 
+-#include <lemon/core.h>
+-#include <lemon/concept_check.h>
++#include "lemon/core.h"
++#include "lemon/concept_check.h"
+ 
+ ///\ingroup map_concepts
+ ///\file
+diff --git a/lemon/concepts/path.h b/lemon/concepts/path.h
+index 18e4b01..886b89b 100644
+--- a/lemon/concepts/path.h
++++ b/lemon/concepts/path.h
+@@ -24,8 +24,8 @@
+ #ifndef LEMON_CONCEPTS_PATH_H
+ #define LEMON_CONCEPTS_PATH_H
+ 
+-#include <lemon/core.h>
+-#include <lemon/concept_check.h>
++#include "lemon/core.h"
++#include "lemon/concept_check.h"
+ 
+ namespace lemon {
+   namespace concepts {
+diff --git a/lemon/connectivity.h b/lemon/connectivity.h
+index 6bd85a1..2e42fbc 100644
+--- a/lemon/connectivity.h
++++ b/lemon/connectivity.h
+@@ -19,15 +19,15 @@
+ #ifndef LEMON_CONNECTIVITY_H
+ #define LEMON_CONNECTIVITY_H
+ 
+-#include <lemon/dfs.h>
+-#include <lemon/bfs.h>
+-#include <lemon/core.h>
+-#include <lemon/maps.h>
+-#include <lemon/adaptors.h>
+-
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concepts/graph.h>
+-#include <lemon/concept_check.h>
++#include "lemon/dfs.h"
++#include "lemon/bfs.h"
++#include "lemon/core.h"
++#include "lemon/maps.h"
++#include "lemon/adaptors.h"
++
++#include "lemon/concepts/digraph.h"
++#include "lemon/concepts/graph.h"
++#include "lemon/concept_check.h"
+ 
+ #include <stack>
+ #include <functional>
+diff --git a/lemon/core.h b/lemon/core.h
+index 507943d..197fe71 100644
+--- a/lemon/core.h
++++ b/lemon/core.h
+@@ -22,10 +22,10 @@
+ #include <vector>
+ #include <algorithm>
+ 
+-#include <lemon/config.h>
+-#include <lemon/bits/enable_if.h>
+-#include <lemon/bits/traits.h>
+-#include <lemon/assert.h>
++#include "lemon/config.h"
++#include "lemon/bits/enable_if.h"
++#include "lemon/bits/traits.h"
++#include "lemon/assert.h"
+ 
+ // Disable the following warnings when compiling with MSVC:
+ // C4250: 'class1' : inherits 'class2::member' via dominance
+diff --git a/lemon/cost_scaling.h b/lemon/cost_scaling.h
+index efecdfe..ca85726 100644
+--- a/lemon/cost_scaling.h
++++ b/lemon/cost_scaling.h
+@@ -27,12 +27,12 @@
+ #include <deque>
+ #include <limits>
+ 
+-#include <lemon/core.h>
+-#include <lemon/maps.h>
+-#include <lemon/math.h>
+-#include <lemon/static_graph.h>
+-#include <lemon/circulation.h>
+-#include <lemon/bellman_ford.h>
++#include "lemon/core.h"
++#include "lemon/maps.h"
++#include "lemon/math.h"
++#include "lemon/static_graph.h"
++#include "lemon/circulation.h"
++#include "lemon/bellman_ford.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/cplex.cc b/lemon/cplex.cc
+index 029a3ef..915c17c 100644
+--- a/lemon/cplex.cc
++++ b/lemon/cplex.cc
+@@ -20,7 +20,7 @@
+ #include <vector>
+ #include <cstring>
+ 
+-#include <lemon/cplex.h>
++#include "lemon/cplex.h"
+ 
+ extern "C" {
+ #include <ilcplex/cplex.h>
+diff --git a/lemon/cplex.h b/lemon/cplex.h
+index c17e792..d3f5495 100644
+--- a/lemon/cplex.h
++++ b/lemon/cplex.h
+@@ -22,7 +22,7 @@
+ ///\file
+ ///\brief Header of the LEMON-CPLEX lp solver interface.
+ 
+-#include <lemon/lp_base.h>
++#include "lemon/lp_base.h"
+ 
+ struct cpxenv;
+ struct cpxlp;
+diff --git a/lemon/cycle_canceling.h b/lemon/cycle_canceling.h
+index 646d299..afc3ec7 100644
+--- a/lemon/cycle_canceling.h
++++ b/lemon/cycle_canceling.h
+@@ -26,16 +26,16 @@
+ #include <vector>
+ #include <limits>
+ 
+-#include <lemon/core.h>
+-#include <lemon/maps.h>
+-#include <lemon/path.h>
+-#include <lemon/math.h>
+-#include <lemon/static_graph.h>
+-#include <lemon/adaptors.h>
+-#include <lemon/circulation.h>
+-#include <lemon/bellman_ford.h>
+-#include <lemon/howard_mmc.h>
+-#include <lemon/hartmann_orlin_mmc.h>
++#include "lemon/core.h"
++#include "lemon/maps.h"
++#include "lemon/path.h"
++#include "lemon/math.h"
++#include "lemon/static_graph.h"
++#include "lemon/adaptors.h"
++#include "lemon/circulation.h"
++#include "lemon/bellman_ford.h"
++#include "lemon/howard_mmc.h"
++#include "lemon/hartmann_orlin_mmc.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/dfs.h b/lemon/dfs.h
+index 6e9e84a..a5af099 100644
+--- a/lemon/dfs.h
++++ b/lemon/dfs.h
+@@ -23,12 +23,12 @@
+ ///\file
+ ///\brief DFS algorithm.
+ 
+-#include <lemon/list_graph.h>
+-#include <lemon/bits/path_dump.h>
+-#include <lemon/core.h>
+-#include <lemon/error.h>
+-#include <lemon/maps.h>
+-#include <lemon/path.h>
++#include "lemon/list_graph.h"
++#include "lemon/bits/path_dump.h"
++#include "lemon/core.h"
++#include "lemon/error.h"
++#include "lemon/maps.h"
++#include "lemon/path.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/dijkstra.h b/lemon/dijkstra.h
+index 1564a03..1b8e967 100644
+--- a/lemon/dijkstra.h
++++ b/lemon/dijkstra.h
+@@ -24,13 +24,13 @@
+ ///\brief Dijkstra algorithm.
+ 
+ #include <limits>
+-#include <lemon/list_graph.h>
+-#include <lemon/bin_heap.h>
+-#include <lemon/bits/path_dump.h>
+-#include <lemon/core.h>
+-#include <lemon/error.h>
+-#include <lemon/maps.h>
+-#include <lemon/path.h>
++#include "lemon/list_graph.h"
++#include "lemon/bin_heap.h"
++#include "lemon/bits/path_dump.h"
++#include "lemon/core.h"
++#include "lemon/error.h"
++#include "lemon/maps.h"
++#include "lemon/path.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/dimacs.h b/lemon/dimacs.h
+index 616879f..0e029a8 100644
+--- a/lemon/dimacs.h
++++ b/lemon/dimacs.h
+@@ -23,8 +23,8 @@
+ #include <string>
+ #include <vector>
+ #include <limits>
+-#include <lemon/maps.h>
+-#include <lemon/error.h>
++#include "lemon/maps.h"
++#include "lemon/error.h"
+ /// \ingroup dimacs_group
+ /// \file
+ /// \brief DIMACS file format reader.
+diff --git a/lemon/edge_set.h b/lemon/edge_set.h
+index 399b7a2..749c403 100644
+--- a/lemon/edge_set.h
++++ b/lemon/edge_set.h
+@@ -19,8 +19,8 @@
+ #ifndef LEMON_EDGE_SET_H
+ #define LEMON_EDGE_SET_H
+ 
+-#include <lemon/core.h>
+-#include <lemon/bits/edge_set_extender.h>
++#include "lemon/core.h"
++#include "lemon/bits/edge_set_extender.h"
+ 
+ /// \ingroup graphs
+ /// \file
+diff --git a/lemon/edmonds_karp.h b/lemon/edmonds_karp.h
+index 92af3cb..0c4a98d 100644
+--- a/lemon/edmonds_karp.h
++++ b/lemon/edmonds_karp.h
+@@ -23,7 +23,7 @@
+ /// \ingroup max_flow
+ /// \brief Implementation of the Edmonds-Karp algorithm.
+ 
+-#include <lemon/tolerance.h>
++#include "lemon/tolerance.h"
+ #include <vector>
+ 
+ namespace lemon {
+diff --git a/lemon/elevator.h b/lemon/elevator.h
+index e4adcd5..b0e666a 100644
+--- a/lemon/elevator.h
++++ b/lemon/elevator.h
+@@ -27,8 +27,8 @@
+ ///for labeling items in push-relabel type algorithms.
+ ///
+ 
+-#include <lemon/core.h>
+-#include <lemon/bits/traits.h>
++#include "lemon/core.h"
++#include "lemon/bits/traits.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/euler.h b/lemon/euler.h
+index 3a3cbd0..516478d 100644
+--- a/lemon/euler.h
++++ b/lemon/euler.h
+@@ -19,9 +19,9 @@
+ #ifndef LEMON_EULER_H
+ #define LEMON_EULER_H
+ 
+-#include<lemon/core.h>
+-#include<lemon/adaptors.h>
+-#include<lemon/connectivity.h>
++#include "lemon/core.h"
++#include "lemon/adaptors.h"
++#include "lemon/connectivity.h"
+ #include <list>
+ 
+ /// \ingroup graph_properties
+diff --git a/lemon/fib_heap.h b/lemon/fib_heap.h
+index 3441722..3a8a271 100644
+--- a/lemon/fib_heap.h
++++ b/lemon/fib_heap.h
+@@ -26,7 +26,7 @@
+ #include <vector>
+ #include <utility>
+ #include <functional>
+-#include <lemon/math.h>
++#include "lemon/math.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/fractional_matching.h b/lemon/fractional_matching.h
+index 7448f41..2e523ae 100644
+--- a/lemon/fractional_matching.h
++++ b/lemon/fractional_matching.h
+@@ -24,12 +24,12 @@
+ #include <set>
+ #include <limits>
+ 
+-#include <lemon/core.h>
+-#include <lemon/unionfind.h>
+-#include <lemon/bin_heap.h>
+-#include <lemon/maps.h>
+-#include <lemon/assert.h>
+-#include <lemon/elevator.h>
++#include "lemon/core.h"
++#include "lemon/unionfind.h"
++#include "lemon/bin_heap.h"
++#include "lemon/maps.h"
++#include "lemon/assert.h"
++#include "lemon/elevator.h"
+ 
+ ///\ingroup matching
+ ///\file
+diff --git a/lemon/full_graph.h b/lemon/full_graph.h
+index b63df2e..74f2c7d 100644
+--- a/lemon/full_graph.h
++++ b/lemon/full_graph.h
+@@ -19,8 +19,8 @@
+ #ifndef LEMON_FULL_GRAPH_H
+ #define LEMON_FULL_GRAPH_H
+ 
+-#include <lemon/core.h>
+-#include <lemon/bits/graph_extender.h>
++#include "lemon/core.h"
++#include "lemon/bits/graph_extender.h"
+ 
+ ///\ingroup graphs
+ ///\file
+diff --git a/lemon/glpk.cc b/lemon/glpk.cc
+index 38d8115..dbf69fe 100644
+--- a/lemon/glpk.cc
++++ b/lemon/glpk.cc
+@@ -19,10 +19,10 @@
+ ///\file
+ ///\brief Implementation of the LEMON GLPK LP and MIP solver interface.
+ 
+-#include <lemon/glpk.h>
++#include "lemon/glpk.h"
+ #include <glpk.h>
+ 
+-#include <lemon/assert.h>
++#include "lemon/assert.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/glpk.h b/lemon/glpk.h
+index ccdc54a..49e4a8e 100644
+--- a/lemon/glpk.h
++++ b/lemon/glpk.h
+@@ -23,7 +23,7 @@
+ ///\brief Header of the LEMON-GLPK lp solver interface.
+ ///\ingroup lp_group
+ 
+-#include <lemon/lp_base.h>
++#include "lemon/lp_base.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/gomory_hu.h b/lemon/gomory_hu.h
+index c43305f..391a460 100644
+--- a/lemon/gomory_hu.h
++++ b/lemon/gomory_hu.h
+@@ -21,10 +21,10 @@
+ 
+ #include <limits>
+ 
+-#include <lemon/core.h>
+-#include <lemon/preflow.h>
+-#include <lemon/concept_check.h>
+-#include <lemon/concepts/maps.h>
++#include "lemon/core.h"
++#include "lemon/preflow.h"
++#include "lemon/concept_check.h"
++#include "lemon/concepts/maps.h"
+ 
+ /// \ingroup min_cut
+ /// \file
+diff --git a/lemon/graph_to_eps.h b/lemon/graph_to_eps.h
+index 29ba836..0752aea 100644
+--- a/lemon/graph_to_eps.h
++++ b/lemon/graph_to_eps.h
+@@ -29,16 +29,16 @@
+ #include<sys/time.h>
+ #include<ctime>
+ #else
+-#include<lemon/bits/windows.h>
++#include "lemon/bits/windows.h"
+ #endif
+ 
+-#include<lemon/math.h>
+-#include<lemon/core.h>
+-#include<lemon/dim2.h>
+-#include<lemon/maps.h>
+-#include<lemon/color.h>
+-#include<lemon/bits/bezier.h>
+-#include<lemon/error.h>
++#include "lemon/math.h"
++#include "lemon/core.h"
++#include "lemon/dim2.h"
++#include "lemon/maps.h"
++#include "lemon/color.h"
++#include "lemon/bits/bezier.h"
++#include "lemon/error.h"
+ 
+ 
+ ///\ingroup eps_io
+diff --git a/lemon/greedy_tsp.h b/lemon/greedy_tsp.h
+index 9546171..31225bc 100644
+--- a/lemon/greedy_tsp.h
++++ b/lemon/greedy_tsp.h
+@@ -25,8 +25,8 @@
+ 
+ #include <vector>
+ #include <algorithm>
+-#include <lemon/full_graph.h>
+-#include <lemon/unionfind.h>
++#include "lemon/full_graph.h"
++#include "lemon/unionfind.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/grid_graph.h b/lemon/grid_graph.h
+index a3dff0f..79e082f 100644
+--- a/lemon/grid_graph.h
++++ b/lemon/grid_graph.h
+@@ -19,10 +19,10 @@
+ #ifndef GRID_GRAPH_H
+ #define GRID_GRAPH_H
+ 
+-#include <lemon/core.h>
+-#include <lemon/bits/graph_extender.h>
+-#include <lemon/dim2.h>
+-#include <lemon/assert.h>
++#include "lemon/core.h"
++#include "lemon/bits/graph_extender.h"
++#include "lemon/dim2.h"
++#include "lemon/assert.h"
+ 
+ ///\ingroup graphs
+ ///\file
+diff --git a/lemon/grosso_locatelli_pullan_mc.h b/lemon/grosso_locatelli_pullan_mc.h
+index 669e1fa..53492a9 100644
+--- a/lemon/grosso_locatelli_pullan_mc.h
++++ b/lemon/grosso_locatelli_pullan_mc.h
+@@ -27,8 +27,8 @@
+ 
+ #include <vector>
+ #include <limits>
+-#include <lemon/core.h>
+-#include <lemon/random.h>
++#include "lemon/core.h"
++#include "lemon/random.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/hao_orlin.h b/lemon/hao_orlin.h
+index 0eeaff9..cf82278 100644
+--- a/lemon/hao_orlin.h
++++ b/lemon/hao_orlin.h
+@@ -23,9 +23,9 @@
+ #include <list>
+ #include <limits>
+ 
+-#include <lemon/maps.h>
+-#include <lemon/core.h>
+-#include <lemon/tolerance.h>
++#include "lemon/maps.h"
++#include "lemon/core.h"
++#include "lemon/tolerance.h"
+ 
+ /// \file
+ /// \ingroup min_cut
+diff --git a/lemon/hartmann_orlin_mmc.h b/lemon/hartmann_orlin_mmc.h
+index 6b60a85..c090315 100644
+--- a/lemon/hartmann_orlin_mmc.h
++++ b/lemon/hartmann_orlin_mmc.h
+@@ -26,10 +26,10 @@
+ 
+ #include <vector>
+ #include <limits>
+-#include <lemon/core.h>
+-#include <lemon/path.h>
+-#include <lemon/tolerance.h>
+-#include <lemon/connectivity.h>
++#include "lemon/core.h"
++#include "lemon/path.h"
++#include "lemon/tolerance.h"
++#include "lemon/connectivity.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/howard_mmc.h b/lemon/howard_mmc.h
+index 6902363..caa782e 100644
+--- a/lemon/howard_mmc.h
++++ b/lemon/howard_mmc.h
+@@ -26,10 +26,10 @@
+ 
+ #include <vector>
+ #include <limits>
+-#include <lemon/core.h>
+-#include <lemon/path.h>
+-#include <lemon/tolerance.h>
+-#include <lemon/connectivity.h>
++#include "lemon/core.h"
++#include "lemon/path.h"
++#include "lemon/tolerance.h"
++#include "lemon/connectivity.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/hypercube_graph.h b/lemon/hypercube_graph.h
+index 2cf37ad..4c2d7c7 100644
+--- a/lemon/hypercube_graph.h
++++ b/lemon/hypercube_graph.h
+@@ -20,9 +20,9 @@
+ #define HYPERCUBE_GRAPH_H
+ 
+ #include <vector>
+-#include <lemon/core.h>
+-#include <lemon/assert.h>
+-#include <lemon/bits/graph_extender.h>
++#include "lemon/core.h"
++#include "lemon/assert.h"
++#include "lemon/bits/graph_extender.h"
+ 
+ ///\ingroup graphs
+ ///\file
+diff --git a/lemon/insertion_tsp.h b/lemon/insertion_tsp.h
+index fa16825..dfe91c1 100644
+--- a/lemon/insertion_tsp.h
++++ b/lemon/insertion_tsp.h
+@@ -25,9 +25,9 @@
+ 
+ #include <vector>
+ #include <functional>
+-#include <lemon/full_graph.h>
+-#include <lemon/maps.h>
+-#include <lemon/random.h>
++#include "lemon/full_graph.h"
++#include "lemon/maps.h"
++#include "lemon/random.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/karp_mmc.h b/lemon/karp_mmc.h
+index 1f05d43..4b30217 100644
+--- a/lemon/karp_mmc.h
++++ b/lemon/karp_mmc.h
+@@ -26,10 +26,10 @@
+ 
+ #include <vector>
+ #include <limits>
+-#include <lemon/core.h>
+-#include <lemon/path.h>
+-#include <lemon/tolerance.h>
+-#include <lemon/connectivity.h>
++#include "lemon/core.h"
++#include "lemon/path.h"
++#include "lemon/tolerance.h"
++#include "lemon/connectivity.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/kruskal.h b/lemon/kruskal.h
+index 04c2ddb..676f7e7 100644
+--- a/lemon/kruskal.h
++++ b/lemon/kruskal.h
+@@ -21,11 +21,11 @@
+ 
+ #include <algorithm>
+ #include <vector>
+-#include <lemon/unionfind.h>
+-#include <lemon/maps.h>
++#include "lemon/unionfind.h"
++#include "lemon/maps.h"
+ 
+-#include <lemon/core.h>
+-#include <lemon/bits/traits.h>
++#include "lemon/core.h"
++#include "lemon/bits/traits.h"
+ 
+ ///\ingroup spantree
+ ///\file
+diff --git a/lemon/lgf_reader.h b/lemon/lgf_reader.h
+index 2f49fa2..61b5594 100644
+--- a/lemon/lgf_reader.h
++++ b/lemon/lgf_reader.h
+@@ -31,12 +31,12 @@
+ #include <set>
+ #include <map>
+ 
+-#include <lemon/core.h>
++#include "lemon/core.h"
+ 
+-#include <lemon/lgf_writer.h>
++#include "lemon/lgf_writer.h"
+ 
+-#include <lemon/concept_check.h>
+-#include <lemon/concepts/maps.h>
++#include "lemon/concept_check.h"
++#include "lemon/concepts/maps.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/lgf_writer.h b/lemon/lgf_writer.h
+index 0695287..b421f34 100644
+--- a/lemon/lgf_writer.h
++++ b/lemon/lgf_writer.h
+@@ -33,11 +33,11 @@
+ #include <vector>
+ #include <functional>
+ 
+-#include <lemon/core.h>
+-#include <lemon/maps.h>
++#include "lemon/core.h"
++#include "lemon/maps.h"
+ 
+-#include <lemon/concept_check.h>
+-#include <lemon/concepts/maps.h>
++#include "lemon/concept_check.h"
++#include "lemon/concepts/maps.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/list_graph.h b/lemon/list_graph.h
+index 2a236cf..597e41f 100644
+--- a/lemon/list_graph.h
++++ b/lemon/list_graph.h
+@@ -23,9 +23,9 @@
+ ///\file
+ ///\brief ListDigraph and ListGraph classes.
+ 
+-#include <lemon/core.h>
+-#include <lemon/error.h>
+-#include <lemon/bits/graph_extender.h>
++#include "lemon/core.h"
++#include "lemon/error.h"
++#include "lemon/bits/graph_extender.h"
+ 
+ #include <vector>
+ #include <list>
+diff --git a/lemon/lp.h b/lemon/lp.h
+index 567763f..7e0bf58 100644
+--- a/lemon/lp.h
++++ b/lemon/lp.h
+@@ -19,19 +19,19 @@
+ #ifndef LEMON_LP_H
+ #define LEMON_LP_H
+ 
+-#include<lemon/config.h>
++#include "lemon/config.h"
+ 
+ 
+ #ifdef LEMON_HAVE_GLPK
+-#include <lemon/glpk.h>
++#include "lemon/glpk.h"
+ #elif LEMON_HAVE_CPLEX
+-#include <lemon/cplex.h>
++#include "lemon/cplex.h"
+ #elif LEMON_HAVE_SOPLEX
+-#include <lemon/soplex.h>
++#include "lemon/soplex.h"
+ #elif LEMON_HAVE_CLP
+-#include <lemon/clp.h>
++#include "lemon/clp.h"
+ #elif LEMON_HAVE_CBC
+-#include <lemon/cbc.h>
++#include "lemon/cbc.h"
+ #endif
+ 
+ ///\file
+diff --git a/lemon/lp_base.cc b/lemon/lp_base.cc
+index 312fd63..6539528 100644
+--- a/lemon/lp_base.cc
++++ b/lemon/lp_base.cc
+@@ -19,7 +19,7 @@
+ ///\file
+ ///\brief The implementation of the LP solver interface.
+ 
+-#include <lemon/lp_base.h>
++#include "lemon/lp_base.h"
+ namespace lemon {
+ 
+   const LpBase::Value LpBase::INF =
+diff --git a/lemon/lp_base.h b/lemon/lp_base.h
+index 22d3e48..b222b73 100644
+--- a/lemon/lp_base.h
++++ b/lemon/lp_base.h
+@@ -23,13 +23,13 @@
+ #include<vector>
+ #include<map>
+ #include<limits>
+-#include<lemon/math.h>
++#include "lemon/math.h"
+ 
+-#include<lemon/error.h>
+-#include<lemon/assert.h>
++#include "lemon/error.h"
++#include "lemon/assert.h"
+ 
+-#include<lemon/core.h>
+-#include<lemon/bits/solver_bits.h>
++#include "lemon/core.h"
++#include "lemon/bits/solver_bits.h"
+ 
+ ///\file
+ ///\brief The interface of the LP solver interface.
+diff --git a/lemon/lp_skeleton.cc b/lemon/lp_skeleton.cc
+index fc1c143..329ae8d 100644
+--- a/lemon/lp_skeleton.cc
++++ b/lemon/lp_skeleton.cc
+@@ -16,7 +16,7 @@
+  *
+  */
+ 
+-#include <lemon/lp_skeleton.h>
++#include "lemon/lp_skeleton.h"
+ 
+ ///\file
+ ///\brief A skeleton file to implement LP solver interfaces
+diff --git a/lemon/lp_skeleton.h b/lemon/lp_skeleton.h
+index 27285a4..14bb2c7 100644
+--- a/lemon/lp_skeleton.h
++++ b/lemon/lp_skeleton.h
+@@ -19,7 +19,7 @@
+ #ifndef LEMON_LP_SKELETON_H
+ #define LEMON_LP_SKELETON_H
+ 
+-#include <lemon/lp_base.h>
++#include "lemon/lp_base.h"
+ 
+ ///\file
+ ///\brief Skeleton file to implement LP/MIP solver interfaces
+diff --git a/lemon/maps.h b/lemon/maps.h
+index 1bc49e9..b973c8c 100644
+--- a/lemon/maps.h
++++ b/lemon/maps.h
+@@ -24,7 +24,7 @@
+ #include <vector>
+ #include <map>
+ 
+-#include <lemon/core.h>
++#include "lemon/core.h"
+ 
+ ///\file
+ ///\ingroup maps
+diff --git a/lemon/matching.h b/lemon/matching.h
+index 5ee2341..3896dfa 100644
+--- a/lemon/matching.h
++++ b/lemon/matching.h
+@@ -24,11 +24,11 @@
+ #include <set>
+ #include <limits>
+ 
+-#include <lemon/core.h>
+-#include <lemon/unionfind.h>
+-#include <lemon/bin_heap.h>
+-#include <lemon/maps.h>
+-#include <lemon/fractional_matching.h>
++#include "lemon/core.h"
++#include "lemon/unionfind.h"
++#include "lemon/bin_heap.h"
++#include "lemon/maps.h"
++#include "lemon/fractional_matching.h"
+ 
+ ///\ingroup matching
+ ///\file
+diff --git a/lemon/max_cardinality_search.h b/lemon/max_cardinality_search.h
+index bfa9edb..e681138 100644
+--- a/lemon/max_cardinality_search.h
++++ b/lemon/max_cardinality_search.h
+@@ -24,11 +24,11 @@
+ /// \file
+ /// \brief Maximum cardinality search in undirected digraphs.
+ 
+-#include <lemon/bin_heap.h>
+-#include <lemon/bucket_heap.h>
++#include "lemon/bin_heap.h"
++#include "lemon/bucket_heap.h"
+ 
+-#include <lemon/error.h>
+-#include <lemon/maps.h>
++#include "lemon/error.h"
++#include "lemon/maps.h"
+ 
+ #include <functional>
+ 
+diff --git a/lemon/min_cost_arborescence.h b/lemon/min_cost_arborescence.h
+index 1d0a2b1..09138a2 100644
+--- a/lemon/min_cost_arborescence.h
++++ b/lemon/min_cost_arborescence.h
+@@ -25,9 +25,9 @@
+ 
+ #include <vector>
+ 
+-#include <lemon/list_graph.h>
+-#include <lemon/bin_heap.h>
+-#include <lemon/assert.h>
++#include "lemon/list_graph.h"
++#include "lemon/bin_heap.h"
++#include "lemon/assert.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/nagamochi_ibaraki.h b/lemon/nagamochi_ibaraki.h
+index 57a6ba6..abd4568 100644
+--- a/lemon/nagamochi_ibaraki.h
++++ b/lemon/nagamochi_ibaraki.h
+@@ -24,12 +24,12 @@
+ /// \file
+ /// \brief Implementation of the Nagamochi-Ibaraki algorithm.
+ 
+-#include <lemon/core.h>
+-#include <lemon/bin_heap.h>
+-#include <lemon/bucket_heap.h>
+-#include <lemon/maps.h>
+-#include <lemon/radix_sort.h>
+-#include <lemon/unionfind.h>
++#include "lemon/core.h"
++#include "lemon/bin_heap.h"
++#include "lemon/bucket_heap.h"
++#include "lemon/maps.h"
++#include "lemon/radix_sort.h"
++#include "lemon/unionfind.h"
+ 
+ #include <cassert>
+ 
+diff --git a/lemon/nearest_neighbor_tsp.h b/lemon/nearest_neighbor_tsp.h
+index 065e145..cd50740 100644
+--- a/lemon/nearest_neighbor_tsp.h
++++ b/lemon/nearest_neighbor_tsp.h
+@@ -26,8 +26,8 @@
+ #include <deque>
+ #include <vector>
+ #include <limits>
+-#include <lemon/full_graph.h>
+-#include <lemon/maps.h>
++#include "lemon/full_graph.h"
++#include "lemon/maps.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/network_simplex.h b/lemon/network_simplex.h
+index 6ccad33..7f2b44c 100644
+--- a/lemon/network_simplex.h
++++ b/lemon/network_simplex.h
+@@ -28,8 +28,8 @@
+ #include <limits>
+ #include <algorithm>
+ 
+-#include <lemon/core.h>
+-#include <lemon/math.h>
++#include "lemon/core.h"
++#include "lemon/math.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/opt2_tsp.h b/lemon/opt2_tsp.h
+index 686cc9c..e346853 100644
+--- a/lemon/opt2_tsp.h
++++ b/lemon/opt2_tsp.h
+@@ -24,7 +24,7 @@
+ /// \brief 2-opt algorithm for symmetric TSP.
+ 
+ #include <vector>
+-#include <lemon/full_graph.h>
++#include "lemon/full_graph.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/pairing_heap.h b/lemon/pairing_heap.h
+index da6ebcb..9bcbf80 100644
+--- a/lemon/pairing_heap.h
++++ b/lemon/pairing_heap.h
+@@ -26,7 +26,7 @@
+ #include <vector>
+ #include <utility>
+ #include <functional>
+-#include <lemon/math.h>
++#include "lemon/math.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/path.h b/lemon/path.h
+index baa92c4..6e0d656 100644
+--- a/lemon/path.h
++++ b/lemon/path.h
+@@ -27,9 +27,9 @@
+ #include <vector>
+ #include <algorithm>
+ 
+-#include <lemon/error.h>
+-#include <lemon/core.h>
+-#include <lemon/concepts/path.h>
++#include "lemon/error.h"
++#include "lemon/core.h"
++#include "lemon/concepts/path.h"
+ 
+ namespace lemon {
+ 
+@@ -228,7 +228,7 @@ namespace lemon {
+       int len = path.length();
+       head.reserve(len);
+       for (typename CPath::RevArcIt it(path); it != INVALID; ++it) {
+-        head.push_back(it);
++        head.push_back(it.arc());
+       }
+     }
+ 
+diff --git a/lemon/planarity.h b/lemon/planarity.h
+index bfe8e85..6cf99dc 100644
+--- a/lemon/planarity.h
++++ b/lemon/planarity.h
+@@ -26,16 +26,16 @@
+ #include <vector>
+ #include <list>
+ 
+-#include <lemon/dfs.h>
+-#include <lemon/bfs.h>
+-#include <lemon/radix_sort.h>
+-#include <lemon/maps.h>
+-#include <lemon/path.h>
+-#include <lemon/bucket_heap.h>
+-#include <lemon/adaptors.h>
+-#include <lemon/edge_set.h>
+-#include <lemon/color.h>
+-#include <lemon/dim2.h>
++#include "lemon/dfs.h"
++#include "lemon/bfs.h"
++#include "lemon/radix_sort.h"
++#include "lemon/maps.h"
++#include "lemon/path.h"
++#include "lemon/bucket_heap.h"
++#include "lemon/adaptors.h"
++#include "lemon/edge_set.h"
++#include "lemon/color.h"
++#include "lemon/dim2.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/preflow.h b/lemon/preflow.h
+index 28ccd67..d9aaea5 100644
+--- a/lemon/preflow.h
++++ b/lemon/preflow.h
+@@ -19,8 +19,8 @@
+ #ifndef LEMON_PREFLOW_H
+ #define LEMON_PREFLOW_H
+ 
+-#include <lemon/tolerance.h>
+-#include <lemon/elevator.h>
++#include "lemon/tolerance.h"
++#include "lemon/elevator.h"
+ 
+ /// \file
+ /// \ingroup max_flow
+diff --git a/lemon/radix_heap.h b/lemon/radix_heap.h
+index 8701ce7..48f7894 100644
+--- a/lemon/radix_heap.h
++++ b/lemon/radix_heap.h
+@@ -24,7 +24,7 @@
+ ///\brief Radix heap implementation.
+ 
+ #include <vector>
+-#include <lemon/error.h>
++#include "lemon/error.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/random.cc b/lemon/random.cc
+index 0295121..2d72ef6 100644
+--- a/lemon/random.cc
++++ b/lemon/random.cc
+@@ -19,7 +19,7 @@
+ ///\file
+ ///\brief Instantiation of the Random class.
+ 
+-#include <lemon/random.h>
++#include "lemon/random.h"
+ 
+ namespace lemon {
+   /// \brief Global random number generator instance
+diff --git a/lemon/random.h b/lemon/random.h
+index 8de74ed..2d4aa36 100644
+--- a/lemon/random.h
++++ b/lemon/random.h
+@@ -68,8 +68,8 @@
+ #include <limits>
+ #include <fstream>
+ 
+-#include <lemon/math.h>
+-#include <lemon/dim2.h>
++#include "lemon/math.h"
++#include "lemon/dim2.h"
+ 
+ #ifndef WIN32
+ #include <sys/time.h>
+@@ -77,7 +77,7 @@
+ #include <sys/types.h>
+ #include <unistd.h>
+ #else
+-#include <lemon/bits/windows.h>
++#include "lemon/bits/windows.h"
+ #endif
+ 
+ ///\ingroup misc
+@@ -249,8 +249,8 @@ namespace lemon {
+ 
+         current = state + length;
+ 
+-        register Word *curr = state + length - 1;
+-        register long num;
++        Word *curr = state + length - 1;
++        long num;
+ 
+         num = length - shift;
+         while (num--) {
+diff --git a/lemon/smart_graph.h b/lemon/smart_graph.h
+index bdbe369..d528ce8 100644
+--- a/lemon/smart_graph.h
++++ b/lemon/smart_graph.h
+@@ -25,9 +25,9 @@
+ 
+ #include <vector>
+ 
+-#include <lemon/core.h>
+-#include <lemon/error.h>
+-#include <lemon/bits/graph_extender.h>
++#include "lemon/core.h"
++#include "lemon/error.h"
++#include "lemon/bits/graph_extender.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/soplex.cc b/lemon/soplex.cc
+index d751723..f9c1cb9 100644
+--- a/lemon/soplex.cc
++++ b/lemon/soplex.cc
+@@ -17,7 +17,7 @@
+  */
+ 
+ #include <iostream>
+-#include <lemon/soplex.h>
++#include "lemon/soplex.h"
+ 
+ #include <soplex.h>
+ #include <spxout.h>
+diff --git a/lemon/soplex.h b/lemon/soplex.h
+index be73f3a..fcd10bf 100644
+--- a/lemon/soplex.h
++++ b/lemon/soplex.h
+@@ -25,7 +25,7 @@
+ #include <vector>
+ #include <string>
+ 
+-#include <lemon/lp_base.h>
++#include "lemon/lp_base.h"
+ 
+ // Forward declaration
+ namespace soplex {
+@@ -40,7 +40,7 @@ namespace lemon {
+   ///
+   /// This class implements an interface for the SoPlex LP solver.
+   /// The SoPlex library is an object oriented lp solver library
+-  /// developed at the Konrad-Zuse-Zentrum für Informationstechnik
++  /// developed at the Konrad-Zuse-Zentrum fï¿½r Informationstechnik
+   /// Berlin (ZIB). You can find detailed information about it at the
+   /// <tt>http://soplex.zib.de</tt> address.
+   class SoplexLp : public LpSolver {
+diff --git a/lemon/static_graph.h b/lemon/static_graph.h
+index 1f04e40..2ef27ae 100644
+--- a/lemon/static_graph.h
++++ b/lemon/static_graph.h
+@@ -23,8 +23,8 @@
+ ///\file
+ ///\brief StaticDigraph class.
+ 
+-#include <lemon/core.h>
+-#include <lemon/bits/graph_extender.h>
++#include "lemon/core.h"
++#include "lemon/bits/graph_extender.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/suurballe.h b/lemon/suurballe.h
+index f1338a2..12b2e99 100644
+--- a/lemon/suurballe.h
++++ b/lemon/suurballe.h
+@@ -26,11 +26,11 @@
+ 
+ #include <vector>
+ #include <limits>
+-#include <lemon/bin_heap.h>
+-#include <lemon/path.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/dijkstra.h>
+-#include <lemon/maps.h>
++#include "lemon/bin_heap.h"
++#include "lemon/path.h"
++#include "lemon/list_graph.h"
++#include "lemon/dijkstra.h"
++#include "lemon/maps.h"
+ 
+ namespace lemon {
+ 
+diff --git a/lemon/time_measure.h b/lemon/time_measure.h
+index 3f7f077..ac241bd 100644
+--- a/lemon/time_measure.h
++++ b/lemon/time_measure.h
+@@ -24,7 +24,7 @@
+ ///\brief Tools for measuring cpu usage
+ 
+ #ifdef WIN32
+-#include <lemon/bits/windows.h>
++#include "lemon/bits/windows.h"
+ #else
+ #include <unistd.h>
+ #include <sys/times.h>
+@@ -34,7 +34,7 @@
+ #include <string>
+ #include <fstream>
+ #include <iostream>
+-#include <lemon/math.h>
++#include "lemon/math.h"
+ 
+ namespace lemon {
+ 
+@@ -280,7 +280,7 @@ namespace lemon {
+   ///Class for measuring the cpu time and real time usage of the process.
+   ///It is quite easy-to-use, here is a short example.
+   ///\code
+-  /// #include<lemon/time_measure.h>
++  /// #include "lemon/time_measure.h"
+   /// #include<iostream>
+   ///
+   /// int main()
+diff --git a/lemon/unionfind.h b/lemon/unionfind.h
+index 3d96b37..3d3160e 100644
+--- a/lemon/unionfind.h
++++ b/lemon/unionfind.h
+@@ -30,7 +30,7 @@
+ #include <algorithm>
+ #include <functional>
+ 
+-#include <lemon/core.h>
++#include "lemon/core.h"
+ 
+ namespace lemon {
+ 
+diff --git a/test/adaptors_test.cc b/test/adaptors_test.cc
+index 9077db9..ecf2cd0 100644
+--- a/test/adaptors_test.cc
++++ b/test/adaptors_test.cc
+@@ -19,18 +19,18 @@
+ #include <iostream>
+ #include <limits>
+ 
+-#include <lemon/list_graph.h>
+-#include <lemon/grid_graph.h>
+-#include <lemon/bfs.h>
+-#include <lemon/path.h>
+-
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concepts/graph.h>
+-#include <lemon/concepts/graph_components.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/concept_check.h>
+-
+-#include <lemon/adaptors.h>
++#include "lemon/list_graph.h"
++#include "lemon/grid_graph.h"
++#include "lemon/bfs.h"
++#include "lemon/path.h"
++
++#include "lemon/concepts/digraph.h"
++#include "lemon/concepts/graph.h"
++#include "lemon/concepts/graph_components.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/concept_check.h"
++
++#include "lemon/adaptors.h"
+ 
+ #include "test/test_tools.h"
+ #include "test/graph_test.h"
+diff --git a/test/bellman_ford_test.cc b/test/bellman_ford_test.cc
+index 14faa07..a7a4259 100644
+--- a/test/bellman_ford_test.cc
++++ b/test/bellman_ford_test.cc
+@@ -16,12 +16,12 @@
+  *
+  */
+ 
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/bellman_ford.h>
+-#include <lemon/path.h>
++#include "lemon/concepts/digraph.h"
++#include "lemon/smart_graph.h"
++#include "lemon/list_graph.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/bellman_ford.h"
++#include "lemon/path.h"
+ 
+ #include "graph_test.h"
+ #include "test_tools.h"
+diff --git a/test/bfs_test.cc b/test/bfs_test.cc
+index 976fa88..ad766a3 100644
+--- a/test/bfs_test.cc
++++ b/test/bfs_test.cc
+@@ -16,12 +16,12 @@
+  *
+  */
+ 
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/bfs.h>
+-#include <lemon/path.h>
++#include "lemon/concepts/digraph.h"
++#include "lemon/smart_graph.h"
++#include "lemon/list_graph.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/bfs.h"
++#include "lemon/path.h"
+ 
+ #include "graph_test.h"
+ #include "test_tools.h"
+diff --git a/test/bpgraph_test.cc b/test/bpgraph_test.cc
+index 45fc5b8..1e6f333 100644
+--- a/test/bpgraph_test.cc
++++ b/test/bpgraph_test.cc
+@@ -16,10 +16,10 @@
+  *
+  */
+ 
+-#include <lemon/concepts/bpgraph.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/full_graph.h>
++#include "lemon/concepts/bpgraph.h"
++#include "lemon/list_graph.h"
++#include "lemon/smart_graph.h"
++#include "lemon/full_graph.h"
+ 
+ #include "test_tools.h"
+ #include "graph_test.h"
+diff --git a/test/circulation_test.cc b/test/circulation_test.cc
+index 3b3a4a9..00f821b 100644
+--- a/test/circulation_test.cc
++++ b/test/circulation_test.cc
+@@ -19,11 +19,11 @@
+ #include <iostream>
+ 
+ #include "test_tools.h"
+-#include <lemon/list_graph.h>
+-#include <lemon/circulation.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concepts/maps.h>
++#include "lemon/list_graph.h"
++#include "lemon/circulation.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/concepts/digraph.h"
++#include "lemon/concepts/maps.h"
+ 
+ using namespace lemon;
+ 
+diff --git a/test/connectivity_test.cc b/test/connectivity_test.cc
+index 4ab343e..a5b193f 100644
+--- a/test/connectivity_test.cc
++++ b/test/connectivity_test.cc
+@@ -16,9 +16,9 @@
+  *
+  */
+ 
+-#include <lemon/connectivity.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/adaptors.h>
++#include "lemon/connectivity.h"
++#include "lemon/list_graph.h"
++#include "lemon/adaptors.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/counter_test.cc b/test/counter_test.cc
+index df31dd4..52a46c2 100644
+--- a/test/counter_test.cc
++++ b/test/counter_test.cc
+@@ -16,7 +16,7 @@
+  *
+  */
+ 
+-#include <lemon/counter.h>
++#include "lemon/counter.h"
+ #include <vector>
+ #include <sstream>
+ 
+diff --git a/test/dfs_test.cc b/test/dfs_test.cc
+index ef5049a..7e2df17 100644
+--- a/test/dfs_test.cc
++++ b/test/dfs_test.cc
+@@ -16,12 +16,12 @@
+  *
+  */
+ 
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/dfs.h>
+-#include <lemon/path.h>
++#include "lemon/concepts/digraph.h"
++#include "lemon/smart_graph.h"
++#include "lemon/list_graph.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/dfs.h"
++#include "lemon/path.h"
+ 
+ #include "graph_test.h"
+ #include "test_tools.h"
+diff --git a/test/digraph_test.cc b/test/digraph_test.cc
+index e3ff545..94f7842 100644
+--- a/test/digraph_test.cc
++++ b/test/digraph_test.cc
+@@ -16,11 +16,11 @@
+  *
+  */
+ 
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/static_graph.h>
+-#include <lemon/full_graph.h>
++#include "lemon/concepts/digraph.h"
++#include "lemon/list_graph.h"
++#include "lemon/smart_graph.h"
++#include "lemon/static_graph.h"
++#include "lemon/full_graph.h"
+ 
+ #include "test_tools.h"
+ #include "graph_test.h"
+diff --git a/test/dijkstra_test.cc b/test/dijkstra_test.cc
+index 20cc76b..1afbb24 100644
+--- a/test/dijkstra_test.cc
++++ b/test/dijkstra_test.cc
+@@ -16,13 +16,13 @@
+  *
+  */
+ 
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/dijkstra.h>
+-#include <lemon/path.h>
+-#include <lemon/bin_heap.h>
++#include "lemon/concepts/digraph.h"
++#include "lemon/smart_graph.h"
++#include "lemon/list_graph.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/dijkstra.h"
++#include "lemon/path.h"
++#include "lemon/bin_heap.h"
+ 
+ #include "graph_test.h"
+ #include "test_tools.h"
+diff --git a/test/dim_test.cc b/test/dim_test.cc
+index 0b2b925..c94a0cc 100644
+--- a/test/dim_test.cc
++++ b/test/dim_test.cc
+@@ -16,7 +16,7 @@
+  *
+  */
+ 
+-#include <lemon/dim2.h>
++#include "lemon/dim2.h"
+ #include <iostream>
+ #include "test_tools.h"
+ 
+diff --git a/test/edge_set_test.cc b/test/edge_set_test.cc
+index dbe74a9..564f776 100644
+--- a/test/edge_set_test.cc
++++ b/test/edge_set_test.cc
+@@ -19,13 +19,13 @@
+ #include <iostream>
+ #include <vector>
+ 
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concepts/graph.h>
+-#include <lemon/concept_check.h>
++#include "lemon/concepts/digraph.h"
++#include "lemon/concepts/graph.h"
++#include "lemon/concept_check.h"
+ 
+-#include <lemon/list_graph.h>
++#include "lemon/list_graph.h"
+ 
+-#include <lemon/edge_set.h>
++#include "lemon/edge_set.h"
+ 
+ #include "graph_test.h"
+ #include "test_tools.h"
+diff --git a/test/error_test.cc b/test/error_test.cc
+index 1527519..9208ca2 100644
+--- a/test/error_test.cc
++++ b/test/error_test.cc
+@@ -18,7 +18,7 @@
+ 
+ #include <iostream>
+ 
+-#include <lemon/error.h>
++#include "lemon/error.h"
+ #include "test_tools.h"
+ 
+ using namespace lemon;
+@@ -37,7 +37,7 @@ using namespace lemon;
+ 
+ //checking disabled asserts
+ #define LEMON_DISABLE_ASSERTS
+-#include <lemon/assert.h>
++#include "lemon/assert.h"
+ 
+ void no_assertion_text_disable() {
+   LEMON_ASSERT(true, "This is a fault message");
+@@ -63,7 +63,7 @@ void my_assert_handler(const char*, int, const char*,
+ }
+ 
+ #define LEMON_CUSTOM_ASSERT_HANDLER my_assert_handler
+-#include <lemon/assert.h>
++#include "lemon/assert.h"
+ 
+ void no_assertion_text_custom() {
+   LEMON_ASSERT(true, "This is a fault message");
+diff --git a/test/euler_test.cc b/test/euler_test.cc
+index 11a39e4..eacc8aa 100644
+--- a/test/euler_test.cc
++++ b/test/euler_test.cc
+@@ -16,9 +16,9 @@
+  *
+  */
+ 
+-#include <lemon/euler.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/adaptors.h>
++#include "lemon/euler.h"
++#include "lemon/list_graph.h"
++#include "lemon/adaptors.h"
+ #include "test_tools.h"
+ 
+ using namespace lemon;
+diff --git a/test/fractional_matching_test.cc b/test/fractional_matching_test.cc
+index bee866c..764f785 100644
+--- a/test/fractional_matching_test.cc
++++ b/test/fractional_matching_test.cc
+@@ -22,12 +22,12 @@
+ #include <queue>
+ #include <cstdlib>
+ 
+-#include <lemon/fractional_matching.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/concepts/graph.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/math.h>
++#include "lemon/fractional_matching.h"
++#include "lemon/smart_graph.h"
++#include "lemon/concepts/graph.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/math.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/gomory_hu_test.cc b/test/gomory_hu_test.cc
+index 178f21f..c9659c7 100644
+--- a/test/gomory_hu_test.cc
++++ b/test/gomory_hu_test.cc
+@@ -19,11 +19,11 @@
+ #include <iostream>
+ 
+ #include "test_tools.h"
+-#include <lemon/smart_graph.h>
+-#include <lemon/concepts/graph.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/gomory_hu.h>
++#include "lemon/smart_graph.h"
++#include "lemon/concepts/graph.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/gomory_hu.h"
+ #include <cstdlib>
+ 
+ using namespace std;
+diff --git a/test/graph_copy_test.cc b/test/graph_copy_test.cc
+index 9a7d815..851c9ae 100644
+--- a/test/graph_copy_test.cc
++++ b/test/graph_copy_test.cc
+@@ -16,11 +16,11 @@
+  *
+  */
+ 
+-#include <lemon/smart_graph.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/static_graph.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/error.h>
++#include "lemon/smart_graph.h"
++#include "lemon/list_graph.h"
++#include "lemon/static_graph.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/error.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/graph_test.cc b/test/graph_test.cc
+index 283b02e..17277c8 100644
+--- a/test/graph_test.cc
++++ b/test/graph_test.cc
+@@ -16,12 +16,12 @@
+  *
+  */
+ 
+-#include <lemon/concepts/graph.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/full_graph.h>
+-#include <lemon/grid_graph.h>
+-#include <lemon/hypercube_graph.h>
++#include "lemon/concepts/graph.h"
++#include "lemon/list_graph.h"
++#include "lemon/smart_graph.h"
++#include "lemon/full_graph.h"
++#include "lemon/grid_graph.h"
++#include "lemon/hypercube_graph.h"
+ 
+ #include "test_tools.h"
+ #include "graph_test.h"
+diff --git a/test/graph_test.h b/test/graph_test.h
+index 70558b7..8945ffd 100644
+--- a/test/graph_test.h
++++ b/test/graph_test.h
+@@ -21,8 +21,8 @@
+ 
+ #include <set>
+ 
+-#include <lemon/core.h>
+-#include <lemon/maps.h>
++#include "lemon/core.h"
++#include "lemon/maps.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/graph_utils_test.cc b/test/graph_utils_test.cc
+index 19a934a..9073ce7 100644
+--- a/test/graph_utils_test.cc
++++ b/test/graph_utils_test.cc
+@@ -19,10 +19,10 @@
+ #include <cstdlib>
+ #include <ctime>
+ 
+-#include <lemon/random.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/maps.h>
++#include "lemon/random.h"
++#include "lemon/list_graph.h"
++#include "lemon/smart_graph.h"
++#include "lemon/maps.h"
+ 
+ #include "graph_test.h"
+ #include "test_tools.h"
+diff --git a/test/hao_orlin_test.cc b/test/hao_orlin_test.cc
+index c245cb7..7af73a0 100644
+--- a/test/hao_orlin_test.cc
++++ b/test/hao_orlin_test.cc
+@@ -18,12 +18,12 @@
+ 
+ #include <sstream>
+ 
+-#include <lemon/smart_graph.h>
+-#include <lemon/adaptors.h>
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/hao_orlin.h>
++#include "lemon/smart_graph.h"
++#include "lemon/adaptors.h"
++#include "lemon/concepts/digraph.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/hao_orlin.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/heap_test.cc b/test/heap_test.cc
+index 38e1577..316a99a 100644
+--- a/test/heap_test.cc
++++ b/test/heap_test.cc
+@@ -21,22 +21,22 @@
+ #include <string>
+ #include <vector>
+ 
+-#include <lemon/concept_check.h>
+-#include <lemon/concepts/heap.h>
+-
+-#include <lemon/smart_graph.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/dijkstra.h>
+-#include <lemon/maps.h>
+-
+-#include <lemon/bin_heap.h>
+-#include <lemon/quad_heap.h>
+-#include <lemon/dheap.h>
+-#include <lemon/fib_heap.h>
+-#include <lemon/pairing_heap.h>
+-#include <lemon/radix_heap.h>
+-#include <lemon/binomial_heap.h>
+-#include <lemon/bucket_heap.h>
++#include "lemon/concept_check.h"
++#include "lemon/concepts/heap.h"
++
++#include "lemon/smart_graph.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/dijkstra.h"
++#include "lemon/maps.h"
++
++#include "lemon/bin_heap.h"
++#include "lemon/quad_heap.h"
++#include "lemon/dheap.h"
++#include "lemon/fib_heap.h"
++#include "lemon/pairing_heap.h"
++#include "lemon/radix_heap.h"
++#include "lemon/binomial_heap.h"
++#include "lemon/bucket_heap.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/kruskal_test.cc b/test/kruskal_test.cc
+index af36c72..beb48cc 100644
+--- a/test/kruskal_test.cc
++++ b/test/kruskal_test.cc
+@@ -20,13 +20,13 @@
+ #include <vector>
+ 
+ #include "test_tools.h"
+-#include <lemon/maps.h>
+-#include <lemon/kruskal.h>
+-#include <lemon/list_graph.h>
++#include "lemon/maps.h"
++#include "lemon/kruskal.h"
++#include "lemon/list_graph.h"
+ 
+-#include <lemon/concepts/maps.h>
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concepts/graph.h>
++#include "lemon/concepts/maps.h"
++#include "lemon/concepts/digraph.h"
++#include "lemon/concepts/graph.h"
+ 
+ using namespace std;
+ using namespace lemon;
+diff --git a/test/lgf_reader_writer_test.cc b/test/lgf_reader_writer_test.cc
+index 25d9423..4240c85 100644
+--- a/test/lgf_reader_writer_test.cc
++++ b/test/lgf_reader_writer_test.cc
+@@ -18,13 +18,13 @@
+ 
+ #include <string>
+ 
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concepts/graph.h>
+-#include <lemon/concepts/bpgraph.h>
++#include "lemon/concepts/digraph.h"
++#include "lemon/concepts/graph.h"
++#include "lemon/concepts/bpgraph.h"
+ 
+-#include <lemon/list_graph.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/lgf_reader.h>
++#include "lemon/list_graph.h"
++#include "lemon/smart_graph.h"
++#include "lemon/lgf_reader.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/lgf_test.cc b/test/lgf_test.cc
+index 839afb1..e8e0083 100644
+--- a/test/lgf_test.cc
++++ b/test/lgf_test.cc
+@@ -16,8 +16,8 @@
+  *
+  */
+ 
+-#include <lemon/list_graph.h>
+-#include <lemon/lgf_reader.h>
++#include "lemon/list_graph.h"
++#include "lemon/lgf_reader.h"
+ #include "test_tools.h"
+ 
+ using namespace lemon;
+diff --git a/test/lp_test.cc b/test/lp_test.cc
+index 914a376..760c6e1 100644
+--- a/test/lp_test.cc
++++ b/test/lp_test.cc
+@@ -17,30 +17,30 @@
+  */
+ 
+ #include <sstream>
+-#include <lemon/lp_skeleton.h>
++#include "lemon/lp_skeleton.h"
+ #include "test_tools.h"
+-#include <lemon/tolerance.h>
++#include "lemon/tolerance.h"
+ 
+-#include <lemon/config.h>
++#include "lemon/config.h"
+ 
+ #ifdef LEMON_HAVE_GLPK
+-#include <lemon/glpk.h>
++#include "lemon/glpk.h"
+ #endif
+ 
+ #ifdef LEMON_HAVE_CPLEX
+-#include <lemon/cplex.h>
++#include "lemon/cplex.h"
+ #endif
+ 
+ #ifdef LEMON_HAVE_SOPLEX
+-#include <lemon/soplex.h>
++#include "lemon/soplex.h"
+ #endif
+ 
+ #ifdef LEMON_HAVE_CLP
+-#include <lemon/clp.h>
++#include "lemon/clp.h"
+ #endif
+ 
+ #ifdef LEMON_HAVE_LP
+-#include <lemon/lp.h>
++#include "lemon/lp.h"
+ #endif
+ using namespace lemon;
+ 
+diff --git a/test/maps_test.cc b/test/maps_test.cc
+index 5502e04..fb6e014 100644
+--- a/test/maps_test.cc
++++ b/test/maps_test.cc
+@@ -19,13 +19,13 @@
+ #include <deque>
+ #include <set>
+ 
+-#include <lemon/concept_check.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/maps.h>
+-#include <lemon/list_graph.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/adaptors.h>
+-#include <lemon/dfs.h>
++#include "lemon/concept_check.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/maps.h"
++#include "lemon/list_graph.h"
++#include "lemon/smart_graph.h"
++#include "lemon/adaptors.h"
++#include "lemon/dfs.h"
+ #include <algorithm>
+ 
+ #include "test_tools.h"
+diff --git a/test/matching_test.cc b/test/matching_test.cc
+index dcb1d3b..aee645e 100644
+--- a/test/matching_test.cc
++++ b/test/matching_test.cc
+@@ -22,12 +22,12 @@
+ #include <queue>
+ #include <cstdlib>
+ 
+-#include <lemon/matching.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/concepts/graph.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/math.h>
++#include "lemon/matching.h"
++#include "lemon/smart_graph.h"
++#include "lemon/concepts/graph.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/math.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/max_cardinality_search_test.cc b/test/max_cardinality_search_test.cc
+index c01066f..ac532af 100644
+--- a/test/max_cardinality_search_test.cc
++++ b/test/max_cardinality_search_test.cc
+@@ -19,12 +19,12 @@
+ #include <iostream>
+ 
+ #include "test_tools.h"
+-#include <lemon/smart_graph.h>
+-#include <lemon/max_cardinality_search.h>
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/concepts/heap.h>
+-#include <lemon/lgf_reader.h>
++#include "lemon/smart_graph.h"
++#include "lemon/max_cardinality_search.h"
++#include "lemon/concepts/digraph.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/concepts/heap.h"
++#include "lemon/lgf_reader.h"
+ 
+ using namespace lemon;
+ using namespace std;
+diff --git a/test/max_clique_test.cc b/test/max_clique_test.cc
+index d16f0f9..35db6d2 100644
+--- a/test/max_clique_test.cc
++++ b/test/max_clique_test.cc
+@@ -17,11 +17,11 @@
+  */
+ 
+ #include <sstream>
+-#include <lemon/list_graph.h>
+-#include <lemon/full_graph.h>
+-#include <lemon/grid_graph.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/grosso_locatelli_pullan_mc.h>
++#include "lemon/list_graph.h"
++#include "lemon/full_graph.h"
++#include "lemon/grid_graph.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/grosso_locatelli_pullan_mc.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/max_flow_test.cc b/test/max_flow_test.cc
+index f63874a..fc2b344 100644
+--- a/test/max_flow_test.cc
++++ b/test/max_flow_test.cc
+@@ -19,13 +19,13 @@
+ #include <iostream>
+ 
+ #include "test_tools.h"
+-#include <lemon/smart_graph.h>
+-#include <lemon/preflow.h>
+-#include <lemon/edmonds_karp.h>
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/elevator.h>
++#include "lemon/smart_graph.h"
++#include "lemon/preflow.h"
++#include "lemon/edmonds_karp.h"
++#include "lemon/concepts/digraph.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/elevator.h"
+ 
+ using namespace lemon;
+ 
+diff --git a/test/min_cost_arborescence_test.cc b/test/min_cost_arborescence_test.cc
+index 3a5ea36..222a721 100644
+--- a/test/min_cost_arborescence_test.cc
++++ b/test/min_cost_arborescence_test.cc
+@@ -21,10 +21,10 @@
+ #include <vector>
+ #include <iterator>
+ 
+-#include <lemon/smart_graph.h>
+-#include <lemon/min_cost_arborescence.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/concepts/digraph.h>
++#include "lemon/smart_graph.h"
++#include "lemon/min_cost_arborescence.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/concepts/digraph.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/min_cost_flow_test.cc b/test/min_cost_flow_test.cc
+index 15dcf54..880b13d 100644
+--- a/test/min_cost_flow_test.cc
++++ b/test/min_cost_flow_test.cc
+@@ -20,17 +20,17 @@
+ #include <fstream>
+ #include <limits>
+ 
+-#include <lemon/list_graph.h>
+-#include <lemon/lgf_reader.h>
++#include "lemon/list_graph.h"
++#include "lemon/lgf_reader.h"
+ 
+-#include <lemon/network_simplex.h>
+-#include <lemon/capacity_scaling.h>
+-#include <lemon/cost_scaling.h>
+-#include <lemon/cycle_canceling.h>
++#include "lemon/network_simplex.h"
++#include "lemon/capacity_scaling.h"
++#include "lemon/cost_scaling.h"
++#include "lemon/cycle_canceling.h"
+ 
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concepts/heap.h>
+-#include <lemon/concept_check.h>
++#include "lemon/concepts/digraph.h"
++#include "lemon/concepts/heap.h"
++#include "lemon/concept_check.h"
+ 
+ #include "test_tools.h"
+ 
+@@ -400,7 +400,7 @@ void runMcfGeqTests( Param param,
+   Digraph gr0;
+   MCF mcf0(gr0);
+   mcf0.run(param);
+-  check(mcf0.totalCost() == 0, "Wrong total cost");  
++  check(mcf0.totalCost() == 0, "Wrong total cost");
+ }
+ 
+ template < typename MCF, typename Param >
+diff --git a/test/min_mean_cycle_test.cc b/test/min_mean_cycle_test.cc
+index e752454..b498b7c 100644
+--- a/test/min_mean_cycle_test.cc
++++ b/test/min_mean_cycle_test.cc
+@@ -19,15 +19,15 @@
+ #include <iostream>
+ #include <sstream>
+ 
+-#include <lemon/smart_graph.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/path.h>
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concept_check.h>
+-
+-#include <lemon/karp_mmc.h>
+-#include <lemon/hartmann_orlin_mmc.h>
+-#include <lemon/howard_mmc.h>
++#include "lemon/smart_graph.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/path.h"
++#include "lemon/concepts/digraph.h"
++#include "lemon/concept_check.h"
++
++#include "lemon/karp_mmc.h"
++#include "lemon/hartmann_orlin_mmc.h"
++#include "lemon/howard_mmc.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/mip_test.cc b/test/mip_test.cc
+index 641ceb5..0bba1c7 100644
+--- a/test/mip_test.cc
++++ b/test/mip_test.cc
+@@ -18,22 +18,22 @@
+ 
+ #include "test_tools.h"
+ 
+-#include <lemon/config.h>
++#include "lemon/config.h"
+ 
+ #ifdef LEMON_HAVE_CPLEX
+-#include <lemon/cplex.h>
++#include "lemon/cplex.h"
+ #endif
+ 
+ #ifdef LEMON_HAVE_GLPK
+-#include <lemon/glpk.h>
++#include "lemon/glpk.h"
+ #endif
+ 
+ #ifdef LEMON_HAVE_CBC
+-#include <lemon/cbc.h>
++#include "lemon/cbc.h"
+ #endif
+ 
+ #ifdef LEMON_HAVE_MIP
+-#include <lemon/lp.h>
++#include "lemon/lp.h"
+ #endif
+ 
+ 
+diff --git a/test/nagamochi_ibaraki_test.cc b/test/nagamochi_ibaraki_test.cc
+index 94ec29d..afe2cbf 100644
+--- a/test/nagamochi_ibaraki_test.cc
++++ b/test/nagamochi_ibaraki_test.cc
+@@ -18,12 +18,12 @@
+ 
+ #include <sstream>
+ 
+-#include <lemon/smart_graph.h>
+-#include <lemon/adaptors.h>
+-#include <lemon/concepts/graph.h>
+-#include <lemon/concepts/maps.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/nagamochi_ibaraki.h>
++#include "lemon/smart_graph.h"
++#include "lemon/adaptors.h"
++#include "lemon/concepts/graph.h"
++#include "lemon/concepts/maps.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/nagamochi_ibaraki.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/path_test.cc b/test/path_test.cc
+index f2d9603..051f4ce 100644
+--- a/test/path_test.cc
++++ b/test/path_test.cc
+@@ -19,12 +19,12 @@
+ #include <string>
+ #include <iostream>
+ 
+-#include <lemon/concepts/path.h>
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concept_check.h>
++#include "lemon/concepts/path.h"
++#include "lemon/concepts/digraph.h"
++#include "lemon/concept_check.h"
+ 
+-#include <lemon/path.h>
+-#include <lemon/list_graph.h>
++#include "lemon/path.h"
++#include "lemon/list_graph.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/planarity_test.cc b/test/planarity_test.cc
+index 0ac11ee..0965baf 100644
+--- a/test/planarity_test.cc
++++ b/test/planarity_test.cc
+@@ -18,12 +18,12 @@
+ 
+ #include <iostream>
+ 
+-#include <lemon/planarity.h>
++#include "lemon/planarity.h"
+ 
+-#include <lemon/smart_graph.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/connectivity.h>
+-#include <lemon/dim2.h>
++#include "lemon/smart_graph.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/connectivity.h"
++#include "lemon/dim2.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/radix_sort_test.cc b/test/radix_sort_test.cc
+index 6ae2deb..0bd4e72 100644
+--- a/test/radix_sort_test.cc
++++ b/test/radix_sort_test.cc
+@@ -16,11 +16,11 @@
+  *
+  */
+ 
+-#include <lemon/time_measure.h>
+-#include <lemon/smart_graph.h>
+-#include <lemon/maps.h>
+-#include <lemon/radix_sort.h>
+-#include <lemon/math.h>
++#include "lemon/time_measure.h"
++#include "lemon/smart_graph.h"
++#include "lemon/maps.h"
++#include "lemon/radix_sort.h"
++#include "lemon/math.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/random_test.cc b/test/random_test.cc
+index 49dd8b6..e44ce64 100644
+--- a/test/random_test.cc
++++ b/test/random_test.cc
+@@ -16,7 +16,7 @@
+  *
+  */
+ 
+-#include <lemon/random.h>
++#include "lemon/random.h"
+ #include "test_tools.h"
+ 
+ int seed_array[] = {1, 2};
+diff --git a/test/suurballe_test.cc b/test/suurballe_test.cc
+index 7c00f21..40405b4 100644
+--- a/test/suurballe_test.cc
++++ b/test/suurballe_test.cc
+@@ -18,12 +18,12 @@
+ 
+ #include <iostream>
+ 
+-#include <lemon/list_graph.h>
+-#include <lemon/lgf_reader.h>
+-#include <lemon/path.h>
+-#include <lemon/suurballe.h>
+-#include <lemon/concepts/digraph.h>
+-#include <lemon/concepts/heap.h>
++#include "lemon/list_graph.h"
++#include "lemon/lgf_reader.h"
++#include "lemon/path.h"
++#include "lemon/suurballe.h"
++#include "lemon/concepts/digraph.h"
++#include "lemon/concepts/heap.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/time_measure_test.cc b/test/time_measure_test.cc
+index 4e7155a..37e9281 100644
+--- a/test/time_measure_test.cc
++++ b/test/time_measure_test.cc
+@@ -16,8 +16,8 @@
+  *
+  */
+ 
+-#include <lemon/time_measure.h>
+-#include <lemon/concept_check.h>
++#include "lemon/time_measure.h"
++#include "lemon/concept_check.h"
+ 
+ using namespace lemon;
+ 
+diff --git a/test/tsp_test.cc b/test/tsp_test.cc
+index 398a812..e783d66 100644
+--- a/test/tsp_test.cc
++++ b/test/tsp_test.cc
+@@ -18,17 +18,17 @@
+ 
+ #include <iostream>
+ 
+-#include <lemon/full_graph.h>
+-#include <lemon/math.h>
+-#include <lemon/maps.h>
+-#include <lemon/random.h>
+-#include <lemon/dim2.h>
+-
+-#include <lemon/nearest_neighbor_tsp.h>
+-#include <lemon/greedy_tsp.h>
+-#include <lemon/insertion_tsp.h>
+-#include <lemon/christofides_tsp.h>
+-#include <lemon/opt2_tsp.h>
++#include "lemon/full_graph.h"
++#include "lemon/math.h"
++#include "lemon/maps.h"
++#include "lemon/random.h"
++#include "lemon/dim2.h"
++
++#include "lemon/nearest_neighbor_tsp.h"
++#include "lemon/greedy_tsp.h"
++#include "lemon/insertion_tsp.h"
++#include "lemon/christofides_tsp.h"
++#include "lemon/opt2_tsp.h"
+ 
+ #include "test_tools.h"
+ 
+diff --git a/test/unionfind_test.cc b/test/unionfind_test.cc
+index e82d8e6..08a8285 100644
+--- a/test/unionfind_test.cc
++++ b/test/unionfind_test.cc
+@@ -16,9 +16,9 @@
+  *
+  */
+ 
+-#include <lemon/list_graph.h>
+-#include <lemon/maps.h>
+-#include <lemon/unionfind.h>
++#include "lemon/list_graph.h"
++#include "lemon/maps.h"
++#include "lemon/unionfind.h"
+ #include "test_tools.h"
+ 
+ using namespace lemon;
+diff --git a/tools/dimacs-solver.cc b/tools/dimacs-solver.cc
+index 60da233..e0bef5f 100644
+--- a/tools/dimacs-solver.cc
++++ b/tools/dimacs-solver.cc
+@@ -32,18 +32,18 @@
+ #include <fstream>
+ #include <cstring>
+ 
+-#include <lemon/smart_graph.h>
+-#include <lemon/dimacs.h>
+-#include <lemon/lgf_writer.h>
+-#include <lemon/time_measure.h>
++#include "lemon/smart_graph.h"
++#include "lemon/dimacs.h"
++#include "lemon/lgf_writer.h"
++#include "lemon/time_measure.h"
+ 
+-#include <lemon/arg_parser.h>
+-#include <lemon/error.h>
++#include "lemon/arg_parser.h"
++#include "lemon/error.h"
+ 
+-#include <lemon/dijkstra.h>
+-#include <lemon/preflow.h>
+-#include <lemon/matching.h>
+-#include <lemon/network_simplex.h>
++#include "lemon/dijkstra.h"
++#include "lemon/preflow.h"
++#include "lemon/matching.h"
++#include "lemon/network_simplex.h"
+ 
+ using namespace lemon;
+ typedef SmartDigraph Digraph;
+diff --git a/tools/dimacs-to-lgf.cc b/tools/dimacs-to-lgf.cc
+index 3968645..cf0986f 100644
+--- a/tools/dimacs-to-lgf.cc
++++ b/tools/dimacs-to-lgf.cc
+@@ -33,12 +33,12 @@
+ #include <fstream>
+ #include <cstring>
+ 
+-#include <lemon/smart_graph.h>
+-#include <lemon/dimacs.h>
+-#include <lemon/lgf_writer.h>
++#include "lemon/smart_graph.h"
++#include "lemon/dimacs.h"
++#include "lemon/lgf_writer.h"
+ 
+-#include <lemon/arg_parser.h>
+-#include <lemon/error.h>
++#include "lemon/arg_parser.h"
++#include "lemon/error.h"
+ 
+ using namespace std;
+ using namespace lemon;
+diff --git a/tools/lgf-gen.cc b/tools/lgf-gen.cc
+index 390c8ae..07d11cc 100644
+--- a/tools/lgf-gen.cc
++++ b/tools/lgf-gen.cc
+@@ -31,19 +31,19 @@
+ #include <algorithm>
+ #include <set>
+ #include <ctime>
+-#include <lemon/list_graph.h>
+-#include <lemon/random.h>
+-#include <lemon/dim2.h>
+-#include <lemon/bfs.h>
+-#include <lemon/counter.h>
+-#include <lemon/suurballe.h>
+-#include <lemon/graph_to_eps.h>
+-#include <lemon/lgf_writer.h>
+-#include <lemon/arg_parser.h>
+-#include <lemon/euler.h>
+-#include <lemon/math.h>
+-#include <lemon/kruskal.h>
+-#include <lemon/time_measure.h>
++#include "lemon/list_graph.h"
++#include "lemon/random.h"
++#include "lemon/dim2.h"
++#include "lemon/bfs.h"
++#include "lemon/counter.h"
++#include "lemon/suurballe.h"
++#include "lemon/graph_to_eps.h"
++#include "lemon/lgf_writer.h"
++#include "lemon/arg_parser.h"
++#include "lemon/euler.h"
++#include "lemon/math.h"
++#include "lemon/kruskal.h"
++#include "lemon/time_measure.h"
+ 
+ using namespace lemon;
+ 
+@@ -415,7 +415,7 @@ inline void delaunay() {
+           delete nbit->second->second;
+           spikeheap.erase(nbit->second);
+         }
+-      
++
+       beach.erase(nbit);
+       beach.erase(bit);
+       beach.erase(pbit);

--- a/modules/coin-or-lemon/1.3.1.bcr.1/presubmit.yml
+++ b/modules/coin-or-lemon/1.3.1.bcr.1/presubmit.yml
@@ -1,0 +1,19 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform:
+      - rockylinux8
+      - debian10
+      - ubuntu2004
+      - ubuntu2004_arm64
+      - macos_arm64
+    bazel: ["7.x", "8.x"]
+  tasks:
+    verify_targets:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - "//..."
+      test_targets:
+      - "//..."

--- a/modules/coin-or-lemon/1.3.1.bcr.1/source.json
+++ b/modules/coin-or-lemon/1.3.1.bcr.1/source.json
@@ -1,0 +1,15 @@
+{
+    "url": "https://github.com/QuantamHD/lemon/archive/refs/tags/1.3.1.tar.gz",
+    "strip_prefix": "lemon-1.3.1",
+    "integrity": "sha256-p/KIIUMbdlBZZumjTJTBgBMPYWLtL8Wa3opoW11dz+s=",
+    "patches": {
+        "allocator-patch.patch": "sha256-PBznCuxS89Nd/qCyzQRBcVt+6iy2P6B5v+EsLksv05Q=",
+        "lemon.patch": "sha256-BkMkn4Vinz4oc/su97gNdZx6hcuhzEI89bvqHjtKzBE="
+    },
+    "patch_strip": 1,
+    "overlay": {
+        "BUILD.bazel": "sha256-BwpmuGfL9Afr48nyXBrIqcXAnW/LC7bzf51atQI13Bc=",
+        "MODULE.bazel": "sha256-pGHGzAPJJWL+50+XYvhD68GrOQRt/MqUNlAbSBHCP8E=",
+        "lemon/config.h": "sha256-cxO/EqtXIHM2DKY/dt0xPscc7E6+07tSMt462p+23Ow="
+    }
+}

--- a/modules/coin-or-lemon/metadata.json
+++ b/modules/coin-or-lemon/metadata.json
@@ -18,7 +18,8 @@
         "github:QuantamHD/lemon"
     ],
     "versions": [
-        "1.3.1"
+        "1.3.1",
+        "1.3.1.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
The ftp.gnu.org is notoriouslly overloaded, so using dependencies that also define a mirror makes things more robust.

(https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/glpk/5.0.bcr.5/source.json#L3-L5)