### PR TITLE
protovalidate@1.2.1

### DIFF
--- a/modules/protovalidate/1.2.1/MODULE.bazel
+++ b/modules/protovalidate/1.2.1/MODULE.bazel
@@ -1,0 +1,39 @@
+# Copyright 2023-2026 Buf Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "protovalidate",
+    version = "1.2.1",
+    repo_name = "com_github_bufbuild_protovalidate",
+)
+
+bazel_dep(name = "rules_go", version = "0.51.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.40.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_buf", version = "0.3.0")
+bazel_dep(name = "protobuf", version = "29.2", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a")
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.20.4")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//tools:go.mod")
+use_repo(go_deps, "com_github_bufbuild_protocompile", "com_github_spf13_pflag", "com_github_stretchr_testify", "in_gopkg_yaml_v3", "org_golang_google_protobuf", "org_golang_x_sync")
+
+buf = use_extension("@rules_buf//buf:extensions.bzl", "buf")
+buf.toolchains(
+    version = "v1.50.0",
+    sha256 = "736e74d1697dcf253bc60b2f0fb4389c39dbc7be68472a7d564a953df8b19d12",
+)

--- a/modules/protovalidate/1.2.1/attestations.json
+++ b/modules/protovalidate/1.2.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/bufbuild/protovalidate/releases/download/v1.2.1/source.json.intoto.jsonl",
+            "integrity": "sha256-gIakGBO4SA1Ewk8Obwcg8mpjKBzIfpOiDEM4o62Pz1U="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/bufbuild/protovalidate/releases/download/v1.2.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-s42ajdlHFDwqE+fSCbnXBo4h3bbdWX7tqMsbDRN6cuI="
+        },
+        "protovalidate-1.2.1.tar.gz": {
+            "url": "https://github.com/bufbuild/protovalidate/releases/download/v1.2.1/protovalidate-1.2.1.tar.gz.intoto.jsonl",
+            "integrity": "sha256-N2Ama7SSWG5NAN0LVyNta7Cr+xfCUz7lcJ1roaTXJUs="
+        }
+    }
+}

--- a/modules/protovalidate/1.2.1/presubmit.yml
+++ b/modules/protovalidate/1.2.1/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["debian10", "macos"]
+    bazel: [7.x, 8.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/protovalidate/1.2.1/source.json
+++ b/modules/protovalidate/1.2.1/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-LAlFrNiiIkshhJxMs3HWJ8ITUUiTj1oPTzG1Gusgdws=",
+    "strip_prefix": "protovalidate-1.2.1",
+    "url": "https://github.com/bufbuild/protovalidate/releases/download/v1.2.1/protovalidate-1.2.1.tar.gz"
+}

--- a/modules/protovalidate/metadata.json
+++ b/modules/protovalidate/metadata.json
@@ -14,6 +14,12 @@
             "github_user_id": 4289451
         },
         {
+            "name": "Jon Bodner",
+            "email": "jbodner@buf.build",
+            "github": "jonbodner-buf",
+            "github_user_id": 268635641
+        },
+        {
             "name": "Sri Krishna Paritala",
             "email": "skrishna@buf.build",
             "github": "srikrsna-buf",
@@ -49,7 +55,8 @@
         "1.0.0",
         "1.1.0",
         "1.1.1",
-        "1.2.0"
+        "1.2.0",
+        "1.2.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/bufbuild/protovalidate/releases/tag/v1.2.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_