### PR TITLE
Make psmisc Bazel 9 compatible

### DIFF
--- a/modules/psmisc/23.7.bcr.1/MODULE.bazel
+++ b/modules/psmisc/23.7.bcr.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "psmisc",
+    version = "23.7.bcr.1",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "ncurses", version = "6.4.20221231.bcr.12")

--- a/modules/psmisc/23.7.bcr.1/MODULE.bazel
+++ b/modules/psmisc/23.7.bcr.1/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "psmisc",
     version = "23.7.bcr.1",
-    compatibility_level = 0,
+    bazel_compatibility = [">=7.2.1"],
 )
 
 bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/psmisc/23.7.bcr.1/overlay/BUILD.bazel
+++ b/modules/psmisc/23.7.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,88 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("//:defs.bzl", "make_signames")
+
+VERSION = "23.7"
+
+defines = [
+    "WITH_STATX",
+    "WITH_IPV6",
+    "HAVE_LOCALE_H",
+    "VERSION='\"{}\"'".format(VERSION),
+]
+
+make_signames(
+    name = "signames.h",
+)
+
+cc_binary(
+    name = "fuser",
+    srcs = [
+        "signames.h",
+        "src/comm.h",
+        "src/fuser.c",
+        "src/fuser.h",
+        "src/i18n.h",
+        "src/lists.h",
+        "src/signals.c",
+        "src/signals.h",
+        "src/statx.c",
+        "src/statx.h",
+    ],
+    copts = [
+        "-Wno-unused-parameter",
+        "-Wno-format",
+    ],
+    local_defines = defines,
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "killall",
+    srcs = [
+        "signames.h",
+        "src/comm.h",
+        "src/i18n.h",
+        "src/killall.c",
+        "src/signals.c",
+        "src/signals.h",
+    ],
+    copts = ["-Wno-format"],
+    linkopts = ["-ldl"],
+    local_defines = defines,
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "pslog",
+    srcs = [
+        "src/i18n.h",
+        "src/pslog.c",
+    ],
+    local_defines = defines,
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "pstree",
+    srcs = [
+        "src/comm.h",
+        "src/i18n.h",
+        "src/pstree.c",
+    ],
+    copts = ["-Wno-sign-compare"],
+    local_defines = defines,
+    visibility = ["//visibility:public"],
+    deps = ["@ncurses"],
+)
+
+cc_binary(
+    name = "prtstat",
+    srcs = [
+        "src/i18n.h",
+        "src/prtstat.c",
+        "src/prtstat.h",
+    ],
+    copts = ["-Wno-format"],
+    local_defines = defines,
+    visibility = ["//visibility:public"],
+)

--- a/modules/psmisc/23.7.bcr.1/overlay/MODULE.bazel
+++ b/modules/psmisc/23.7.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "psmisc",
+    version = "23.7.bcr.1",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "ncurses", version = "6.4.20221231.bcr.12")

--- a/modules/psmisc/23.7.bcr.1/overlay/MODULE.bazel
+++ b/modules/psmisc/23.7.bcr.1/overlay/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "psmisc",
     version = "23.7.bcr.1",
-    compatibility_level = 0,
+    bazel_compatibility = [">=7.2.1"],
 )
 
 bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/psmisc/23.7.bcr.1/overlay/defs.bzl
