### PR TITLE
Add qhull 8.0.2.bcr.2 to include missing source/header QhullUser

### DIFF
--- a/modules/qhull/8.0.2.bcr.2/MODULE.bazel
+++ b/modules/qhull/8.0.2.bcr.2/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "qhull",
+    version = "8.0.2.bcr.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.11")
+bazel_dep(name = "package_metadata", version = "0.0.7")

--- a/modules/qhull/8.0.2.bcr.2/overlay/BUILD.bazel
+++ b/modules/qhull/8.0.2.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,199 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@package_metadata//licenses:defs.bzl", "license", "license_kind")
+
+package(
+    default_package_metadata = [":license"],
+)
+
+exports_files(["COPYING.txt"])
+
+license_kind(
+    name = "qhull_license_kind",
+    identifier = "Qhull",
+    full_name = "Qhull License",
+)
+
+license(
+    name = "license",
+    kind = ":qhull_license_kind",
+    text = "COPYING.txt",
+)
+
+cc_library(
+    name = "qhull",
+    srcs = [
+        "src/libqhull/geom.c",
+        "src/libqhull/geom2.c",
+        "src/libqhull/global.c",
+        "src/libqhull/io.c",
+        "src/libqhull/libqhull.c",
+        "src/libqhull/mem.c",
+        "src/libqhull/merge.c",
+        "src/libqhull/poly.c",
+        "src/libqhull/poly2.c",
+        "src/libqhull/qset.c",
+        "src/libqhull/random.c",
+        "src/libqhull/rboxlib.c",
+        "src/libqhull/stat.c",
+        "src/libqhull/user.c",
+        "src/libqhull/usermem.c",
+        "src/libqhull/userprintf.c",
+        "src/libqhull/userprintf_rbox.c",
+    ],
+    hdrs = [
+        "src/libqhull/geom.h",
+        "src/libqhull/io.h",
+        "src/libqhull/libqhull.h",
+        "src/libqhull/mem.h",
+        "src/libqhull/merge.h",
+        "src/libqhull/poly.h",
+        "src/libqhull/qhull_a.h",
+        "src/libqhull/qset.h",
+        "src/libqhull/random.h",
+        "src/libqhull/stat.h",
+        "src/libqhull/user.h",
+    ],
+    includes = ["src"],
+    linkopts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "-lm",
+        ],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "qhull_r",
+    srcs = [
+        "src/libqhull_r/geom2_r.c",
+        "src/libqhull_r/geom_r.c",
+        "src/libqhull_r/global_r.c",
+        "src/libqhull_r/io_r.c",
+        "src/libqhull_r/libqhull_r.c",
+        "src/libqhull_r/mem_r.c",
+        "src/libqhull_r/merge_r.c",
+        "src/libqhull_r/poly2_r.c",
+        "src/libqhull_r/poly_r.c",
+        "src/libqhull_r/qset_r.c",
+        "src/libqhull_r/random_r.c",
+        "src/libqhull_r/rboxlib_r.c",
+        "src/libqhull_r/stat_r.c",
+        "src/libqhull_r/user_r.c",
+        "src/libqhull_r/usermem_r.c",
+        "src/libqhull_r/userprintf_r.c",
+        "src/libqhull_r/userprintf_rbox_r.c",
+    ],
+    hdrs = [
+        "src/libqhull_r/geom_r.h",
+        "src/libqhull_r/io_r.h",
+        "src/libqhull_r/libqhull_r.h",
+        "src/libqhull_r/mem_r.h",
+        "src/libqhull_r/merge_r.h",
+        "src/libqhull_r/poly_r.h",
+        "src/libqhull_r/qhull_ra.h",
+        "src/libqhull_r/qset_r.h",
+        "src/libqhull_r/random_r.h",
+        "src/libqhull_r/stat_r.h",
+        "src/libqhull_r/user_r.h",
+    ],
+    includes = ["src"],
+    linkopts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "-lm",
+        ],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "qhullcpp",
+    srcs = [
+        "src/libqhullcpp/Coordinates.cpp",
+        "src/libqhullcpp/PointCoordinates.cpp",
+        "src/libqhullcpp/Qhull.cpp",
+        "src/libqhullcpp/QhullFacet.cpp",
+        "src/libqhullcpp/QhullFacetList.cpp",
+        "src/libqhullcpp/QhullFacetSet.cpp",
+        "src/libqhullcpp/QhullHyperplane.cpp",
+        "src/libqhullcpp/QhullPoint.cpp",
+        "src/libqhullcpp/QhullPointSet.cpp",
+        "src/libqhullcpp/QhullPoints.cpp",
+        "src/libqhullcpp/QhullQh.cpp",
+        "src/libqhullcpp/QhullRidge.cpp",
+        "src/libqhullcpp/QhullSet.cpp",
+        "src/libqhullcpp/QhullStat.cpp",
+        "src/libqhullcpp/QhullUser.cpp",
+        "src/libqhullcpp/QhullVertex.cpp",
+        "src/libqhullcpp/QhullVertexSet.cpp",
+        "src/libqhullcpp/RboxPoints.cpp",
+        "src/libqhullcpp/RoadError.cpp",
+        "src/libqhullcpp/RoadLogEvent.cpp",
+    ],
+    hdrs = [
+        "src/libqhullcpp/Coordinates.h",
+        "src/libqhullcpp/PointCoordinates.h",
+        "src/libqhullcpp/Qhull.h",
+        "src/libqhullcpp/QhullError.h",
+        "src/libqhullcpp/QhullFacet.h",
+        "src/libqhullcpp/QhullFacetList.h",
+        "src/libqhullcpp/QhullFacetSet.h",
+        "src/libqhullcpp/QhullHyperplane.h",
+        "src/libqhullcpp/QhullIterator.h",
+        "src/libqhullcpp/QhullLinkedList.h",
+        "src/libqhullcpp/QhullPoint.h",
+        "src/libqhullcpp/QhullPointSet.h",
+        "src/libqhullcpp/QhullPoints.h",
+        "src/libqhullcpp/QhullQh.h",
+        "src/libqhullcpp/QhullRidge.h",
+        "src/libqhullcpp/QhullSet.h",
+        "src/libqhullcpp/QhullSets.h",
+        "src/libqhullcpp/QhullStat.h",
+        "src/libqhullcpp/QhullUser.h",
+        "src/libqhullcpp/QhullVertex.h",
+        "src/libqhullcpp/QhullVertexSet.h",
+        "src/libqhullcpp/RboxPoints.h",
+        "src/libqhullcpp/RoadError.h",
+        "src/libqhullcpp/RoadLogEvent.h",
+        "src/libqhullcpp/functionObjects.h",
+        "src/qhulltest/RoadTest.h",
+    ],
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+    deps = [":qhull_r"],
+)
+
+alias(
+    name = "libqhull",
+    actual = ":qhull",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libqhull_r",
+    actual = ":qhull_r",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libqhullcpp",
+    actual = ":qhullcpp",
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "user_eg3_test",
+    srcs = ["src/user_eg3/user_eg3_r.cpp"],
+    args = [
+        "eg-100",
+        "eg-convex",
+        "eg-delaunay",
+        "eg-voronoi",
+        "eg-fifo",
+    ],
+    deps = [
+        ":qhullcpp",
+        ":qhull_r",
+    ],
+)

