### PR TITLE
suitesparse@7.10.1.bcr.4

### DIFF
--- a/modules/suitesparse/7.10.1.bcr.4/MODULE.bazel
+++ b/modules/suitesparse/7.10.1.bcr.4/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "suitesparse",
+    version = "7.10.1.bcr.4",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/suitesparse/7.10.1.bcr.4/overlay/BUILD.bazel
+++ b/modules/suitesparse/7.10.1.bcr.4/overlay/BUILD.bazel
@@ -1,0 +1,82 @@
+# Copyright 2016 Robot Locomotion Group @ CSAIL. All rights reserved.
+#
+# All components of Drake are licensed under the BSD 3-Clause License.
+# See LICENSE.TXT or https://drake.mit.edu/ for details.
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+licenses(["notice"])  # BSD-3-Clause
+
+package(default_visibility = ["//visibility:private"])
+
+exports_files([
+    "LICENSE.txt",
+    "AMD/Doc/License.txt",
+    "CCOLAMD/Doc/License.txt",
+])
+
+cc_library(
+    name = "config",
+    srcs = ["SuiteSparse_config/SuiteSparse_config.c"],
+    hdrs = ["SuiteSparse_config/SuiteSparse_config.h"],
+    defines = select({
+        "@platforms//os:windows": ["NTIMER"],
+        "//conditions:default": [],
+    }),
+    strip_include_prefix = "SuiteSparse_config",
+    visibility = ["//visibility:public"],
+)
+
+# Per the upstream build system, libamd source code is compiled twice: once as
+# 32-bit and once as 64-bit. It provides `amd_l_{foo}.c` files for 64-bit mode
+# that `#define DLONG` and then `#include "amd_{foo}.c"`. To allow including
+# `*.c` files, we must list them as textual_hdrs, but we don't want those to be
+# exposed downstream so we need to wrap them in an implementation_deps library.
+cc_library(
+    name = "amd_implementation_deps",
+    hdrs = glob(["AMD/Include/*.h"]),
+    includes = [
+        "AMD/Include",
+        "AMD/Source",
+    ],
+    textual_hdrs = glob(["AMD/Source/*.c"]),
+    deps = [
+        ":config",
+    ],
+)
+
+cc_library(
+    name = "amd",
+    srcs = glob(["AMD/Source/*.c"]),
+    hdrs = ["AMD/Include/amd.h"],
+    implementation_deps = [
+        ":amd_implementation_deps",
+    ],
+    strip_include_prefix = "AMD/Include",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":config",
+    ],
+)
+
+filegroup(
+    name = "source_files",
+    srcs = glob([
+        "CCOLAMD/Include/*.h",
+        "CCOLAMD/Source/*.c",
+    ]) + ["SuiteSparse_config/SuiteSparse_config.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ccolamd",
+    srcs = ["CCOLAMD/Source/ccolamd.c"],
+    hdrs = ["CCOLAMD/Include/ccolamd.h"],
+    defines = [
+        "NDEBUG",
+        "NPRINT",
+    ],
+    strip_include_prefix = "CCOLAMD/Include",
+    visibility = ["//visibility:public"],
+    deps = [":config"],
+)

--- a/modules/suitesparse/7.10.1.bcr.4/overlay/MODULE.bazel
+++ b/modules/suitesparse/7.10.1.bcr.4/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "suitesparse",
+    version = "7.10.1.bcr.4",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/suitesparse/7.10.1.bcr.4/presubmit.yml
+++ b/modules/suitesparse/7.10.1.bcr.4/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2204_arm64
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+    - windows
+  bazel: [7.x, 8.x, 9.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@suitesparse//:amd"
+      - "@suitesparse//:ccolamd"

--- a/modules/suitesparse/7.10.1.bcr.4/source.json
+++ b/modules/suitesparse/7.10.1.bcr.4/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.10.1.tar.gz",
+    "integrity": "sha256-nil04i26JqPP/iaXMTOa6OATZc/pIbBr5jWZAr0Fhiw=",
+    "strip_prefix": "SuiteSparse-7.10.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-qzc24mb7/O2KIWxhIaJbGK/mYt1JbOP93uRnoJTgb+0=",
+        "MODULE.bazel": "sha256-fq9Ky8U5dmT55vCMh73GJ/4wit8I5a0omjP/Yh1VIME="
+    },
+    "patch_strip": 0
+}

--- a/modules/suitesparse/metadata.json
+++ b/modules/suitesparse/metadata.json
@@ -18,7 +18,8 @@
         "7.10.1",
         "7.10.1.bcr.1",
         "7.10.1.bcr.2",
-        "7.10.1.bcr.3"
+        "7.10.1.bcr.3",
+        "7.10.1.bcr.4"
     ],
     "yanked_versions": {
         "7.10.1": "suitesparse 7.10.1 is yanked due to unnecessary compatibility level update, please upgrade to 7.10.1.bcr.1"


### PR DESCRIPTION
Add support for 32-bit AMD.

Don't expose amd_internal.h downstream.

Add exports_files for relevant license docs.