### PR TITLE
pocketfft@0.0.2.bcr.1: use (more) stable GH source mirror

### DIFF
--- a/modules/pocketfft/0.0.2.bcr.1/MODULE.bazel
+++ b/modules/pocketfft/0.0.2.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "pocketfft",
+    version = "0.0.2.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.4")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/pocketfft/0.0.2.bcr.1/overlay/BUILD.bazel
+++ b/modules/pocketfft/0.0.2.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])
+
+cc_library(
+    name = "pocketfft",
+    hdrs = [
+        "pocketfft_hdronly.h",
+    ],
+    copts = [
+        "-fexceptions",
+    ],
+    features = [
+        "-use_header_modules",
+    ],
+)

--- a/modules/pocketfft/0.0.2.bcr.1/overlay/MODULE.bazel
+++ b/modules/pocketfft/0.0.2.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "pocketfft",
+    version = "0.0.2.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.4")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/pocketfft/0.0.2.bcr.1/presubmit.yml
+++ b/modules/pocketfft/0.0.2.bcr.1/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  # - windows
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@pocketfft//:pocketfft'

--- a/modules/pocketfft/0.0.2.bcr.1/source.json
+++ b/modules/pocketfft/0.0.2.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/mreineck/pocketfft/archive/bb5bdb776c64819f66cb2205f78bef1581448628.tar.gz",
+    "strip_prefix": "pocketfft-bb5bdb776c64819f66cb2205f78bef1581448628",
+    "integrity": "sha256-E+GjYxIOqf2fMZ9EVak+LqhgXpmGspUbJ01ypypYkJA=",
+    "overlay": {
+        "BUILD.bazel": "sha256-3gdgzX/c0+TcumAidQsW1d870AI6MLuPlyrlCLS+Tq4=",
+        "MODULE.bazel": "sha256-0EDAt5udVhbPMJIXvleH+VAf3VGmA/HoOoN0lKQkpxE="
+    }
+}

--- a/modules/pocketfft/metadata.json
+++ b/modules/pocketfft/metadata.json
@@ -9,11 +9,13 @@
         }
     ],
     "repository": [
-        "https://gitlab.mpcdf.mpg.de/mtr/pocketfft"
+        "https://gitlab.mpcdf.mpg.de/mtr/pocketfft",
+        "https://github.com/mreineck/pocketfft/"
     ],
     "versions": [
         "0.0.1",
-        "0.0.2"
+        "0.0.2",
+        "0.0.2.bcr.1"
     ],
     "yanked_versions": {
         "0.0.1": "Please use 0.0.2 or later"


### PR DESCRIPTION
The original `https://gitlab.mpcdf.mpg.de/mtr/pocketfft` URL has had numerous connectivity issues recently, so this updates the source URL to a GH mirror.