### PR TITLE
Add xsimd 14.2.0

### DIFF
--- a/modules/xsimd/14.2.0/MODULE.bazel
+++ b/modules/xsimd/14.2.0/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "xsimd",
+    version = "14.2.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/modules/xsimd/14.2.0/overlay/BUILD.bazel
+++ b/modules/xsimd/14.2.0/overlay/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "xsimd",
+    hdrs = glob(["include/**/*.hpp"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/modules/xsimd/14.2.0/overlay/MODULE.bazel
+++ b/modules/xsimd/14.2.0/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "xsimd",
+    version = "14.2.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/modules/xsimd/14.2.0/overlay/test/BUILD.bazel
+++ b/modules/xsimd/14.2.0/overlay/test/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "xsimd_test",
+    srcs = ["xsimd_test.cc"],
+    deps = ["@xsimd"],
+)

--- a/modules/xsimd/14.2.0/overlay/test/MODULE.bazel
+++ b/modules/xsimd/14.2.0/overlay/test/MODULE.bazel
@@ -1,0 +1,7 @@
+bazel_dep(name = "xsimd")
+local_path_override(
+    module_name = "xsimd",
+    path = "..",
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/modules/xsimd/14.2.0/overlay/test/xsimd_test.cc
+++ b/modules/xsimd/14.2.0/overlay/test/xsimd_test.cc
@@ -1,0 +1,7 @@
+#include "xsimd/xsimd.hpp"
+
+int main() {
+  using batch = xsimd::batch<float>;
+  const batch values(1.0F);
+  return xsimd::reduce_add(values) == static_cast<float>(batch::size) ? 0 : 1;
+}

--- a/modules/xsimd/14.2.0/presubmit.yml
+++ b/modules/xsimd/14.2.0/presubmit.yml
@@ -1,0 +1,36 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+    - windows
+  bazel: [7.x, 8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify xsimd build target
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@xsimd//:xsimd"
+bcr_test_module:
+  module_path: test
+  matrix:
+    platform:
+      - debian11
+      - ubuntu2204
+      - ubuntu2404
+      - macos
+      - macos_arm64
+      - windows
+    bazel: [7.x, 8.x, rolling]
+  tasks:
+    run_test_module:
+      name: Compile and run xsimd SIMD operations
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - //:xsimd_test
+      test_targets:
+        - //:xsimd_test

--- a/modules/xsimd/14.2.0/source.json
+++ b/modules/xsimd/14.2.0/source.json
@@ -1,0 +1,12 @@
+{
+    "url": "https://github.com/xtensor-stack/xsimd/archive/refs/tags/14.2.0.tar.gz",
+    "integrity": "sha256-IehBq2hLBTMegef3gkMXU6Ap73t9nW092rg353gqQO4=",
+    "strip_prefix": "xsimd-14.2.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-Nz/f6kgW6ND+v+T2qZmmpI2Gqj2gtLFIB3ktmp39KJE=",
+        "MODULE.bazel": "sha256-cxVf3B0sw2xedYiwxdror725GqGDqfsaBS1nNMYYzQY=",
+        "test/BUILD.bazel": "sha256-JhxxO2MdRciH14iVwbTbHMhvIWmz0NA4bQVrb2IUqh0=",
+        "test/MODULE.bazel": "sha256-rQKOE8swfhJtimtAU4KQQWQFxycEFbEmhrdOkyN4eiA=",
+        "test/xsimd_test.cc": "sha256-XpUaRP6cZ2FJEcI3xxQBA21wDefYujLT04yTSQJJxtw="
+    }
+}

--- a/modules/xsimd/metadata.json
+++ b/modules/xsimd/metadata.json
@@ -10,7 +10,8 @@
         "github:xtensor-stack/xsimd"
     ],
     "versions": [
-        "8.1.0"
+        "8.1.0",
+        "14.2.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
## Summary

- Publish xsimd 14.2.0 as a header-only C++ SIMD library.
- Preserve the public `@xsimd//:xsimd` target and the existing compatibility level.
- Add a dependent-module test that compiles and executes real SIMD batch operations.

## Validation

- Built and ran the dependent-module SIMD test successfully with Bazel 9.2.
- Checked the upstream archive checksum, overlay integrity, and module metadata.
