### PR TITLE
Add dlpack 1.3.bcr.1

### DIFF
--- a/modules/dlpack/1.3.bcr.1/MODULE.bazel
+++ b/modules/dlpack/1.3.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "dlpack",
+    version = "1.3.bcr.1",
+    compatibility_level = 0,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/dlpack/1.3.bcr.1/overlay/BUILD.bazel
+++ b/modules/dlpack/1.3.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "dlpack",
+    hdrs = ["include/dlpack/dlpack.h"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/modules/dlpack/1.3.bcr.1/overlay/MODULE.bazel
+++ b/modules/dlpack/1.3.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "dlpack",
+    version = "1.3.bcr.1",
+    compatibility_level = 0,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/dlpack/1.3.bcr.1/presubmit.yml
+++ b/modules/dlpack/1.3.bcr.1/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - debian11
+  - ubuntu2204
+  - ubuntu2404
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@dlpack'

--- a/modules/dlpack/1.3.bcr.1/source.json
+++ b/modules/dlpack/1.3.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/dmlc/dlpack/archive/refs/tags/v1.3.tar.gz",
+    "integrity": "sha256-89Vn+IX2wUIYOvyRpYhzsx0OCzb6ouRcIyuYx0WWQE8=",
+    "strip_prefix": "dlpack-1.3",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-f/BtVjqoIdyorSEuK8mQuLErf4kBEiFvA4IL2EolUnY=",
+        "MODULE.bazel": "sha256-vfunlwORwl3D67WI0rByYWIjDjNAitr+rFo8JhJ27IU="
+    }
+}

--- a/modules/dlpack/metadata.json
+++ b/modules/dlpack/metadata.json
@@ -11,7 +11,8 @@
         "github:dmlc/dlpack"
     ],
     "versions": [
-        "1.3"
+        "1.3",
+        "1.3.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds **dlpack 1.3.bcr.1** — a registry-only revision of the existing `1.3` module (same upstream source archive).

### What changed
The `1.3` overlay `BUILD.bazel` declares:
```python
hdrs = ["include/dlpack.h"],
```
but dlpack v1.3 ships its header **nested** at `include/dlpack/dlpack.h` — there is no top-level `include/dlpack.h`. As a result the `dlpack` `cc_library` exposes no usable header, and any consumer that does the standard `#include <dlpack/dlpack.h>` fails at compile time with:
```
missing input file '//:include/dlpack.h'
```
This revision points `hdrs` at the header's real location:
```
-    hdrs = ["include/dlpack.h"],
+    hdrs = ["include/dlpack/dlpack.h"],
```
The overlay diff vs `1.3` is exactly that one line.

### Why 1.3's presubmit didn't catch it
The `verify_targets` task only builds `@dlpack`, a header-only library. Building a header-only target produces no compile action that stages the (missing) header, so the break never surfaces there — it only appears when something actually compiles against the library.

### Verification
- `bazel build @dlpack` succeeds on Bazel 7.4.1.
- A `#include <dlpack/dlpack.h>` consumer builds successfully against the fixed overlay (it fails against `1.3`).