### PR TITLE
rules_odin@0.4.1

### DIFF
--- a/modules/rules_odin/0.4.1/MODULE.bazel
+++ b/modules/rules_odin/0.4.1/MODULE.bazel
@@ -1,0 +1,29 @@
+"""rules_odin - Bazel rules for the Odin programming language."""
+
+# NOTE: `version` is intentionally left empty. The real release version is
+# stamped from the git tag at archive time by
+# `.github/workflows/release_prep.sh` (and reflected in the BCR entry), so the
+# committed source never needs a manual version bump. An empty version is also
+# required for correct version sorting when this module is consumed via a
+# non-registry override (e.g. `local_path_override` in the e2e workspaces): the
+# empty string is treated as the highest version, whereas a placeholder like
+# "0.0.0" sorts lowest and can break overrides.
+# See https://bazel.build/external/faq#module-versioning-best-practices
+module(
+    name = "rules_odin",
+    version = "0.4.1",
+    compatibility_level = 0,
+)
+
+# Runtime dependencies
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.10")
+
+# Note: These are minimum versions. Users may get newer versions via resolution.
+
+# Toolchain registration for development/testing
+odin = use_extension("//odin:extensions.bzl", "odin")
+odin.toolchain(odin_version = "dev-2026-06")
+use_repo(odin, "odin_toolchains")
+
+register_toolchains("@odin_toolchains//:all")

--- a/modules/rules_odin/0.4.1/attestations.json
+++ b/modules/rules_odin/0.4.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/clappingmonkey/rules_odin/releases/download/v0.4.1/source.json.intoto.jsonl",
+            "integrity": "sha256-7vqY2Q3VByPEat0GVkz+nw5W4QCNjJUCrdLYXJjI5sE="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/clappingmonkey/rules_odin/releases/download/v0.4.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-E9vBwwvTqWvV8PysYROEvuxfibnc+Yp+Xhe9/CtV4pA="
+        },
+        "rules_odin-v0.4.1.tar.gz": {
+            "url": "https://github.com/clappingmonkey/rules_odin/releases/download/v0.4.1/rules_odin-v0.4.1.tar.gz.intoto.jsonl",
+            "integrity": "sha256-8doC5pofNShv8IjwlhHfBwgJV1N+RJoMv92a+pYs5+c="
+        }
+    }
+}

--- a/modules/rules_odin/0.4.1/presubmit.yml
+++ b/modules/rules_odin/0.4.1/presubmit.yml
@@ -1,0 +1,14 @@
+bcr_test_module:
+  module_path: "e2e/bcr_smoke"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: ["7.x", "8.x", "9.x"]
+  tasks:
+    run_tests:
+      name: "Build & test Odin smoke module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."
+      test_targets:
+        - "//..."

--- a/modules/rules_odin/0.4.1/source.json
+++ b/modules/rules_odin/0.4.1/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-GHl1SrU1cVp4B3rXkLxOWWkTsq29cdZfo+tLx2+1xOw=",
+    "strip_prefix": "rules_odin-0.4.1",
+    "url": "https://github.com/clappingmonkey/rules_odin/releases/download/v0.4.1/rules_odin-v0.4.1.tar.gz"
+}

--- a/modules/rules_odin/metadata.json
+++ b/modules/rules_odin/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/clappingmonkey/rules_odin",
+    "maintainers": [
+        {
+            "name": "Ventsislav Kostadinov",
+            "email": "clappingmonkey33@gmail.com",
+            "github": "clappingmonkey",
+            "github_user_id": 17432099
+        }
+    ],
+    "repository": [
+        "github:clappingmonkey/rules_odin"
+    ],
+    "versions": [
+        "0.4.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/clappingmonkey/rules_odin/releases/tag/v0.4.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_