### PR TITLE
liburing@2.10: make generate_headers header-copy POSIX-portable (unbreak macOS exec host)

### DIFF
--- a/modules/liburing/2.10/overlay/BUILD.bazel
+++ b/modules/liburing/2.10/overlay/BUILD.bazel
@@ -28,7 +28,9 @@ genrule(
 
             # collect the outputs
             for out in $(OUTS); do
-              cp $$(realpath --relative-to=$(BINDIR) $$out) $$out
+              # BSD realpath (e.g. a macOS exec host) lacks --relative-to; strip
+              # the $(BINDIR)/ prefix with a POSIX shell expansion instead.
+              cp "$${out#$(BINDIR)/}" "$$out"
             done
           """,
     toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],

--- a/modules/liburing/2.10/source.json
+++ b/modules/liburing/2.10/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "liburing-liburing-2.10",
     "patch_strip": 0,
     "overlay": {
-        "BUILD.bazel": "sha256-I2zFirR92K5vnCt7/7d4c483py9Ib+sZH5gtLaZH84c=",
+        "BUILD.bazel": "sha256-OyctN+M7L5WkY9EiXWto2RG7xmg8t7ui+jnjSqEwK8M=",
         "MODULE.bazel": "sha256-/TmFks2zREKHCWXABOboLg7YX23CkNW3H9yK+DML5gw="
     }
 }


### PR DESCRIPTION
# PR title

`liburing@2.10: make generate_headers header-copy POSIX-portable (unbreak macOS exec host)`

# PR description

## Problem

The `generate_headers` genrule in `modules/liburing/2.10/overlay/BUILD.bazel` collects
`./configure`'s outputs with:

```starlark
for out in $(OUTS); do
  cp $$(realpath --relative-to=$(BINDIR) $$out) $$out
done
```

`realpath --relative-to` is a **GNU coreutils extension**. On a host whose `realpath` is
the BSD implementation (most notably **macOS**), it fails immediately:

```
realpath: illegal option -- -
usage: realpath [-q] [path ...]
ERROR: ... Executing genrule @@liburing+//:generate_headers failed: (Exit 64)
```

so the genrule — and therefore anything depending on `@liburing` — cannot build.

## Who hits this

liburing is Linux-only, so this is invisible to the current presubmit matrix (all Linux
distros, where GNU `realpath` is present). But the genrule runs on the **execution
platform**, not the target platform. When **cross-compiling from a macOS host to a Linux
target** with a hermetic C++ toolchain (e.g. building for `aarch64-linux` from Apple
Silicon), the genrule executes on macOS and fails on the very first `cp`.

## Fix

The loop only needs to strip the leading `$(BINDIR)/` prefix off each declared output to
recover the exec-root-relative path `configure` wrote. A POSIX shell parameter expansion
does that with no external tool:

```starlark
for out in $(OUTS); do
  # BSD realpath (e.g. a macOS exec host) lacks --relative-to; strip
  # the $(BINDIR)/ prefix with a POSIX shell expansion instead.
  cp "$${out#$(BINDIR)/}" "$$out"
done
```

`$(BINDIR)` is Bazel-substituted to a literal path, and the genrule already runs under
bash, so `${out#$(BINDIR)/}` is well-defined. **Behavior is byte-identical on Linux** — no
external tool, no functional change — so it is a no-op for the existing (Linux-only)
presubmit and carries zero regression risk. It simply also works on non-GNU hosts.

## Scope

This changes only the header-copy step's portability. The genrule's existing behavior of
running `configure` on the execution platform is unchanged.

## Verification (macOS, darwin/arm64, cross-compiling to aarch64-linux)

**Before:**
```
ERROR: .../liburing+/BUILD.bazel:9:8: Executing genrule @@liburing+//:generate_headers
failed: (Exit 64): bash failed ...
  cp $(realpath --relative-to=... $out) $out
realpath: illegal option -- -
usage: realpath [-q] [path ...]
```

**After (fresh execution, remote cache disabled):**
```
$ bazel build @liburing//:generate_headers @liburing//:uring
[41 / 48] Executing genrule @@liburing+//:generate_headers; 0s darwin-sandbox
INFO: Build completed successfully, 41 total actions
```
`@liburing//:uring` then compiles against the generated `config-host.h` / `compat.h` /
`io_uring_version.h` with no errors.
