### PR TITLE
openfst@1.8.6-20260819-694dc53, opengrm@1.4.1-20260818-7034690

### DIFF
--- a/modules/openfst/1.8.6-20260819-694dc53/MODULE.bazel
+++ b/modules/openfst/1.8.6-20260819-694dc53/MODULE.bazel
@@ -1,0 +1,80 @@
+# Copyright 2026 The OpenFst Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Module file for Bazel build system for OpenFst.
+#
+# See https://registry.bazel.build/ for central Bazel package registry.
+
+module(
+    name = "openfst",
+    version = "1.8.6-20260819-694dc53",
+    bazel_compatibility = [">=8.0.0"],
+    compatibility_level = 0,
+)
+
+# Bazel core modules providing rules.
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.9.0",
+)
+bazel_dep(
+    name = "rules_cc",
+    version = "0.2.22",
+)
+bazel_dep(
+    name = "rules_python",
+    version = "2.2.0",
+)
+bazel_dep(
+    name = "rules_shell",
+    version = "0.8.0",
+)
+bazel_dep(
+    name = "platforms",
+    version = "1.1.0",
+)
+bazel_dep(
+    name = "rules_license",
+    version = "1.0.0",
+)
+bazel_dep(
+    name = "cython",
+    version = "3.2.8",
+)
+
+# Prod dependencies.
+bazel_dep(
+    name = "abseil-cpp",
+    version = "20260526.0",
+    repo_name = "com_google_absl",
+)
+bazel_dep(
+    name = "abseil-py",
+    version = "2.4.0",
+    repo_name = "com_google_absl_py",
+)
+
+# Dev dependencies.
+bazel_dep(
+    name = "googletest",
+    version = "1.17.0.bcr.2",
+    dev_dependency = True,
+    repo_name = "com_google_googletest",
+)
+bazel_dep(
+    name = "google_benchmark",
+    version = "1.9.5",
+    dev_dependency = True,
+    repo_name = "com_google_benchmark",
+)

--- a/modules/openfst/1.8.6-20260819-694dc53/patches/module_dot_bazel.patch
+++ b/modules/openfst/1.8.6-20260819-694dc53/patches/module_dot_bazel.patch
@@ -1,0 +1,87 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -18,7 +18,9 @@
+ 
+ module(
+     name = "openfst",
++    version = "1.8.6-20260819-694dc53",
+     bazel_compatibility = [">=8.0.0"],
++    compatibility_level = 0,
+ )
+ 
+ # Bazel core modules providing rules.
+@@ -26,14 +28,6 @@
+     name = "bazel_skylib",
+     version = "1.9.0",
+ )
+-# NOTE: GCC toolchains are broken with Bazel 9.
+-# TODO: Update to 0.9.0.bcr.1 when
+-# https://github.com/bazelbuild/bazel-central-registry/pull/7391
+-# is merged.
+-bazel_dep(
+-    name = "gcc_toolchain",
+-    version = "0.9.0",
+-)
+ bazel_dep(
+     name = "rules_cc",
+     version = "0.2.22",
+@@ -55,59 +49,10 @@
+     version = "1.0.0",
+ )
+ bazel_dep(
+-    name = "toolchains_llvm",
+-    version = "1.6.0",
+-)
+-bazel_dep(
+     name = "cython",
+     version = "3.2.8",
+ )
+ 
+-# Module extensions.
+-# GCC
+-gcc = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains")
+-
+-# We would like to support 7.5.0, but the lowest version available via
+-# bzlmod is 12.5.0.
+-# https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md#compilers-tools-build-systems
+-gcc.toolchain(
+-    name = "gcc_toolchain_old",
+-    gcc_version = "12.5.0",
+-    target_arch = "x86_64",
+-    extra_ldflags = ["-lstdc++"],
+-)
+-use_repo(gcc, "gcc_toolchain_old")
+-
+-# Current version.
+-# https://gcc.gnu.org/releases.html
+-gcc.toolchain(
+-    name = "gcc_toolchain_cur",
+-    gcc_version = "15.2.0",
+-    target_arch = "x86_64",
+-    extra_ldflags = ["-lstdc++"],
+-)
+-use_repo(gcc, "gcc_toolchain_cur")
+-
+-# LLVM
+-llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+-
+-# Lowest supported clang version.
+-llvm.toolchain(
+-    name = "llvm_toolchain_old",
+-    llvm_version = "14.0.0",
+-)
+-use_repo(llvm, "llvm_toolchain_old")
+-
+-# Latest downloadable release.
+-# https://releases.llvm.org/
+-llvm.toolchain(
+-    name = "llvm_toolchain_cur",
+-    llvm_version = "20.1.0",
+-)
+-use_repo(llvm, "llvm_toolchain_cur")
+-# Note we're not using `register_toolchain()`; `--extra_toolchains` is
+-# configured in `.bazelrc`.
+-
+ # Prod dependencies.
+ bazel_dep(
+     name = "abseil-cpp",

--- a/modules/openfst/1.8.6-20260819-694dc53/presubmit.yml
+++ b/modules/openfst/1.8.6-20260819-694dc53/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  platform:
+  - debian12
+  - ubuntu2404
+  bazel:
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@openfst//openfst/lib'
+    - '@openfst//openfst/lib:lib_lite'
+    - '@openfst//openfst/compat:compat'
+    - '@openfst//openfst/extensions/far:lib'
+    - '@openfst//openfst/script'
+    - '@openfst//openfst/bin:fstcompile'

--- a/modules/openfst/1.8.6-20260819-694dc53/source.json
+++ b/modules/openfst/1.8.6-20260819-694dc53/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/google-research/openfst/archive/694dc53ae6dea820ab001932a522f03f9129b344.tar.gz",
+    "integrity": "sha256-RGXCIhbQaEO21x2tUZWrmXUFRM2S1s3KCC2/MgsQU1E=",
+    "strip_prefix": "openfst-694dc53ae6dea820ab001932a522f03f9129b344",
+    "patches": {
+        "module_dot_bazel.patch": "sha256-0xHvtegNAhDZOY7RSE315UeoZlgsM7LAMm3txXm6Y2o="
+    },
+    "patch_strip": 1
+}

