### PR TITLE
fix(lz4): v1.10.0.bcr.2 - namespace bundled xxHash

### DIFF
--- a/modules/lz4/1.10.0.bcr.2/MODULE.bazel
+++ b/modules/lz4/1.10.0.bcr.2/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "lz4",
+    version = "1.10.0.bcr.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.8")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")

--- a/modules/lz4/1.10.0.bcr.2/overlay/BUILD.bazel
+++ b/modules/lz4/1.10.0.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,83 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "lz4",
+    srcs = [
+        "lib/lz4.c",
+        "lib/xxhash.c",
+        "lib/xxhash.h",
+    ],
+    hdrs = [
+        "lib/lz4.h",
+    ],
+    local_defines = ["XXH_NAMESPACE=LZ4_"],
+    strip_include_prefix = "lib/",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "lz4_lz4c_include",
+    hdrs = [
+        "lib/lz4.c",
+    ],
+    strip_include_prefix = "lib/",
+)
+
+cc_library(
+    name = "lz4_hc",
+    srcs = [
+        "lib/lz4hc.c",
+    ],
+    hdrs = [
+        "lib/lz4hc.h",
+    ],
+    strip_include_prefix = "lib/",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":lz4",
+        ":lz4_lz4c_include",
+    ],
+)
+
+cc_library(
+    name = "lz4_file",
+    srcs = [
+        "lib/lz4file.c",
+    ],
+    hdrs = [
+        "lib/lz4file.h",
+    ],
+    strip_include_prefix = "lib/",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":lz4",
+        ":lz4_frame",
+    ],
+)
+
+cc_library(
+    name = "lz4_frame",
+    srcs = [
+        "lib/lz4frame.c",
+        "lib/lz4frame_static.h",
+    ],
+    hdrs = [
+        "lib/lz4frame.h",
+    ],
+    local_defines = ["XXH_NAMESPACE=LZ4_"],
+    strip_include_prefix = "lib/",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":lz4",
+        ":lz4_hc",
+    ],
+)
+
+cc_library(
+    name = "lz4_xxhash_include",
+    hdrs = [
+        "lib/xxhash.h",
+    ],
+    strip_include_prefix = "lib/",
+    visibility = ["//:__subpackages__"],
+)

--- a/modules/lz4/1.10.0.bcr.2/overlay/MODULE.bazel
+++ b/modules/lz4/1.10.0.bcr.2/overlay/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "lz4",
+    version = "1.10.0.bcr.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.8")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")

--- a/modules/lz4/1.10.0.bcr.2/overlay/programs/BUILD.bazel
+++ b/modules/lz4/1.10.0.bcr.2/overlay/programs/BUILD.bazel
@@ -1,0 +1,63 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+package(default_visibility = ["//visibility:private"])
+
+bool_flag(
+    name = "multithreading",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+config_setting(
+    name = "multithreading_on_windows",
+    flag_values = {":multithreading": "true"},
+    constraint_values = ["@platforms//os:windows"],
+)
+
+config_setting(
+    name = "multithreading_enabled",
+    flag_values = {":multithreading": "true"},
+)
+
+cc_binary(
+    name = "lz4",
+    srcs = [
+        "bench.c",
+        "bench.h",
+        "lorem.c",
+        "lorem.h",
+        "lz4cli.c",
+        "lz4conf.h",
+        "lz4io.c",
+        "lz4io.h",
+        "platform.h",
+        "threadpool.c",
+        "threadpool.h",
+        "timefn.c",
+        "timefn.h",
+        "util.c",
+        "util.h",
+    ],
+    local_defines = ["XXH_NAMESPACE=LZ4_"],
+    visibility = ["//visibility:public"],
+    copts = select({
+        ":multithreading_on_windows": ["-DLZ4IO_MULTITHREAD=1"],
+        ":multithreading_enabled": [
+            "-DLZ4IO_MULTITHREAD=1",
+            "-pthread",
+        ],
+        "//conditions:default": ["-DLZ4IO_MULTITHREAD=0"],
+    }),
+    linkopts = select({
+        ":multithreading_on_windows": [],
+        ":multithreading_enabled": ["-pthread"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//:lz4",
+        "//:lz4_file",
+        "//:lz4_frame",
+        "//:lz4_hc",
+        "//:lz4_xxhash_include",
+    ],
+)

--- a/modules/lz4/1.10.0.bcr.2/presubmit.yml
+++ b/modules/lz4/1.10.0.bcr.2/presubmit.yml
@@ -1,0 +1,29 @@
+matrix:
+  platform:
+    - debian11
+    - fedora40
+    - macos
+    - macos_arm64
+    - windows
+  bazel: [7.x, 8.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@lz4//:lz4"
+      - "@lz4//:lz4_hc"
+      - "@lz4//:lz4_frame"
+      - "@lz4//programs:lz4"
+  verify_multithreading_targets:
+    name: Verify build targets with multithreading
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@lz4//:lz4"
+      - "@lz4//:lz4_hc"
+      - "@lz4//:lz4_frame"
+      - "@lz4//programs:lz4"
+    build_flags:
+      - "--@lz4//programs:multithreading=true"

--- a/modules/lz4/1.10.0.bcr.2/source.json
+++ b/modules/lz4/1.10.0.bcr.2/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/lz4/lz4/releases/download/v1.10.0/lz4-1.10.0.tar.gz",
+    "integrity": "sha256-U3USkEdEs14jKRIFXM+Oxm12hjn/Or5XiNkNeS7F9Is=",
+    "strip_prefix": "lz4-1.10.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-+PZ3wxxEQKN6QlKKeyxG7BhiompGPl1/SSgZ7haz4/s=",
+        "MODULE.bazel": "sha256-vy2ayS3Tt5LlFMpBKWXXiGO6OgU0THf0EJtNqo3YHas=",
+        "programs/BUILD.bazel": "sha256-T3vQpof7NkLrIYn/yulPOX56mNPmsGuSosKoxMEJoy4="
+    },
+    "patch_strip": 0
+}

--- a/modules/lz4/metadata.json
+++ b/modules/lz4/metadata.json
@@ -16,7 +16,8 @@
         "1.9.4.bcr.1",
         "1.9.4.bcr.2",
         "1.10.0",
-        "1.10.0.bcr.1"
+        "1.10.0.bcr.1",
+        "1.10.0.bcr.2"
     ],
     "yanked_versions": {
         "1.10.0": "Contains an unintentional breaking change to build targets. Fixed in 1.10.0.bcr.1"


### PR DESCRIPTION
Match the upstream LZ4 build by prefixing bundled xxHash symbols, avoiding collisions with separately linked xxHash versions.