### PR TITLE
docs: remove trailing whitespace in stardoc.md

### DIFF
--- a/docs/stardoc.md
+++ b/docs/stardoc.md
@@ -15,7 +15,7 @@ Authors are free to generate these files however they choose.
 The simplest option is to add a `starlark_doc_extract` target for each `bzl_library` target you wish to document.
 
 Note that the `bzl_library` rule from `bazel_skylib` has `filegroup` semantics - it doesn't produce any outputs, nor verify that the `bzl_library` has all dependencies provided.
-See https://github.com/bazel-contrib/bazel-lib/blob/main/bzl_library.bzl for an alternative that fixes this. 
+See https://github.com/bazel-contrib/bazel-lib/blob/main/bzl_library.bzl for an alternative that fixes this.
 
 It is wise to run `bazel query 'kind(starlark_doc_extract, //...)'` to confirm which starlark modules your ruleset documents.
 


### PR DESCRIPTION
Minor cosmetic fix: removes trailing whitespace on line 18 of docs/stardoc.md. No functional change.