### PR TITLE
rules_odin@0.3.2

### DIFF
--- a/modules/rules_odin/0.3.2/MODULE.bazel
+++ b/modules/rules_odin/0.3.2/MODULE.bazel
@@ -1,0 +1,20 @@
+"""rules_odin - Bazel rules for the Odin programming language."""
+
+module(
+    name = "rules_odin",
+    version = "0.3.2",
+    compatibility_level = 0,
+)
+
+# Runtime dependencies
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.10")
+
+# Note: These are minimum versions. Users may get newer versions via resolution.
+
+# Toolchain registration for development/testing
+odin = use_extension("//odin:extensions.bzl", "odin")
+odin.toolchain(odin_version = "dev-2026-06")
+use_repo(odin, "odin_toolchains")
+
+register_toolchains("@odin_toolchains//:all")

--- a/modules/rules_odin/0.3.2/attestations.json
+++ b/modules/rules_odin/0.3.2/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/clappingmonkey/rules_odin/releases/download/v0.3.2/source.json.intoto.jsonl",
+            "integrity": "sha256-ND5bYu2y5clFp39qrIxXAhJHbrrguH8szPLZCwhWJ2I="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/clappingmonkey/rules_odin/releases/download/v0.3.2/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-4EY0vXOnMFxF7aqFHBD6yKIzkkp3sz13dmq7HYpdUdY="
+        },
+        "rules_odin-v0.3.2.tar.gz": {
+            "url": "https://github.com/clappingmonkey/rules_odin/releases/download/v0.3.2/rules_odin-v0.3.2.tar.gz.intoto.jsonl",
+            "integrity": "sha256-Cst5LlLb55/s1PeieerKj/2C8S8l4gx9A6cm5cxcm7w="
+        }
+    }
+}

--- a/modules/rules_odin/0.3.2/presubmit.yml
+++ b/modules/rules_odin/0.3.2/presubmit.yml
@@ -1,0 +1,14 @@
+bcr_test_module:
+  module_path: "e2e/bcr_smoke"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: ["7.x", "8.x", "9.x"]
+  tasks:
+    run_tests:
+      name: "Build & test Odin smoke module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."
+      test_targets:
+        - "//..."

--- a/modules/rules_odin/0.3.2/source.json
+++ b/modules/rules_odin/0.3.2/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-LRQyFWi4k8Qt/8+0VlWHpVDEkGp46NNcX5iyULWe/xc=",
+    "strip_prefix": "rules_odin-0.3.2",
+    "url": "https://github.com/clappingmonkey/rules_odin/releases/download/v0.3.2/rules_odin-v0.3.2.tar.gz"
+}

--- a/modules/rules_odin/metadata.json
+++ b/modules/rules_odin/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/clappingmonkey/rules_odin",
+    "maintainers": [
+        {
+            "name": "Ventsislav Kostadinov",
+            "email": "clappingmonkey33@gmail.com",
+            "github": "clappingmonkey",
+            "github_user_id": 17432099
+        }
+    ],
+    "repository": [
+        "github:clappingmonkey/rules_odin"
+    ],
+    "versions": [
+        "0.3.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/clappingmonkey/rules_odin/releases/tag/v0.3.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_