### PR TITLE
valkey: add version 7.2.13

### DIFF
--- a/modules/valkey/7.2.13/MODULE.bazel
+++ b/modules/valkey/7.2.13/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "valkey",
+    version = "7.2.13",
+    compatibility_level = 0,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_shell", version = "0.5.1")

--- a/modules/valkey/7.2.13/overlay/BUILD.bazel
+++ b/modules/valkey/7.2.13/overlay/BUILD.bazel
@@ -1,0 +1,246 @@
+# Adapted from the Bazel Central Registry's Redis 7.2.4 build overlay. Valkey
+# 7.2 is a fork of Redis OSS 7.2 and uses the same source layout, with renamed
+# server and CLI binaries.
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+cc_library(
+    name = "fpconv",
+    srcs = glob(["deps/fpconv/*.c"]),
+    hdrs = glob(["deps/fpconv/*.h"]),
+    strip_include_prefix = "deps/fpconv",
+)
+
+cc_library(
+    name = "hdr_histogram",
+    srcs = glob(["deps/hdr_histogram/*.c"]),
+    hdrs = glob(["deps/hdr_histogram/*.h"]),
+    local_defines = ['HDR_MALLOC_INCLUDE=\\"hdr_redis_malloc.h\\"'],
+    strip_include_prefix = "deps/hdr_histogram",
+)
+
+cc_library(
+    name = "linenoise",
+    srcs = glob(["deps/linenoise/*.c"]),
+    hdrs = glob(["deps/linenoise/*.h"]),
+    strip_include_prefix = "deps/linenoise",
+)
+
+cc_library(
+    name = "hiredis",
+    srcs = glob(
+        ["deps/hiredis/*.c"],
+        exclude = [
+            "deps/hiredis/dict.c",
+            "deps/hiredis/test.c",
+            "deps/hiredis/ssl.*",
+        ],
+    ),
+    hdrs = glob(["deps/hiredis/*.h"]),
+    strip_include_prefix = "deps/hiredis",
+    textual_hdrs = ["deps/hiredis/dict.c"],
+)
+
+cc_library(
+    name = "lua",
+    srcs = glob(
+        ["deps/lua/src/*.c"],
+        exclude = [
+            "deps/lua/src/lua.c",
+            "deps/lua/src/luac.c",
+        ],
+    ) + ["src/solarisfixes.h"],
+    hdrs = glob(["deps/lua/src/*.h"]),
+    local_defines = ["ENABLE_CJSON_GLOBAL"],
+    copts = ["-Wno-deprecated-declarations"],
+    strip_include_prefix = "deps/lua/src",
+)
+
+sh_binary(
+    name = "mkreleasehdr",
+    srcs = ["src/mkreleasehdr.sh"],
+)
+
+genrule(
+    name = "generate_release_header",
+    outs = ["release.h"],
+    cmd = "SOURCE_DATE_EPOCH=0 $(location mkreleasehdr) && mv release.h $@",
+    tools = [":mkreleasehdr"],
+)
+
+cc_library(
+    name = "valkey_lib",
+    srcs = [
+        "src/acl.c",
+        "src/adlist.c",
+        "src/ae.c",
+        "src/anet.c",
+        "src/aof.c",
+        "src/bio.c",
+        "src/bitops.c",
+        "src/blocked.c",
+        "src/call_reply.c",
+        "src/childinfo.c",
+        "src/cluster.c",
+        "src/commands.c",
+        "src/config.c",
+        "src/connection.c",
+        "src/crc16.c",
+        "src/crc64.c",
+        "src/crcspeed.c",
+        "src/db.c",
+        "src/debug.c",
+        "src/defrag.c",
+        "src/dict.c",
+        "src/endianconv.c",
+        "src/eval.c",
+        "src/evict.c",
+        "src/expire.c",
+        "src/function_lua.c",
+        "src/functions.c",
+        "src/geo.c",
+        "src/geohash.c",
+        "src/geohash_helper.c",
+        "src/hyperloglog.c",
+        "src/intset.c",
+        "src/latency.c",
+        "src/lazyfree.c",
+        "src/listpack.c",
+        "src/localtime.c",
+        "src/logreqres.c",
+        "src/lolwut.c",
+        "src/lolwut5.c",
+        "src/lolwut6.c",
+        "src/lzf_c.c",
+        "src/lzf_d.c",
+        "src/memtest.c",
+        "src/module.c",
+        "src/monotonic.c",
+        "src/mt19937-64.c",
+        "src/multi.c",
+        "src/networking.c",
+        "src/notify.c",
+        "src/object.c",
+        "src/pqsort.c",
+        "src/pubsub.c",
+        "src/quicklist.c",
+        "src/rand.c",
+        "src/rax.c",
+        "src/rdb.c",
+        "src/release.c",
+        "src/replication.c",
+        "src/resp_parser.c",
+        "src/rio.c",
+        "src/script.c",
+        "src/script_lua.c",
+        "src/sds.c",
+        "src/sentinel.c",
+        "src/server.c",
+        "src/setcpuaffinity.c",
+        "src/setproctitle.c",
+        "src/sha1.c",
+        "src/sha256.c",
+        "src/siphash.c",
+        "src/slowlog.c",
+        "src/socket.c",
+        "src/sort.c",
+        "src/sparkline.c",
+        "src/strl.c",
+        "src/syncio.c",
+        "src/syscheck.c",
+        "src/t_hash.c",
+        "src/t_list.c",
+        "src/t_set.c",
+        "src/t_stream.c",
+        "src/t_string.c",
+        "src/t_zset.c",
+        "src/timeout.c",
+        "src/tls.c",
+        "src/tracking.c",
+        "src/unix.c",
+        "src/util.c",
+        "src/valkey-check-aof.c",
+        "src/valkey-check-rdb.c",
+        "src/ziplist.c",
+        "src/zipmap.c",
+        "src/zmalloc.c",
+    ] + glob(["src/*.h"]) + ["release.h"],
+    copts = ["-Wno-implicit-const-int-float-conversion"],
+    includes = ["src"],
+    local_defines = ["REDIS_STATIC="],
+    textual_hdrs = select({
+        "@platforms//os:linux": ["src/ae_epoll.c"],
+        "@platforms//os:osx": ["src/ae_kqueue.c"],
+    }) + ["src/commands.def"],
+    deps = [
+        ":fpconv",
+        ":hdr_histogram",
+        ":hiredis",
+        ":lua",
+    ],
+)
+
+cc_library(
+    name = "valkey_cli_lib",
+    srcs = [
+        "src/acl.c",
+        "src/adlist.c",
+        "src/ae.c",
+        "src/anet.c",
+        "src/cli_commands.c",
+        "src/cli_common.c",
+        "src/crc16.c",
+        "src/crc64.c",
+        "src/crcspeed.c",
+        "src/dict.c",
+        "src/monotonic.c",
+        "src/mt19937-64.c",
+        "src/release.c",
+        "src/redisassert.c",
+        "src/siphash.c",
+        "src/strl.c",
+        "src/valkey-cli.c",
+        "src/zmalloc.c",
+    ] + glob(["src/*.h"]) + ["release.h"],
+    includes = [
+        "deps/hiredis",
+        "src",
+    ],
+    textual_hdrs = select({
+        "@platforms//os:linux": ["src/ae_epoll.c"],
+        "@platforms//os:osx": ["src/ae_kqueue.c"],
+    }) + ["src/commands.def"],
+    deps = [
+        ":hiredis",
+        ":linenoise",
+        ":lua",
+    ],
+)
+
+cc_binary(
+    name = "valkey-cli",
+    visibility = ["//visibility:public"],
+    deps = [":valkey_cli_lib"],
+)
+
+cc_binary(
+    name = "valkey-server",
+    linkopts = select({
+        "@platforms//os:linux": [
+            "-ldl",
+            "-lpthread",
+        ],
+        "@platforms//os:osx": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":valkey_lib"],
+)
+
+filegroup(
+    name = "valkey",
+    srcs = [
+        ":valkey-server",
+        ":valkey-cli",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/modules/valkey/7.2.13/overlay/MODULE.bazel
+++ b/modules/valkey/7.2.13/overlay/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "valkey",
+    version = "7.2.13",
+    compatibility_level = 0,
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_shell", version = "0.5.1")

--- a/modules/valkey/7.2.13/presubmit.yml
+++ b/modules/valkey/7.2.13/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@valkey'
+    - '@valkey//:valkey-server'
+    - '@valkey//:valkey-cli'

--- a/modules/valkey/7.2.13/source.json
+++ b/modules/valkey/7.2.13/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/valkey-io/valkey/archive/refs/tags/7.2.13.tar.gz",
+    "strip_prefix": "valkey-7.2.13",
+    "overlay": {
+        "BUILD.bazel": "sha256-2kpw0r9aAtVerz2pxkVpM+IdVgFcS4tgmgenA9sM2bI=",
+        "MODULE.bazel": "sha256-gA3PSipYNDvZchJBqEZ+CBNRgcqtTFppYT4XzMXVqR0="
+    },
+    "integrity": "sha256-MfGdQsmDdJ6B5pZUqMRdzcncISwjzxG3vcSSizKNUKk="
+}

--- a/modules/valkey/metadata.json
+++ b/modules/valkey/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://valkey.io/",
+    "maintainers": [
+        {
+            "github": "sluongng",
+            "github_user_id": 26684313,
+            "name": "Son Luong Ngoc"
+        }
+    ],
+    "repository": [
+        "github:valkey-io/valkey"
+    ],
+    "versions": [
+        "7.2.13"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Register this release so that Bzlmod consumers can build and test
against exact Valkey 7.2.13. Valkey does not ship Bazel build
metadata, which otherwise requires every consumer to maintain a
custom archive override.

Use the official tag archive and add a C build overlay adapted from
the Redis 7.2.4 module. Expose the Valkey server, CLI, and an aggregate
target for downstream consumers.

Upstream does not publish a stable source release asset, so this uses
GitHub-generated tag sources.
