### PR TITLE
Make googletest 1.17.0 compatible with new Bazel 9.1.1.

### DIFF
--- a/modules/googletest/1.17.0/MODULE.bazel
+++ b/modules/googletest/1.17.0/MODULE.bazel
@@ -58,6 +58,11 @@ bazel_dep(
     dev_dependency = True,
 )
 
+bazel_dep(
+    name = "rules_cc",
+    version = "0.2.17"
+)
+
 # https://rules-python.readthedocs.io/en/stable/toolchains.html#library-modules-with-dev-only-python-usage
 python = use_extension(
     "@rules_python//python/extensions:python.bzl",


### PR DESCRIPTION
Without this, I have this error:

```
ERROR: Traceback (most recent call last):
	File "/some_local_path/external/googletest+/BUILD.bazel", line 79, column 11, in <toplevel>
		cc_library(
	File "/virtual_builtins_bzl/bazel/exports.bzl", line 40, column 9, in _removed_rule_failure
Error in fail: 
         This rule has been removed from Bazel. Please add a `load()` statement for it.
         This can also be done automatically by running:
         buildifier --lint=fix <path-to-BUILD-or-bzl-file>
```