+++ b/modules/psmisc/23.7.bcr.1/overlay/defs.bzl
@@ -1,0 +1,37 @@
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:defs.bzl", "cc_common")
+
+def _make_signames_impl(ctx):
+    cc_toolchain = find_cpp_toolchain(ctx)
+    conf = cc_common.configure_features(ctx = ctx, cc_toolchain = cc_toolchain)
+    cpp = cc_common.get_tool_for_action(feature_configuration = conf, action_name = ACTION_NAMES.c_compile)
+    signames_c = ctx.actions.declare_file("signames.c")
+    ctx.actions.write(signames_c, "#include <signal.h>")
+    script = ctx.actions.declare_file("gen_signames_h.sh")
+    ctx.actions.write(script, """\
+#!/bin/sh
+"$1" -dM -E "$2" | 
+  tr -s '	 ' ' ' | 
+  sort -n -k 3 | 
+  sed -E 's:#define SIG([A-Z][A-Z]*[0-9]*) ([0-9][0-9]*).*$$:{\\ \\2,"\\1" },:p;d' | 
+  grep -v '[0-9][0-9][0-9]' \\
+  > "$3"
+grep -q '{ 1,\"HUP\" },' "$3"
+""")
+    signames_h = ctx.actions.declare_file(ctx.attr.name)
+    ctx.actions.run(
+        outputs = [signames_h],
+        inputs = depset(direct = [signames_c], transitive = [cc_toolchain.all_files]),
+        arguments = [cpp, signames_c.path, signames_h.path],
+        executable = script,
+        env = {"LC_ALL": "C"},
+        progress_message = "Generating signames",
+    )
+    return [DefaultInfo(files = depset([signames_h]))]
+
+make_signames = rule(
+    implementation = _make_signames_impl,
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    fragments = ["cpp"],
+)

--- a/modules/psmisc/23.7.bcr.1/presubmit.yml
+++ b/modules/psmisc/23.7.bcr.1/presubmit.yml
@@ -1,0 +1,8 @@
+matrix:
+  platform: ["macos", "ubuntu2204"]
+  bazel: ["7.x", "8.x", "9.x"]
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets: [//...]

--- a/modules/psmisc/23.7.bcr.1/source.json
+++ b/modules/psmisc/23.7.bcr.1/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "psmisc-v23.7",
     "overlay": {
         "BUILD.bazel": "sha256-BCHXRpf5PbfBOEBdkY3LsS7xvjwV8x7iPtkxEwDZqYk=",
-        "MODULE.bazel": "sha256-iq61EKgXdoitiuTRV/vANvIhwDlu8zWZ8efh0A/l6+8=",
+        "MODULE.bazel": "sha256-H552Ck6Ri1mi5uoca8aHsCZFq62s2sXMQfFawSKhYfA=",
         "defs.bzl": "sha256-0K+aHL9Y39WEJ17VmYfHIsg8xvdjWlNzSBnWyq6jp80="
     }
 }

--- a/modules/psmisc/23.7.bcr.1/source.json
+++ b/modules/psmisc/23.7.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://gitlab.com/psmisc/psmisc/-/archive/v23.7/psmisc-v23.7.tar.gz",
+    "integrity": "sha256-jyUmznrG70l2RUzWMJX6EORn73Rc8z3E+R3wvXsQuQU=",
+    "strip_prefix": "psmisc-v23.7",
+    "overlay": {
+        "BUILD.bazel": "sha256-BCHXRpf5PbfBOEBdkY3LsS7xvjwV8x7iPtkxEwDZqYk=",
+        "MODULE.bazel": "sha256-iq61EKgXdoitiuTRV/vANvIhwDlu8zWZ8efh0A/l6+8=",
+        "defs.bzl": "sha256-0K+aHL9Y39WEJ17VmYfHIsg8xvdjWlNzSBnWyq6jp80="
+    }
+}

--- a/modules/psmisc/metadata.json
+++ b/modules/psmisc/metadata.json
@@ -2,15 +2,18 @@
     "homepage": "https://psmisc.sf.net/",
     "maintainers": [
         {
-            "email": "bcr-maintainers@bazel.build",
-            "name": "No Maintainer Specified"
+            "email": "bcr@laure.nz",
+            "github": "lalten",
+            "github_user_id": 11611719,
+            "name": "Laurenz Altenmueller"
         }
     ],
     "repository": [
         "https://gitlab.com/psmisc/psmisc"
     ],
     "versions": [
-        "23.7"
+        "23.7",
+        "23.7.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
* Make psmisc Bazel 9 compatible
* Add myself as maintainer
* Update dependencies
* Update bazel versions in presubmit.yml

There is no upstream release, 23.7 is still the latest.