--- a/modules/openfst/metadata.json
+++ b/modules/openfst/metadata.json
@@ -6,6 +6,18 @@
             "github": "ryanli",
             "github_user_id": 148289,
             "name": "Ryan Li"
+        },
+        {
+            "email": "sorenj@google.com",
+            "github": "sorensenjs",
+            "github_user_id": 8582676,
+            "name": "Jeffrey Sorensen"
+        },
+        {
+            "email": "jmr@google.com",
+            "github": "jmr",
+            "github_user_id": 949741,
+            "name": "Jesse Rosenstock"
         }
     ],
     "repository": [

--- a/modules/openfst/metadata.json
+++ b/modules/openfst/metadata.json
@@ -9,12 +9,14 @@
         }
     ],
     "repository": [
+        "github:google-research/openfst",
         "https://www.openfst.org/twiki/pub/FST/FstDownload",
         "https://storage.googleapis.com/rime-public/mirror"
     ],
     "versions": [
         "1.8.4",
-        "1.8.4.bcr.1"
+        "1.8.4.bcr.1",
+        "1.8.6-20260819-694dc53"
     ],
     "yanked_versions": {}
 }

--- a/modules/opengrm/1.4.1-20260818-7034690/MODULE.bazel
+++ b/modules/opengrm/1.4.1-20260818-7034690/MODULE.bazel
@@ -1,0 +1,96 @@
+# Copyright 2026 The OpenGrm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Module file for Bazel build system for OpenGrm.
+#
+# See https://registry.bazel.build/ for central Bazel package registry.
+
+module(
+    name = "opengrm",
+    version = "1.4.1-20260818-7034690",
+    bazel_compatibility = [">=8.0.0"],
+    compatibility_level = 0,
+)
+
+# Bazel core modules providing rules.
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.9.0",
+)
+bazel_dep(
+    name = "rules_cc",
+    version = "0.2.22",
+)
+bazel_dep(
+    name = "rules_python",
+    version = "2.2.0",
+)
+bazel_dep(
+    name = "rules_bison",
+    version = "0.4.bcr.1",
+)
+bazel_dep(
+    name = "rules_m4",
+    version = "0.3.bcr.1",
+)
+bazel_dep(
+    name = "rules_shell",
+    version = "0.8.0",
+)
+bazel_dep(
+    name = "platforms",
+    version = "1.1.0",
+)
+bazel_dep(
+    name = "rules_license",
+    version = "1.0.0",
+)
+bazel_dep(
+    name = "cython",
+    version = "3.2.8",
+)
+
+# Prod dependencies.
+bazel_dep(
+    name = "abseil-cpp",
+    version = "20260526.0",
+    repo_name = "com_google_absl",
+)
+bazel_dep(  # For Thrax `rewrite-tester`.
+    name = "readline",
+    version = "8.3.bcr.1",
+)
+bazel_dep(
+    name = "abseil-py",
+    version = "2.4.0",
+    repo_name = "com_google_absl_py",
+)
+bazel_dep(
+    name = "protobuf",
+    version = "35.1",
+    repo_name = "com_google_protobuf",
+)
+bazel_dep(
+    name = "openfst",
+    version = "1.8.6-20260819-694dc53",
+    repo_name = "com_google_openfst",
+)
+
+# Dev dependencies.
+bazel_dep(
+    name = "googletest",
+    version = "1.17.0.bcr.2",
+    dev_dependency = True,
+    repo_name = "com_google_googletest",
+)

