### PR TITLE
supply_chain_tools@0.0.3

### DIFF
--- a/modules/supply_chain_tools/0.0.3/MODULE.bazel
+++ b/modules/supply_chain_tools/0.0.3/MODULE.bazel
@@ -1,0 +1,27 @@
+module(
+    name = "supply_chain_tools",
+    version = "0.0.3",  # Automatically updated by release pipeline.
+)
+
+# Do not update to newer versions until you need a specific new feature.
+bazel_dep(name = "package_metadata", version = "0.0.13")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "bazel_features", version = "1.46.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "supply-chain-go", version = "0.0.6")
+
+# For development, we use our sibling projects directly.
+local_path_override(
+    module_name = "package_metadata",
+    path = "../metadata",
+)
+
+local_path_override(
+    module_name = "supply-chain-go",
+    path = "../lib/supplychain-go",
+)
+
+local_path_override(
+    module_name = "rules_license",
+    path = "../rules_license",
+)

--- a/modules/supply_chain_tools/0.0.3/attestations.json
+++ b/modules/supply_chain_tools/0.0.3/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/bazel-contrib/supply-chain/releases/download/supply_chain_tools-0.0.3/source.json.intoto.jsonl",
+            "integrity": "sha256-BvNPJyjbzeg1SQL6mNYzqs41IQPgbj9kz1SluDGAMN0="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/bazel-contrib/supply-chain/releases/download/supply_chain_tools-0.0.3/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-b/CwwUBdfvhA/4RZ+BkfUrnyiuunKrU3FZy4B9NhRZM="
+        },
+        "supply_chain_tools-0.0.3.tar.gz": {
+            "url": "https://github.com/bazel-contrib/supply-chain/releases/download/supply_chain_tools-0.0.3/supply_chain_tools-0.0.3.tar.gz.intoto.jsonl",
+            "integrity": "sha256-+ZaD/I6BbPsChg+0cTVNzXWUosNRYsOdEPjonmU670M="
+        }
+    }
+}

--- a/modules/supply_chain_tools/0.0.3/presubmit.yml
+++ b/modules/supply_chain_tools/0.0.3/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+  bazel:
+  - 8.x
+  - 7.x
+  - 6.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@supply_chain_tools//...'

--- a/modules/supply_chain_tools/0.0.3/source.json
+++ b/modules/supply_chain_tools/0.0.3/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-YpP3ZodjRBBKIAgyOXhRMyGDIs4oqsC0MEC8VHn1pRM=",
+    "strip_prefix": "supply_chain_tools-0.0.3/tools",
+    "url": "https://github.com/bazel-contrib/supply-chain/releases/download/supply_chain_tools-0.0.3/supply_chain_tools-0.0.3.tar.gz"
+}

--- a/modules/supply_chain_tools/metadata.json
+++ b/modules/supply_chain_tools/metadata.json
@@ -2,12 +2,6 @@
     "homepage": "https://github.com/bazel-contrib/supply-chain",
     "maintainers": [
         {
-            "email": "aiuto@aiuto.dev",
-            "github": "aiuto",
-            "name": "Tony Aiuto",
-            "github_user_id": 3044252
-        },
-        {
             "email": "antonio@engflow.com",
             "github": "TheGrizzlyDev",
             "name": "Antonio Di Stefano",
@@ -20,6 +14,12 @@
             "github_user_id": 12609729
         },
         {
+            "email": "tony.aiuto@datadoghq.com",
+            "github": "aiuto",
+            "name": "Tony Aiuto",
+            "github_user_id": 3044252
+        },
+        {
             "email": "yannic@engflow.com",
             "github": "Yannic",
             "name": "Yannic Bonenberger",
@@ -30,7 +30,8 @@
         "github:bazel-contrib/supply-chain"
     ],
     "versions": [
-        "0.0.1"
+        "0.0.1",
+        "0.0.3"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/bazel-contrib/supply-chain/releases/tag/supply_chain_tools-0.0.3

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_