### PR TITLE
cudnn_frontend@1.12.0

### DIFF
--- a/modules/cudnn_frontend/1.12.0/MODULE.bazel
+++ b/modules/cudnn_frontend/1.12.0/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "cudnn_frontend",
+    version = "1.12.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/modules/cudnn_frontend/1.12.0/overlay/BUILD.bazel
+++ b/modules/cudnn_frontend/1.12.0/overlay/BUILD.bazel
@@ -1,0 +1,34 @@
+# Description:
+#   cuDNN Frontend: NVIDIA's C++ entry point to the cuDNN library.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # MIT
+
+exports_files(["LICENSE.txt"])
+
+# Header-only, mirroring upstream's cmake INTERFACE target: CMakeLists.txt adds
+# include/ to the include path and builds no artifacts.
+#
+# The headers `#include <cudnn.h>` and require C++17, which upstream's cmake
+# supplies via find_package(CUDAToolkit) and cxx_std_17. There is no
+# registry-neutral cuDNN module in the BCR, so this target deliberately declares
+# no CUDA dependency: consumers put their own cuDNN and CUDA headers on the
+# target that compiles against this one, which keeps the module usable with any
+# CUDA setup (cuda_toolkit, rules_cuda, a system toolchain, ...) and adds no
+# CUDA download for consumers that only need the headers.
+#
+# nlohmann/json is vendored upstream at
+# include/cudnn_frontend/thirdparty/nlohmann/json.hpp and included by relative
+# path, so no external json dependency is needed; define
+# CUDNN_FRONTEND_SKIP_JSON_LIB to compile that support out.
+cc_library(
+    name = "cudnn_frontend",
+    hdrs = glob([
+        "include/**/*.h",
+        "include/**/*.hpp",
+    ]),
+    strip_include_prefix = "include",
+)

--- a/modules/cudnn_frontend/1.12.0/presubmit.yml
+++ b/modules/cudnn_frontend/1.12.0/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+    - debian10
+    - ubuntu2004
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+    - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@cudnn_frontend'

--- a/modules/cudnn_frontend/1.12.0/source.json
+++ b/modules/cudnn_frontend/1.12.0/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.12.0.tar.gz",
+    "integrity": "sha256-oGUeAagFBjwXzGJR/ojgRSkgcYTtiQm3yy3CZDMrY4g=",
+    "strip_prefix": "cudnn-frontend-1.12.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-htYpz9bZ9VpVEB8gOWpW7mBNs67Zivr3nyBtpmofZvs="
+    }
+}

--- a/modules/cudnn_frontend/metadata.json
+++ b/modules/cudnn_frontend/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/NVIDIA/cudnn-frontend",
+    "maintainers": [
+        {
+            "github": "Wito-1",
+            "github_user_id": 92177112,
+            "name": "Juan Ortega"
+        }
+    ],
+    "repository": [
+        "github:NVIDIA/cudnn-frontend"
+    ],
+    "versions": [
+        "1.12.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds [cuDNN Frontend](https://github.com/NVIDIA/cudnn-frontend) — NVIDIA's C++ entry point to the cuDNN library, MIT licensed.

Header-only, mirroring upstream's cmake `INTERFACE` target: `CMakeLists.txt` adds `include/` to the include path and builds no artifacts. The module exposes a single header-only `cc_library` named after the module, so `@cudnn_frontend` shorthand works.

### No CUDA dependency, by design

The headers `#include <cudnn.h>` and require C++17, which upstream's cmake supplies via `find_package(CUDAToolkit)` and `cxx_std_17`. There is no registry-neutral cuDNN module in the BCR, so this target deliberately declares no CUDA dependency: consumers put their own cuDNN and CUDA headers on whatever target compiles against this one. That keeps the module usable with any CUDA setup (`cuda_toolkit`, `rules_cuda`, a system toolchain) and adds no CUDA download for consumers that only need the headers. The BUILD file documents this so it doesn't read as an oversight.

`nlohmann/json` is vendored upstream at `include/cudnn_frontend/thirdparty/nlohmann/json.hpp` and included by relative path, so no external json dependency is needed either. (`CUDNN_FRONTEND_SKIP_JSON_LIB` compiles that support out.)

### Overlay

The BUILD file ships as `overlay/BUILD.bazel` rather than a patch, so `MODULE.bazel` declares `bazel_compatibility = [">=7.2.1"]` per registry policy for overlays.

### Verification

On Bazel 9.2.0, resolving the module out of a local registry:

- `@cudnn_frontend` (the presubmit target) builds.
- A consumer `cc_test` that compiles `#include <cudnn_frontend/thirdparty/nlohmann/json.hpp>`, constructs a `nlohmann::json` and checks `dump()` builds, links, and passes — confirming `strip_include_prefix` exposes `include/` at the paths upstream's own headers use.
- A consumer including `<cudnn_frontend.h>` resolves the module header from `_virtual_includes/cudnn_frontend/cudnn_frontend.h` and proceeds into `cudnn.h`, i.e. only the consumer-supplied CUDA headers remain.

Upstream's latest release is v1.26.0; this adds 1.12.0 because that is the version in use. Later versions can follow as separate PRs.
