### PR TITLE
rules_go@0.62.0

### DIFF
--- a/modules/rules_go/0.62.0/MODULE.bazel
+++ b/modules/rules_go/0.62.0/MODULE.bazel
@@ -1,0 +1,106 @@
+module(
+    name = "rules_go",
+    compatibility_level = 0,
+    repo_name = "io_bazel_rules_go",
+    version = "0.62.0",
+)
+
+# The custom repo_name is used to prevent our bazel_features polyfill for WORKSPACE builds from
+# conflicting with the real bazel_features repo.
+bazel_dep(name = "bazel_features", version = "1.36.0", repo_name = "io_bazel_rules_go_bazel_features")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_proto", version = "7.0.2")
+bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_shell", version = "0.3.0")
+bazel_dep(name = "rules_cc", version = "0.1.5")
+
+go_sdk = use_extension("//go:extensions.bzl", "go_sdk")
+
+# Don't depend on this repo by name, use toolchains instead.
+# See https://github.com/bazel-contrib/rules_go/blob/master/go/toolchains.rst
+go_sdk.from_file(
+    name = "go_default_sdk",
+    go_mod = "//:go.mod",
+)
+use_repo(
+    go_sdk,
+    "go_host_compatible_sdk_label",
+    "go_toolchains",
+    # This name is ugly on purpose to avoid a conflict with a user-named SDK.
+    "io_bazel_rules_nogo",
+)
+
+register_toolchains("@go_toolchains//:all")
+
+bazel_dep(name = "gazelle", version = "0.51.3")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_aymanbagabas_go_udiff",
+    "com_github_gogo_protobuf",
+    "com_github_golang_mock",
+    "com_github_golang_protobuf",
+    "org_golang_google_genproto",
+    "org_golang_google_grpc",
+    "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
+    "org_golang_google_protobuf",
+    "org_golang_x_net",
+    "org_golang_x_tools",
+    # Exported by gazelle specifically for rules_go.
+    "bazel_gazelle_go_repository_config",
+    "org_golang_google_genproto_googleapis_bytestream",
+    "org_golang_google_genproto_googleapis_rpc",
+    "org_golang_x_crypto",
+)
+
+### Dev dependencies
+
+bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
+
+dev_go_sdk = use_extension("//go:extensions.bzl", "go_sdk", dev_dependency = True)
+dev_go_sdk.download(
+    name = "rules_go_internal_compatibility_sdk",
+    version = "1.22.12",
+)
+
+bazel_dep(name = "toolchains_protoc", version = "0.6.0", dev_dependency = True)
+
+protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc", dev_dependency = True)
+protoc.toolchain(
+    name = "protoc_toolchains",
+    version = "v25.3",
+)
+use_repo(protoc, "protoc_toolchains")
+
+register_toolchains(
+    "@protoc_toolchains//...",
+    dev_dependency = True,
+)
+
+# Used to transition binaries in rules_go's test suite to different configurations.
+bazel_dep(name = "with_cfg.bzl", version = "0.14.1", dev_dependency = True)
+bazel_dep(name = "runfiles_remote_test", version = "0.0.0", dev_dependency = True)
+local_path_override(
+    module_name = "runfiles_remote_test",
+    path = "tests/core/runfiles/runfiles_remote_test",
+)
+
+bazel_dep(name = "googleapis", version = "0.0.0-20241220-5e258e33", dev_dependency = True)
+
+# Used for both testing objc interop and building on Apple platforms.
+bazel_dep(name = "apple_support", version = "1.24.3", dev_dependency = True, repo_name = "build_bazel_apple_support")
+
+# For manual testing against an LLVM toolchain.
+# Use --extra_toolchains=@llvm_toolchain//:cc-toolchain-linux,@llvm_toolchain//:cc-toolchain-darwin
+bazel_dep(name = "toolchains_llvm", version = "0.10.3", dev_dependency = True)
+
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
+llvm.toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "8.0.0",
+)
+
+bazel_dep(name = "bazel_ci_rules", version = "1.0.0", dev_dependency = True)

