### PR TITLE
Add esaxx@20250106.1.bcr.1

### DIFF
--- a/modules/esaxx/20250106.1.bcr.1/MODULE.bazel
+++ b/modules/esaxx/20250106.1.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "esaxx",
+    version = "20250106.1.bcr.1",
+    compatibility_level = 1,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/esaxx/20250106.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/esaxx/20250106.1.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "esa",
+    hdrs = ["esa.hxx"],
+    includes = ["."],
+    deps = [":sais"],
+)
+
+cc_library(
+    name = "sais",
+    hdrs = ["sais.hxx"],
+    includes = ["."],
+)

--- a/modules/esaxx/20250106.1.bcr.1/patches/esaxx_fix_index_type_deduction.patch
+++ b/modules/esaxx/20250106.1.bcr.1/patches/esaxx_fix_index_type_deduction.patch
@@ -1,0 +1,18 @@
+Fix the template argument deduction of saisxx() for 64-bit index
+types: the integer literal 0 deduces index_type as int, which
+conflicts with the deduction from the other arguments and fails to
+compile when SentencePiece instantiates esaxx() with int64_t
+(--train_extremely_large_corpus). Same fix as the vendored copy in
+google/sentencepiece third_party/esaxx.
+
+--- sais.hxx
++++ sais.hxx
+@@ -326,7 +326,7 @@
+   int err;
+   if((n < 0) || (k <= 0)) { return -1; }
+   if(n <= 1) { if(n == 1) { SA[0] = 0; } return 0; }
+-  try { err = saisxx_private::suffixsort(T, SA, 0, n, k, false); }
++  try { err = saisxx_private::suffixsort(T, SA, index_type(0), n, k, false); }
+   catch(...) { err = -2; }
+   return err;
+ }

--- a/modules/esaxx/20250106.1.bcr.1/presubmit.yml
+++ b/modules/esaxx/20250106.1.bcr.1/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@esaxx//:esa'
+    - '@esaxx//:sais'
+    build_flags:
+    - '--features=parse_headers'
+    - '--process_headers_in_dependencies'

--- a/modules/esaxx/20250106.1.bcr.1/source.json
+++ b/modules/esaxx/20250106.1.bcr.1/source.json
@@ -1,0 +1,12 @@
+{
+    "url": "https://github.com/hillbig/esaxx/archive/ca7cb332011ec37a8436487f210f396b84bd8273.tar.gz",
+    "integrity": "sha256-qeK4tUBPA0XAwJGcvT37o1wmmRk1fsZstOkw6qzHRCY=",
+    "strip_prefix": "esaxx-ca7cb332011ec37a8436487f210f396b84bd8273",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-svJq9G9pWbrJ8cHabFdPKO/WB7pVGDA1vawnLDalrKU="
+    },
+    "patches": {
+        "esaxx_fix_index_type_deduction.patch": "sha256-VV9QVDe/AhKFvC8elhzjWKAPHhGhF4RosCDsWcvXXKI="
+    }
+}

--- a/modules/esaxx/metadata.json
+++ b/modules/esaxx/metadata.json
@@ -6,6 +6,12 @@
             "github": "eustas",
             "name": "Evgenii Kliuchnikov",
             "github_user_id": 203457
+        },
+        {
+            "email": "byvoid@byvoid.com",
+            "github": "BYVoid",
+            "name": "Carbo Kuo",
+            "github_user_id": 245270
         }
     ],
     "repository": [
@@ -13,7 +19,8 @@
     ],
     "versions": [
         "20250106.0",
-        "20250106.1"
+        "20250106.1",
+        "20250106.1.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds `esaxx@20250106.1.bcr.1`, a BCR revision of 20250106.1 that folds in the patches SentencePiece has been carrying in its own repository (https://github.com/BYVoid/sentencepiece/tree/master/bazel/patches):

- **New `:esa` target** (overlay `BUILD.bazel`): exports the `esa.hxx` suffix-tree enumeration header, which the previous overlay did not expose (it only provided `:sais` for `sais.hxx`).
- **`esaxx_fix_index_type_deduction.patch`**: fixes template argument deduction of `saisxx()` for 64-bit index types — the integer literal `0` deduces `index_type` as `int`, which fails to compile when instantiated with `int64_t` (e.g. SentencePiece's `--train_extremely_large_corpus`). Same fix as the vendored copy in google/sentencepiece `third_party/esaxx`.

Also adds BYVoid (Carbo Kuo) as a module maintainer.

The presubmit now additionally builds `@esaxx//:esa`.