### PR TITLE
fribidi@1.0.16

### DIFF
--- a/modules/fribidi/1.0.16/MODULE.bazel
+++ b/modules/fribidi/1.0.16/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "fribidi",
+    version = "1.0.16",
+    compatibility_level = 1,
+    # need support for "overlay" directory in source.json
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/fribidi/1.0.16/MODULE.bazel
+++ b/modules/fribidi/1.0.16/MODULE.bazel
@@ -1,8 +1,6 @@
 module(
     name = "fribidi",
     version = "1.0.16",
-    compatibility_level = 1,
-    # need support for "overlay" directory in source.json
     bazel_compatibility = [">=7.2.1"],
 )
 

--- a/modules/fribidi/1.0.16/overlay/BUILD.bazel
+++ b/modules/fribidi/1.0.16/overlay/BUILD.bazel
@@ -7,11 +7,7 @@ cc_library(
         # common.h, debug.h, run.h, bidi-types.h, joining-types.h
         exclude = ["lib/fribidi*.h"],
     ),
-    # Public API headers, including the shipped fribidi-unicode-version.h and
-    # the overlay's checked-in fribidi-config.h.
     hdrs = glob(["lib/fribidi*.h"]),
-    # Consumers do `#include <fribidi.h>`, matching pkg-config's
-    # -I${includedir}/fribidi.
     includes = ["lib"],
     # These match what meson/configure would detect on all supported
     # platforms; config.h itself is skipped (HAVE_CONFIG_H stays undefined).

--- a/modules/fribidi/1.0.16/overlay/BUILD.bazel
+++ b/modules/fribidi/1.0.16/overlay/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "fribidi",
+    srcs = glob(["lib/*.c"]) + glob(
+        ["lib/*.h"],
+        # common.h, debug.h, run.h, bidi-types.h, joining-types.h
+        exclude = ["lib/fribidi*.h"],
+    ),
+    # Public API headers, including the shipped fribidi-unicode-version.h and
+    # the overlay's checked-in fribidi-config.h.
+    hdrs = glob(["lib/fribidi*.h"]),
+    # Consumers do `#include <fribidi.h>`, matching pkg-config's
+    # -I${includedir}/fribidi.
+    includes = ["lib"],
+    # These match what meson/configure would detect on all supported
+    # platforms; config.h itself is skipped (HAVE_CONFIG_H stays undefined).
+    # The value-sensitive `#if HAVE_*` checks require the `=1`.
+    local_defines = [
+        "HAVE_STDLIB_H=1",
+        "HAVE_STRING_H=1",
+        "HAVE_MEMORY_H=1",
+        "HAVE_MEMSET=1",
+        "HAVE_MEMMOVE=1",
+        "HAVE_STRINGIZE=1",
+        "STDC_HEADERS=1",
+    ],
+    # Propagated to consumers: keeps FRIBIDI_ENTRY empty on Windows, where it
+    # would otherwise expand to __declspec(dllimport).
+    defines = ["FRIBIDI_LIB_STATIC"],
+    # The Unicode tables are #included by the .c files and must not be
+    # compiled on their own.
+    textual_hdrs = glob(["lib/*.tab.i"]),
+    visibility = ["//visibility:public"],
+)

--- a/modules/fribidi/1.0.16/overlay/MODULE.bazel
+++ b/modules/fribidi/1.0.16/overlay/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "fribidi",
+    version = "1.0.16",
+    compatibility_level = 1,
+    # need support for "overlay" directory in source.json
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/fribidi/1.0.16/overlay/MODULE.bazel
+++ b/modules/fribidi/1.0.16/overlay/MODULE.bazel
@@ -1,8 +1,6 @@
 module(
     name = "fribidi",
     version = "1.0.16",
-    compatibility_level = 1,
-    # need support for "overlay" directory in source.json
     bazel_compatibility = [">=7.2.1"],
 )
 

--- a/modules/fribidi/1.0.16/overlay/lib/fribidi-config.h
+++ b/modules/fribidi/1.0.16/overlay/lib/fribidi-config.h
@@ -1,6 +1,3 @@
-/* fribidi-config.h checked in by the Bazel Central Registry overlay;
- * values taken from lib/meson.build for this release. */
-/* Not copyrighted, in public domain. */
 #ifndef FRIBIDI_CONFIG_H
 #define FRIBIDI_CONFIG_H
 

