### PR TITLE
Self nominate pico-sdk, picotool modules maintainership.

### DIFF
--- a/modules/pico-sdk/metadata.json
+++ b/modules/pico-sdk/metadata.json
@@ -17,6 +17,11 @@
             "github_user_id": 575810
         },
         {
+            "github": "prabhuk",
+            "name": "Prabhu Karthikeyan Rajasekaran",
+            "github_user_id": 515853
+        },
+        {
             "github": "tpudlik",
             "name": "Ted Pudlik",
             "github_user_id": 4148295

--- a/modules/picotool/metadata.json
+++ b/modules/picotool/metadata.json
@@ -2,12 +2,6 @@
     "homepage": "https://github.com/raspberrypi/picotool",
     "maintainers": [
         {
-            "email": "tpudlik@google.com",
-            "github": "tpudlik",
-            "name": "Ted Pudlik",
-            "github_user_id": 4148295
-        },
-        {
             "email": "amontanez@google.com",
             "github": "armandomontanez",
             "name": "Armando Montanez",
@@ -17,6 +11,17 @@
             "github": "davexroth",
             "name": "Dave Roth",
             "github_user_id": 49175007
+        },
+        {
+            "github": "prabhuk",
+            "name": "Prabhu Karthikeyan Rajasekaran",
+            "github_user_id": 515853
+        },
+        {
+            "email": "tpudlik@google.com",
+            "github": "tpudlik",
+            "name": "Ted Pudlik",
+            "github_user_id": 4148295
         },
         {
             "email": "pigweed-team@googlegroups.com",


### PR DESCRIPTION
I work on providing Google Clang/LLVM toolchain support for pico-sdk.
Self nominating to be added to maintainers list.
Also alphabetizing owners list in this patch.