--- a/modules/opengrm/1.4.1-20260818-7034690/patches/module_dot_bazel.patch
+++ b/modules/opengrm/1.4.1-20260818-7034690/patches/module_dot_bazel.patch
@@ -1,0 +1,134 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -18,7 +18,9 @@
+ 
+ module(
+     name = "opengrm",
++    version = "1.4.1-20260818-7034690",
+     bazel_compatibility = [">=8.0.0"],
++    compatibility_level = 0,
+ )
+ 
+ # Bazel core modules providing rules.
+@@ -26,14 +28,6 @@
+     name = "bazel_skylib",
+     version = "1.9.0",
+ )
+-# NOTE: GCC toolchains are broken with Bazel 9.
+-# TODO: Update to 0.9.0.bcr.1 when
+-# https://github.com/bazelbuild/bazel-central-registry/pull/7391
+-# is merged.
+-bazel_dep(
+-    name = "gcc_toolchain",
+-    version = "0.9.0",
+-)
+ bazel_dep(
+     name = "rules_cc",
+     version = "0.2.22",
+@@ -44,11 +38,11 @@
+ )
+ bazel_dep(
+     name = "rules_bison",
+-    version = "0.4.bcr.1"
++    version = "0.4.bcr.1",
+ )
+ bazel_dep(
+     name = "rules_m4",
+-    version = "0.3.bcr.1"
++    version = "0.3.bcr.1",
+ )
+ bazel_dep(
+     name = "rules_shell",
+@@ -63,59 +57,10 @@
+     version = "1.0.0",
+ )
+ bazel_dep(
+-    name = "toolchains_llvm",
+-    version = "1.6.0",
+-)
+-bazel_dep(
+     name = "cython",
+     version = "3.2.8",
+ )
+ 
+-# Module extensions.
+-# GCC
+-gcc = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains")
+-
+-# We would like to support 7.5.0, but the lowest version available via
+-# bzlmod is 12.5.0.
+-# https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md#compilers-tools-build-systems
+-gcc.toolchain(
+-    name = "gcc_toolchain_old",
+-    gcc_version = "12.5.0",
+-    target_arch = "x86_64",
+-    extra_ldflags = ["-lstdc++"],
+-)
+-use_repo(gcc, "gcc_toolchain_old")
+-
+-# Current version.
+-# https://gcc.gnu.org/releases.html
+-gcc.toolchain(
+-    name = "gcc_toolchain_cur",
+-    gcc_version = "15.2.0",
+-    target_arch = "x86_64",
+-    extra_ldflags = ["-lstdc++"],
+-)
+-use_repo(gcc, "gcc_toolchain_cur")
+-
+-# LLVM
+-llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+-
+-# Lowest supported clang version.
+-llvm.toolchain(
+-    name = "llvm_toolchain_old",
+-    llvm_version = "14.0.0",
+-)
+-use_repo(llvm, "llvm_toolchain_old")
+-
+-# Latest downloadable release.
+-# https://releases.llvm.org/
+-llvm.toolchain(
+-    name = "llvm_toolchain_cur",
+-    llvm_version = "20.1.0",
+-)
+-use_repo(llvm, "llvm_toolchain_cur")
+-# Note we're not using `register_toolchain()`; `--extra_toolchains` is
+-# configured in `.bazelrc`.
+-
+ # Prod dependencies.
+ bazel_dep(
+     name = "abseil-cpp",
+@@ -124,7 +69,7 @@
+ )
+ bazel_dep(  # For Thrax `rewrite-tester`.
+     name = "readline",
+-    version = "8.3.bcr.1"
++    version = "8.3.bcr.1",
+ )
+ bazel_dep(
+     name = "abseil-py",
+@@ -134,18 +79,12 @@
+ bazel_dep(
+     name = "protobuf",
+     version = "35.1",
+-    repo_name = "com_google_protobuf"
++    repo_name = "com_google_protobuf",
+ )
+-
+-# Some modules are not yet available in the bazel central registry. We define
+-# a dummy module and then use `git_override` to point it at the specific commit
+-# in the respective github repo.
+-OPENFST_COMMIT = "a676239535d308e7351d130ced3fdf6c2faec497"  # 07/08/26.
+-bazel_dep(name = "openfst", version = "0.0.0", repo_name = "com_google_openfst")
+-git_override(
+-    module_name = "openfst",
+-    remote = "https://github.com/google-research/openfst.git",
+-    commit = OPENFST_COMMIT,
++bazel_dep(
++    name = "openfst",
++    version = "1.8.6-20260819-694dc53",
++    repo_name = "com_google_openfst",
+ )
+ 
+ # Dev dependencies.

--- a/modules/opengrm/1.4.1-20260818-7034690/presubmit.yml
+++ b/modules/opengrm/1.4.1-20260818-7034690/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  platform:
+  - debian12
+  - ubuntu2404
+  bazel:
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@opengrm//opengrm/thrax:grm-manager-lib'
+    - '@opengrm//opengrm/thrax:compiler'
+    - '@opengrm//opengrm/thrax:rewrite-tester'
+    - '@opengrm//opengrm/rewrite'
+    - '@opengrm//opengrm/paths'
+    - '@opengrm//opengrm/ngram:opengrm-ngram-lib'

--- a/modules/opengrm/1.4.1-20260818-7034690/source.json
+++ b/modules/opengrm/1.4.1-20260818-7034690/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/google-research/opengrm/archive/7034690e34407619f0fee1e2544a41079cf2b905.tar.gz",
+    "integrity": "sha256-OmrIzlabiV9o+StoKVaEGb5aKigh/aFgE/Z8Wbt1O+w=",
+    "strip_prefix": "opengrm-7034690e34407619f0fee1e2544a41079cf2b905",
+    "patches": {
+        "module_dot_bazel.patch": "sha256-FXsEnxy20FNMUa9QOJVtmHuxdioEBOAL/K4yxpLDxrc="
+    },
+    "patch_strip": 1
+}

--- a/modules/opengrm/metadata.json
+++ b/modules/opengrm/metadata.json
@@ -8,7 +8,7 @@
             "name": "Ryan Li"
         },
         {
-            "email": "kgb@google.com",
+            "email": "kbg@google.com",
             "github": "kylebgorman",
             "github_user_id": 159289,
             "name": "Kyle Gorman"

--- a/modules/opengrm/metadata.json
+++ b/modules/opengrm/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://www.opengrm.org/",
+    "maintainers": [
+        {
+            "email": "ryanli@ryanli.org",
+            "github": "ryanli",
+            "github_user_id": 148289,
+            "name": "Ryan Li"
+        }
+    ],
+    "repository": [
+        "github:google-research/opengrm"
+    ],
+    "versions": [
+        "1.4.1-20260818-7034690"
+    ],
+    "yanked_versions": {}
+}

