### PR TITLE
rules_google_secret_manager@0.1.0

### DIFF
--- a/modules/rules_google_secret_manager/0.1.0/MODULE.bazel
+++ b/modules/rules_google_secret_manager/0.1.0/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "rules_google_secret_manager",
+    version = "0.1.0",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.2")

--- a/modules/rules_google_secret_manager/0.1.0/presubmit.yml
+++ b/modules/rules_google_secret_manager/0.1.0/presubmit.yml
@@ -1,0 +1,11 @@
+matrix:
+  platform: ["ubuntu2204", "macos", "macos_arm64"]
+  bazel: [8.x, 9.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@rules_google_secret_manager//secret:extensions"
+      - "@rules_google_secret_manager//secret:repo_rules"

--- a/modules/rules_google_secret_manager/0.1.0/source.json
+++ b/modules/rules_google_secret_manager/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-13U+cxW4E0qO/ZkMdOigziksx/VtWJHPd2ecKDq7h90=",
+    "strip_prefix": "rules_google_secret_manager-0.1.0",
+    "url": "https://github.com/rimelabs/rules_google_secret_manager/releases/download/v0.1.0/rules_google_secret_manager-v0.1.0.tar.gz"
+}

--- a/modules/rules_google_secret_manager/metadata.json
+++ b/modules/rules_google_secret_manager/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/rimelabs/rules_google_secret_manager",
+    "maintainers": [
+        {
+            "name": "Ryan Li",
+            "email": "ryanli@ryanli.org",
+            "github": "ryanli",
+            "github_user_id": 148289
+        }
+    ],
+    "repository": [
+        "github:rimelabs/rules_google_secret_manager"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds [rules_google_secret_manager](https://github.com/rimelabs/rules_google_secret_manager) 0.1.0, a new module providing a module extension and repository rules for fetching Google Secret Manager values into the build graph as file targets, pinned by a JSON lockfile.

- Release: https://github.com/rimelabs/rules_google_secret_manager/releases/tag/v0.1.0
- `tools/bcr_validation.py --check rules_google_secret_manager@0.1.0` passes locally (only the expected new-module maintainer-review notice).