### PR TITLE
Update comments in Au MODULE.bazel files

### DIFF
--- a/modules/au/0.5.0/MODULE.bazel
+++ b/modules/au/0.5.0/MODULE.bazel
@@ -19,14 +19,9 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.0.4")
 
-# GoogleTest is required for our publically available `//au:testing` target.  We
-# specify the current version we use here so this will participate in any users
-# BCR resolution, but it won't actually be pulled down to the users workspace if
-# they don't actually depend on a target that depends on `googletest`.
+# GoogleTest is required for our publicly available `//au:testing` target.
 bazel_dep(
     name = "googletest",
-    # NOTE: if updating this version, also update the version numbers in
-    # `CMakelists.txt`.
     version = "1.12.1",
     repo_name = "com_google_googletest",
 )

--- a/modules/au/0.5.1/MODULE.bazel
+++ b/modules/au/0.5.1/MODULE.bazel
@@ -1,4 +1,4 @@
-# Copyright 2025 Aurora Operations, Inc.
+# Copyright 2026 Aurora Operations, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,14 +19,9 @@ module(
 
 bazel_dep(name = "rules_cc", version = "0.0.4")
 
-# GoogleTest is required for our publically available `//au:testing` target.  We
-# specify the current version we use here so this will participate in any users
-# BCR resolution, but it won't actually be pulled down to the users workspace if
-# they don't actually depend on a target that depends on `googletest`.
+# GoogleTest is required for our publicly available `//au:testing` target.
 bazel_dep(
     name = "googletest",
-    # NOTE: if updating this version, also update the version numbers in
-    # `CMakelists.txt`.
     version = "1.12.1",
     repo_name = "com_google_googletest",
 )


### PR DESCRIPTION
Remove some of the unneeded verbosity.  Update the copyright for the
0.5.1 module to 2026 when it was actually submitted.
