### PR TITLE
circe@1.0.0

### DIFF
--- a/modules/circe/1.0.0/MODULE.bazel
+++ b/modules/circe/1.0.0/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "circe",
+    version = "1.0.0",
+)
+
+bazel_dep(name = "apple_support", version = "2.2.0", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "rules_apple", version = "4.5.3", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_swift", version = "3.6.1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_xcodeproj", version = "4.1.0", dev_dependency = True)

--- a/modules/circe/1.0.0/presubmit.yml
+++ b/modules/circe/1.0.0/presubmit.yml
@@ -1,0 +1,11 @@
+matrix:
+  bazel:
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: macos_arm64
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@circe//Circe:Circe'

--- a/modules/circe/1.0.0/source.json
+++ b/modules/circe/1.0.0/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/xiemotongye/circe/releases/download/1.0.0/circe-1.0.0.tar.gz",
+    "integrity": "sha256-AayZdvAbwd45aFD4kwIzSrBBSWj1C9YFrbYs83UDw/I=",
+    "strip_prefix": "circe-1.0.0"
+}

--- a/modules/circe/metadata.json
+++ b/modules/circe/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/xiemotongye/circe",
+    "maintainers": [
+        {
+            "email": "xiemotongye@gmail.com",
+            "github": "xiemotongye",
+            "github_user_id": 2883398,
+            "name": "xiemotongye"
+        }
+    ],
+    "repository": [
+        "github:xiemotongye/circe"
+    ],
+    "versions": [
+        "1.0.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Circe converts pre-built arm64 iOS device binaries (`.a`, `.framework`, IPA) into arm64 iOS Simulator format by rewriting the `LC_BUILD_VERSION` load command in Mach-O files.

It ships Bazel (bzlmod) drop-in replacements for `cc_import`, `apple_static_framework_import`, `apple_dynamic_framework_import`, and `objc_import` that transparently convert dependencies for simulator builds.

This is common when third-party SDKs ship only device or x86_64 simulator slices and can no longer be compiled or linked for the arm64 simulator — especially for older binaries whose maintainers are no longer available to rebuild them.

- Repository: https://github.com/xiemotongye/circe
- macOS-only toolchain (depends on rules_apple / rules_swift), so presubmit targets only `macos_arm64`, matching the convention used by rules_apple.