--- a/modules/rules_go/0.62.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_go/0.62.0/patches/module_dot_bazel_version.patch
@@ -1,10 +1,13 @@
 ===================================================================
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -1,5 +1,6 @@
+@@ -1,8 +1,9 @@
  module(
      name = "rules_go",
      compatibility_level = 0,
      repo_name = "io_bazel_rules_go",
 +    version = "0.62.0",
  )
+ 
+ # The custom repo_name is used to prevent our bazel_features polyfill for WORKSPACE builds from
+ # conflicting with the real bazel_features repo.

--- a/modules/rules_go/0.62.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_go/0.62.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,10 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,5 +1,6 @@
+ module(
+     name = "rules_go",
+     compatibility_level = 0,
+     repo_name = "io_bazel_rules_go",
++    version = "0.62.0",
+ )

--- a/modules/rules_go/0.62.0/presubmit.yml
+++ b/modules/rules_go/0.62.0/presubmit.yml
@@ -1,0 +1,33 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004_arm64
+    - macos_arm64
+    - windows
+  bazel: [7.*, 8.*, 9.*]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@rules_go//go/tools/bzltestutil/..."
+bcr_test_module:
+  module_path: tests/bcr
+  matrix:
+    platform:
+      - debian11
+      - ubuntu2004_arm64
+      - macos_arm64
+      - windows
+    bazel: [7.*, 8.*, 9.*]
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - //...
+        - "@go_default_sdk//..."
+      test_targets:
+        - //...

--- a/modules/rules_go/0.62.0/source.json
+++ b/modules/rules_go/0.62.0/source.json
@@ -3,7 +3,7 @@
     "strip_prefix": "",
     "url": "https://github.com/bazel-contrib/rules_go/releases/download/v0.62.0/rules_go-v0.62.0.zip",
     "patches": {
-        "module_dot_bazel_version.patch": "sha256-G9jhOSGb3T3vBXZf9Bk8nVcV4SRHAWcMM7C8scFvTg4="
+        "module_dot_bazel_version.patch": "sha256-XNMdK2KLBp81gs8OSObZKitqpe3CTxs/eti7L1PGOy8="
     },
     "patch_strip": 1
 }

--- a/modules/rules_go/0.62.0/source.json
+++ b/modules/rules_go/0.62.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-C4BclPs3MNwj3zKSXtR3s/TtN7VgddysbyGMPqe0q0I=",
+    "strip_prefix": "",
+    "url": "https://github.com/bazel-contrib/rules_go/releases/download/v0.62.0/rules_go-v0.62.0.zip",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-G9jhOSGb3T3vBXZf9Bk8nVcV4SRHAWcMM7C8scFvTg4="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_go/metadata.json
+++ b/modules/rules_go/metadata.json
@@ -79,7 +79,8 @@
         "0.59.0",
         "0.60.0",
         "0.61.0",
-        "0.61.1"
+        "0.61.1",
+        "0.62.0"
     ],
     "yanked_versions": {
         "0.33.0": "Obsolete experimental version that emits debug prints. Update to 0.39.1 or higher",


### PR DESCRIPTION
## Summary

Author: zbarsky-bot

Add `rules_go@0.62.0` from the published `bazel-contrib/rules_go` release. The legacy Publish-to-BCR GitHub app did not create a registry pull request after the release was published, so this pull request adds the `MODULE.bazel`, `presubmit.yml`, `source.json`, and `module_dot_bazel_version.patch` files and records `0.62.0` in `modules/rules_go/metadata.json`.

Release: https://github.com/bazel-contrib/rules_go/releases/tag/v0.62.0

Source archive SHA-256: `0b805c94fb3730dc23df32925ed477b3f4ed37b56075dcac6f218c3ea7b4ab42`.

## Validation

```sh
bazel run //tools:bcr_validation -- \
  --registry=/private/tmp/bcr-rules-go-v0.62.0 \
  --check=rules_go@0.62.0
```

`bcr_validation` passed the source URL, source integrity, version patch, `MODULE.bazel`, `presubmit.yml`, attestation, and maintainer metadata checks.
