### PR TITLE
Make linenoise compatible with bazel 9

### DIFF
--- a/modules/linenoise/2.0.0.bcr.1/MODULE.bazel
+++ b/modules/linenoise/2.0.0.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "linenoise",
+    version = "2.0.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/linenoise/2.0.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/linenoise/2.0.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+license(
+    name = "license",
+    package_name = "linenoise",
+    license_kind = "@rules_license//licenses/spdx:BSD-2-Clause",
+    license_text = "LICENSE",
+)
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "linenoise",
+    srcs = ["linenoise.c"],
+    hdrs = ["linenoise.h"],
+)

--- a/modules/linenoise/2.0.0.bcr.1/overlay/MODULE.bazel
+++ b/modules/linenoise/2.0.0.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "linenoise",
+    version = "2.0.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/linenoise/2.0.0.bcr.1/presubmit.yml
+++ b/modules/linenoise/2.0.0.bcr.1/presubmit.yml
@@ -1,0 +1,11 @@
+matrix:
+  platform: [ "debian11", "ubuntu2204", "macos", "macos_arm64" ]
+  bazel: [ "7.x", "8.x", "9.x" ]
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@linenoise//:linenoise"

--- a/modules/linenoise/2.0.0.bcr.1/source.json
+++ b/modules/linenoise/2.0.0.bcr.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/antirez/linenoise/archive/refs/tags/2.0.tar.gz",
+    "integrity": "sha256-l619QEHhHX+jlYGf13PBiS3qieUpI0I3ioNFaSzonCk=",
+    "strip_prefix": "linenoise-2.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-c36k0vnbF03xu1hL0v5zdYDu7ezA6NyFZoc2N0dtGmg=",
+        "MODULE.bazel": "sha256-0jovlvUPNLhgM2bDs0o+4/FzptIkLYMjKILyyvj51v0="
+    }
+}

--- a/modules/linenoise/metadata.json
+++ b/modules/linenoise/metadata.json
@@ -12,7 +12,8 @@
         "github:antirez/linenoise"
     ],
     "versions": [
-        "2.0.0"
+        "2.0.0",
+        "2.0.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Need to load cc_library.