### PR TITLE
Add sentencepiece@0.2.1

### DIFF
--- a/modules/sentencepiece/0.2.1/MODULE.bazel
+++ b/modules/sentencepiece/0.2.1/MODULE.bazel
@@ -1,0 +1,25 @@
+"""SentencePiece is an unsupervised text tokenizer and detokenizer mainly for Neural Network-based text generation systems."""
+
+module(
+    name = "sentencepiece",
+    version = "0.2.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "abseil-cpp", version = "20260526.0")
+
+# Upstream darts-clone v0.32h plus the compatibility helpers (copy_array,
+# validate, ...) that the vendored third_party/darts_clone copy carries.
+bazel_dep(name = "darts-clone", version = "0.32h.bcr.1")
+
+# Upstream esaxx at the commit the vendored third_party/esaxx copy is based
+# on. The .bcr.1 revision exports esa.hxx and carries the index_type(0)
+# template-deduction fix that the int64_t instantiation of esaxx() needs.
+bazel_dep(name = "esaxx", version = "20250106.1.bcr.1")
+bazel_dep(name = "platforms", version = "1.1.0")
+
+# The .pb.cc/.pb.h files are regenerated from src/*.proto at build time, so
+# the Bazel build follows the SPM_PROTOBUF_PROVIDER=package CMake
+# configuration instead of the vendored third_party/protobuf-lite runtime.
+bazel_dep(name = "protobuf", version = "35.1")
+bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/sentencepiece/0.2.1/overlay/BUILD.bazel
+++ b/modules/sentencepiece/0.2.1/overlay/BUILD.bazel
@@ -1,0 +1,31 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.!
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "VERSION.txt",
+    "config.h.in",
+    "LICENSE",
+])
+
+alias(
+    name = "sentencepiece",
+    actual = "//src:sentencepiece",
+)
+
+alias(
+    name = "sentencepiece_train",
+    actual = "//src:sentencepiece_train",
+)

--- a/modules/sentencepiece/0.2.1/overlay/bcr_tests/BUILD.bazel
+++ b/modules/sentencepiece/0.2.1/overlay/bcr_tests/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "roundtrip_test",
+    srcs = ["roundtrip_test.cc"],
+    deps = [
+        "@sentencepiece//:sentencepiece",
+        "@sentencepiece//:sentencepiece_train",
+    ],
+)