--- a/modules/qhull/8.0.2.bcr.2/presubmit.yml
+++ b/modules/qhull/8.0.2.bcr.2/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+    - debian11
+    - debian12
+    - macos
+    - macos_arm64
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel: [7.x, 8.x, 9.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@qhull//...'
+    test_targets:
+      - '@qhull//...'

--- a/modules/qhull/8.0.2.bcr.2/source.json
+++ b/modules/qhull/8.0.2.bcr.2/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-h3TpoSxwsBgLldawtWPFqkvqjVlgwV4YrjttJSHWT4s=",
+    "strip_prefix": "qhull-8.0.2",
+    "url": "https://github.com/qhull/qhull/archive/refs/tags/v8.0.2.tar.gz",
+    "patch_strip": 0,
+    "overlay": {
+        "BUILD.bazel": "sha256-hZDYqNvTvw5hHXeL30GQNzLco+xdXWppDRklTPn6TBo="
+    }
+}

--- a/modules/qhull/metadata.json
+++ b/modules/qhull/metadata.json
@@ -19,7 +19,8 @@
     ],
     "versions": [
         "8.0.2",
-        "8.0.2.bcr.1"
+        "8.0.2.bcr.1",
+        "8.0.2.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Publish qhull@8.0.2.bcr.2 (https://github.com/bazelbuild/bazel-central-registry/pull/10103)

From: https://github.com/qhull/qhull/archive/refs/tags/v8.0.2.tar.gz

Includes missing header/source files (QhullUser.h, QhullUser.cpp) causing a program crash.
Added a test to make sure that it works as expected.