### PR TITLE
psimd@0.0.0-20200517-072586a

### DIFF
--- a/modules/psimd/0.0.0-20200517-072586a/MODULE.bazel
+++ b/modules/psimd/0.0.0-20200517-072586a/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "psimd",
+    version = "0.0.0-20200517-072586a",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/psimd/0.0.0-20200517-072586a/overlay/BUILD.bazel
+++ b/modules/psimd/0.0.0-20200517-072586a/overlay/BUILD.bazel
@@ -1,0 +1,19 @@
+# Description:
+#   Portable 128-bit SIMD intrinsics. Header-only: upstream ships a single
+#   include/psimd.h and has no build outputs, so this exposes it as a
+#   header-only cc_library. Upstream's own CMakeLists.txt likewise only does
+#   target_include_directories on include/.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # MIT
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "psimd",
+    hdrs = glob(["include/**/*.h"]),
+    strip_include_prefix = "include",
+)

--- a/modules/psimd/0.0.0-20200517-072586a/presubmit.yml
+++ b/modules/psimd/0.0.0-20200517-072586a/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+    - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@psimd'

--- a/modules/psimd/0.0.0-20200517-072586a/source.json
+++ b/modules/psimd/0.0.0-20200517-072586a/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/Maratyszcza/psimd/archive/072586a71b55b7f8c584153d223e95687148a900.tar.gz",
+    "integrity": "sha256-9sTauRrpoDswGefKsFcnQ6/Q4bbnW5f8ylAlnHN8kk4=",
+    "strip_prefix": "psimd-072586a71b55b7f8c584153d223e95687148a900",
+    "overlay": {
+        "BUILD.bazel": "sha256-R525vlHVMsR2nahNfwpMNAbog+xEzb+UshKPLHY0u8s="
+    }
+}

--- a/modules/psimd/metadata.json
+++ b/modules/psimd/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/Maratyszcza/psimd",
+    "maintainers": [
+        {
+            "github": "Wito-1",
+            "github_user_id": 92177112,
+            "name": "Juan Ortega"
+        }
+    ],
+    "repository": [
+        "github:Maratyszcza/psimd"
+    ],
+    "versions": [
+        "0.0.0-20200517-072586a"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds [psimd](https://github.com/Maratyszcza/psimd) — portable 128-bit SIMD intrinsics, MIT licensed.

Header-only: upstream ships a single `include/psimd.h` and produces no build outputs, and its own `CMakeLists.txt` does nothing but `target_include_directories` on `include/`. The module therefore exposes one header-only `cc_library` named after the module, so `@psimd` shorthand works.

### Version naming

Upstream has no releases or tags, so the version follows the convention already used by its sibling modules in this registry (`cpuinfo`, `fp16`, `fxdiv`, `pthreadpool`): `0.0.0-<commit date>-<short sha>`. Here that is commit `072586a` dated 2020-05-17, which is upstream's current HEAD.

### Overlay

The BUILD file ships as `overlay/BUILD.bazel` rather than an `add_build_file.patch`, so `MODULE.bazel` declares `bazel_compatibility = [">=7.2.1"]` per registry policy for overlays.

Relative to the sibling modules' BUILD files this uses `strip_include_prefix = "include"` alone rather than `includes` + `strip_include_prefix`; `#include <psimd.h>` resolves either way.

### Verification

On Bazel 9.2.0, resolving the module out of a local registry: a consumer `cc_test` that does `#include <psimd.h>` and calls `psimd_splat_f32` / `psimd_add_f32` / `psimd_store_f32` compiles, links, and passes. `@psimd` (the presubmit target) also builds.