--- a/modules/sentencepiece/0.2.1/overlay/bcr_tests/MODULE.bazel
+++ b/modules/sentencepiece/0.2.1/overlay/bcr_tests/MODULE.bazel
@@ -1,0 +1,9 @@
+module(name = "sentencepiece_bcr_tests")
+
+bazel_dep(name = "sentencepiece")
+local_path_override(
+    module_name = "sentencepiece",
+    path = "..",
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/sentencepiece/0.2.1/overlay/bcr_tests/roundtrip_test.cc
+++ b/modules/sentencepiece/0.2.1/overlay/bcr_tests/roundtrip_test.cc
@@ -1,0 +1,68 @@
+// Trains a small model fully in memory, then checks that encoding and
+// decoding roundtrips. This replaces the upstream spm_test, whose test data
+// (data/) is not shipped in the release tarball.
+//
+// SentencePiece 0.2.1 reports errors as sentencepiece::util::Status, so the
+// check macro takes the status by auto instead of naming the type.
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "sentencepiece_processor.h"
+#include "sentencepiece_trainer.h"
+
+#define CHECK_TEST(condition)                                         \
+  if (!(condition)) {                                                 \
+    std::cerr << __FILE__ << ":" << __LINE__ << " check failed: "     \
+              << #condition << std::endl;                             \
+    return 1;                                                         \
+  }
+
+#define CHECK_OK_TEST(expr)                                           \
+  {                                                                   \
+    const auto _status = (expr);                                      \
+    if (!_status.ok()) {                                              \
+      std::cerr << __FILE__ << ":" << __LINE__ << " status not ok: "  \
+                << _status.ToString() << std::endl;                   \
+      return 1;                                                       \
+    }                                                                 \
+  }
+
+int main() {
+  const std::vector<std::string> base = {
+      "The quick brown fox jumps over the lazy dog.",
+      "SentencePiece is an unsupervised text tokenizer and detokenizer.",
+      "Hello world. Hello Bazel.",
+      "I saw a girl with a telescope.",
+  };
+  std::vector<std::string> sentences;
+  for (int i = 0; i < 200; ++i) {
+    sentences.push_back(base[i % base.size()]);
+  }
+
+  std::string serialized_model;
+  CHECK_OK_TEST(sentencepiece::SentencePieceTrainer::Train(
+      "--vocab_size=60 --hard_vocab_limit=false --minloglevel=1", sentences,
+      &serialized_model));
+  CHECK_TEST(!serialized_model.empty());
+
+  sentencepiece::SentencePieceProcessor sp;
+  CHECK_OK_TEST(sp.LoadFromSerializedProto(serialized_model));
+
+  const std::string input = "Hello world.";
+  std::vector<std::string> pieces;
+  CHECK_OK_TEST(sp.Encode(input, &pieces));
+  CHECK_TEST(!pieces.empty());
+
+  std::string detokenized;
+  CHECK_OK_TEST(sp.Decode(pieces, &detokenized));
+  CHECK_TEST(detokenized == input);
+
+  std::vector<int> ids;
+  CHECK_OK_TEST(sp.Encode(input, &ids));
+  CHECK_TEST(!ids.empty());
+
+  std::cout << "PASS" << std::endl;
+  return 0;
+}

--- a/modules/sentencepiece/0.2.1/overlay/src/BUILD.bazel
+++ b/modules/sentencepiece/0.2.1/overlay/src/BUILD.bazel
@@ -1,0 +1,240 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.!
+
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+NOT_WIN_COPTS = [
+    "-pthread",
+    "-Wall",
+]
+
+# Generates config.h from config.h.in, like the configure_file() step in
+# CMakeLists.txt. The version is read from VERSION.txt.
+genrule(
+    name = "config_h",
+    srcs = [
+        "//:VERSION.txt",
+        "//:config.h.in",
+    ],
+    outs = ["config.h"],
+    cmd = "VERSION=$$(tr -d ' \\r\\n' < $(location //:VERSION.txt)); " +
+          "sed -e \"s/@PROJECT_VERSION@/$${VERSION}/g\" " +
+          "-e \"s/@PROJECT_NAME@/sentencepiece/g\" " +
+          "-e \"s|@INSTALL_DATADIR@|share/sentencepiece|g\" " +
+          "$(location //:config.h.in) > $@",
+)
+
+cc_library(
+    name = "config",
+    hdrs = [":config_h"],
+    includes = ["."],
+)
+
+# The protobuf code is regenerated from the .proto files at build time with
+# the protobuf module from the Bazel Central Registry, matching the
+# SPM_PROTOBUF_PROVIDER=package CMake configuration. The pre-generated
+# sources in builtin_pb/ and the vendored third_party/protobuf-lite runtime
+# are only used by CMake (SPM_PROTOBUF_PROVIDER=internal, its default).
+proto_library(
+    name = "sentencepiece_proto",
+    srcs = ["sentencepiece.proto"],
+)
+
+cc_proto_library(
+    name = "sentencepiece_cc_proto",
+    deps = [":sentencepiece_proto"],
+)
+
+proto_library(
+    name = "sentencepiece_model_proto",
+    srcs = ["sentencepiece_model.proto"],
+)
+
+cc_proto_library(
+    name = "sentencepiece_model_cc_proto",
+    deps = [":sentencepiece_model_proto"],
+)
+
+# Wrapper that puts the generated headers on the include path expected by
+# the sources (#include "sentencepiece.pb.h") and selects the external
+# protobuf branch of the #ifdef _USE_EXTERNAL_PROTOBUF includes.
+cc_library(
+    name = "pb",
+    defines = ["_USE_EXTERNAL_PROTOBUF"],
+    includes = ["."],
+    deps = [
+        ":sentencepiece_cc_proto",
+        ":sentencepiece_model_cc_proto",
+    ],
+)
+
+# Runtime library (the `sentencepiece` target in CMake; SPM_SRCS).
+cc_library(
+    name = "sentencepiece",
+    srcs = [
+        "bpe_model.cc",
+        "char_model.cc",
+        "error.cc",
+        "filesystem.cc",
+        "model_factory.cc",
+        "model_interface.cc",
+        "normalizer.cc",
+        "sentencepiece_processor.cc",
+        "unigram_model.cc",
+        "util.cc",
+        "word_model.cc",
+    ],
+    hdrs = [
+        "bpe_model.h",
+        "char_model.h",
+        "common.h",
+        "filesystem.h",
+        "freelist.h",
+        "init.h",
+        "model_factory.h",
+        "model_interface.h",
+        "normalizer.h",
+        "sentencepiece_processor.h",
+        "unigram_model.h",
+        "util.h",
+        "word_model.h",
+    ],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": NOT_WIN_COPTS,
+    }),
+    # Selects the external-absl branch of the #ifdef _USE_EXTERNAL_ABSL in
+    # error.cc, which defines the --minloglevel flag (the internal branch
+    # gets it from the vendored third_party/absl/flags/flag.cc shim).
+    defines = ["_USE_EXTERNAL_ABSL"],
+    linkopts = select({
+        "@platforms//cpu:riscv64": ["-latomic"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":config",
+        ":pb",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/flags:parse",
+        "@abseil-cpp//absl/flags:usage",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
+        "@darts-clone//:darts-clone",
+    ],
+)
+
+# Trainer library (the `sentencepiece_train` target in CMake; SPM_TRAIN_SRCS).
+cc_library(
+    name = "sentencepiece_train",
+    srcs = [
+        "bpe_model_trainer.cc",
+        "builder.cc",
+        "char_model_trainer.cc",
+        "pretokenizer_for_training.cc",
+        "sentencepiece_trainer.cc",
+        "trainer_factory.cc",
+        "trainer_interface.cc",
+        "unicode_script.cc",
+        "unigram_model_trainer.cc",
+        "word_model_trainer.cc",
+    ],
+    hdrs = [
+        "bpe_model_trainer.h",
+        "builder.h",
+        "char_model_trainer.h",
+        "normalization_rule.h",
+        "pretokenizer_for_training.h",
+        "sentencepiece_trainer.h",
+        "spec_parser.h",
+        "trainer_factory.h",
+        "trainer_interface.h",
+        "unicode_script.h",
+        "unicode_script_map.h",
+        "unigram_model_trainer.h",
+        "word_model_trainer.h",
+    ],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": NOT_WIN_COPTS,
+    }),
+    deps = [
+        ":sentencepiece",
+        "@abseil-cpp//absl/container:btree",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
+        "@esaxx//:esa",
+    ],
+)
+
+cc_binary(
+    name = "spm_encode",
+    srcs = ["spm_encode_main.cc"],
+    deps = [
+        ":sentencepiece",
+        # For trainer_interface.h.
+        ":sentencepiece_train",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cc_binary(
+    name = "spm_decode",
+    srcs = ["spm_decode_main.cc"],
+    deps = [
+        ":sentencepiece",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cc_binary(
+    name = "spm_normalize",
+    srcs = ["spm_normalize_main.cc"],
+    deps = [
+        ":sentencepiece",
+        ":sentencepiece_train",
+        "@abseil-cpp//absl/flags:flag",
+    ],
+)
+
+cc_binary(
+    name = "spm_train",
+    srcs = ["spm_train_main.cc"],
+    deps = [
+        ":sentencepiece",
+        ":sentencepiece_train",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cc_binary(
+    name = "spm_export_vocab",
+    srcs = ["spm_export_vocab_main.cc"],
+    deps = [
+        ":sentencepiece",
+        "@abseil-cpp//absl/flags:flag",
+    ],
+)

--- a/modules/sentencepiece/0.2.1/patches/use_bcr_dependency_includes.patch
+++ b/modules/sentencepiece/0.2.1/patches/use_bcr_dependency_includes.patch
@@ -1,0 +1,532 @@
+diff --git a/src/bpe_model.cc b/src/bpe_model.cc
+index 889fc62..f78e5b7 100644
+--- a/src/bpe_model.cc
++++ b/src/bpe_model.cc
+@@ -22,7 +22,7 @@
+ #include <vector>
+ 
+ #include "freelist.h"
+-#include "third_party/absl/container/flat_hash_map.h"
++#include "absl/container/flat_hash_map.h"
+ #include "util.h"
+ 
+ namespace sentencepiece {
+diff --git a/src/bpe_model_trainer.cc b/src/bpe_model_trainer.cc
+index 1f5241b..b6994ec 100644
+--- a/src/bpe_model_trainer.cc
++++ b/src/bpe_model_trainer.cc
+@@ -20,9 +20,9 @@
+ #include <vector>
+ 
+ #include "pretokenizer_for_training.h"
+-#include "third_party/absl/container/flat_hash_set.h"
+-#include "third_party/absl/strings/str_join.h"
+-#include "third_party/absl/strings/str_replace.h"
++#include "absl/container/flat_hash_set.h"
++#include "absl/strings/str_join.h"
++#include "absl/strings/str_replace.h"
+ #include "util.h"
+ 
+ namespace sentencepiece {
+diff --git a/src/bpe_model_trainer.h b/src/bpe_model_trainer.h
+index 15ca479..62f0368 100644
+--- a/src/bpe_model_trainer.h
++++ b/src/bpe_model_trainer.h
+@@ -21,8 +21,8 @@
+ #include <vector>
+ 
+ #include "sentencepiece_model.pb.h"
+-#include "third_party/absl/container/btree_set.h"
+-#include "third_party/absl/container/flat_hash_map.h"
++#include "absl/container/btree_set.h"
++#include "absl/container/flat_hash_map.h"
+ #include "trainer_interface.h"
+ 
+ namespace sentencepiece {
+diff --git a/src/builder.cc b/src/builder.cc
+index ebb2019..f1db2af 100644
+--- a/src/builder.cc
++++ b/src/builder.cc
+@@ -19,11 +19,11 @@
+ #include <utility>
+ 
+ #include "filesystem.h"
+-#include "third_party/absl/strings/str_cat.h"
+-#include "third_party/absl/strings/str_join.h"
+-#include "third_party/absl/strings/str_replace.h"
+-#include "third_party/absl/strings/str_split.h"
+-#include "third_party/absl/strings/strip.h"
++#include "absl/strings/str_cat.h"
++#include "absl/strings/str_join.h"
++#include "absl/strings/str_replace.h"
++#include "absl/strings/str_split.h"
++#include "absl/strings/strip.h"
+ 
+ #ifdef ENABLE_NFKC_COMPILE
+ #include <unicode/errorcode.h>
+@@ -37,7 +37,7 @@
+ #include <set>
+ 
+ #include "normalizer.h"
+-#include "third_party/darts_clone/darts.h"
++#include "darts.h"
+ #include "util.h"
+ 
+ #ifndef DISABLE_EMBEDDED_DATA
+diff --git a/src/builder.h b/src/builder.h
+index 2e844b2..d14a64e 100644
+--- a/src/builder.h
++++ b/src/builder.h
+@@ -22,7 +22,7 @@
+ #include "common.h"
+ #include "sentencepiece_model.pb.h"
+ #include "sentencepiece_processor.h"
+-#include "third_party/absl/strings/string_view.h"
++#include "absl/strings/string_view.h"
+ 
+ namespace sentencepiece {
+ namespace normalizer {
+diff --git a/src/common.h b/src/common.h
+index 48a4980..43be98f 100644
+--- a/src/common.h
++++ b/src/common.h
+@@ -26,7 +26,7 @@
+ #include <vector>
+ 
+ #include "config.h"
+-#include "third_party/absl/strings/string_view.h"
++#include "absl/strings/string_view.h"
+ 
+ #if defined(_WIN32) && !defined(__CYGWIN__)
+ #define OS_WIN
+diff --git a/src/error.cc b/src/error.cc
+index c901ee9..9513052 100644
+--- a/src/error.cc
++++ b/src/error.cc
+@@ -21,8 +21,8 @@
+ #ifdef _USE_EXTERNAL_ABSL
+ // Naive workaround to define minloglevel on external absl package.
+ // We want to define them in other cc file.
+-#include "third_party/absl/flags/flag.h"
+-#include "third_party/absl/flags/parse.h"
++#include "absl/flags/flag.h"
++#include "absl/flags/parse.h"
+ ABSL_FLAG(int32_t, minloglevel, 0,
+           "Messages logged at a lower level than this don't actually.");
+ #endif
+diff --git a/src/filesystem.h b/src/filesystem.h
+index e572b4b..dbcce48 100644
+--- a/src/filesystem.h
++++ b/src/filesystem.h
+@@ -23,7 +23,7 @@
+ 
+ #include "common.h"
+ #include "sentencepiece_processor.h"
+-#include "third_party/absl/strings/string_view.h"
++#include "absl/strings/string_view.h"
+ 
+ namespace sentencepiece {
+ namespace filesystem {
+diff --git a/src/init.h b/src/init.h
+index 5a69100..3f1b953 100644
+--- a/src/init.h
++++ b/src/init.h
+@@ -16,9 +16,9 @@
+ #define INIT_H_
+ 
+ #include "common.h"
+-#include "third_party/absl/flags/flag.h"
+-#include "third_party/absl/flags/parse.h"
+-#include "third_party/absl/flags/usage.h"
++#include "absl/flags/flag.h"
++#include "absl/flags/parse.h"
++#include "absl/flags/usage.h"
+ 
+ #ifdef _USE_EXTERNAL_PROTOBUF
+ #include "google/protobuf/message_lite.h"
+diff --git a/src/model_interface.cc b/src/model_interface.cc
+index bb52f9a..7c52398 100644
+--- a/src/model_interface.cc
++++ b/src/model_interface.cc
+@@ -17,7 +17,7 @@
+ #include <algorithm>
+ 
+ #include "sentencepiece_model.pb.h"
+-#include "third_party/absl/strings/str_format.h"
++#include "absl/strings/str_format.h"
+ #include "util.h"
+ 
+ namespace sentencepiece {
+diff --git a/src/model_interface.h b/src/model_interface.h
+index 06e9243..a10a817 100644
+--- a/src/model_interface.h
++++ b/src/model_interface.h
+@@ -25,9 +25,9 @@
+ #include "normalizer.h"
+ #include "sentencepiece_model.pb.h"
+ #include "sentencepiece_processor.h"
+-#include "third_party/absl/container/flat_hash_map.h"
+-#include "third_party/absl/strings/string_view.h"
+-#include "third_party/darts_clone/darts.h"
++#include "absl/container/flat_hash_map.h"
++#include "absl/strings/string_view.h"
++#include "darts.h"
+ #include "util.h"
+ 
+ namespace sentencepiece {
+diff --git a/src/normalizer.cc b/src/normalizer.cc
+index 5d81f4e..c58d12a 100644
+--- a/src/normalizer.cc
++++ b/src/normalizer.cc
+@@ -19,10 +19,10 @@
+ #include <vector>
+ 
+ #include "common.h"
+-#include "third_party/absl/strings/match.h"
+-#include "third_party/absl/strings/string_view.h"
+-#include "third_party/absl/strings/strip.h"
+-#include "third_party/darts_clone/darts.h"
++#include "absl/strings/match.h"
++#include "absl/strings/string_view.h"
++#include "absl/strings/strip.h"
++#include "darts.h"
+ #include "util.h"
+ 
+ namespace sentencepiece {
+diff --git a/src/normalizer.h b/src/normalizer.h
+index f8c9b88..2042932 100644
+--- a/src/normalizer.h
++++ b/src/normalizer.h
+@@ -24,8 +24,8 @@
+ #include "common.h"
+ #include "sentencepiece_model.pb.h"
+ #include "sentencepiece_processor.h"
+-#include "third_party/absl/strings/string_view.h"
+-#include "third_party/darts_clone/darts.h"
++#include "absl/strings/string_view.h"
++#include "darts.h"
+ 
+ namespace sentencepiece {
+ namespace normalizer {
+diff --git a/src/pretokenizer_for_training.cc b/src/pretokenizer_for_training.cc
+index d4f492c..54bdff1 100644
+--- a/src/pretokenizer_for_training.cc
++++ b/src/pretokenizer_for_training.cc
+@@ -15,7 +15,7 @@
+ 
+ #include <string>
+ 
+-#include "third_party/absl/strings/str_replace.h"
++#include "absl/strings/str_replace.h"
+ 
+ namespace sentencepiece {
+ namespace pretokenizer {
+diff --git a/src/pretokenizer_for_training.h b/src/pretokenizer_for_training.h
+index fa54f95..b5f9ae9 100644
+--- a/src/pretokenizer_for_training.h
++++ b/src/pretokenizer_for_training.h
+@@ -21,7 +21,7 @@
+ #include "common.h"
+ #include "sentencepiece.pb.h"
+ #include "sentencepiece_processor.h"
+-#include "third_party/absl/strings/string_view.h"
++#include "absl/strings/string_view.h"
+ 
+ namespace sentencepiece {
+ namespace pretokenizer {
+diff --git a/src/sentencepiece_processor.cc b/src/sentencepiece_processor.cc
+index bca962e..0572afa 100644
+--- a/src/sentencepiece_processor.cc
++++ b/src/sentencepiece_processor.cc
+@@ -30,13 +30,13 @@
+ #include "model_interface.h"
+ #include "normalizer.h"
+ #include "sentencepiece.pb.h"
+-#include "third_party/absl/strings/numbers.h"
+-#include "third_party/absl/strings/str_cat.h"
+-#include "third_party/absl/strings/str_join.h"
+-#include "third_party/absl/strings/str_replace.h"
+-#include "third_party/absl/strings/str_split.h"
+-#include "third_party/absl/strings/string_view.h"
+-#include "third_party/absl/strings/strip.h"
++#include "absl/strings/numbers.h"
++#include "absl/strings/str_cat.h"
++#include "absl/strings/str_join.h"
++#include "absl/strings/str_replace.h"
++#include "absl/strings/str_split.h"
++#include "absl/strings/string_view.h"
++#include "absl/strings/strip.h"
+ #include "unigram_model.h"
+ #include "util.h"
+ 
+diff --git a/src/sentencepiece_trainer.cc b/src/sentencepiece_trainer.cc
+index e08594c..8ba7797 100644
+--- a/src/sentencepiece_trainer.cc
++++ b/src/sentencepiece_trainer.cc
+@@ -23,12 +23,12 @@
+ #include "sentencepiece.pb.h"
+ #include "sentencepiece_model.pb.h"
+ #include "spec_parser.h"
+-#include "third_party/absl/flags/flag.h"
+-#include "third_party/absl/strings/numbers.h"
+-#include "third_party/absl/strings/str_cat.h"
+-#include "third_party/absl/strings/str_split.h"
+-#include "third_party/absl/strings/string_view.h"
+-#include "third_party/absl/strings/strip.h"
++#include "absl/flags/flag.h"
++#include "absl/strings/numbers.h"
++#include "absl/strings/str_cat.h"
++#include "absl/strings/str_split.h"
++#include "absl/strings/string_view.h"
++#include "absl/strings/strip.h"
+ #include "trainer_factory.h"
+ #include "util.h"
+ 
+diff --git a/src/spec_parser.h b/src/spec_parser.h
+index 0667976..ad0c672 100644
+--- a/src/spec_parser.h
++++ b/src/spec_parser.h
+@@ -19,8 +19,8 @@
+ #include <vector>
+ 
+ #include "sentencepiece_processor.h"
+-#include "third_party/absl/strings/ascii.h"
+-#include "third_party/absl/strings/str_split.h"
++#include "absl/strings/ascii.h"
++#include "absl/strings/str_split.h"
+ #include "util.h"
+ 
+ namespace sentencepiece {
+diff --git a/src/spm_decode_main.cc b/src/spm_decode_main.cc
+index bc49bd3..ed80939 100644
+--- a/src/spm_decode_main.cc
++++ b/src/spm_decode_main.cc
+@@ -21,8 +21,8 @@
+ #include "init.h"
+ #include "sentencepiece.pb.h"
+ #include "sentencepiece_processor.h"
+-#include "third_party/absl/flags/flag.h"
+-#include "third_party/absl/strings/str_split.h"
++#include "absl/flags/flag.h"
++#include "absl/strings/str_split.h"
+ #include "util.h"
+ 
+ ABSL_FLAG(std::string, model, "", "model file name");
+diff --git a/src/spm_encode_main.cc b/src/spm_encode_main.cc
+index 0b2633e..95a3a47 100644
+--- a/src/spm_encode_main.cc
++++ b/src/spm_encode_main.cc
+@@ -22,10 +22,10 @@
+ #include "init.h"
+ #include "sentencepiece.pb.h"
+ #include "sentencepiece_processor.h"
+-#include "third_party/absl/container/flat_hash_map.h"
+-#include "third_party/absl/flags/flag.h"
+-#include "third_party/absl/strings/str_cat.h"
+-#include "third_party/absl/strings/str_join.h"
++#include "absl/container/flat_hash_map.h"
++#include "absl/flags/flag.h"
++#include "absl/strings/str_cat.h"
++#include "absl/strings/str_join.h"
+ #include "trainer_interface.h"
+ 
+ ABSL_FLAG(std::string, model, "", "model file name");
+diff --git a/src/spm_export_vocab_main.cc b/src/spm_export_vocab_main.cc
+index e5b97df..480c639 100644
+--- a/src/spm_export_vocab_main.cc
++++ b/src/spm_export_vocab_main.cc
+@@ -19,7 +19,7 @@
+ #include "init.h"
+ #include "sentencepiece_model.pb.h"
+ #include "sentencepiece_processor.h"
+-#include "third_party/absl/flags/flag.h"
++#include "absl/flags/flag.h"
+ 
+ ABSL_FLAG(std::string, output, "", "Output filename");
+ ABSL_FLAG(std::string, model, "", "input model file name");
+diff --git a/src/spm_normalize_main.cc b/src/spm_normalize_main.cc
+index 39f3ef9..b2b7562 100644
+--- a/src/spm_normalize_main.cc
++++ b/src/spm_normalize_main.cc
+@@ -21,7 +21,7 @@
+ #include "sentencepiece_model.pb.h"
+ #include "sentencepiece_processor.h"
+ #include "sentencepiece_trainer.h"
+-#include "third_party/absl/flags/flag.h"
++#include "absl/flags/flag.h"
+ 
+ ABSL_FLAG(std::string, model, "", "Model file name");
+ ABSL_FLAG(bool, use_internal_normalization, false,
+diff --git a/src/spm_train_main.cc b/src/spm_train_main.cc
+index b59bc27..f1ecf7e 100644
+--- a/src/spm_train_main.cc
++++ b/src/spm_train_main.cc
+@@ -18,10 +18,10 @@
+ #include "init.h"
+ #include "sentencepiece_model.pb.h"
+ #include "sentencepiece_trainer.h"
+-#include "third_party/absl/flags/flag.h"
+-#include "third_party/absl/strings/ascii.h"
+-#include "third_party/absl/strings/str_join.h"
+-#include "third_party/absl/strings/str_split.h"
++#include "absl/flags/flag.h"
++#include "absl/strings/ascii.h"
++#include "absl/strings/str_join.h"
++#include "absl/strings/str_split.h"
+ #include "util.h"
+ 
+ using sentencepiece::NormalizerSpec;
+diff --git a/src/trainer_interface.cc b/src/trainer_interface.cc
+index 9e06471..e688538 100644
+--- a/src/trainer_interface.cc
++++ b/src/trainer_interface.cc
+@@ -29,12 +29,12 @@
+ #include "normalizer.h"
+ #include "sentencepiece_processor.h"
+ #include "sentencepiece_trainer.h"
+-#include "third_party/absl/container/flat_hash_map.h"
+-#include "third_party/absl/strings/numbers.h"
+-#include "third_party/absl/strings/str_cat.h"
+-#include "third_party/absl/strings/str_format.h"
+-#include "third_party/absl/strings/str_join.h"
+-#include "third_party/absl/strings/str_split.h"
++#include "absl/container/flat_hash_map.h"
++#include "absl/strings/numbers.h"
++#include "absl/strings/str_cat.h"
++#include "absl/strings/str_format.h"
++#include "absl/strings/str_join.h"
++#include "absl/strings/str_split.h"
+ #include "unicode_script.h"
+ #include "util.h"
+ 
+diff --git a/src/trainer_interface.h b/src/trainer_interface.h
+index 748d088..ab039fd 100644
+--- a/src/trainer_interface.h
++++ b/src/trainer_interface.h
+@@ -27,7 +27,7 @@
+ #include "sentencepiece_model.pb.h"
+ #include "sentencepiece_processor.h"
+ #include "sentencepiece_trainer.h"
+-#include "third_party/absl/container/flat_hash_map.h"
++#include "absl/container/flat_hash_map.h"
+ #include "util.h"
+ 
+ namespace sentencepiece {
+diff --git a/src/unicode_script.cc b/src/unicode_script.cc
+index 583dc30..11b24dc 100644
+--- a/src/unicode_script.cc
++++ b/src/unicode_script.cc
+@@ -14,7 +14,7 @@
+ 
+ #include <unordered_map>
+ 
+-#include "third_party/absl/container/flat_hash_map.h"
++#include "absl/container/flat_hash_map.h"
+ #include "unicode_script.h"
+ #include "unicode_script_map.h"
+ #include "util.h"
+diff --git a/src/unicode_script_map.h b/src/unicode_script_map.h
+index f2e67e9..f1b8299 100644
+--- a/src/unicode_script_map.h
++++ b/src/unicode_script_map.h
+@@ -14,7 +14,7 @@
+ 
+ #ifndef UNICODE_SCRIPT_DATA_H_
+ #define UNICODE_SCRIPT_DATA_H_
+-#include "third_party/absl/container/flat_hash_map.h"
++#include "absl/container/flat_hash_map.h"
+ namespace sentencepiece {
+ namespace unicode_script {
+ namespace {
+diff --git a/src/unigram_model.cc b/src/unigram_model.cc
+index 13f15c8..8863c7c 100644
+--- a/src/unigram_model.cc
++++ b/src/unigram_model.cc
+@@ -24,9 +24,9 @@
+ #include <utility>
+ #include <vector>
+ 
+-#include "third_party/absl/container/flat_hash_map.h"
+-#include "third_party/absl/strings/str_split.h"
+-#include "third_party/absl/strings/string_view.h"
++#include "absl/container/flat_hash_map.h"
++#include "absl/strings/str_split.h"
++#include "absl/strings/string_view.h"
+ #include "util.h"
+ 
+ namespace sentencepiece {
+diff --git a/src/unigram_model.h b/src/unigram_model.h
+index d1b214e..0a6308f 100644
+--- a/src/unigram_model.h
++++ b/src/unigram_model.h
+@@ -24,7 +24,7 @@
+ #include "freelist.h"
+ #include "model_interface.h"
+ #include "sentencepiece_model.pb.h"
+-#include "third_party/darts_clone/darts.h"
++#include "darts.h"
+ 
+ namespace sentencepiece {
+ namespace unigram {
+diff --git a/src/unigram_model_trainer.cc b/src/unigram_model_trainer.cc
+index 201ea5e..14bbeab 100644
+--- a/src/unigram_model_trainer.cc
++++ b/src/unigram_model_trainer.cc
+@@ -28,11 +28,11 @@
+ #include "normalizer.h"
+ #include "pretokenizer_for_training.h"
+ #include "sentencepiece_trainer.h"
+-#include "third_party/absl/container/flat_hash_map.h"
+-#include "third_party/absl/strings/numbers.h"
+-#include "third_party/absl/strings/str_replace.h"
+-#include "third_party/absl/strings/str_split.h"
+-#include "third_party/esaxx/esa.hxx"  // Suffix array library.
++#include "absl/container/flat_hash_map.h"
++#include "absl/strings/numbers.h"
++#include "absl/strings/str_replace.h"
++#include "absl/strings/str_split.h"
++#include "esa.hxx"  // Suffix array library.
+ #include "trainer_interface.h"
+ #include "unicode_script.h"
+ #include "util.h"
+diff --git a/src/unigram_model_trainer.h b/src/unigram_model_trainer.h
+index 3f57e31..58abff0 100644
+--- a/src/unigram_model_trainer.h
++++ b/src/unigram_model_trainer.h
+@@ -21,7 +21,7 @@
+ #include <vector>
+ 
+ #include "sentencepiece_model.pb.h"
+-#include "third_party/absl/strings/string_view.h"
++#include "absl/strings/string_view.h"
+ #include "trainer_interface.h"
+ #include "unigram_model.h"
+ #include "util.h"
+diff --git a/src/util.h b/src/util.h
+index 9ee06ff..04be9af 100644
+--- a/src/util.h
++++ b/src/util.h
+@@ -30,7 +30,7 @@
+ 
+ #include "common.h"
+ #include "sentencepiece_processor.h"
+-#include "third_party/absl/strings/string_view.h"
++#include "absl/strings/string_view.h"
+ 
+ #ifdef SPM_NO_THREADLOCAL
+ #include <pthread.h>
+diff --git a/src/word_model_trainer.cc b/src/word_model_trainer.cc
+index 77522a3..e4039f6 100644
+--- a/src/word_model_trainer.cc
++++ b/src/word_model_trainer.cc
+@@ -15,8 +15,8 @@
+ #include <cmath>
+ #include <string>
+ 
+-#include "third_party/absl/container/flat_hash_map.h"
+-#include "third_party/absl/strings/string_view.h"
++#include "absl/container/flat_hash_map.h"
++#include "absl/strings/string_view.h"
+ #include "util.h"
+ #include "word_model.h"
+ #include "word_model_trainer.h"

--- a/modules/sentencepiece/0.2.1/presubmit.yml
+++ b/modules/sentencepiece/0.2.1/presubmit.yml
@@ -1,0 +1,92 @@
+matrix:
+  unix_platform:
+  - debian11
+  - ubuntu2404
+  - ubuntu2404_arm64
+  - macos
+  - macos_arm64
+  windows_platform:
+  - windows
+  bazel:
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets_unix:
+    name: Verify build targets (Unix)
+    platform: ${{ unix_platform }}
+    bazel: ${{ bazel }}
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@sentencepiece//:sentencepiece'
+    - '@sentencepiece//:sentencepiece_train'
+    - '@sentencepiece//src:spm_decode'
+    - '@sentencepiece//src:spm_encode'
+    - '@sentencepiece//src:spm_export_vocab'
+    - '@sentencepiece//src:spm_normalize'
+    - '@sentencepiece//src:spm_train'
+  verify_targets_windows:
+    name: Verify build targets (Windows)
+    platform: ${{ windows_platform }}
+    bazel: ${{ bazel }}
+    environment:
+      ANDROID_HOME: ""
+      ANDROID_NDK_HOME: ""
+    build_flags:
+    - '--cxxopt=/std:c++17'
+    - '--host_cxxopt=/std:c++17'
+    - '--cxxopt=/utf-8'
+    - '--host_cxxopt=/utf-8'
+    build_targets:
+    - '@sentencepiece//:sentencepiece'
+    - '@sentencepiece//:sentencepiece_train'
+    - '@sentencepiece//src:spm_decode'
+    - '@sentencepiece//src:spm_encode'
+    - '@sentencepiece//src:spm_export_vocab'
+    - '@sentencepiece//src:spm_normalize'
+    - '@sentencepiece//src:spm_train'
+bcr_test_module:
+  module_path: bcr_tests
+  matrix:
+    unix_platform:
+    - debian11
+    - ubuntu2404
+    - ubuntu2404_arm64
+    - macos
+    - macos_arm64
+    windows_platform:
+    - windows
+    bazel:
+    - 8.x
+    - 9.x
+  tasks:
+    run_test_module_unix:
+      name: Run test module (Unix)
+      platform: ${{ unix_platform }}
+      bazel: ${{ bazel }}
+      environment:
+        ANDROID_HOME: ""
+        ANDROID_NDK_HOME: ""
+      build_flags:
+      - '--cxxopt=-std=c++17'
+      - '--host_cxxopt=-std=c++17'
+      test_targets:
+      - '//...'
+    run_test_module_windows:
+      name: Run test module (Windows)
+      platform: ${{ windows_platform }}
+      bazel: ${{ bazel }}
+      environment:
+        ANDROID_HOME: ""
+        ANDROID_NDK_HOME: ""
+      build_flags:
+      - '--cxxopt=/std:c++17'
+      - '--host_cxxopt=/std:c++17'
+      - '--cxxopt=/utf-8'
+      - '--host_cxxopt=/utf-8'
+      test_targets:
+      - '//...'

--- a/modules/sentencepiece/0.2.1/source.json
+++ b/modules/sentencepiece/0.2.1/source.json
@@ -1,0 +1,16 @@
+{
+    "url": "https://github.com/google/sentencepiece/releases/download/v0.2.1/sentencepiece-0.2.1.tar.gz",
+    "integrity": "sha256-gTjOwnwvIoL0o02aAW4zdM1A5cbpyzNQY9tmoKO3H60=",
+    "strip_prefix": "sentencepiece-0.2.1/sentencepiece",
+    "patch_strip": 1,
+    "overlay": {
+        "BUILD.bazel": "sha256-1J6GYEpKhJYzSsidqRT3qJ8s8DWbkt5Da2teqqKokgU=",
+        "bcr_tests/BUILD.bazel": "sha256-y8efyi+o6d5tcwr1o2ZxH6QNkvZ/4KaULcucniiTvOM=",
+        "bcr_tests/MODULE.bazel": "sha256-pgtl4d8+AKoXk+Hjjtn2hVANPGqBSHEQueTQ0J+jl/Q=",
+        "bcr_tests/roundtrip_test.cc": "sha256-a3gnQlReClBHgAPeHrga/8KSZQIlFQoMW06McxRaIs0=",
+        "src/BUILD.bazel": "sha256-pC5gB2m5132aLFz3otpFsEs4G0VSatPws6QTen/jawE="
+    },
+    "patches": {
+        "use_bcr_dependency_includes.patch": "sha256-H4g0tthiLM+0l3gmO7Hko+hUW8nretlsjm/5lqAcUDA="
+    }
+}

--- a/modules/sentencepiece/metadata.json
+++ b/modules/sentencepiece/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/google/sentencepiece",
+    "maintainers": [
+        {
+            "email": "byvoid@byvoid.com",
+            "github": "BYVoid",
+            "name": "Carbo Kuo",
+            "github_user_id": 245270
+        }
+    ],
+    "repository": [
+        "github:google/sentencepiece"
+    ],
+    "versions": [
+        "0.2.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds [SentencePiece](https://github.com/google/sentencepiece) v0.2.1 as a new module.

The Bazel build definitions are taken from the upstream PR google/sentencepiece#1280 (not yet merged), adapted for the 0.2.1 release tarball:

- `overlay/BUILD.bazel` + `overlay/src/BUILD.bazel`: root aliases, `//src:sentencepiece` (runtime), `//src:sentencepiece_train` (trainer), and the `spm_{train,encode,decode,normalize,export_vocab}` CLIs. The protobuf code is regenerated from `src/*.proto` at build time (matching the `SPM_PROTOBUF_PROVIDER=package` CMake configuration). `defines = ["_USE_EXTERNAL_ABSL"]` selects the external-absl branch of `error.cc`, which defines the `--minloglevel` flag (normally supplied by the vendored mini-absl shim's `flag.cc`), matching the `SPM_ABSL_PROVIDER=module|package` CMake configurations.
- `patches/use_bcr_dependency_includes.patch`: rewrites `#include "third_party/absl/..."` → `"absl/..."`, `"third_party/darts_clone/darts.h"` → `"darts.h"`, and `"third_party/esaxx/esa.hxx"` → `"esa.hxx"` so the sources resolve against the BCR modules (abseil-cpp, darts-clone@0.32h.bcr.1, esaxx@20250106.1.bcr.1) instead of the vendored copies.
- The release tarball is a Python sdist, so `strip_prefix` is `sentencepiece-0.2.1/sentencepiece`. It does not ship the `data/` directory, so the upstream `spm_test` target is not included. Instead, the overlay adds a `bcr_tests/` test module (`bcr_test_module` in presubmit) with an in-memory train → encode → decode roundtrip `cc_test`; presubmit also verifies all library and CLI targets on Linux/macOS/Windows with C++17 flags.

Locally verified: all targets build (Bazel 9.1.1), the `bcr_tests` roundtrip test passes, `spm_train`/`spm_encode` work end to end, and `bcr_validation.py --check sentencepiece@0.2.1` passes.
