### PR TITLE
Add lobster 1.0.3

### DIFF
--- a/modules/lobster/1.0.3/MODULE.bazel
+++ b/modules/lobster/1.0.3/MODULE.bazel
@@ -1,0 +1,69 @@
+module(
+    name = "lobster",
+    compatibility_level = 1,
+    version = "1.0.3",
+)
+
+bazel_dep(
+    name = "rules_python",
+    version = "1.5.1",
+)
+
+bazel_dep(name = "rules_python_gazelle_plugin", version = "1.5.1")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+
+
+python.toolchain(
+    is_default = True,
+    configure_coverage_tool = True,
+    python_version = "3.9",
+)
+python.toolchain(python_version = "3.10")
+python.toolchain(python_version = "3.11")
+python.toolchain(python_version = "3.12")
+
+use_repo(python, "python_versions")
+
+uv = use_extension("@rules_python//python/uv:uv.bzl", "uv")
+uv.configure(version = "0.8.24")
+
+bazel_dep(name = "googletest", version = "1.13.0")
+bazel_dep(name = "trlc", version = "2.0.5")
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
+[
+    pip.parse(
+        hub_name = "lobster_pip_hub_dependencies",
+         envsubst = ["PIP_INDEX_URL"],
+        # For all .whl artifacts use the Bazel downloader, allowing caching of artifacts.
+        # Also, the Bazel download approach is supposed to be faster and on top offers parallel downloading.
+        # For sdist packages this will fall back automatically to 'python -m pip --isolated wheel ..', unless we set 'download_only = True'.
+        experimental_index_url = "${PIP_INDEX_URL:-https://pypi.org/simple}",
+        python_version = "3.{}".format(version),
+        requirements_lock = "//:requirements_lock.txt".format(version),
+    )
+    for version in ["9", "10", "11", "12"]
+]
+
+use_repo(pip, "lobster_pip_hub_dependencies")
+
+bazel_dep(name = "gazelle", version = "0.44.0", repo_name = "bazel_gazelle")
+
+pip.parse(
+    experimental_requirement_cycles = {
+        "sphinx": [
+            "sphinx",
+            "sphinxcontrib-serializinghtml",
+            "sphinxcontrib-qthelp",
+            "sphinxcontrib-htmlhelp",
+            "sphinxcontrib-devhelp",
+            "sphinxcontrib-applehelp",
+        ],
+    },
+    hub_name = "lobster_sphinx_dependencies",
+    python_version = "3.12",
+    requirements_lock = "//:requirements_dev.txt",
+)
+use_repo(pip, "lobster_sphinx_dependencies")

