### PR TITLE
rules_ocx@0.1.2

### DIFF
--- a/modules/rules_ocx/0.1.2/MODULE.bazel
+++ b/modules/rules_ocx/0.1.2/MODULE.bazel
@@ -1,0 +1,32 @@
+"""rules_ocx — Bazel module extension provisioning tools via the OCX package manager.
+
+OCX (https://ocx.sh) resolves, downloads, and composes tool packages from OCI
+registries. rules_ocx bootstraps a pinned `ocx` CLI binary and shells out to it
+from repository rules — it never re-implements OCX internals in Starlark.
+"""
+
+module(
+    name = "rules_ocx",
+    version = "0.1.2",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+
+bazel_dep(name = "rules_shell", version = "0.6.1", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
+
+ocx = use_extension("//ocx:extensions.bzl", "ocx")
+use_repo(ocx, "ocx_tool")
+
+# Dogfooding: rules_ocx provisions its own dev toolchain from ocx.toml.
+# dev_dependency keeps these tags out of consumer builds (project tags are
+# root-module-only).
+ocx_dev = use_extension("//ocx:extensions.bzl", "ocx", dev_dependency = True)
+ocx_dev.project(
+    name = "dev_tools",
+    ocx_lock = "//:ocx.lock",
+    ocx_toml = "//:ocx.toml",
+)
+use_repo(ocx_dev, "dev_tools")

--- a/modules/rules_ocx/0.1.2/presubmit.yml
+++ b/modules/rules_ocx/0.1.2/presubmit.yml
@@ -1,0 +1,16 @@
+# Exercises rules_ocx as a downstream bzlmod dependency. Runs the module under
+# test as a non-root dep, so its dogfooding `ocx.project` dev tags are ignored
+# and no dev toolchain is provisioned. Build-only: the lazy launcher renders
+# without pulling from an OCI registry (see e2e/bzlmod).
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["debian11", "ubuntu2204", "macos", "windows"]
+    bazel: ["8.x", "9.x"]
+  tasks:
+    verify_test_module:
+      name: "Build rules_ocx consumer (lazy launcher, no OCI pull)"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."

--- a/modules/rules_ocx/0.1.2/source.json
+++ b/modules/rules_ocx/0.1.2/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-6Fu54LALSeiD61/684uTIzKSjiupfYkpJNYRq4soGDg=",
+    "strip_prefix": "rules_ocx-0.1.2",
+    "url": "https://github.com/ocx-sh/rules_ocx/releases/download/v0.1.2/rules_ocx-v0.1.2.tar.gz"
+}

--- a/modules/rules_ocx/metadata.json
+++ b/modules/rules_ocx/metadata.json
@@ -1,17 +1,18 @@
 {
-  "homepage": "https://github.com/ocx-sh/rules_ocx",
-  "maintainers": [
-    {
-      "name": "Michael Herwig",
-      "github": "michael-herwig",
-      "github_user_id": 3511590
-    }
-  ],
-  "repository": [
-    "github:ocx-sh/rules_ocx"
-  ],
-  "versions": [
-    "0.1.1"
-  ],
-  "yanked_versions": {}
+    "homepage": "https://github.com/ocx-sh/rules_ocx",
+    "maintainers": [
+        {
+            "name": "Michael Herwig",
+            "github": "michael-herwig",
+            "github_user_id": 3511590
+        }
+    ],
+    "repository": [
+        "github:ocx-sh/rules_ocx"
+    ],
+    "versions": [
+        "0.1.1",
+        "0.1.2"
+    ],
+    "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/ocx-sh/rules_ocx/releases/tag/v0.1.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_