### PR TITLE
Fix yosys-slang integrity hash.

### DIFF
--- a/modules/yosys-slang/0.0.0.bcr.1/MODULE.bazel
+++ b/modules/yosys-slang/0.0.0.bcr.1/MODULE.bazel
@@ -1,0 +1,18 @@
+"""yosys-slang plugin: SystemVerilog frontend for yosys via slang."""
+
+module(
+    name = "yosys-slang",
+    version = "0.0.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+# yosys 0.62.bcr.2 is the first release that exports :hdrs for plugins.
+bazel_dep(name = "yosys", version = "0.62.bcr.2")
+bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_python", version = "2.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "fmt", version = "12.1.0")
+
+slang_ext = use_extension("//:dependency_support/slang_ext.bzl", "vendored_slang_extension")
+use_repo(slang_ext, "vendored-slang")

--- a/modules/yosys-slang/0.0.0.bcr.1/patches/bcr-version.patch
+++ b/modules/yosys-slang/0.0.0.bcr.1/patches/bcr-version.patch
@@ -1,0 +1,11 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -2,7 +2,7 @@
+ 
+ module(
+     name = "yosys-slang",
+-    version = "0.0.0",
++    version = "0.0.0.bcr.1",
+     bazel_compatibility = [">=7.2.1"],
+ )
+ 

--- a/modules/yosys-slang/0.0.0.bcr.1/presubmit.yml
+++ b/modules/yosys-slang/0.0.0.bcr.1/presubmit.yml
@@ -1,0 +1,12 @@
+matrix:
+  platform: [ "ubuntu2204", "ubuntu2404"]
+  bazel: [ "7.x", "8.x", "9.x" ]
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags: [ "--cxxopt=-std=c++20", "--host_cxxopt=-std=c++20" ]
+    build_targets:
+      - "@yosys-slang//..."

--- a/modules/yosys-slang/0.0.0.bcr.1/source.json
+++ b/modules/yosys-slang/0.0.0.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/povik/yosys-slang/archive/6760afa2c9b9ba231a9c6a9e94f0939dd39f0a20.tar.gz",
+    "integrity": "sha256-NBmPLtey0xdcPOPJ+xxskfKNvP5THZe5HWsSxIQxve8=",
+    "strip_prefix": "sv-elab-6760afa2c9b9ba231a9c6a9e94f0939dd39f0a20/",
+    "patches": {
+         "bcr-version.patch": "sha256-Y/Srotg1T4Fu3Rx6tIkY/mwUwnxQZezCFlb3pQXU8kk="
+     },
+     "patch_strip": 1
+}

--- a/modules/yosys-slang/metadata.json
+++ b/modules/yosys-slang/metadata.json
@@ -17,7 +17,8 @@
         "github:povik/yosys-slang"
     ],
     "versions": [
-        "0.0.0"
+        "0.0.0",
+        "0.0.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Since the project got renamed (new one in #9571), here the old hash does not work anymore.
So as last update to yosys-slang on BCR, fix the hash but otherwise keep the exact same version.