### PR TITLE
Drop licenses declaration for bazel 9 compatibility and bump remotery to 1.0.0.bcr.1

### DIFF
--- a/modules/remotery/1.0.0.bcr.1/MODULE.bazel
+++ b/modules/remotery/1.0.0.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "remotery",
+    version = "1.0.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.18")
+bazel_dep(name = "rules_license", version = "1.0.0")

--- a/modules/remotery/1.0.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/remotery/1.0.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+)
+
+license(
+    name = "license",
+    package_name = "remotery",
+)
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "remotery",
+    srcs = ["lib/Remotery.c"],
+    hdrs = ["lib/Remotery.h"],
+    includes = ["lib"],
+    copts = [
+        "-w",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/modules/remotery/1.0.0.bcr.1/presubmit.yml
+++ b/modules/remotery/1.0.0.bcr.1/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+    - ubuntu2404
+    - ubuntu2404_arm64
+    - macos
+    - macos_arm64
+    - windows
+    - windows_arm64
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@remotery//:remotery'

--- a/modules/remotery/1.0.0.bcr.1/source.json
+++ b/modules/remotery/1.0.0.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/Celtoys/Remotery/archive/refs/tags/v1.0.0.tar.gz",
+    "integrity": "sha256-ZdbLrC0BnDX8odhXKc6LPSlNhfrHXFOSGZGhTR83m7g=",
+    "strip_prefix": "Remotery-1.0.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-wIxpMkUODHddMQ11OwfZ8t9rU5Ftvvn+HTBpbk4Hfbg="
+    },
+    "patch_strip": 0
+}

--- a/modules/remotery/metadata.json
+++ b/modules/remotery/metadata.json
@@ -13,7 +13,8 @@
     ],
     "versions": [
         "1.0.0",
-        "1.0.0.bcr.0"
+        "1.0.0.bcr.0",
+        "1.0.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
There was a `licenses` target that was missed in https://github.com/bazelbuild/bazel-central-registry/pull/9186