### PR TITLE
bugfix: updates to libsvtav1 required to fix missing symbol errors

### DIFF
--- a/modules/libsvtav1/2.2.1.bcr.1/MODULE.bazel
+++ b/modules/libsvtav1/2.2.1.bcr.1/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "libsvtav1",
+    version = "2.2.1.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "cpuinfo", version = "0.0.0-20260312-7607ca5")
+bazel_dep(name = "nasm", version = "2.16.03.bcr.3")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_nasm", version = "0.5.0")

--- a/modules/libsvtav1/2.2.1.bcr.1/overlay/BUILD.bazel
+++ b/modules/libsvtav1/2.2.1.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,362 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+load("@rules_nasm//nasm:defs.bzl", "nasm_library")
+
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+exports_files(["LICENSE.md"])
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:BSD-3-Clause"],
+    license_text = "LICENSE.md",
+)
+
+genrule(
+    name = "eb_version_h",
+    srcs = ["Source/Lib/Codec/EbVersion.h.in"],
+    outs = ["Source/Lib/Codec/EbVersion.h"],
+    cmd = "sed 's/@PACKAGE_VERSION_STRING@/v2.2.1/g' $< > $@",
+)
+
+cc_library(
+    name = "libsvtav1_headers",
+    hdrs = glob([
+        "Source/API/*.h",
+        "Source/Lib/Codec/*.h",
+        "Source/Lib/C_DEFAULT/*.h",
+        "Source/Lib/Globals/*.h",
+        "Source/Lib/ASM_SSE2/*.h",
+        "Source/Lib/ASM_SSSE3/*.h",
+        "Source/Lib/ASM_SSE4_1/*.h",
+        "Source/Lib/ASM_AVX2/*.h",
+        "Source/Lib/ASM_AVX512/*.h",
+        "third_party/fastfeat/*.h",
+    ]) + [
+        ":eb_version_h",
+    ],
+    includes = [
+        "Source/API",
+        "Source/Lib/ASM_AVX2",
+        "Source/Lib/ASM_AVX512",
+        "Source/Lib/ASM_SSE2",
+        "Source/Lib/ASM_SSE4_1",
+        "Source/Lib/ASM_SSSE3",
+        "Source/Lib/C_DEFAULT",
+        "Source/Lib/Codec",
+        "Source/Lib/Globals",
+        "third_party/fastfeat",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "safestringlib",
+    srcs = [
+        "third_party/safestringlib/ignore_handler_s.c",
+        "third_party/safestringlib/safe_str_constraint.c",
+        "third_party/safestringlib/strcpy_s.c",
+        "third_party/safestringlib/strncpy_s.c",
+        "third_party/safestringlib/strnlen_s.c",
+    ],
+    hdrs = [
+        "third_party/safestringlib/safe_lib.h",
+        "third_party/safestringlib/safe_lib_errno.h",
+        "third_party/safestringlib/safe_str_constraint.h",
+        "third_party/safestringlib/safe_str_lib.h",
+        "third_party/safestringlib/safe_types.h",
+        "third_party/safestringlib/safeclib_private.h",
+    ],
+    copts = [
+        "-DSAFECLIB_STR_NULL_SLACK=1",
+    ],
+    includes = [
+        "third_party/safestringlib",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+_NASM_HDRS = glob([
+    "Source/Lib/ASM_SSE2/*.asm",
+    "Source/Lib/ASM_SSSE3/*.asm",
+    "Source/Lib/ASM_AVX2/*.asm",
+])
+
+_ASM_SRCS = [
+    "Source/Lib/ASM_SSE2/aom_subpixel_8t_sse2.asm",
+    "Source/Lib/ASM_SSE2/highbd_intrapred_sse2_.asm",
+    "Source/Lib/ASM_SSE2/highbd_variance_impl_sse2.asm",
+    "Source/Lib/ASM_SSE2/intrapred_sse2.asm",
+    "Source/Lib/ASM_SSE2/picture_operators_sse2.asm",
+    "Source/Lib/ASM_SSE2/subpel_variance_sse2.asm",
+    "Source/Lib/ASM_SSE2/subtract_sse2.asm",
+    "Source/Lib/ASM_SSE2/x64RegisterUtil.asm",
+    "Source/Lib/ASM_SSSE3/aom_subpixel_bilinear_ssse3.asm",
+    "Source/Lib/ASM_SSSE3/aom_subpixel_8t_ssse3.asm",
+    "Source/Lib/ASM_SSSE3/subpel_variance_ssse3.asm",
+    "Source/Lib/ASM_AVX2/itx_avx2.asm",
+    "Source/Lib/ASM_AVX2/itx16_avx2.asm",
+    "Source/Lib/ASM_AVX2/mc_avx2.asm",
+    "Source/Lib/ASM_AVX2/mc16_avx2.asm",
+]
+
+nasm_library(
+    name = "libsvtav1_asm",
+    srcs = _ASM_SRCS,
+    hdrs = _NASM_HDRS,
+    copts = [
+        "-DUNIX64=1",
+    ],
+    includes = [
+        "Source/Lib/ASM_AVX2",
+        "Source/Lib/ASM_SSE2",
+    ],
+)
+
+# The AVX2 kernels are ported from dav1d and, following dav1d's x86inc.asm
+# convention, every asm symbol carries ELF hidden visibility. Hidden symbols
+# cannot cross a shared-library boundary, but under --dynamic_mode=default Bazel
+# builds each cc_library below as its own .so, splitting the asm away from the C
+# kernels that call it. Any consumer that links dynamically -- notably a
+# cc_test, whose linkstatic defaults to False -- then breaks on
+# 'svt_dav1d_inv_txfm_add_*_avx2'.
+#
+# Upstream's CMake build has no such split: it links all of this into a single
+# libSvtAv1Enc, which is exactly why hiding the symbols is correct there. The
+# linkstatic below restores that invariant. It has to be set on every target in
+# the link, not just this one -- a .so anywhere in the chain reintroduces the
+# boundary. alwayslink does not help: a cc_library's .so contains only its own
+# srcs' objects, so no dep attribute can pull the asm into liblibsvtav1_avx2.so.
+#
+# Setting it only here is worse than not setting it at all: the .so is left with
+# undefined references that the executable satisfies at link time but the
+# dynamic loader cannot, turning a build failure into a runtime
+# "symbol lookup error".
+cc_library(
+    name = "libsvtav1_asm_wrapper",
+    srcs = [
+        ":libsvtav1_asm",
+    ],
+    linkstatic = True,
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "libsvtav1_sse2",
+    srcs = glob(["Source/Lib/ASM_SSE2/*.c"]),
+    copts = [
+        "-msse2",
+        "-DARCH_X86_64=1",
+        "-DEN_AVX512_SUPPORT=1",
+        "-DEXCLUDE_HASH=1",
+        "-DREPRODUCIBLE_BUILDS=1",
+    ],
+    linkstatic = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":libsvtav1_asm_wrapper",
+        ":libsvtav1_headers",
+    ],
+)
+
+cc_library(
+    name = "libsvtav1_ssse3",
+    srcs = glob(["Source/Lib/ASM_SSSE3/*.c"]),
+    copts = [
+        "-mssse3",
+        "-DARCH_X86_64=1",
+        "-DEN_AVX512_SUPPORT=1",
+        "-DEXCLUDE_HASH=1",
+        "-DREPRODUCIBLE_BUILDS=1",
+    ],
+    linkstatic = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":libsvtav1_asm_wrapper",
+        ":libsvtav1_headers",
+    ],
+)
+
+cc_library(
+    name = "libsvtav1_sse4_1",
+    srcs = glob(["Source/Lib/ASM_SSE4_1/*.c"]),
+    copts = [
+        "-msse4.1",
+        "-DARCH_X86_64=1",
+        "-DEN_AVX512_SUPPORT=1",
+        "-DEXCLUDE_HASH=1",
+        "-DREPRODUCIBLE_BUILDS=1",
+    ],
+    linkstatic = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":libsvtav1_asm_wrapper",
+        ":libsvtav1_headers",
+    ],
+)
+
+cc_library(
+    name = "libsvtav1_avx2",
+    srcs = glob(["Source/Lib/ASM_AVX2/*.c"]),
+    copts = [
+        "-mavx2",
+        "-DARCH_X86_64=1",
+        "-DEN_AVX512_SUPPORT=1",
+        "-DEXCLUDE_HASH=1",
+        "-DREPRODUCIBLE_BUILDS=1",
+    ],
+    linkstatic = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":libsvtav1_asm_wrapper",
+        ":libsvtav1_headers",
+    ],
+)
+
+cc_library(
+    name = "libsvtav1_avx512",
+    srcs = glob(["Source/Lib/ASM_AVX512/*.c"]),
+    copts = [
+        "-mavx2",
+        "-mavx512f",
+        "-mavx512bw",
+        "-mavx512dq",
+        "-mavx512vl",
+        "-DARCH_X86_64=1",
+        "-DEN_AVX512_SUPPORT=1",
+        "-DEXCLUDE_HASH=1",
+        "-DREPRODUCIBLE_BUILDS=1",
+    ],
+    linkstatic = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":libsvtav1_asm_wrapper",
+        ":libsvtav1_headers",
+    ],
+)
+
+cc_library(
+    name = "libsvtav1_neon",
+    srcs = glob(
+        [
+            "Source/Lib/ASM_NEON/*.c",
+            "Source/Lib/ASM_NEON/*.S",
+        ],
+        # Stray file not referenced by upstream's own
+        # Source/Lib/ASM_NEON/CMakeLists.txt: an older, unused variant of
+        # highbd_jnt_convolve_neon.c that references a header
+        # (EbDefinitions.h) that no longer exists in this version.
+        exclude = [
+            "Source/Lib/ASM_NEON/highbd_jnt_convolve_neon_y.c",
+            "Source/Lib/ASM_NEON/dav1d_asm.S",
+            "Source/Lib/ASM_NEON/dav1d_util.S",
+        ],
+    ),
+    hdrs = glob(["Source/Lib/ASM_NEON/*.h"]) + [
+        "Source/Lib/ASM_NEON/dav1d_asm.S",
+        "Source/Lib/ASM_NEON/dav1d_util.S",
+    ],
+    copts = [
+        "-DARCH_AARCH64=1",
+        "-DEXCLUDE_HASH=1",
+        "-DREPRODUCIBLE_BUILDS=1",
+    ],
+    includes = [
+        "Source/Lib/ASM_NEON",
+    ],
+    linkstatic = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":libsvtav1_headers",
+    ],
+)
+
+# Arm's Neon optimizations (Source/Lib/ASM_NEON) are ported from dav1d and
+# include hand-written GAS assembly (.S); Neon is baseline on aarch64 so,
+# unlike x86, no extra -march flag is needed. Other targets (e.g. riscv)
+# fall back to the plain-C implementation upstream already supports via its
+# own ARCH_X86_64/ARCH_AARCH64-gated code paths (see e.g.
+# Source/Lib/Codec/aom_dsp_rtcd.c).
+_ARCH_COPTS = select({
+    "@platforms//cpu:x86_64": [
+        "-DARCH_X86_64=1",
+        "-DEN_AVX512_SUPPORT=1",
+    ],
+    "@platforms//cpu:aarch64": [
+        "-DARCH_AARCH64=1",
+        "-DHAVE_NEON=1",
+        "-DHAVE_ARM_CRC32=0",
+        "-DHAVE_NEON_DOTPROD=0",
+        "-DHAVE_NEON_I8MM=0",
+        "-DHAVE_SVE=0",
+        "-DHAVE_SVE2=0",
+    ],
+    "//conditions:default": [],
+})
+
+cc_library(
+    name = "SvtAv1Enc",
+    srcs = glob([
+        "third_party/fastfeat/*.c",
+        "Source/Lib/Globals/*.c",
+        "Source/Lib/Codec/*.c",
+        "Source/Lib/C_DEFAULT/*.c",
+    ]),
+    hdrs = glob(["Source/API/*.h"]),
+    copts = _ARCH_COPTS + [
+        "-DEXCLUDE_HASH=1",
+        "-DREPRODUCIBLE_BUILDS=1",
+    ],
+    includes = [
+        "Source/API",
+    ],
+    linkopts = [
+        "-lpthread",
+        "-lm",
+    ],
+    linkstatic = True,
+    deps = [
+        ":libsvtav1_headers",
+        "@cpuinfo",
+    ] + select({
+        "@platforms//cpu:x86_64": [
+            ":libsvtav1_avx2",
+            ":libsvtav1_avx512",
+            ":libsvtav1_sse2",
+            ":libsvtav1_sse4_1",
+            ":libsvtav1_ssse3",
+        ],
+        "@platforms//cpu:aarch64": [
+            ":libsvtav1_neon",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+cc_binary(
+    name = "SvtAv1EncApp",
+    srcs = glob([
+        "Source/App/*.c",
+        "Source/App/*.h",
+    ]),
+    copts = _ARCH_COPTS + [
+        "-DEXCLUDE_HASH=1",
+        "-DREPRODUCIBLE_BUILDS=1",
+    ],
+    includes = [
+        ".",
+        "Source/App",
+    ],
+    deps = [
+        ":SvtAv1Enc",
+        ":safestringlib",
+    ],
+)
+
+alias(
+    name = "libsvtav1",
+    actual = ":SvtAv1Enc",
+)

--- a/modules/libsvtav1/2.2.1.bcr.1/presubmit.yml
+++ b/modules/libsvtav1/2.2.1.bcr.1/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+    - ubuntu2204
+    - ubuntu2204_arm64
+    - macos
+    - macos_arm64
+    - windows
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@libsvtav1//:SvtAv1Enc'
+      - '@libsvtav1//:SvtAv1EncApp'

--- a/modules/libsvtav1/2.2.1.bcr.1/source.json
+++ b/modules/libsvtav1/2.2.1.bcr.1/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v2.2.1/SVT-AV1-v2.2.1.tar.gz",
+    "integrity": "sha256-0CtUaFVC3gI2vOS+G1CRKrpor/mXxDs1DYSlGN8M9OU=",
+    "strip_prefix": "SVT-AV1-v2.2.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-iJ/hzfc+R3Ob9lIwjDO7sdYazZAokaGj6VV7pJQTI4c="
+    }
+}

--- a/modules/libsvtav1/metadata.json
+++ b/modules/libsvtav1/metadata.json
@@ -12,7 +12,8 @@
         "https://gitlab.com/AOMediaCodec/SVT-AV1"
     ],
     "versions": [
-        "2.2.1"
+        "2.2.1",
+        "2.2.1.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Changes to `libsvtav1` ported from this PR:
https://github.com/bazelbuild/bazel-central-registry/pull/9486