### PR TITLE
rules_dart_proto@0.4.7

### DIFF
--- a/modules/rules_dart_proto/0.4.7/MODULE.bazel
+++ b/modules/rules_dart_proto/0.4.7/MODULE.bazel
@@ -1,0 +1,55 @@
+"Bazel dependencies"
+
+# NOTE: The version field is intentionally omitted. Leaving it unset (the
+# default "") prevents issues when the module is used via non-registry
+# overrides (e.g. https://github.com/bazel-contrib/rules_go/issues/4380).
+# The publish-to-bcr GitHub Action patches in the release version when
+# submitting to the Bazel Central Registry.
+#
+# NOTE: compatibility_level is omitted (defaults to 0). Bumping it is very
+# disruptive — as soon as a module is requested at two different compatibility
+# levels in the dependency tree, users see an error. Only bump it when the
+# breaking change affects most use cases and isn't easy to work around, and
+# in the same commit that introduces the incompatible change.
+module(
+    name = "rules_dart_proto",
+    version = "0.4.7",
+)
+
+bazel_dep(name = "rules_dart", version = "0.4.6")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "protobuf", version = "34.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
+bazel_dep(name = "package_metadata", version = "0.0.10")
+
+bazel_dep(name = "rules_multitool", version = "1.11.1", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
+
+# TODO: remove once protobuf upgrades to a rules_android version compatible
+# with Bazel 9.0.1 (rules_android 0.6.4 uses the removed CcInfo builtin).
+bazel_dep(name = "rules_android", version = "0.7.3")
+bazel_dep(name = "bazelrc-preset.bzl", version = "1.9.2")
+
+# Dart toolchain (needed to compile protoc-gen-dart plugin)
+dart = use_extension("@rules_dart//dart:extensions.bzl", "dart")
+dart.toolchain(dart_version = "3.12.1")
+use_repo(dart, "dart_toolchains")
+
+register_toolchains("@dart_toolchains//:all")
+
+# Fetch protoc_plugin and all transitive dependencies from pub.dev
+pub = use_extension("@rules_dart//dart/pub:extensions.bzl", "pub")
+pub.from_lock(
+    name = "dart_proto_deps",
+    lock = "//dart_proto:pubspec.lock",
+)
+use_repo(pub, "dart_proto_deps")
+
+multitool = use_extension(
+    "@rules_multitool//multitool:extension.bzl",
+    "multitool",
+    dev_dependency = True,
+)
+multitool.hub(lockfile = "//:multitool.lock.json")
+use_repo(multitool, "multitool")

--- a/modules/rules_dart_proto/0.4.7/attestations.json
+++ b/modules/rules_dart_proto/0.4.7/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/aran/rules_dart_proto/releases/download/v0.4.7/source.json.intoto.jsonl",
+            "integrity": "sha256-B8HIv9FFGpDVase0yDQfS7NuBSsi843bNac0gOdCD90="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/aran/rules_dart_proto/releases/download/v0.4.7/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-Oplm3yTCukQtZvSDDjEUtwQfTYV6WECiLyhAiRNS73c="
+        },
+        "rules_dart_proto-v0.4.7.tar.gz": {
+            "url": "https://github.com/aran/rules_dart_proto/releases/download/v0.4.7/rules_dart_proto-v0.4.7.tar.gz.intoto.jsonl",
+            "integrity": "sha256-CWQb6hYZr3NfQAoLcT08t7HRXCG3Iv4yl2h4yba4Pyg="
+        }
+    }
+}

--- a/modules/rules_dart_proto/0.4.7/patches/module_dot_bazel_version.patch
+++ b/modules/rules_dart_proto/0.4.7/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -12,8 +12,9 @@
+ # breaking change affects most use cases and isn't easy to work around, and
+ # in the same commit that introduces the incompatible change.
+ module(
+     name = "rules_dart_proto",
++    version = "0.4.7",
+ )
+ 
+ bazel_dep(name = "rules_dart", version = "0.4.6")
+ bazel_dep(name = "rules_proto", version = "7.1.0")

--- a/modules/rules_dart_proto/0.4.7/presubmit.yml
+++ b/modules/rules_dart_proto/0.4.7/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/simple_proto"
+  matrix:
+    platform: ["debian11", "macos_arm64", "ubuntu2204"]
+    bazel: ["9.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_dart_proto/0.4.7/source.json
+++ b/modules/rules_dart_proto/0.4.7/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-/u+GHrlmdCO0Lnmsy22Zg+jHThZRbkcCJjVPOnSfPTc=",
+    "strip_prefix": "rules_dart_proto-0.4.7",
+    "url": "https://github.com/aran/rules_dart_proto/releases/download/v0.4.7/rules_dart_proto-v0.4.7.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-qxEo8romMy7GeY4/FxEwaZbq8Yy+3N7iDi4RIGKg28k="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_dart_proto/metadata.json
+++ b/modules/rules_dart_proto/metadata.json
@@ -4,8 +4,8 @@
         {
             "email": "aran.donohue@gmail.com",
             "github": "aran",
-            "name": "Aran Donohue",
-            "github_user_id": 5295
+            "github_user_id": 5295,
+            "name": "Aran Donohue"
         }
     ],
     "repository": [
@@ -16,7 +16,8 @@
         "0.4.3",
         "0.4.4",
         "0.4.5",
-        "0.4.6"
+        "0.4.6",
+        "0.4.7"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/aran/rules_dart_proto/releases/tag/v0.4.7

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_