### PR TITLE
Add darts-clone@0.32h

### DIFF
--- a/modules/darts-clone/0.32h/MODULE.bazel
+++ b/modules/darts-clone/0.32h/MODULE.bazel
@@ -1,0 +1,9 @@
+"""Darts-clone is a clone of Darts (Double-ARray Trie System) which is a C++ header library for a static double-array trie structure."""
+
+module(
+    name = "darts-clone",
+    version = "0.32h",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/darts-clone/0.32h/patches/add_build_file.patch
+++ b/modules/darts-clone/0.32h/patches/add_build_file.patch
@@ -1,0 +1,11 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "darts-clone",
++    hdrs = glob(["include/*.h"]),
++    strip_include_prefix = "include",
++    visibility = ["//visibility:public"],
++)

--- a/modules/darts-clone/0.32h/patches/module_dot_bazel.patch
+++ b/modules/darts-clone/0.32h/patches/module_dot_bazel.patch
@@ -1,0 +1,12 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,9 @@
++"""Darts-clone is a clone of Darts (Double-ARray Trie System) which is a C++ header library for a static double-array trie structure."""
++
++module(
++    name = "darts-clone",
++    version = "0.32h",
++    compatibility_level = 0,
++)
++
++bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/darts-clone/0.32h/presubmit.yml
+++ b/modules/darts-clone/0.32h/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2404_arm64
+  - macos
+  - macos_arm64
+  - windows
+  - windows_arm64
+  bazel:
+  - 6.x
+  - 7.x
+  - 8.x
+  - 9.x
+  - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@darts-clone'

--- a/modules/darts-clone/0.32h/source.json
+++ b/modules/darts-clone/0.32h/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/s-yata/darts-clone/archive/refs/tags/v0.32h.tar.gz",
+    "integrity": "sha256-XU+h4QP21UMgi3X8BsIAFTP6jCCjRw5Dhgq6Vu54iKM=",
+    "strip_prefix": "darts-clone-0.32h",
+    "patches": {
+        "add_build_file.patch": "sha256-GxOv7TScVq0w/+B2MBoVU5jvuHJYYlnl4m3sqbp9pZk=",
+        "module_dot_bazel.patch": "sha256-Jr+ulEry0zUSQKb1MqHumAdjLAJ5nsbbbY1OLBPjAvQ="
+    },
+    "patch_strip": 0
+}

--- a/modules/darts-clone/metadata.json
+++ b/modules/darts-clone/metadata.json
@@ -9,11 +9,13 @@
         }
     ],
     "repository": [
-        "https://storage.googleapis.com/google-code-archive-downloads"
+        "https://storage.googleapis.com/google-code-archive-downloads",
+        "github:s-yata/darts-clone"
     ],
     "versions": [
         "0.32",
-        "0.32.bcr.1"
+        "0.32.bcr.1",
+        "0.32h"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds `darts-clone@0.32h`, the latest upstream release (https://github.com/s-yata/darts-clone/releases/tag/v0.32h), with Bazel 9 and rolling support.

## Changes
- Source switched to the upstream GitHub release `v0.32h` (the previous `0.32` used the old google-code-archive mirror).
- Patched `BUILD.bazel` loads `cc_library` from `@rules_cc//cc:defs.bzl` (native `cc_library` is removed in Bazel 9 / rolling), and `MODULE.bazel` adds `bazel_dep(name = "rules_cc", version = "0.2.17")`.
- Presubmit matrix covers Bazel `6.x`, `7.x`, `8.x`, `9.x`, `rolling` across `debian10`, `ubuntu2404_arm64`, `macos`, `macos_arm64`, `windows`, `windows_arm64`.
- Set the module maintainer to Carbo Kuo (BYVoid).

The upstream release only provides the auto-generated source tarball, so the unstable-URL check is skipped via `@bazel-io skip_check unstable_url`.