### PR TITLE
ssl_lib@1.0.0

### DIFF
--- a/modules/ssl_lib/1.0.0/MODULE.bazel
+++ b/modules/ssl_lib/1.0.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "ssl_lib",
+    version = "1.0.0",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "boringssl", version = "0.20240913.0")

--- a/modules/ssl_lib/1.0.0/MODULE.bazel
+++ b/modules/ssl_lib/1.0.0/MODULE.bazel
@@ -4,4 +4,7 @@ module(
     bazel_compatibility = [">=7.2.1"],
 )
 
+bazel_dep(name = "bazel_skylib", version = "1.0.3")
 bazel_dep(name = "boringssl", version = "0.20240913.0")
+bazel_dep(name = "openssl", version = "3.3.1.bcr.0")
+bazel_dep(name = "rules_cc", version = "0.0.13")

--- a/modules/ssl_lib/1.0.0/overlay/BUILD.bazel
+++ b/modules/ssl_lib/1.0.0/overlay/BUILD.bazel
@@ -1,0 +1,11 @@
+label_flag(
+    name = "crypto",
+    build_setting_default = "@boringssl//:crypto",
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "ssl",
+    build_setting_default = "@boringssl//:ssl",
+    visibility = ["//visibility:public"],
+)

--- a/modules/ssl_lib/1.0.0/overlay/BUILD.bazel
+++ b/modules/ssl_lib/1.0.0/overlay/BUILD.bazel
@@ -1,11 +1,64 @@
-label_flag(
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+string_flag(
+    name = "ssl_module",
+    build_setting_default = "boringssl",
+    values = [
+        "boringssl",
+        "openssl",
+        "custom",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
     name = "crypto",
-    build_setting_default = "@boringssl//:crypto",
+    actual = select({
+        ":is_boringssl": "@boringssl//:crypto",
+        ":is_openssl": "@openssl//:crypto",
+        ":is_custom": ":custom_crypto",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "ssl",
+    actual = select({
+        ":is_boringssl": "@boringssl//:ssl",
+        ":is_openssl": "@openssl//:ssl",
+        ":is_custom": ":custom_ssl",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "is_boringssl",
+    flag_values = {":ssl_module": "boringssl"},
+)
+
+config_setting(
+    name = "is_openssl",
+    flag_values = {":ssl_module": "openssl"},
+)
+
+config_setting(
+    name = "is_custom",
+    flag_values = {":ssl_module": "custom"},
+)
+
+cc_library(
+    name = "empty",
+)
+
+label_flag(
+    name = "custom_crypto",
+    build_setting_default = ":empty",
     visibility = ["//visibility:public"],
 )
 
 label_flag(
-    name = "ssl",
-    build_setting_default = "@boringssl//:ssl",
+    name = "custom_ssl",
+    build_setting_default = ":empty",
     visibility = ["//visibility:public"],
 )

--- a/modules/ssl_lib/1.0.0/presubmit.yml
+++ b/modules/ssl_lib/1.0.0/presubmit.yml
@@ -1,0 +1,22 @@
+matrix:
+  platform:
+  - debian11
+  - debian12
+  - debian13
+  - ubuntu2204
+  - ubuntu2404
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@ssl_lib//:crypto'
+    - '@ssl_lib//:ssl'

--- a/modules/ssl_lib/1.0.0/source.json
+++ b/modules/ssl_lib/1.0.0/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://bcr.bazel.build/empty.zip",
+    "archive_type": "zip",
+    "integrity": "sha256-9Ft7jgVHf/y8vQvp7lMSTRaHSCxx1qMcdqEKZZZeJLE=",
+    "overlay": {
+        "BUILD.bazel": "sha256-P22n1JqxMv0Yn8CTftR6pOzDYO15xHtVpNnfeRrIskY="
+    }
+}

--- a/modules/ssl_lib/1.0.0/source.json
+++ b/modules/ssl_lib/1.0.0/source.json
@@ -3,6 +3,6 @@
     "archive_type": "zip",
     "integrity": "sha256-9Ft7jgVHf/y8vQvp7lMSTRaHSCxx1qMcdqEKZZZeJLE=",
     "overlay": {
-        "BUILD.bazel": "sha256-P22n1JqxMv0Yn8CTftR6pOzDYO15xHtVpNnfeRrIskY="
+        "BUILD.bazel": "sha256-OJEiOVaQGkYGLUR9XOg3hktQRhJAOEyX6acc8cSWLQA="
     }
 }

--- a/modules/ssl_lib/README.md
+++ b/modules/ssl_lib/README.md
@@ -1,0 +1,23 @@
+# ssl_lib
+
+## Purpose
+
+The purpose of the `ssl_lib` module in BCR is to provide a single point of
+control for choosing the SSL. This module provides a standardized `deps` for
+other modules that require SSL, i.e., `deps = ["@ssl_lib//:crypto"]` and
+`deps = ["@ssl_lib//:ssl"]`.
+
+In other packaging systems, this is sometimes known as a "virtual package".
+
+By default this module points to the BoringSSL library. Applications that would
+like to use a different implementation should set the `crypto_lib` and `ssl_lib`
+flags to the replacement labels, e.g.,
+`--@ssl_lib//:crypto_lib=@openssl//:crypto` and
+`--@ssl_lib//:ssl_lib=@openssl//:ssl`.
+
+## Version updates
+
+This module specifically does NOT pin the latest version of boringssl. We don't
+want to churn here every time boringssl releases. Downstream projects should
+rely on their own top-level MODULE file to set the MVS baseline for their
+minimum version.

--- a/modules/ssl_lib/metadata.json
+++ b/modules/ssl_lib/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/ssl_lib",
+    "maintainers": [
+        {
+            "email": "keithbsmiley@gmail.com",
+            "github": "keith",
+            "github_user_id": 283886,
+            "name": "Keith Smiley"
+        }
+    ],
+    "repository": [
+        "https://bcr.bazel.build/"
+    ],
+    "versions": [
+        "1.0.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This is intended to be a "virtual package" to provide a point of indirection for which SSL library to use.

Closes https://github.com/bazelbuild/bazel/issues/26827.