### PR TITLE
rules_periphery@0.1.0

### DIFF
--- a/modules/rules_periphery/0.1.0/MODULE.bazel
+++ b/modules/rules_periphery/0.1.0/MODULE.bazel
@@ -1,0 +1,18 @@
+module(
+    name = "rules_periphery",
+    version = "0.1.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_apple", version = "4.5.2")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+bazel_dep(name = "rules_swift", version = "3.6.0", max_compatibility_level = 3)
+
+periphery = use_extension("//:extensions.bzl", "periphery")
+use_repo(periphery, "periphery_bin", "periphery_generated")
+
+register_toolchains("@periphery_bin//:toolchain")
+
+# Dev dependencies
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.1", dev_dependency = True)

--- a/modules/rules_periphery/0.1.0/presubmit.yml
+++ b/modules/rules_periphery/0.1.0/presubmit.yml
@@ -1,0 +1,17 @@
+# Exercises rules_periphery as a downstream consumer would: it depends on the
+# published module, configures a Periphery binary via the module extension, and
+# builds a scan target. Building (rather than running) keeps the check free of a
+# Swift toolchain and network access while still exercising the extension, the
+# public macro, and the driver.
+bcr_test_module:
+  module_path: "e2e/bcr"
+  matrix:
+    platform: ["ubuntu2204", "macos"]
+    bazel: ["8.x", "9.x"]
+  tasks:
+    build_targets:
+      name: "Build the test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."

--- a/modules/rules_periphery/0.1.0/source.json
+++ b/modules/rules_periphery/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-Ee/h9KWyMNFr9XqxHgVC5fBaX+sQPh6eQHeMaUMF/7o=",
+    "strip_prefix": "rules_periphery-0.1.0",
+    "url": "https://github.com/periphery-pro/rules_periphery/releases/download/0.1.0/rules_periphery-0.1.0.tar.gz"
+}

--- a/modules/rules_periphery/metadata.json
+++ b/modules/rules_periphery/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/periphery-pro/rules_periphery",
+    "maintainers": [
+        {
+            "name": "Ian Leitch",
+            "email": "ian@leitch.io",
+            "github": "ileitch",
+            "github_user_id": 48235
+        }
+    ],
+    "repository": [
+        "github:periphery-pro/rules_periphery"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/periphery-pro/rules_periphery/releases/tag/0.1.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_