--- a/modules/fribidi/1.0.16/overlay/lib/fribidi-config.h
+++ b/modules/fribidi/1.0.16/overlay/lib/fribidi-config.h
@@ -1,0 +1,24 @@
+/* fribidi-config.h checked in by the Bazel Central Registry overlay;
+ * values taken from lib/meson.build for this release. */
+/* Not copyrighted, in public domain. */
+#ifndef FRIBIDI_CONFIG_H
+#define FRIBIDI_CONFIG_H
+
+#define FRIBIDI "fribidi"
+#define FRIBIDI_NAME "GNU FriBidi"
+#define FRIBIDI_BUGREPORT "https://github.com/fribidi/fribidi/issues/new"
+
+#define FRIBIDI_VERSION "1.0.16"
+#define FRIBIDI_MAJOR_VERSION 1
+#define FRIBIDI_MINOR_VERSION 0
+#define FRIBIDI_MICRO_VERSION 16
+#define FRIBIDI_INTERFACE_VERSION 4
+#define FRIBIDI_INTERFACE_VERSION_STRING "4"
+
+/* The size of a `int', as computed by sizeof. 4 on all supported platforms
+   (LP64/LLP64); fribidi-types.h only checks >= 4. */
+#define FRIBIDI_SIZEOF_INT 4
+
+/* FRIBIDI_BUILT_WITH_MSVC left undefined: no source file references it. */
+
+#endif /* FRIBIDI_CONFIG_H */

--- a/modules/fribidi/1.0.16/overlay/tests/BUILD.bazel
+++ b/modules/fribidi/1.0.16/overlay/tests/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "smoke",
+    srcs = ["smoke.c"],
+    deps = ["@fribidi"],
+)

--- a/modules/fribidi/1.0.16/overlay/tests/MODULE.bazel
+++ b/modules/fribidi/1.0.16/overlay/tests/MODULE.bazel
@@ -1,0 +1,7 @@
+bazel_dep(name = "fribidi")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+
+local_path_override(
+    module_name = "fribidi",
+    path = "..",
+)

--- a/modules/fribidi/1.0.16/overlay/tests/smoke.c
+++ b/modules/fribidi/1.0.16/overlay/tests/smoke.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <fribidi.h>
+
+int
+main (void)
+{
+  /* Hebrew letters alef, bet, gimel in logical order. */
+  FriBidiChar logical[3] = { 0x05D0, 0x05D1, 0x05D2 };
+  FriBidiChar visual[3] = { 0, 0, 0 };
+  FriBidiParType base = FRIBIDI_PAR_ON;
+  FriBidiLevel levels;
+
+  if (fribidi_version_info == NULL
+      || strstr (fribidi_version_info, FRIBIDI_VERSION) == NULL)
+    {
+      fprintf (stderr, "unexpected fribidi_version_info\n");
+      return 1;
+    }
+
+  levels = fribidi_log2vis (logical, 3, &base, visual, NULL, NULL, NULL);
+  if (levels == 0)
+    {
+      fprintf (stderr, "fribidi_log2vis failed\n");
+      return 1;
+    }
+
+  if (!FRIBIDI_IS_RTL (base))
+    {
+      fprintf (stderr, "paragraph direction not detected as RTL\n");
+      return 1;
+    }
+
+  /* An RTL run must come out reversed in visual order. */
+  if (visual[0] != 0x05D2 || visual[1] != 0x05D1 || visual[2] != 0x05D0)
+    {
+      fprintf (stderr, "unexpected visual reordering\n");
+      return 1;
+    }
+
+  printf ("fribidi " FRIBIDI_VERSION " smoke test passed\n");
+  return 0;
+}

