### PR TITLE
Add darts-clone@0.32.bcr.1

### DIFF
--- a/modules/darts-clone/0.32.bcr.1/MODULE.bazel
+++ b/modules/darts-clone/0.32.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+"""Darts-clone is a clone of Darts (Double-ARray Trie System) which is a C++ header library for a static double-array trie structure."""
+
+module(
+    name = "darts-clone",
+    version = "0.32.bcr.1",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/darts-clone/0.32.bcr.1/patches/add_build_file.patch
+++ b/modules/darts-clone/0.32.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,11 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
++cc_library(
++    name = "darts-clone",
++    hdrs = glob(["include/*.h"]),
++    strip_include_prefix = "include",
++    visibility = ["//visibility:public"],
++)

--- a/modules/darts-clone/0.32.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/darts-clone/0.32.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,12 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,9 @@
++"""Darts-clone is a clone of Darts (Double-ARray Trie System) which is a C++ header library for a static double-array trie structure."""
++
++module(
++    name = "darts-clone",
++    version = "0.32.bcr.1",
++    compatibility_level = 0,
++)
++
++bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/darts-clone/0.32.bcr.1/presubmit.yml
+++ b/modules/darts-clone/0.32.bcr.1/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2404_arm64
+  - macos
+  - macos_arm64
+  - windows
+  - windows_arm64
+  bazel:
+  - 6.x
+  - 7.x
+  - 8.x
+  - 9.x
+  - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@darts-clone'

--- a/modules/darts-clone/0.32.bcr.1/source.json
+++ b/modules/darts-clone/0.32.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/darts-clone/darts-clone-0.32g.tar.gz",
+    "integrity": "sha256-6Rp9pm0Zl2cMiQDSJKfrw79RK+kjESlrwEDTNVbbGLc=",
+    "strip_prefix": "darts-clone-0.32g",
+    "patches": {
+        "add_build_file.patch": "sha256-GxOv7TScVq0w/+B2MBoVU5jvuHJYYlnl4m3sqbp9pZk=",
+        "module_dot_bazel.patch": "sha256-+qfR3Qp6xigJ1FLNKUG17lHqN9LcgLGriug5EckE0WM="
+    },
+    "patch_strip": 0
+}

--- a/modules/darts-clone/metadata.json
+++ b/modules/darts-clone/metadata.json
@@ -2,15 +2,18 @@
     "homepage": "https://github.com/s-yata/darts-clone",
     "maintainers": [
         {
-            "email": "bcr-maintainers@bazel.build",
-            "name": "No Maintainer Specified"
+            "email": "byvoid@byvoid.com",
+            "github": "BYVoid",
+            "name": "Carbo Kuo",
+            "github_user_id": 245270
         }
     ],
     "repository": [
         "https://storage.googleapis.com/google-code-archive-downloads"
     ],
     "versions": [
-        "0.32"
+        "0.32",
+        "0.32.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds `darts-clone@0.32.bcr.1`, a BCR republish of `0.32` (same Google Code `darts-clone-0.32g` source) with Bazel 9 and rolling support.

## Changes
- Patched `BUILD.bazel` now loads `cc_library` from `@rules_cc//cc:defs.bzl` (native `cc_library` is removed in Bazel 9 / rolling), and `MODULE.bazel` adds `bazel_dep(name = "rules_cc", version = "0.2.17")`.
- Presubmit matrix covers Bazel `6.x`, `7.x`, `8.x`, `9.x`, `rolling` across `debian10`, `ubuntu2404_arm64`, `macos`, `macos_arm64`, `windows`, `windows_arm64` (mirrors `0.32h`).
- Set the module maintainer to Carbo Kuo (BYVoid).

The source tarball, integrity, and `strip_prefix` are unchanged from the existing `0.32` release.