### PR TITLE
gavel_tools@0.3.8

### DIFF
--- a/modules/gavel_tools/0.3.8/MODULE.bazel
+++ b/modules/gavel_tools/0.3.8/MODULE.bazel
@@ -1,0 +1,81 @@
+module(
+    name = "gavel_tools",
+    version = "0.3.8",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_go", version = "0.60.0")
+bazel_dep(name = "rules_java", version = "9.1.0")
+bazel_dep(name = "rules_python", version = "1.7.0")
+bazel_dep(name = "gazelle", version = "0.50.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
+bazel_dep(name = "aspect_rules_js", version = "3.0.3")
+bazel_dep(name = "aspect_rules_ts", version = "3.8.8")
+bazel_dep(name = "aspect_rules_esbuild", version = "0.25.1")
+bazel_dep(name = "rules_nodejs", version = "6.7.4")
+bazel_dep(name = "rules_rust", version = "0.70.0")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.25.11")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_stretchr_testify",
+    "in_gopkg_yaml_v3",
+)
+
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+node.toolchain(node_version = "22.16.0")
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
+npm.npm_translate_lock(
+    name = "gavel_eslint",
+    pnpm_lock = "//lint/lang/typescript/eslint:pnpm-lock.yaml",
+)
+use_repo(npm, "gavel_eslint")
+
+# Linter tool binaries the aspects depend on. Owned here (not by consumers) so
+# the aspect labels (@golangci_lint, @pmd, …) resolve within this module.
+golangci_lint_binary = use_repo_rule("//lint/lang/go/golangci_lint:repositories.bzl", "golangci_lint_binary")
+
+golangci_lint_binary(
+    name = "golangci_lint",
+    version = "2.11.4",
+)
+
+pmd_binary = use_repo_rule("//lint/lang/java/pmd:repositories.bzl", "pmd_binary")
+
+pmd_binary(
+    name = "pmd",
+    version = "7.24.0",
+)
+
+spotbugs_binary = use_repo_rule("//lint/lang/java/spotbugs:repositories.bzl", "spotbugs_binary")
+
+spotbugs_binary(
+    name = "spotbugs",
+    version = "4.9.8",
+)
+
+error_prone_binary = use_repo_rule("//lint/lang/java/error_prone:repositories.bzl", "error_prone_binary")
+
+error_prone_binary(
+    name = "error_prone",
+    version = "2.49.0",
+)
+
+ruff_binary = use_repo_rule("//lint/lang/python/ruff:repositories.bzl", "ruff_binary")
+
+ruff_binary(
+    name = "ruff",
+    version = "0.15.12",
+)
+
+bandit_binary = use_repo_rule("//lint/lang/python/bandit:repositories.bzl", "bandit_binary")
+
+bandit_binary(
+    name = "bandit",
+    version = "1.9.4",
+)

--- a/modules/gavel_tools/0.3.8/presubmit.yml
+++ b/modules/gavel_tools/0.3.8/presubmit.yml
@@ -1,0 +1,12 @@
+matrix:
+  platform: ["ubuntu2004"]
+  bazel: ["7.x", "8.x"]
+tasks:
+  verify:
+    name: "Build and test gavel_tools"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "//..."
+    test_targets:
+      - "//..."

--- a/modules/gavel_tools/0.3.8/presubmit.yml
+++ b/modules/gavel_tools/0.3.8/presubmit.yml
@@ -7,6 +7,6 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_targets:
-      - "//..."
+      - "@gavel_tools//..."
     test_targets:
-      - "//..."
+      - "@gavel_tools//..."

--- a/modules/gavel_tools/0.3.8/source.json
+++ b/modules/gavel_tools/0.3.8/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/gavelcode/gavel-tools/archive/refs/tags/v0.3.8.tar.gz",
+    "strip_prefix": "gavel-tools-0.3.8",
+    "integrity": "sha256-s2fU/KkPqx98lNtMq3FsAyqMpu3BpdVi4k02hOQ1kq4="
+}

--- a/modules/gavel_tools/metadata.json
+++ b/modules/gavel_tools/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/gavelcode/gavel-tools",
+    "maintainers": [
+        {
+            "name": "Jorge Olmos Mallol",
+            "email": "jorolma@gmail.com",
+            "github": "JorgeOlmosDev",
+            "github_user_id": 5722037
+        }
+    ],
+    "repository": [
+        "github:gavelcode/gavel-tools"
+    ],
+    "versions": [
+        "0.3.8"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds gavel_tools 0.3.8 to the registry. Bazel tooling that runs static analyzers as aspects and normalizes their output to SARIF. Homepage/repo: https://github.com/gavelcode/gavel-tools