### PR TITLE
rules_periphery@0.2.0

### DIFF
--- a/modules/rules_periphery/0.2.0/MODULE.bazel
+++ b/modules/rules_periphery/0.2.0/MODULE.bazel
@@ -1,0 +1,18 @@
+module(
+    name = "rules_periphery",
+    version = "0.2.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_apple", version = "4.5.2")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+bazel_dep(name = "rules_swift", version = "3.6.0", max_compatibility_level = 3)
+
+periphery = use_extension("//:extensions.bzl", "periphery")
+use_repo(periphery, "periphery_bin", "periphery_generated")
+
+register_toolchains("@periphery_bin//:toolchain")
+
+# Dev dependencies
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.1", dev_dependency = True)

--- a/modules/rules_periphery/0.2.0/patches/e2e_module_version.patch
+++ b/modules/rules_periphery/0.2.0/patches/e2e_module_version.patch
@@ -1,0 +1,9 @@
+--- a/e2e/bcr/MODULE.bazel
++++ b/e2e/bcr/MODULE.bazel
+@@ -1,5 +1,5 @@
+ module(name = "rules_periphery_e2e")
+ 
+-bazel_dep(name = "rules_periphery", version = "0.1.0")
++bazel_dep(name = "rules_periphery", version = "0.2.0")
+ 
+ # A stand-in Periphery binary. Building the scan target never executes it, so a

--- a/modules/rules_periphery/0.2.0/patches/module_dot_bazel_version.patch
+++ b/modules/rules_periphery/0.2.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_periphery",
+-    version = "0.1.0",
++    version = "0.2.0",
+     compatibility_level = 1,
+ )
+ 
+ bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/modules/rules_periphery/0.2.0/presubmit.yml
+++ b/modules/rules_periphery/0.2.0/presubmit.yml
@@ -1,0 +1,17 @@
+# Exercises rules_periphery as a downstream consumer would: it depends on the
+# published module, configures a Periphery binary via the module extension, and
+# builds a scan target. Building (rather than running) keeps the check free of a
+# Swift toolchain and network access while still exercising the extension, the
+# public macro, and the driver.
+bcr_test_module:
+  module_path: "e2e/bcr"
+  matrix:
+    platform: ["ubuntu2204", "macos"]
+    bazel: ["8.x", "9.x"]
+  tasks:
+    build_targets:
+      name: "Build the test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//..."

--- a/modules/rules_periphery/0.2.0/source.json
+++ b/modules/rules_periphery/0.2.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-1pxbnCIbs2rQrLlW2NQy9QNxBjG/sqfMD6+rAbD+ub4=",
+    "strip_prefix": "rules_periphery-0.2.0",
+    "url": "https://github.com/periphery-pro/rules_periphery/releases/download/0.2.0/rules_periphery-0.2.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-+ChQ/PjjuPyKUBubpQjRlHQ4GcasOK2i5b85swf8BrI="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_periphery/0.2.0/source.json
+++ b/modules/rules_periphery/0.2.0/source.json
@@ -3,6 +3,7 @@
     "strip_prefix": "rules_periphery-0.2.0",
     "url": "https://github.com/periphery-pro/rules_periphery/releases/download/0.2.0/rules_periphery-0.2.0.tar.gz",
     "patches": {
+        "e2e_module_version.patch": "sha256-K6SJs/eCT5lugfMcVvrZji++c8x5FKKTe+rXCp51Ppg=",
         "module_dot_bazel_version.patch": "sha256-+ChQ/PjjuPyKUBubpQjRlHQ4GcasOK2i5b85swf8BrI="
     },
     "patch_strip": 1

--- a/modules/rules_periphery/metadata.json
+++ b/modules/rules_periphery/metadata.json
@@ -12,7 +12,8 @@
         "github:periphery-pro/rules_periphery"
     ],
     "versions": [
-        "0.1.0"
+        "0.1.0",
+        "0.2.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/periphery-pro/rules_periphery/releases/tag/0.2.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_