### PR TITLE
fix(bcr_validation): always use the PEP 706 data filter when extracting tar archives

### DIFF
--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -497,10 +497,7 @@ class BcrValidator:
         if archive_type in ("tar.zst", "tzst"):
             with open(archive_file, "rb") as fh, zstandard.ZstdDecompressor().stream_reader(fh) as reader:
                 with tarfile.open(fileobj=reader, mode="r|") as tar:
-                    if sys.version_info >= (3, 12):
-                        tar.extractall(output_dir, filter="data")
-                    else:
-                        tar.extractall(output_dir)
+                    tar.extractall(output_dir, filter="data")
             return
         format = {
             "tar.gz": "gztar",
@@ -513,12 +510,15 @@ class BcrValidator:
             "war": "zip",
             "aar": "zip",
         }.get(archive_type)
-        # Use PEP 706 safe extraction if available (Python 3.12+)
-        if sys.version_info >= (3, 12) and format != "zip":
-            shutil.unpack_archive(str(archive_file), output_dir, format=format, filter="data")
-        else:
-            # Fallback for older Python versions. Since CI is 3.12+, this handles local dev compatibility.
+        # Always use PEP 706 safe ("data") extraction for tar archives so that a malicious source
+        # archive cannot write outside output_dir via `../` members or symlinks. The filter is
+        # available on every interpreter the BCR runs on (CPython 3.8.17+/3.9.17+/3.10.12+/3.11.4+/
+        # 3.12+). zip/jar/war/aar are handled by zipfile, which sanitizes member names and never
+        # creates symlinks, so they need no filter.
+        if format == "zip":
             shutil.unpack_archive(str(archive_file), output_dir, format=format)
+        else:
+            shutil.unpack_archive(str(archive_file), output_dir, format=format, filter="data")
 
     @staticmethod
     def extract_attribute_from_module(module_dot_bazel_file, attribute, default=None):


### PR DESCRIPTION
Fixes #9697

## What

`BcrValidator._download_source_archive()` gated safe archive extraction on
`sys.version_info >= (3, 12)`. On older interpreters tar archives were extracted with the default
`fully_trusted` filter, so a source archive whose members contain `..` (or a symlink) can write files
outside the temporary extraction directory. The archive bytes come from the PR-submitted
`source.json`, whose recorded `integrity` is just the SHA-256 of that same archive, so this is
reachable from an ordinary module PR.

The validator runs under Python < 3.12 in practice:

- `bazel run //tools:bcr_validation` uses the toolchain pinned in `MODULE.bazel`
  (`python_version = "3.11"`);
- `bcr_presubmit.py` invokes it via the agent's system `python3`.

So the "Since CI is 3.12+" assumption in the comment does not hold and the fully-trusted branch is
reachable.

## Fix

Apply the PEP 706 `data` filter to tar extraction unconditionally. The filter is available on every
interpreter the BCR runs on (CPython 3.8.17+ / 3.9.17+ / 3.10.12+ / 3.11.4+ / 3.12+), so the version
gate is unnecessary and unsafe. `zip`/`jar`/`war`/`aar` stay on `zipfile`, which already sanitizes
member names and never creates symlinks (see #8395).

## Testing

- Normal `tar.gz` / `tar.zst` / `zip` module archives still extract on Python 3.10 and 3.11.
- A crafted archive with a `..` member (and a symlink member) is now rejected by the `data` filter
  (`OutsideDestinationError`) instead of escaping the extraction directory, on Python 3.10 and 3.11.

Happy to add a regression test under `tools/bcr_validation_test.py` if desired.

Reported via the Google OSS VRP: https://issuetracker.google.com/issues/524574159
