### PR TITLE
rules_idb@0.1.3

### DIFF
--- a/modules/rules_idb/0.1.3/MODULE.bazel
+++ b/modules/rules_idb/0.1.3/MODULE.bazel
@@ -1,0 +1,40 @@
+"""rules_idb: idb-based test runners for rules_apple tests."""
+
+module(
+    name = "rules_idb",
+    version = "0.1.3",
+    bazel_compatibility = [">=7.0.0"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "apple_support", version = "2.7.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_apple", version = "4.5.3")
+bazel_dep(name = "rules_swift", version = "3.6.1")
+bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "rules_python", version = "1.7.0")
+
+# Hermetic python for the vendored idb client (it needs >= 3.10; macOS's
+# system python is 3.9).
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(python_version = "3.12")
+use_repo(python, "python_3_12_host")
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip.parse(
+    hub_name = "rules_idb_pip",
+    python_version = "3.12",
+    requirements_lock = "//third_party:requirements_lock.txt",
+)
+use_repo(pip, "rules_idb_pip")
+
+# Prebuilt idb_companion, fetched from this repository's GitHub releases.
+idb = use_extension("//idb:extensions.bzl", "idb")
+use_repo(idb, "idb_companion_dist")
+
+# Uncomment to develop against a local rules_apple checkout:
+# local_path_override(
+#     module_name = "rules_apple",
+#     path = "../rules_apple",
+# )

--- a/modules/rules_idb/0.1.3/presubmit.yml
+++ b/modules/rules_idb/0.1.3/presubmit.yml
@@ -1,0 +1,12 @@
+# BCR presubmit: build-only — BCR CI cannot run simulator tests.
+matrix:
+  platform: ["macos_arm64"]
+  bazel: ["9.x"]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@rules_idb//idb:default_runner"
+      - "@rules_idb//tools:preboot"

--- a/modules/rules_idb/0.1.3/source.json
+++ b/modules/rules_idb/0.1.3/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-QElXL+GRZbf8cSedXtlSNihL1vnjiz3ykopYRwoBLcc=",
+    "strip_prefix": "rules_idb-0.1.3",
+    "url": "https://github.com/erneestoc/rules_idb/releases/download/v0.1.3/rules_idb-0.1.3.tar.gz"
+}

--- a/modules/rules_idb/metadata.json
+++ b/modules/rules_idb/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/erneestoc/rules_idb",
+    "maintainers": [
+        {
+            "name": "Ernesto Cambuston",
+            "email": "e.cambuston@gmail.com",
+            "github": "erneestoc",
+            "github_user_id": 1932403
+        }
+    ],
+    "repository": [
+        "github:erneestoc/rules_idb"
+    ],
+    "versions": [
+        "0.1.3"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/erneestoc/rules_idb/releases/tag/v0.1.3

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_