### PR TITLE
Fix invalid metadata.json format

### DIFF
--- a/modules/openmesh/metadata.json
+++ b/modules/openmesh/metadata.json
@@ -1,5 +1,8 @@
 {
     "homepage": "https://www.graphics.rwth-aachen.de/software/openmesh/",
+    "repository": [
+        "https://www.graphics.rwth-aachen.de/"
+    ],
     "maintainers": [
         {
             "email": "shameek@google.com",

--- a/modules/rules_runfile_codegen_core/metadata.json
+++ b/modules/rules_runfile_codegen_core/metadata.json
@@ -1,5 +1,4 @@
 {
-    "name": "rules_runfile_codegen_core",
     "homepage": "https://github.com/meta-programming/rules_runfiles_codegen",
     "maintainers": [
         {

--- a/modules/rules_runfile_codegen_go/metadata.json
+++ b/modules/rules_runfile_codegen_go/metadata.json
@@ -1,5 +1,4 @@
 {
-    "name": "rules_runfile_codegen_go",
     "homepage": "https://github.com/meta-programming/rules_runfiles_codegen",
     "maintainers": [
         {

--- a/modules/rules_runfile_codegen_kotlin/metadata.json
+++ b/modules/rules_runfile_codegen_kotlin/metadata.json
@@ -1,5 +1,4 @@
 {
-    "name": "rules_runfile_codegen_kotlin",
     "homepage": "https://github.com/meta-programming/rules_runfiles_codegen",
     "maintainers": [
         {


### PR DESCRIPTION
BCR's own presubmit (not the per-module presubmit) was broken but silently passing for a while, leading to these missed broken metadata.json files. The pipeline has since been fixed to properly fail on them.