### PR TITLE
Add darts-clone 0.32h.bcr.1

### DIFF
--- a/modules/darts-clone/0.32h.bcr.1/MODULE.bazel
+++ b/modules/darts-clone/0.32h.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+"""Darts-clone is a clone of Darts (Double-ARray Trie System) which is a C++ header library for a static double-array trie structure."""
+
+module(
+    name = "darts-clone",
+    version = "0.32h.bcr.1",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/darts-clone/0.32h.bcr.1/patches/add_build_file.patch
+++ b/modules/darts-clone/0.32h.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,19 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,16 @@
++load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
++
++cc_library(
++    name = "darts-clone",
++    hdrs = glob(["include/*.h"]),
++    strip_include_prefix = "include",
++    visibility = ["//visibility:public"],
++)
++
++cc_test(
++    name = "darts_clone_compat_test",
++    srcs = ["darts_clone_compat_test.cc"],
++    deps = [
++        ":darts-clone",
++    ],
++)

--- a/modules/darts-clone/0.32h.bcr.1/patches/add_compat_test.patch
+++ b/modules/darts-clone/0.32h.bcr.1/patches/add_compat_test.patch
@@ -1,0 +1,60 @@
+--- /dev/null
++++ darts_clone_compat_test.cc
+@@ -0,0 +1,57 @@
++#include "darts.h"
++
++#include <cstddef>
++
++// Exercises helpers adapted from google/sentencepiece commit d685ef31.
++int main() {
++  Darts::DoubleArray array;
++  const char* keys[] = {
++      "a",
++      "ab",
++      "b",
++  };
++  const int values[] = {
++      0,
++      1,
++      2,
++  };
++
++  if (array.build(3, keys, NULL, values) != 0) {
++    return 1;
++  }
++  if (!array.validate(3)) {
++    return 2;
++  }
++  if (array.validate(2)) {
++    return 3;
++  }
++
++  Darts::DoubleArray::result_pair_type result;
++  array.exactMatchSearch("ab", result);
++  if (result.value != 1 || result.length != 2) {
++    return 4;
++  }
++
++  Darts::DoubleArray copied;
++  copied.copy_array(array.array(), array.total_size());
++  if (!copied.validate(3)) {
++    return 5;
++  }
++  if (copied.array() == array.array()) {
++    return 6;
++  }
++
++  copied.exactMatchSearch("ab", result);
++  if (result.value != 1 || result.length != 2) {
++    return 7;
++  }
++
++  const char raw_bytes[] = {0, 0, 0, 0, 0};
++  Darts::DoubleArray padded_copy;
++  padded_copy.copy_array(raw_bytes, sizeof(raw_bytes));
++  if (padded_copy.size() != 2) {
++    return 8;
++  }
++
++  return 0;
++}

--- a/modules/darts-clone/0.32h.bcr.1/patches/darts_header_compat.patch
+++ b/modules/darts-clone/0.32h.bcr.1/patches/darts_header_compat.patch
@@ -1,0 +1,139 @@
+Add the Darts-clone compatibility helpers needed by downstream users.
+
+This patch is based on the Darts-clone changes from google/sentencepiece
+commit d685ef31. The final diff is adapted to the upstream v0.32h source in
+this module, so it is not expected to be byte-for-byte identical to that
+commit.
+
+--- include/darts.h
++++ include/darts.h
+@@ -2,6 +2,7 @@
+ #define DARTS_H_
+ 
+ #include <cstdio>
++#include <cstring>
+ #include <exception>
+ #include <new>
+ 
+@@ -173,6 +174,14 @@
+     array_ = static_cast<const unit_type *>(ptr);
+     size_ = size;
+   }
++  void copy_array(const void* ptr, std::size_t num_bytes) {
++    clear();
++    const std::size_t extra_padding = num_bytes % unit_size() == 0 ? 0 : 1;
++    size_ = num_bytes / unit_size() + extra_padding;
++    buf_ = new unit_type[size_];
++    std::memcpy(buf_, ptr, num_bytes);
++    array_ = buf_;
++  }
+   // array() returns a pointer to the array of units.
+   const void *array() const {
+     return array_;
+@@ -314,6 +323,8 @@
+   // updates `node_pos' and `key_pos' after each transition.
+   inline value_type traverse(const key_type *key, std::size_t &node_pos,
+       std::size_t &key_pos, std::size_t length = 0) const;
++
++  bool validate(value_type max_value_limit = -1) const;
+ 
+  private:
+   typedef Details::uchar_type uchar_type;
+@@ -451,6 +462,29 @@
+   }
+   std::fclose(file);
+   return 0;
++}
++
++template <typename A, typename B, typename T, typename C>
++bool DoubleArrayImpl<A, B, T, C>::validate(value_type max_value_limit) const {
++  if (size_ == 0 || array_ == NULL) {
++    return false;
++  }
++  if (array_[0].label() != '\0' || array_[0].has_leaf() ||
++      array_[0].offset() == 0 || ((0 ^ array_[0].offset()) | 0xFF) >= size_) {
++    return false;
++  }
++  for (std::size_t i = 1; i < size_; ++i) {
++    if (array_[i].label() <= 0xFF) {
++      if (((i ^ array_[i].offset()) | 0xFF) >= size_) {
++        return false;
++      }
++    } else if (max_value_limit >= 0) {
++      if (array_[i].value() >= max_value_limit) {
++        return false;
++      }
++    }
++  }
++  return true;
+ }
+ 
+ template <typename A, typename B, typename T, typename C>
+@@ -910,7 +944,7 @@
+ 
+   num_ones_ = 0;
+   for (std::size_t i = 0; i < units_.size(); ++i) {
+-    ranks_[i] = num_ones_;
++    ranks_[i] = static_cast<id_type>(num_ones_);
+     num_ones_ += pop_count(units_[i]);
+   }
+ }
+@@ -1832,7 +1866,7 @@
+ 
+ inline id_type DoubleArrayBuilder::find_valid_offset(id_type id) const {
+   if (extras_head_ >= units_.size()) {
+-    return units_.size() | (id & LOWER_MASK);
++    return static_cast<id_type>(units_.size()) | (id & LOWER_MASK);
+   }
+ 
+   id_type unfixed_id = extras_head_;
+@@ -1844,7 +1878,7 @@
+     unfixed_id = extras(unfixed_id).next();
+   } while (unfixed_id != extras_head_);
+ 
+-  return units_.size() | (id & LOWER_MASK);
++  return static_cast<id_type>(units_.size()) | (id & LOWER_MASK);
+ }
+ 
+ inline bool DoubleArrayBuilder::is_valid_offset(id_type id,
+@@ -1875,7 +1909,7 @@
+   if (id == extras_head_) {
+     extras_head_ = extras(id).next();
+     if (extras_head_ == id) {
+-      extras_head_ = units_.size();
++      extras_head_ = static_cast<id_type>(units_.size());
+     }
+   }
+   extras(extras(id).prev()).set_next(extras(id).next());
+@@ -1884,8 +1918,8 @@
+ }
+ 
+ inline void DoubleArrayBuilder::expand_units() {
+-  id_type src_num_units = units_.size();
+-  id_type src_num_blocks = num_blocks();
++  id_type src_num_units = static_cast<id_type>(units_.size());
++  id_type src_num_blocks = static_cast<id_type>(num_blocks());
+ 
+   id_type dest_num_units = src_num_units + BLOCK_SIZE;
+   id_type dest_num_blocks = src_num_blocks + 1;
+@@ -1897,7 +1931,7 @@
+   units_.resize(dest_num_units);
+ 
+   if (dest_num_blocks > NUM_EXTRA_BLOCKS) {
+-    for (std::size_t id = src_num_units; id < dest_num_units; ++id) {
++    for (id_type id = src_num_units; id < dest_num_units; ++id) {
+       extras(id).set_is_used(false);
+       extras(id).set_is_fixed(false);
+     }
+@@ -1921,9 +1955,9 @@
+ inline void DoubleArrayBuilder::fix_all_blocks() {
+   id_type begin = 0;
+   if (num_blocks() > NUM_EXTRA_BLOCKS) {
+-    begin = num_blocks() - NUM_EXTRA_BLOCKS;
++    begin = static_cast<id_type>(num_blocks()) - NUM_EXTRA_BLOCKS;
+   }
+-  id_type end = num_blocks();
++  id_type end = static_cast<id_type>(num_blocks());
+ 
+   for (id_type block_id = begin; block_id != end; ++block_id) {
+     fix_block(block_id);

--- a/modules/darts-clone/0.32h.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/darts-clone/0.32h.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,12 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,9 @@
++"""Darts-clone is a clone of Darts (Double-ARray Trie System) which is a C++ header library for a static double-array trie structure."""
++
++module(
++    name = "darts-clone",
++    version = "0.32h.bcr.1",
++    compatibility_level = 0,
++)
++
++bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/darts-clone/0.32h.bcr.1/presubmit.yml
+++ b/modules/darts-clone/0.32h.bcr.1/presubmit.yml
@@ -1,0 +1,27 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2404_arm64
+  - macos
+  - macos_arm64
+  - windows
+  - windows_arm64
+  bazel:
+  - 6.x
+  - 7.x
+  - 8.x
+  - 9.x
+  - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@darts-clone'
+  test_targets:
+    name: Test compatibility targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+    - '@darts-clone//:darts_clone_compat_test'

--- a/modules/darts-clone/0.32h.bcr.1/source.json
+++ b/modules/darts-clone/0.32h.bcr.1/source.json
@@ -1,0 +1,12 @@
+{
+    "url": "https://github.com/s-yata/darts-clone/archive/refs/tags/v0.32h.tar.gz",
+    "integrity": "sha256-XU+h4QP21UMgi3X8BsIAFTP6jCCjRw5Dhgq6Vu54iKM=",
+    "strip_prefix": "darts-clone-0.32h",
+    "patches": {
+        "add_compat_test.patch": "sha256-+8ykZmgxj+ThU3x3eVq248aCX5oKSB7Hq98VfGr+FIg=",
+        "add_build_file.patch": "sha256-7NsBy/E5749XQXhyWyoFPoic8Qx5EwIUD87k1/POTPU=",
+        "darts_header_compat.patch": "sha256-MSIsakimRJgNLtDx7aomzznpe0t+GckDmK03WL1bL8g=",
+        "module_dot_bazel.patch": "sha256-kLHF29lLr4HsSupu5wQsGjm4/pLGaWpptyksBU7EfcM="
+    },
+    "patch_strip": 0
+}

--- a/modules/darts-clone/metadata.json
+++ b/modules/darts-clone/metadata.json
@@ -15,7 +15,8 @@
     "versions": [
         "0.32",
         "0.32.bcr.1",
-        "0.32h"
+        "0.32h",
+        "0.32h.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Package the OpenCC-compatible darts-clone header changes as a BCR patch release so downstream modules can depend on the patched archive directly.