### PR TITLE
Add sv-elab

### DIFF
--- a/modules/sv-elab/2026-07-07/MODULE.bazel
+++ b/modules/sv-elab/2026-07-07/MODULE.bazel
@@ -1,0 +1,20 @@
+"""sv-elab: SystemVerilog elaborator"""
+
+module(
+    name = "sv-elab",
+    version = "2026-07-07",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+# yosys 0.62.bcr.2 is the first release that exports :hdrs for plugins.
+bazel_dep(name = "yosys", version = "0.62.bcr.2")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_python", version = "2.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "fmt", version = "12.1.0")
+bazel_dep(name = "boost.regex", version = "1.90.0.bcr.1")
+tomlplusplus_ext = use_extension("//:dependency_support/tomlplusplus_ext.bzl", "tomlplusplus_ext")
+use_repo(tomlplusplus_ext, "tomlplusplus")
+slang_ext = use_extension("//:dependency_support/slang_ext.bzl", "vendored_slang_extension")
+use_repo(slang_ext, "vendored-slang")

--- a/modules/sv-elab/2026-07-07/presubmit.yml
+++ b/modules/sv-elab/2026-07-07/presubmit.yml
@@ -1,0 +1,12 @@
+matrix:
+  platform: [ "ubuntu2204", "ubuntu2404"]
+  bazel: [ "7.x", "8.x", "9.x" ]
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags: [ "--cxxopt=-std=c++20", "--host_cxxopt=-std=c++20" ]
+    build_targets:
+      - "@sv-elab//..."

--- a/modules/sv-elab/2026-07-07/source.json
+++ b/modules/sv-elab/2026-07-07/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/povik/sv-elab/releases/download/2026-07-07/sv-elab-2026-07-07.tar.gz",
+    "integrity": "sha256-Qy0BAj/XvjH5wWIBvOkvRt7YobOIrZCSOP/0aqfhwNo=",
+    "strip_prefix": "sv-elab-2026-07-07"
+}

--- a/modules/sv-elab/metadata.json
+++ b/modules/sv-elab/metadata.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "https://github.com/povik/sv-elab",
+    "maintainers": [
+        {
+            "github": "povik",
+            "name": "Martin Povišer",
+            "github_user_id": 382160
+        },
+        {
+            "email": "h.zeller@acm.org",
+            "github": "hzeller",
+            "name": "Henner Zeller",
+            "github_user_id": 140937
+        }
+    ],
+    "repository": [
+        "github:povik/sv-elab"
+    ],
+    "versions": [
+        "2026-07-07"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
The yosys-slang project got renamed to sv-elab, so maybe we need to provide some sort of re-direct to this one (or we just let it age out while this one accumulates new versions).