### PR TITLE
theluckystrike_rules_sitemap@0.1.0

### DIFF
--- a/modules/theluckystrike_rules_sitemap/0.1.0/MODULE.bazel
+++ b/modules/theluckystrike_rules_sitemap/0.1.0/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "theluckystrike_rules_sitemap",
+    version = "0.1.0",
+    bazel_compatibility = [">=7.0.0"],
+    compatibility_level = 1,
+)
+
+# Only the tests need Skylib (unittest, analysistest, diff_test); consumers of
+# the rules pull in no transitive dependencies at all.
+bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency = True)

--- a/modules/theluckystrike_rules_sitemap/0.1.0/presubmit.yml
+++ b/modules/theluckystrike_rules_sitemap/0.1.0/presubmit.yml
@@ -1,0 +1,35 @@
+matrix:
+  platform:
+  - ubuntu2204
+  - macos
+  - windows
+  bazel:
+  - 7.x
+  - 8.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@theluckystrike_rules_sitemap//:theluckystrike_rules_sitemap'
+
+bcr_test_module:
+  module_path: examples/site
+  matrix:
+    platform:
+    - ubuntu2204
+    - macos
+    - windows
+    bazel:
+    - 7.x
+    - 8.x
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - '//:site'
+      test_targets:
+      - '//...'

--- a/modules/theluckystrike_rules_sitemap/0.1.0/source.json
+++ b/modules/theluckystrike_rules_sitemap/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-5anPLQFibG+dv8TZ4wfUtL+LLphjpuAbBauMgxP5L9M=",
+    "strip_prefix": "theluckystrike_rules_sitemap-0.1.0",
+    "url": "https://github.com/theluckystrike/rules_sitemap/releases/download/v0.1.0/theluckystrike_rules_sitemap-0.1.0.tar.gz"
+}

--- a/modules/theluckystrike_rules_sitemap/metadata.json
+++ b/modules/theluckystrike_rules_sitemap/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://toolsthatrank.com/rules-sitemap/",
+    "maintainers": [
+        {
+            "github": "theluckystrike",
+            "github_user_id": 51033404,
+            "name": "Michael Lip"
+        }
+    ],
+    "repository": [
+        "github:theluckystrike/rules_sitemap"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds `theluckystrike_rules_sitemap@0.1.0`.

### What it is

Pure-Starlark Bazel rules that generate `sitemap.xml`, a sitemap index and `robots.txt` for a statically built site, and turn an invalid result into a build error rather than a file that is served with HTTP 200 and then quietly discarded by the crawler.

Three rules: `sitemap_xml`, `sitemap_index`, `robots_txt`. No toolchain, no host tools, no network access, and no transitive dependencies for consumers — the files are written by `ctx.actions.write` during analysis. Skylib is a `dev_dependency` used only by the tests.

Rejected at analysis time: a `base_url` that is not absolute, page paths that are not root-relative, duplicate `<loc>` entries, more than 50,000 URLs in one sitemap, an out-of-range `priority`, an unknown `changefreq`, a `lastmod` that is not a W3C Datetime, and unescaped XML entities in query strings.

### Verification I ran before opening this

- `bazel test //...` in the source repo: **19/19 pass** on Bazel 8.4.2 — Starlark unit tests for the rendering helpers, golden byte-comparison tests per rule, and one analysis test per rejected input above.
- `bazel test //...` in `examples/site` as a standalone root module: 2/2 pass. This is the `bcr_test_module` path in `presubmit.yml`.
- `python3 tools/bcr_validation.py --check=theluckystrike_rules_sitemap@0.1.0`: all checks GOOD, with the expected `NEED_BCR_MAINTAINER_REVIEW` for a new module's `presubmit.yml`.
- The anonymous module test, locally: `bazel build --registry=file:///path/to/bcr --lockfile_mode=off @theluckystrike_rules_sitemap//:theluckystrike_rules_sitemap` succeeds against the real release tarball.

### Notes for reviewers

- The module name is prefixed with my GitHub org per the naming guidance in `docs/bcr-policies.md`; I did not want to claim a bare `rules_sitemap`.
- The source archive is a release asset I uploaded, not a GitHub auto-generated tag archive, so the URL is stable.
- I am the author and am listed as the module maintainer.
- `homepage` points at the documentation page for the ruleset on a site I operate; the canonical source of truth is the repository, https://github.com/theluckystrike/rules_sitemap.
- Disclosure: the ruleset, its tests and this PR were written by an AI coding agent (Claude) working under my direction and on my account. Every command quoted above was actually run and the output is real; I take responsibility for the module and for maintaining it.
