### PR TITLE
Add libcap@2.27.bcr.2 with working source URLs

### DIFF
--- a/modules/libcap/2.27.bcr.2/MODULE.bazel
+++ b/modules/libcap/2.27.bcr.2/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "libcap",
+    version = "2.27.bcr.2",
+    compatibility_level = 0,
+    bazel_compatibility = ['>=7.2.1'],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "sed", version = "4.9.bcr.3")

--- a/modules/libcap/2.27.bcr.2/overlay/BUILD.bazel
+++ b/modules/libcap/2.27.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,95 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
+
+genrule(
+    name = "cap_names_list_h",
+    srcs = ["libcap/include/uapi/linux/capability.h"],
+    outs = ["cap_names.list.h"],
+    # Use the same logic as libcap/Makefile
+    cmd = """
+        $(location @sed) -ne '/^#define[ \\t]CAP[_A-Z]\\+[ \\t]\\+[0-9]\\+/{s/^#define \\([^ \\t]*\\)[ \\t]*\\([^ \\t]*\\)/\\{"\\1",\\2\\},/p;}' $< | \\
+        $(location @sed) 'y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/' > $@
+    """,
+    tools = ["@sed"],
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "makenames_textual_hdrs",
+    textual_hdrs = [
+        ":cap_names.list.h",
+        "libcap/include/uapi/linux/capability.h",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+cc_binary(
+    name = "makenames",
+    srcs = [
+        "libcap/_makenames.c",
+        "libcap/include/sys/capability.h",
+    ],
+    includes = [
+        "libcap/..",
+        "libcap/include",
+        "libcap/include/uapi",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [":makenames_textual_hdrs"],
+)
+
+genrule(
+    name = "cap_names_h",
+    outs = ["libcap/cap_names.h"],
+    cmd = "mkdir -p libcap && $(location makenames) > $@ || { rm -f $@; false; }",
+    tools = [":makenames"],
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "cap",
+    srcs = [
+        "libcap/cap_alloc.c",
+        "libcap/cap_extint.c",
+        "libcap/cap_file.c",
+        "libcap/cap_flag.c",
+        "libcap/cap_proc.c",
+        "libcap/cap_text.c",
+    ],
+    copts = [
+        "-Wno-tautological-compare",
+        "-Wno-unused-result",
+        # Work around sys/xattr.h not declaring this
+        "-DXATTR_NAME_CAPS=\"\\\"security.capability\\\"\"",
+    ],
+    includes = [
+        "libcap",
+        "libcap/include",
+        "libcap/include/uapi",
+    ],
+    textual_hdrs = [
+        "libcap/include/sys/capability.h",
+        "libcap/include/uapi/linux/capability.h",
+        "libcap/libcap.h",
+        "libcap/cap_names.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+   name = "libcap",
+   actual = ":cap",
+   visibility = ["//visibility:public"],
+)

--- a/modules/libcap/2.27.bcr.2/overlay/MODULE.bazel
+++ b/modules/libcap/2.27.bcr.2/overlay/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "libcap",
+    version = "2.27.bcr.2",
+    compatibility_level = 0,
+    bazel_compatibility = ['>=7.2.1'],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "sed", version = "4.9.bcr.3")

--- a/modules/libcap/2.27.bcr.2/presubmit.yml
+++ b/modules/libcap/2.27.bcr.2/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  bazel:
+  - 8.x
+  - 7.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@libcap'

--- a/modules/libcap/2.27.bcr.2/source.json
+++ b/modules/libcap/2.27.bcr.2/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://mirrors.mit.edu/kernel/linux/libs/security/linux-privs/libcap2/libcap-2.27.tar.gz",
+    "mirror_urls": [
+        "https://mirrors.ustc.edu.cn/kernel.org/linux/libs/security/linux-privs/libcap2/libcap-2.27.tar.gz"
+    ],
+    "integrity": "sha256-JgtUnBVLB8PNwWuczJPARjPDn0+2pKO40fpbipw/X+g=",
+    "strip_prefix": "libcap-2.27",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-t0rIdsYn1pc33QEhu8EJdYprH38Tv86ZrsaI4DHPb/I=",
+        "MODULE.bazel": "sha256-PmeoA9Jd+V4d50Acu+HkxMVI3sno9QDVD5qvCfcA+BA="
+    }
+}

--- a/modules/libcap/metadata.json
+++ b/modules/libcap/metadata.json
@@ -9,11 +9,14 @@
         }
     ],
     "repository": [
-        "https://www.kernel.org/pub/linux/libs/security/linux-privs"
+        "https://www.kernel.org/pub/linux/libs/security/linux-privs",
+        "https://mirrors.mit.edu/kernel/linux/libs/security/linux-privs",
+        "https://mirrors.ustc.edu.cn/kernel.org/linux/libs/security/linux-privs"
     ],
     "versions": [
         "2.27",
-        "2.27.bcr.1"
+        "2.27.bcr.1",
+        "2.27.bcr.2"
     ],
     "yanked_versions": {}
 }

--- a/modules/libcap/metadata.json
+++ b/modules/libcap/metadata.json
@@ -6,6 +6,12 @@
             "github": "johnor",
             "name": "Johan Norberg",
             "github_user_id": 6647461
+        },
+        {
+            "email": "byvoid@byvoid.com",
+            "github": "BYVoid",
+            "name": "Carbo Kuo",
+            "github_user_id": 245270
         }
     ],
     "repository": [


### PR DESCRIPTION
## Problem

The canonical source URL for `libcap@2.27` and `libcap@2.27.bcr.1`:

`https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.27.tar.gz`

currently returns **HTTP 404**, so both existing versions fail to download. kernel.org's whole `/pub` tree appears to not be serving files at the moment (even current kernel tarballs linked from the kernel.org homepage 404), so this may be an upstream infrastructure issue rather than a deliberate removal.

## Fix

Since existing module versions must not be modified (add-only policy), this follows the approach of #5983 (ftp.gnu.org outage): add a new version **`2.27.bcr.2`**, identical to `2.27.bcr.1` except that the source URL points to kernel.org mirrors that still carry the file:

- `url`: `https://mirrors.mit.edu/kernel/linux/libs/security/linux-privs/libcap2/libcap-2.27.tar.gz`
- `mirror_urls`: `https://mirrors.ustc.edu.cn/kernel.org/linux/libs/security/linux-privs/libcap2/libcap-2.27.tar.gz`

Both mirrors serve an archive **byte-identical** to the original — SHA-256 `260b549c154b07c3cdc16b9ccc93c04633c39f4fb6a4a3b8d1fa5b8a9c3f5fe8` matches the existing `integrity` value, so reproducibility is preserved. The mirror URL prefixes are added to `metadata.json`'s `repository` list accordingly.

`tools/bcr_validation.py --check libcap@2.27.bcr.2` passes all checks locally.

Note: the git snapshot URL (`https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.27.tar.gz`) was considered but is **not** usable — it has a different SHA-256 and slightly different contents (missing `progs/nscap.pl`, extra `.gitignore`) than the release tarball.