### PR TITLE
rules_cc@0.2.21

### DIFF
--- a/modules/rules_cc/0.2.21/MODULE.bazel
+++ b/modules/rules_cc/0.2.21/MODULE.bazel
@@ -1,0 +1,56 @@
+module(
+    name = "rules_cc",
+    version = "0.2.21",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_features", version = "1.50.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.0")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "protobuf", version = "27.0", repo_name = "com_google_protobuf")
+
+cc_configure = use_extension("//cc:extensions.bzl", "cc_configure_extension")
+use_repo(cc_configure, "local_config_cc", "local_config_cc_toolchains")
+
+register_toolchains(
+    "@local_config_cc_toolchains//:all",
+    "//cc/private/toolchain/test:default_test_runner_toolchain",
+)
+
+bazel_dep(name = "rules_shell", version = "0.2.0", dev_dependency = True)
+
+bazel_dep(name = "rules_python", version = "1.7.0")
+
+bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)
+single_version_override(
+    module_name = "googletest",
+    patch_strip = 1,
+    patches = ["//:googletest.patch"],
+    version = "1.17.0",
+)
+
+bazel_dep(name = "test_repo", dev_dependency = True, repo_name = "cross_repo_test")
+local_path_override(
+    module_name = "test_repo",
+    path = "tests/builtins_bzl/cc/cc_shared_library/test2",
+)
+
+# Required commit 2c30bc1e "Add is_empty() and is_not_empty() assertions to CollectionSubject"
+# TODO: pzembrod - Change to a released version again when the commit is in a release.
+bazel_dep(name = "rules_testing", dev_dependency = True)
+archive_override(
+    module_name = "rules_testing",
+    integrity = "sha256-cr6LqrpM60hzy/jr8j3Q3V286Cl4fEhrHnRokSYGjtU=",
+    strip_prefix = "rules_testing-c30bc1eda772d837997d03515d30ac3f6b70c3bf",
+    urls = ["https://github.com/bazelbuild/rules_testing/archive/c30bc1eda772d837997d03515d30ac3f6b70c3bf.tar.gz"],
+)
+
+bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
+
+# Compatibility layer
+compat = use_extension("//cc:extensions.bzl", "compatibility_proxy")
+use_repo(compat, "cc_compatibility_proxy")
+
+local_bazel_import = use_repo_rule("//:local_bazel.bzl", "local_bazel_import")
+
+local_bazel_import(name = "local_bazel")

--- a/modules/rules_cc/0.2.21/attestations.json
+++ b/modules/rules_cc/0.2.21/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/bazelbuild/rules_cc/releases/download/0.2.21/source.json.intoto.jsonl",
+            "integrity": "sha256-IwoH+WFEHCn0ggRRt9zlpW/VodfZ2dDq2cwc/yP3I8g="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/bazelbuild/rules_cc/releases/download/0.2.21/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-/MtrFpdBAcW/xMARIwQBIfN96KvknEg2Kxg03jmrH/Q="
+        },
+        "rules_cc-0.2.21.tar.gz": {
+            "url": "https://github.com/bazelbuild/rules_cc/releases/download/0.2.21/rules_cc-0.2.21.tar.gz.intoto.jsonl",
+            "integrity": "sha256-j6J3dbf5aKDrn/RiFUOl7eLRQlC2welOWAw/Ji93Mz0="
+        }
+    }
+}

--- a/modules/rules_cc/0.2.21/patches/module_dot_bazel_version.patch
+++ b/modules/rules_cc/0.2.21/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_cc",
+-    version = "0.0.0",
++    version = "0.2.21",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "bazel_features", version = "1.50.0")

--- a/modules/rules_cc/0.2.21/presubmit.yml
+++ b/modules/rules_cc/0.2.21/presubmit.yml
@@ -1,0 +1,13 @@
+matrix:
+  platform: ["rockylinux8", "debian11", "macos", "macos_arm64", "ubuntu2404", "windows"]
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: "Verify build targets"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@rules_cc//cc/..."

--- a/modules/rules_cc/0.2.21/source.json
+++ b/modules/rules_cc/0.2.21/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-liJRkjQ40n/AMMLZ01wFin99pP7ULEKtU0LHtEA9TPI=",
+    "strip_prefix": "rules_cc-0.2.21",
+    "url": "https://github.com/bazelbuild/rules_cc/releases/download/0.2.21/rules_cc-0.2.21.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-Bti8ZsNzX4AYSZ/uHrJez40nr4bp9gGAbRrRkBtvWhc="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_cc/metadata.json
+++ b/modules/rules_cc/metadata.json
@@ -61,7 +61,8 @@
         "0.2.17",
         "0.2.18",
         "0.2.19",
-        "0.2.20"
+        "0.2.20",
+        "0.2.21"
     ],
     "yanked_versions": {
         "0.0.14": "rules_cc 0.0.14 is yanked due to incompatible change (prematurely removing cc_proto_library from defs.bzl), please upgrade to 0.0.15",


### PR DESCRIPTION
Release: https://github.com/bazelbuild/rules_cc/releases/tag/0.2.21

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_