### PR TITLE
Add cutlass 4.2.1

### DIFF
--- a/modules/cutlass/4.2.1/MODULE.bazel
+++ b/modules/cutlass/4.2.1/MODULE.bazel
@@ -3,3 +3,5 @@ module(
     version = "4.2.1",
     compatibility_level = 1,
 )
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/cutlass/4.2.1/MODULE.bazel
+++ b/modules/cutlass/4.2.1/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "cutlass",
+    version = "4.2.1",
+    compatibility_level = 1,
+)

--- a/modules/cutlass/4.2.1/patches/add_build_file.patch
+++ b/modules/cutlass/4.2.1/patches/add_build_file.patch
@@ -1,0 +1,21 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,18 @@
++package(default_visibility = ["//visibility:public"])
++
++filegroup(
++    name = "all",
++    srcs = glob(["**"]),
++)
++
++cc_library(
++    name = "cutlass",
++    srcs = [],
++    hdrs = glob([
++        "include/**/*.h",
++        "include/**/*.hpp",
++        "include/**/*.inl",
++    ]),
++    strip_include_prefix = "include",
++    visibility = ["//visibility:public"],
++)

--- a/modules/cutlass/4.2.1/patches/add_build_file.patch
+++ b/modules/cutlass/4.2.1/patches/add_build_file.patch
@@ -1,6 +1,8 @@
 --- /dev/null
 +++ BUILD.bazel
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,20 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++
 +package(default_visibility = ["//visibility:public"])
 +
 +filegroup(

--- a/modules/cutlass/4.2.1/patches/module_dot_bazel.patch
+++ b/modules/cutlass/4.2.1/patches/module_dot_bazel.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -0,0 +1,5 @@
++module(
++    name = "cutlass",
++    version = "4.2.1",
++    compatibility_level = 1,
++)

--- a/modules/cutlass/4.2.1/patches/module_dot_bazel.patch
+++ b/modules/cutlass/4.2.1/patches/module_dot_bazel.patch
@@ -1,8 +1,10 @@
 --- MODULE.bazel
 +++ MODULE.bazel
-@@ -0,0 +1,5 @@
+@@ -0,0 +1,7 @@
 +module(
 +    name = "cutlass",
 +    version = "4.2.1",
 +    compatibility_level = 1,
 +)
++
++bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/cutlass/4.2.1/presubmit.yml
+++ b/modules/cutlass/4.2.1/presubmit.yml
@@ -8,6 +8,7 @@ matrix:
   bazel:
     - 7.x
     - 8.x
+    - 9.x
     - rolling
 tasks:
   verify_targets:

--- a/modules/cutlass/4.2.1/presubmit.yml
+++ b/modules/cutlass/4.2.1/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 6.x
+    - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@cutlass//:cutlass'

--- a/modules/cutlass/4.2.1/presubmit.yml
+++ b/modules/cutlass/4.2.1/presubmit.yml
@@ -7,7 +7,7 @@ matrix:
     - windows
   bazel:
     - 7.x
-    - 6.x
+    - 8.x
     - rolling
 tasks:
   verify_targets:

--- a/modules/cutlass/4.2.1/source.json
+++ b/modules/cutlass/4.2.1/source.json
@@ -3,8 +3,8 @@
     "integrity": "sha256-pFE7ozroL9dUhDxthDe+4axxpu8cdN+IbeIzjjkX1N8=",
     "strip_prefix": "cutlass-4.2.1",
     "patches": {
-        "add_build_file.patch": "sha256-nFDVIxs/M03FglGctcWe+eF9ELqvCN5XEtMgHjH1nPs=",
-        "module_dot_bazel.patch": "sha256-P5lu/+e8BqN5bi0v1VLbu6TGz3oc0/hnIm0jh7juSKA="
+        "add_build_file.patch": "sha256-fn61jyymzHC/WYFMpaU2585GYnUHqk/TzeDRXsjBNj4=",
+        "module_dot_bazel.patch": "sha256-lxoga34kKdEf2A74K/uducBJ57BD4dXDH0eRXKAgGp8="
     },
     "patch_strip": 0
 }

--- a/modules/cutlass/4.2.1/source.json
+++ b/modules/cutlass/4.2.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/NVIDIA/cutlass/archive/refs/tags/v4.2.1.tar.gz",
+    "integrity": "sha256-pFE7ozroL9dUhDxthDe+4axxpu8cdN+IbeIzjjkX1N8=",
+    "strip_prefix": "cutlass-4.2.1",
+    "patches": {
+        "add_build_file.patch": "sha256-nFDVIxs/M03FglGctcWe+eF9ELqvCN5XEtMgHjH1nPs=",
+        "module_dot_bazel.patch": "sha256-P5lu/+e8BqN5bi0v1VLbu6TGz3oc0/hnIm0jh7juSKA="
+    },
+    "patch_strip": 0
+}

--- a/modules/cutlass/metadata.json
+++ b/modules/cutlass/metadata.json
@@ -10,7 +10,8 @@
         "github:NVIDIA/cutlass"
     ],
     "versions": [
-        "3.5.1"
+        "3.5.1",
+        "4.2.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds version **4.2.1** of [NVIDIA/cutlass](https://github.com/NVIDIA/cutlass) (CUDA Templates for Linear Algebra).

Mirrors the existing `3.5.1` module:
- Overlay `BUILD.bazel` exposing the header-only `@cutlass//:cutlass` target (and an `:all` filegroup), plus a `MODULE.bazel`, both added via patch.
- The header glob additionally includes `**/*.inl`: cutlass 4.2.1 ships 36 `.inl` headers that its public `.h`/`.hpp` headers `#include`, so consumers that compile against cutlass headers need them present in the sandbox.

Verified locally:
- Archive integrity matches the upstream `v4.2.1.tar.gz` tag.
- Both patches apply cleanly (`patch -p0`) and reproduce the committed `MODULE.bazel`.
- `bazel build @cutlass//:cutlass` succeeds.