--- a/modules/lobster/1.0.3/patches/module_bazel_version_and_trlc.patch
+++ b/modules/lobster/1.0.3/patches/module_bazel_version_and_trlc.patch
@@ -1,0 +1,33 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "lobster",
+     compatibility_level = 1,
+-    version = "0.13.2",
++    version = "1.0.3",
+ )
+ 
+ bazel_dep(
+@@ -29,7 +29,7 @@
+ uv.configure(version = "0.8.24")
+ 
+ bazel_dep(name = "googletest", version = "1.13.0")
+-bazel_dep(name = "trlc", version = "0.0.0")
++bazel_dep(name = "trlc", version = "2.0.5")
+ 
+ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+ 
+@@ -51,12 +51,6 @@
+ 
+ bazel_dep(name = "gazelle", version = "0.44.0", repo_name = "bazel_gazelle")
+ 
+-git_override(
+-    commit = "650b51a47264a4f232b3341f473527710fc32669",
+-    module_name = "trlc",
+-    remote = "https://github.com/bmw-software-engineering/trlc.git",
+-)
+-
+ pip.parse(
+     experimental_requirement_cycles = {
+         "sphinx": [

--- a/modules/lobster/1.0.3/presubmit.yml
+++ b/modules/lobster/1.0.3/presubmit.yml
@@ -1,0 +1,87 @@
+incompatible_flags:
+  "--incompatible_config_setting_private_default_visibility":
+    - 8.x
+  "--incompatible_disable_starlark_host_transitions":
+    - 8.x
+  "--incompatible_disable_native_repo_rules":
+    - 8.x
+  "--incompatible_strict_action_env":
+    - 8.x
+
+matrix:
+  platform:
+    - ubuntu2204
+    - macos
+  bazel:
+    - 8.x
+  python_version:
+    - "3.9"
+    - "3.10"
+    - "3.11"
+    - "3.12"
+
+# Verify all lobster module entry points build correctly across all supported platforms and Python versions before release.
+tasks:
+  run_test_module:
+    name: "Verify lobster (Python ${{ python_version }})"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # explicit Python version
+    build_targets:
+      - "@lobster//:lobster"
+    test_flags:
+      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # explicit Python version
+    test_targets:
+      - "@lobster//tests_unit/..."
+      - "@lobster//tests_system/..."
+      - "@lobster//tests_integration/..."
+      # cpp_focus:fruit_test is an intentionally-failing gtest fixture used only to
+      # generate LOBSTER tracing metadata (upstream runs it with "|| true"). Its
+      # BasketTest.ClearBasket case asserts an empty basket while the clearing code
+      # is commented out, so it must be excluded from the presubmit test run.
+      - "-@lobster//tests_integration/projects/cpp_focus:fruit_test"
+      # projects/basic:traceability renders an HTML report with lobster-html-report,
+      # which requires the Graphviz "dot" binary. Graphviz is not part of the BCR CI
+      # images, so this test fails with "please install Graphviz".
+      - "-@lobster//tests_integration/projects/basic:traceability"
+      # The lobster_codebeamer system tests stand up a Flask HTTPS mock server on
+      # localhost; they depend on lobster's own provisioned CI environment and do not
+      # run reliably in the sandboxed BCR test environment.
+      - "-@lobster//tests_system/lobster_codebeamer/..."
+
+  # Windows needs its own task because lobster's shared requirements_lock.txt is not
+  # universal, so the lobster_pip_hub_dependencies hub is missing Windows-only marker
+  # dependencies. Two of them break analysis (which aborts the whole build) on Windows:
+  #   * Sphinx requires `colorama`  -> breaks tests_unit/sphinx_extension
+  #   * Selenium (via trio) needs `cffi` -> breaks tests_system/lobster_html_report
+  # Both target trees are therefore additionally excluded on Windows only.
+  run_test_module_windows:
+    name: "Verify lobster on Windows (Python ${{ python_version }})"
+    platform: windows
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # explicit Python version
+    build_targets:
+      - "@lobster//:lobster"
+    test_flags:
+      - "--@@rules_python+//python/config_settings:python_version=${{ python_version }}"  # explicit Python version
+    test_targets:
+      - "@lobster//tests_unit/..."
+      - "@lobster//tests_system/..."
+      - "@lobster//tests_integration/..."
+      # Keep the exclusions in sync with the run_test_module task above.
+      - "-@lobster//tests_integration/projects/cpp_focus:fruit_test"
+      - "-@lobster//tests_integration/projects/basic:traceability"
+      - "-@lobster//tests_system/lobster_codebeamer/..."
+      # Windows-only: the shared pip hub has no `colorama`, which Sphinx requires on
+      # Windows, so the Sphinx extension tests cannot be analyzed here.
+      - "-@lobster//tests_unit/sphinx_extension/..."
+      # Windows-only: the shared pip hub has no `cffi`, which Selenium (via trio)
+      # requires on Windows, so the html-report tests cannot be analyzed here.
+      - "-@lobster//tests_system/lobster_html_report/..."
+      # Windows-only: the online-report tool converts filesystem paths to GitHub URLs,
+      # and these tests compare against golden files/strings that assume POSIX path
+      # separators ("/") and LF line endings, so they fail on Windows only.
+      - "-@lobster//tests_unit/lobster_online_report/..."
+      - "-@lobster//tests_system/lobster_online_report/..."

--- a/modules/lobster/1.0.3/source.json
+++ b/modules/lobster/1.0.3/source.json
@@ -1,0 +1,9 @@
+{
+  "integrity": "sha256-rOfj1N7Lipo/uLzITMCR54W3xC469Ea5ymVMWYQ7qpQ=",
+  "strip_prefix": "lobster-lobster-1.0.3",
+  "url": "https://github.com/bmw-software-engineering/lobster/archive/refs/tags/lobster-1.0.3.tar.gz",
+  "patches": {
+    "module_bazel_version_and_trlc.patch": "sha256-zyxzJrahfxkoLZHnxEHdaIUcbAgVoOJVulP4sA23dKM="
+  },
+  "patch_strip": 1
+}

--- a/modules/lobster/metadata.json
+++ b/modules/lobster/metadata.json
@@ -18,7 +18,8 @@
     "github:bmw-software-engineering/lobster"
   ],
   "versions": [
-    "0.13.2"
+    "0.13.2",
+    "1.0.3"
   ],
   "yanked_versions": {}
 }


### PR DESCRIPTION
Register lobster@1.0.3 (upstream tag lobster-1.0.3).

- Patch MODULE.bazel: set version to 1.0.3, pin trlc to 2.0.5, and drop the trlc git_override (not allowed in BCR).
- Expand presubmit to build and test across ubuntu2204/macos/windows with Python 3.9-3.12, covering tests_unit, tests_system and tests_integration.

The upstream archive is a git-tag tarball, so the unstable_url check must be skipped on the PR.