### PR TITLE
xctestrunner@0.2.16-20260212-4c6f493

### DIFF
--- a/modules/xctestrunner/0.2.16-20260212-4c6f493/MODULE.bazel
+++ b/modules/xctestrunner/0.2.16-20260212-4c6f493/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "xctestrunner",
+    version = "0.2.16-20260212-4c6f493",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_python", version = "1.0.0")

--- a/modules/xctestrunner/0.2.16-20260212-4c6f493/patches/module_dot_bazel_version.patch
+++ b/modules/xctestrunner/0.2.16-20260212-4c6f493/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 258f0a4..5d89d6d 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "xctestrunner",
+-    version = "0.2.15",
++    version = "0.2.16-20260212-4c6f493",
+     compatibility_level = 1,
+ )
+ 

--- a/modules/xctestrunner/0.2.16-20260212-4c6f493/presubmit.yml
+++ b/modules/xctestrunner/0.2.16-20260212-4c6f493/presubmit.yml
@@ -1,0 +1,12 @@
+matrix:
+  platform:
+    - macos
+    - macos_arm64
+  bazel: [7.x, 8.x, 9.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@xctestrunner//:ios_test_runner'

--- a/modules/xctestrunner/0.2.16-20260212-4c6f493/source.json
+++ b/modules/xctestrunner/0.2.16-20260212-4c6f493/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/google/xctestrunner/archive/4c6f4931aa65b3e6573b3ca11753c98fc8d3071c.tar.gz",
+    "strip_prefix": "xctestrunner-4c6f4931aa65b3e6573b3ca11753c98fc8d3071c",
+    "patch_strip": 1,
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-YgorF3Wzm+42rtoCYLYxyK/gfxJgI7BRUDL6VC8UKas="
+    },
+    "integrity": "sha256-RWeTLHMJspCS7EXFoN6sddaK+YejsREs/deQtM/63tQ="
+}

--- a/modules/xctestrunner/metadata.json
+++ b/modules/xctestrunner/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/google/xctestrunner",
+    "maintainers": [
+        {
+            "email": "byoungchan.lee@gmx.com",
+            "github": "bc-lee",
+            "github_user_id": 7533290,
+            "name": "Byoungchan Lee"
+        }
+    ],
+    "repository": [
+        "github:google/xctestrunner"
+    ],
+    "versions": [
+        "0.2.16-20260212-4c6f493"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Register `google/xctestrunner` at upstream HEAD as `xctestrunner@0.2.16-20260212-4c6f493`. Its last stable release, `0.2.15`, was over five years ago, and there is no suitable current upstream tag, so this pseudo-version tracks immutable commit `4c6f493`. This lets downstream projects such as `rules_apple` consume xctestrunner through Bzlmod instead of bundling it through an `http_archive`.