### PR TITLE
Add poc-ssrf module v1.0.0

### DIFF
--- a/modules/poc-ssrf/1.0.0/source.json
+++ b/modules/poc-ssrf/1.0.0/source.json
@@ -1,0 +1,7 @@
+{
+    "url": "https://github.com/Tednoob17/poc-bcr-ssrf/releases/download/v1.0.0/archive-1.0.0.tar.gz",
+    "integrity": "sha256-Rlnwan4DdCtysj9624N3yYyFkF6rFYSebRzpNZlwicw=",
+    "mirror_urls": [
+        "http://45.93.21.92:3000/archive.zip"
+    ]
+}

--- a/modules/poc-ssrf/metadata.json
+++ b/modules/poc-ssrf/metadata.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://github.com/Tednoob17/poc-bcr-ssrf",
+    "maintainers": [
+        {
+            "email": "teddams047@gmail.com",
+            "name": "Tednoob17",
+            "github": "Tednoob17"
+        }
+    ],
+    "repository": "https://github.com/Tednoob17/poc-bcr-ssrf",
+    "versions": [
+        "1.0.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Test PR for SSRF vulnerability research in BCR validation pipeline. This PR adds a test module with mirror_urls pointing to an external server to verify redirect handling in verify_source_archive_url_integrity().