--- a/modules/opengrm/metadata.json
+++ b/modules/opengrm/metadata.json
@@ -6,6 +6,24 @@
             "github": "ryanli",
             "github_user_id": 148289,
             "name": "Ryan Li"
+        },
+        {
+            "email": "kgb@google.com",
+            "github": "kylebgorman",
+            "github_user_id": 159289,
+            "name": "Kyle Gorman"
+        },
+        {
+            "email": "wolfsonkin@google.com",
+            "github": "lwolfsonkin",
+            "github_user_id": 16690774,
+            "name": "Lawrence Wolf-Sonkin"
+        },
+        {
+            "email": "agutkin@google.com",
+            "github": "agutkin",
+            "github_user_id": 35786058,
+            "name": "Alexander Gutkin"
         }
     ],
     "repository": [


### PR DESCRIPTION
OpenFst and OpenGrm are now developed in the open on GitHub with native Bazel builds, so these versions track the upstream repositories instead of the openfst.org release tarballs:

* `openfst@1.8.6-20260819-694dc53` — [google-research/openfst@694dc53](https://github.com/google-research/openfst/commit/694dc53ae6dea820ab001932a522f03f9129b344) (2026-08-19)
* `opengrm@1.4.1-20260818-7034690` — [google-research/opengrm@7034690](https://github.com/google-research/opengrm/commit/7034690e34407619f0fee1e2544a41079cf2b905) (2026-08-18)

Thrax is no longer released standalone; it is now part of the OpenGrm monorepo, which builds as a single `opengrm` module with its Thrax targets under `@opengrm//opengrm/thrax`. No new `thrax` version is submitted here.

The upstream `MODULE.bazel` files are patched to set the module version, to drop the `gcc_toolchain` and `toolchains_llvm` deps that only serve the projects' own `.bazelrc` toolchain configs, and to replace opengrm's `git_override` on openfst with a plain `bazel_dep`.

The presubmit matrix is Bazel 9 only. OpenFst needs `@abseil-cpp//absl/status:status_macros`, which first appears in `abseil-cpp@20260526.0`, and that version dropped `compatibility_level`; on Bazel 8 it therefore collides with the `compatibility_level = 1` still requested by anything reaching abseil-cpp through protobuf. Bazel 9 no longer enforces compatibility levels.

Verified end to end with [Sparrowhawk](https://github.com/ryanli/sparrowhawk), which depends on both modules: its normalizer builds against these versions, the toy grammars in its documentation compile with `@opengrm//opengrm/thrax:compiler`, and the normalized output is byte-identical to the same grammars run against `openfst@1.8.4.bcr.1` + `thrax@1.3.9.bcr.1`.
