### PR TITLE
evidence_store_bazel@0.0.2

### DIFF
--- a/modules/evidence_store_bazel/0.0.2/MODULE.bazel
+++ b/modules/evidence_store_bazel/0.0.2/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "evidence_store_bazel",
+    version = "0.0.2",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_go", version = "0.60.0")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.from_file(go_mod = "//:go.mod")

--- a/modules/evidence_store_bazel/0.0.2/presubmit.yml
+++ b/modules/evidence_store_bazel/0.0.2/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2004
+    - macos
+  bazel: [7.*, 8.*, 9.*]
+
+tasks:
+  verify_build:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@evidence_store_bazel//cmd/evidence-bazel"

--- a/modules/evidence_store_bazel/0.0.2/source.json
+++ b/modules/evidence_store_bazel/0.0.2/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-tyi9skyrAddb5tThAw8Ux1KH5M0rAoJLzW+WnWd5v+I=",
+    "strip_prefix": "evidence_store_bazel-v0.0.2",
+    "url": "https://github.com/nesono/evidence_store/releases/download/evidence_store_bazel-v0.0.2/evidence_store_bazel-v0.0.2.tar.gz"
+}

--- a/modules/evidence_store_bazel/metadata.json
+++ b/modules/evidence_store_bazel/metadata.json
@@ -12,7 +12,8 @@
         "github:nesono/evidence_store"
     ],
     "versions": [
-        "0.0.1"
+        "0.0.1",
+        "0.0.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/nesono/evidence_store/releases/tag/evidence_store_bazel-v0.0.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_