--- a/modules/fribidi/1.0.16/presubmit.yml
+++ b/modules/fribidi/1.0.16/presubmit.yml
@@ -1,0 +1,30 @@
+matrix:
+  platform:
+    - debian13
+    - ubuntu2404
+    - macos
+    - macos_arm64
+    - windows
+  bazel: [7.x, 8.x, 9.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets: ["@fribidi//:fribidi"]
+bcr_test_module:
+  module_path: tests
+  matrix:
+    platform:
+      - debian13
+      - ubuntu2404
+      - macos
+      - macos_arm64
+      - windows
+    bazel: [7.x, 8.x, 9.x, rolling]
+  tasks:
+    run_test_module:
+      name: Run smoke test
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets: ["//:smoke"]

--- a/modules/fribidi/1.0.16/source.json
+++ b/modules/fribidi/1.0.16/source.json
@@ -3,9 +3,9 @@
     "integrity": "sha256-GxzeWyNdQEeekb4vDoijCeMhTIq0cOyKJ0TYKlqeoFw=",
     "strip_prefix": "fribidi-1.0.16",
     "overlay": {
-        "BUILD.bazel": "sha256-Ds+EZ62CzTbD4hZ92axKhGmhtOExUOXGGn0K/+WL8Lw=",
-        "MODULE.bazel": "sha256-H9HOMFPeGmw/x7NY4zTbL9mW7yl/h8m2REnC5jb/tu8=",
-        "lib/fribidi-config.h": "sha256-6t6f5n6c3xiyaHHrT7thyJdgXx7aS7ZYvlD0VjkOhUU=",
+        "BUILD.bazel": "sha256-AkC6Znpg/jvspczf1jGgaBckUpfgJRZzfti6jmpY1NI=",
+        "MODULE.bazel": "sha256-B5LjhT6yn3UehYEGReG7i8z+iDPNcefd2yh1vocQy0Q=",
+        "lib/fribidi-config.h": "sha256-iJQe2tW5ajeew3PqM99XkCnkn3kxsJaHi4flPeHloRA=",
         "tests/BUILD.bazel": "sha256-9WzDpQc2gKodlQzTIut8ZwQcQQcyHREkybRS1HRHzYk=",
         "tests/MODULE.bazel": "sha256-sCGsynhPiC7VrV95D9z+m1omuMitB7DX1tELyCDwhaI=",
         "tests/smoke.c": "sha256-G1EtR18rVeVR6a5+DqfpH4uNDlFgkdn2uh3sqZBshmU="

--- a/modules/fribidi/1.0.16/source.json
+++ b/modules/fribidi/1.0.16/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://github.com/fribidi/fribidi/releases/download/v1.0.16/fribidi-1.0.16.tar.xz",
+    "integrity": "sha256-GxzeWyNdQEeekb4vDoijCeMhTIq0cOyKJ0TYKlqeoFw=",
+    "strip_prefix": "fribidi-1.0.16",
+    "overlay": {
+        "BUILD.bazel": "sha256-Ds+EZ62CzTbD4hZ92axKhGmhtOExUOXGGn0K/+WL8Lw=",
+        "MODULE.bazel": "sha256-H9HOMFPeGmw/x7NY4zTbL9mW7yl/h8m2REnC5jb/tu8=",
+        "lib/fribidi-config.h": "sha256-6t6f5n6c3xiyaHHrT7thyJdgXx7aS7ZYvlD0VjkOhUU=",
+        "tests/BUILD.bazel": "sha256-9WzDpQc2gKodlQzTIut8ZwQcQQcyHREkybRS1HRHzYk=",
+        "tests/MODULE.bazel": "sha256-sCGsynhPiC7VrV95D9z+m1omuMitB7DX1tELyCDwhaI=",
+        "tests/smoke.c": "sha256-G1EtR18rVeVR6a5+DqfpH4uNDlFgkdn2uh3sqZBshmU="
+    }
+}

--- a/modules/fribidi/metadata.json
+++ b/modules/fribidi/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/fribidi/fribidi",
+    "maintainers": [
+        {
+            "email": "cebic.ad@gmail.com",
+            "github": "adincebic",
+            "github_user_id": 19636856,
+            "name": "Adin Cebic"
+        }
+    ],
+    "repository": [
+        "github:fribidi/fribidi"
+    ],
+    "versions": [
+        "1.0.16"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds [GNU FriBidi](https://github.com/fribidi/fribidi) 1.0.16, the Unicode Bidirectional Algorithm library (a dependency of pango, libass, and other text-rendering stacks).