### PR TITLE
Add apache_arrow 25.0.1 with Parquet, Dataset, and optional cloud filesystems

### DIFF
--- a/modules/apache_arrow/25.0.1/MODULE.bazel
+++ b/modules/apache_arrow/25.0.1/MODULE.bazel
@@ -1,0 +1,28 @@
+module(
+    name = "apache_arrow",
+    version = "25.0.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "aws_sdk", version = "1.11.876")
+bazel_dep(name = "azure-core-cpp", version = "1.14.1.bcr.2")
+bazel_dep(name = "azure-identity-cpp", version = "1.10.1")
+bazel_dep(name = "azure-storage-blobs-cpp", version = "12.13.0")
+bazel_dep(name = "azure-storage-files-datalake-cpp", version = "12.12.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "boost.numeric_conversion", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.predef", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.uuid", version = "1.89.0.bcr.2")
+bazel_dep(name = "bzip2", version = "1.0.8.bcr.4")
+bazel_dep(name = "lz4", version = "1.10.0.bcr.1")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rapidjson", version = "1.1.0.bcr.20250205")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "snappy", version = "1.2.2.bcr.3")
+bazel_dep(name = "xsimd", version = "14.2.0")
+bazel_dep(name = "zlib", version = "1.3.2")
+bazel_dep(name = "zstd", version = "1.5.7.bcr.1")
+
+apache_arrow_deps = use_extension("//:extensions.bzl", "apache_arrow_deps")
+use_repo(apache_arrow_deps, "apache_arrow_thrift")

--- a/modules/apache_arrow/25.0.1/README.md
+++ b/modules/apache_arrow/25.0.1/README.md
@@ -1,0 +1,25 @@
+# Apache Arrow C++
+
+The BUILD overlay follows the source lists and generated configuration in
+Apache Arrow's CMake build. It exposes the Arrow, Acero, Parquet, and Dataset
+libraries, with CSV, JSON, IPC, local filesystems, and common compression codecs
+enabled. The module uses the system allocator rather than bundling jemalloc or
+mimalloc.
+
+Apache Thrift is not available as a Bazel Central Registry module, so the module
+extension downloads the exact Thrift 0.22.0 release selected by Arrow 25.0.1
+and builds only the compact-protocol sources needed by Parquet.
+
+Azure Storage support can be enabled with:
+
+```text
+--@apache_arrow//:with_azure --@curl//:ssl_lib=openssl
+```
+
+Amazon S3 support is available on Linux and can be enabled with:
+
+```text
+--@apache_arrow//:with_s3 --@curl//:ssl_lib=openssl
+```
+
+The OpenSSL flag allows the Azure and AWS SDKs to share one TLS implementation.

--- a/modules/apache_arrow/25.0.1/overlay/BUILD.bazel
+++ b/modules/apache_arrow/25.0.1/overlay/BUILD.bazel
@@ -1,0 +1,427 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:private"])
+
+bool_flag(
+    name = "with_azure",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "with_s3",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "azure_enabled",
+    flag_values = {":with_azure": "true"},
+)
+
+config_setting(
+    name = "s3_enabled",
+    constraint_values = ["@platforms//os:linux"],
+    flag_values = {":with_s3": "true"},
+)
+
+# Source groups mirror cpp/src/arrow/CMakeLists.txt. Optional components with
+# their own libraries are excluded here and listed explicitly below.
+ARROW_SRCS = glob(
+    [
+        "cpp/src/arrow/**/*.cc",
+        "cpp/src/arrow/**/*.cpp",
+    ],
+    exclude = [
+        "cpp/src/arrow/**/*_avx2.cc",
+        "cpp/src/arrow/**/*_avx512.cc",
+        "cpp/src/arrow/**/*_benchmark.cc",
+        "cpp/src/arrow/**/*_neon.cc",
+        "cpp/src/arrow/**/*_test.cc",
+        "cpp/src/arrow/**/*.inc.cc",
+        "cpp/src/arrow/**/benchmark/**",
+        "cpp/src/arrow/**/benchmark_*.cc",
+        "cpp/src/arrow/**/test/**",
+        "cpp/src/arrow/**/test_*.cc",
+        "cpp/src/arrow/acero/**",
+        "cpp/src/arrow/adapters/**",
+        "cpp/src/arrow/compute/kernels/aggregate_basic_avx2.cc",
+        "cpp/src/arrow/compute/kernels/aggregate_basic_avx512.cc",
+        "cpp/src/arrow/compute/row/compare_internal_avx2.cc",
+        "cpp/src/arrow/compute/row/encode_internal_avx2.cc",
+        "cpp/src/arrow/compute/util_avx2.cc",
+        "cpp/src/arrow/csv/*fuzz*",
+        "cpp/src/arrow/dataset/**",
+        "cpp/src/arrow/engine/**",
+        "cpp/src/arrow/filesystem/azurefs*.cc",
+        "cpp/src/arrow/filesystem/gcsfs*.cc",
+        "cpp/src/arrow/filesystem/hdfs.cc",
+        "cpp/src/arrow/filesystem/s3_test_util.cc",
+        "cpp/src/arrow/filesystem/s3fs*.cc",
+        "cpp/src/arrow/flight/**",
+        "cpp/src/arrow/gpu/**",
+        "cpp/src/arrow/integration/**",
+        "cpp/src/arrow/ipc/*fuzz*",
+        "cpp/src/arrow/ipc/file_to_stream.cc",
+        "cpp/src/arrow/ipc/generate_fuzz_corpus.cc",
+        "cpp/src/arrow/ipc/generate_tensor_fuzz_corpus.cc",
+        "cpp/src/arrow/ipc/stream_to_file.cc",
+        "cpp/src/arrow/memory_pool_jemalloc.cc",
+        "cpp/src/arrow/memory_pool_mimalloc.cc",
+        "cpp/src/arrow/telemetry/**",
+        "cpp/src/arrow/testing/**",
+        "cpp/src/arrow/util/bpacking_simd_256.cc",
+        "cpp/src/arrow/util/compression_*.cc",
+        "cpp/src/arrow/util/tracing_internal.cc",
+        "cpp/src/arrow/vendored/datetime/tz.cpp",
+    ],
+)
+
+ARROW_HDRS = glob(
+    [
+        "cpp/src/arrow/**/*.h",
+        "cpp/src/arrow/**/*.hpp",
+        "cpp/src/arrow/**/*.inc.cc",
+        "cpp/src/arrow/vendored/datetime/tz.cpp",
+        "cpp/src/generated/*.h",
+    ],
+    exclude = [
+        "cpp/src/arrow/**/benchmark/**",
+        "cpp/src/arrow/**/test/**",
+        "cpp/src/arrow/**/test_*.h",
+        "cpp/src/arrow/**/test_*.hpp",
+        "cpp/src/arrow/acero/**",
+        "cpp/src/arrow/adapters/**",
+        "cpp/src/arrow/dataset/**",
+        "cpp/src/arrow/engine/**",
+        "cpp/src/arrow/flight/**",
+        "cpp/src/arrow/gpu/**",
+        "cpp/src/arrow/integration/**",
+        "cpp/src/arrow/telemetry/**",
+        "cpp/src/arrow/testing/**",
+    ],
+) + ["cpp/src/arrow/compute/test_util_internal.h"]
+
+ACERO_SRCS = [
+    "cpp/src/arrow/acero/accumulation_queue.cc",
+    "cpp/src/arrow/acero/aggregate_internal.cc",
+    "cpp/src/arrow/acero/asof_join_node.cc",
+    "cpp/src/arrow/acero/bloom_filter.cc",
+    "cpp/src/arrow/acero/exec_plan.cc",
+    "cpp/src/arrow/acero/fetch_node.cc",
+    "cpp/src/arrow/acero/filter_node.cc",
+    "cpp/src/arrow/acero/groupby_aggregate_node.cc",
+    "cpp/src/arrow/acero/hash_join.cc",
+    "cpp/src/arrow/acero/hash_join_dict.cc",
+    "cpp/src/arrow/acero/hash_join_node.cc",
+    "cpp/src/arrow/acero/map_node.cc",
+    "cpp/src/arrow/acero/options.cc",
+    "cpp/src/arrow/acero/order_by_impl.cc",
+    "cpp/src/arrow/acero/order_by_node.cc",
+    "cpp/src/arrow/acero/partition_util.cc",
+    "cpp/src/arrow/acero/pivot_longer_node.cc",
+    "cpp/src/arrow/acero/project_node.cc",
+    "cpp/src/arrow/acero/query_context.cc",
+    "cpp/src/arrow/acero/scalar_aggregate_node.cc",
+    "cpp/src/arrow/acero/sink_node.cc",
+    "cpp/src/arrow/acero/sorted_merge_node.cc",
+    "cpp/src/arrow/acero/source_node.cc",
+    "cpp/src/arrow/acero/swiss_join.cc",
+    "cpp/src/arrow/acero/task_util.cc",
+    "cpp/src/arrow/acero/time_series_util.cc",
+    "cpp/src/arrow/acero/tpch_node.cc",
+    "cpp/src/arrow/acero/union_node.cc",
+    "cpp/src/arrow/acero/util.cc",
+]
+
+DATASET_SRCS = [
+    "cpp/src/arrow/dataset/dataset.cc",
+    "cpp/src/arrow/dataset/dataset_writer.cc",
+    "cpp/src/arrow/dataset/discovery.cc",
+    "cpp/src/arrow/dataset/file_base.cc",
+    "cpp/src/arrow/dataset/file_csv.cc",
+    "cpp/src/arrow/dataset/file_ipc.cc",
+    "cpp/src/arrow/dataset/file_json.cc",
+    "cpp/src/arrow/dataset/file_parquet.cc",
+    "cpp/src/arrow/dataset/partition.cc",
+    "cpp/src/arrow/dataset/plan.cc",
+    "cpp/src/arrow/dataset/projector.cc",
+    "cpp/src/arrow/dataset/scan_node.cc",
+    "cpp/src/arrow/dataset/scanner.cc",
+]
+
+PARQUET_SRCS = [
+    "cpp/src/generated/parquet_types.cpp",
+    "cpp/src/parquet/arrow/path_internal.cc",
+    "cpp/src/parquet/arrow/reader.cc",
+    "cpp/src/parquet/arrow/reader_internal.cc",
+    "cpp/src/parquet/arrow/schema.cc",
+    "cpp/src/parquet/arrow/schema_internal.cc",
+    "cpp/src/parquet/arrow/writer.cc",
+    "cpp/src/parquet/bloom_filter.cc",
+    "cpp/src/parquet/bloom_filter_reader.cc",
+    "cpp/src/parquet/bloom_filter_writer.cc",
+    "cpp/src/parquet/chunker_internal.cc",
+    "cpp/src/parquet/column_reader.cc",
+    "cpp/src/parquet/column_scanner.cc",
+    "cpp/src/parquet/column_writer.cc",
+    "cpp/src/parquet/decoder.cc",
+    "cpp/src/parquet/encoder.cc",
+    "cpp/src/parquet/encryption/encryption.cc",
+    "cpp/src/parquet/encryption/encryption_internal_nossl.cc",
+    "cpp/src/parquet/encryption/internal_file_decryptor.cc",
+    "cpp/src/parquet/encryption/internal_file_encryptor.cc",
+    "cpp/src/parquet/exception.cc",
+    "cpp/src/parquet/file_reader.cc",
+    "cpp/src/parquet/file_writer.cc",
+    "cpp/src/parquet/geospatial/statistics.cc",
+    "cpp/src/parquet/geospatial/util_internal.cc",
+    "cpp/src/parquet/geospatial/util_json_internal.cc",
+    "cpp/src/parquet/level_comparison.cc",
+    "cpp/src/parquet/level_conversion.cc",
+    "cpp/src/parquet/metadata.cc",
+    "cpp/src/parquet/page_index.cc",
+    "cpp/src/parquet/platform.cc",
+    "cpp/src/parquet/printer.cc",
+    "cpp/src/parquet/properties.cc",
+    "cpp/src/parquet/schema.cc",
+    "cpp/src/parquet/size_statistics.cc",
+    "cpp/src/parquet/statistics.cc",
+    "cpp/src/parquet/stream_reader.cc",
+    "cpp/src/parquet/stream_writer.cc",
+    "cpp/src/parquet/types.cc",
+    "cpp/src/parquet/xxhasher.cc",
+]
+
+write_file(
+    name = "arrow_config",
+    out = "cpp/src/arrow/util/config.h",
+    content = [
+        "#pragma once",
+        "#define ARROW_VERSION_MAJOR 25",
+        "#define ARROW_VERSION_MINOR 0",
+        "#define ARROW_VERSION_PATCH 1",
+        "#define ARROW_VERSION ((ARROW_VERSION_MAJOR * 1000) + ARROW_VERSION_MINOR) * 1000 + ARROW_VERSION_PATCH",
+        "#define ARROW_VERSION_STRING \"25.0.1\"",
+        "#define ARROW_SO_VERSION \"2500\"",
+        "#define ARROW_FULL_SO_VERSION \"2500.1.0\"",
+        "#define ARROW_CXX_COMPILER_ID \"Bazel\"",
+        "#define ARROW_CXX_COMPILER_VERSION \"unknown\"",
+        "#define ARROW_BUILD_TYPE \"RELEASE\"",
+        "#define ARROW_PACKAGE_KIND \"source\"",
+        "#define ARROW_COMPUTE 1",
+        "#define ARROW_CSV 1",
+        "#define ARROW_DATASET 1",
+        "#define ARROW_ENABLE_THREADING 1",
+        "#define ARROW_FILESYSTEM 1",
+        "#define ARROW_IPC 1",
+        "#define ARROW_JSON 1",
+        "#define ARROW_PARQUET 1",
+        "#define ARROW_USE_NATIVE_INT128 1",
+        "#define ARROW_WITH_BZ2 1",
+        "#define ARROW_WITH_LZ4 1",
+        "#define ARROW_WITH_SNAPPY 1",
+        "#define ARROW_WITH_ZLIB 1",
+        "#define ARROW_WITH_ZSTD 1",
+    ] + select({
+        ":azure_enabled": ["#define ARROW_AZURE 1"],
+        "//conditions:default": [],
+    }) + select({
+        ":s3_enabled": ["#define ARROW_S3 1"],
+        "//conditions:default": [],
+    }),
+)
+
+write_file(
+    name = "arrow_config_internal",
+    out = "cpp/src/arrow/util/config_internal.h",
+    content = [
+        "#pragma once",
+        "#define ARROW_CXX_COMPILER_FLAGS \"-std=c++20\"",
+        "#define ARROW_GIT_ID \"apache-arrow-25.0.1\"",
+        "#define ARROW_GIT_DESCRIPTION \"apache-arrow-25.0.1\"",
+    ],
+)
+
+write_file(
+    name = "parquet_version",
+    out = "cpp/src/parquet/parquet_version.h",
+    content = [
+        "#pragma once",
+        "#define PARQUET_VERSION_MAJOR 25",
+        "#define PARQUET_VERSION_MINOR 0",
+        "#define PARQUET_VERSION_PATCH 1",
+        "#define PARQUET_SO_VERSION \"2500\"",
+        "#define PARQUET_FULL_SO_VERSION \"2500.1.0\"",
+        "#define CREATED_BY_VERSION \"parquet-cpp-arrow version 25.0.1\"",
+    ],
+)
+
+# Arrow's archive contains the FlatBuffers and Hadoop headers its CMake build
+# vendors. Reusing them avoids pulling either project's full build graph.
+cc_library(
+    name = "flatbuffers_headers",
+    hdrs = glob(["cpp/thirdparty/flatbuffers/include/**/*.h"]),
+    strip_include_prefix = "cpp/thirdparty/flatbuffers/include",
+)
+
+cc_library(
+    name = "hadoop_headers",
+    hdrs = ["cpp/thirdparty/hadoop/include/hdfs.h"],
+    strip_include_prefix = "cpp/thirdparty/hadoop/include",
+)
+
+cc_library(
+    name = "arrow_c",
+    srcs = glob([
+        "cpp/src/arrow/vendored/uriparser/*.c",
+        "cpp/src/arrow/vendored/xxhash/*.c",
+    ]),
+    hdrs = glob([
+        "cpp/src/arrow/vendored/uriparser/*.h",
+        "cpp/src/arrow/vendored/xxhash/*.h",
+    ]),
+    includes = ["cpp/src/arrow/vendored"],
+)
+
+cc_library(
+    name = "arrow",
+    srcs = ARROW_SRCS + [
+        "cpp/src/arrow/util/compression_bz2.cc",
+        "cpp/src/arrow/util/compression_lz4.cc",
+        "cpp/src/arrow/util/compression_snappy.cc",
+        "cpp/src/arrow/util/compression_zlib.cc",
+        "cpp/src/arrow/util/compression_zstd.cc",
+    ] + select({
+        ":azure_enabled": ["cpp/src/arrow/filesystem/azurefs.cc"],
+        "//conditions:default": [],
+    }) + select({
+        ":s3_enabled": ["cpp/src/arrow/filesystem/s3fs.cc"],
+        "//conditions:default": [],
+    }),
+    hdrs = ARROW_HDRS + [
+        ":arrow_config",
+        ":arrow_config_internal",
+    ],
+    copts = ["-std=c++20"],
+    defines = ["ARROW_STATIC"],
+    includes = ["cpp/src/arrow/vendored"],
+    linkopts = select({
+        "@platforms//os:linux": [
+            "-ldl",
+            "-pthread",
+        ],
+        "//conditions:default": ["-pthread"],
+    }),
+    strip_include_prefix = "cpp/src",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":arrow_c",
+        ":flatbuffers_headers",
+        ":hadoop_headers",
+        "@bzip2//:bz2",
+        "@lz4//:lz4_frame",
+        "@rapidjson",
+        "@snappy",
+        "@xsimd",
+        "@zlib",
+        "@zstd",
+    ] + select({
+        ":azure_enabled": [
+            "@azure-core-cpp//:azure_core_cpp",
+            "@azure-identity-cpp//:azure_identity_cpp",
+            "@azure-storage-blobs-cpp//:azure_storage_blobs_cpp",
+            "@azure-storage-files-datalake-cpp//:azure_storage_files_datalake_cpp",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        ":s3_enabled": [
+            "@aws_sdk//:core",
+            "@aws_sdk//:crt",
+            "@aws_sdk//:identity_management",
+            "@aws_sdk//:s3",
+            "@aws_sdk//:sts",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+alias(
+    name = "apache_arrow",
+    actual = ":arrow",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "acero",
+    srcs = ACERO_SRCS,
+    hdrs = glob(
+        ["cpp/src/arrow/acero/**/*.h"],
+        exclude = [
+            "cpp/src/arrow/acero/**/*_test.h",
+            "cpp/src/arrow/acero/**/test_*.h",
+        ],
+    ),
+    # Arrow supports C++20; C++23 breaks as-of joins (apache/arrow#47576).
+    copts = ["-std=c++20"],
+    defines = ["ARROW_ACERO_STATIC"],
+    strip_include_prefix = "cpp/src",
+    visibility = ["//visibility:public"],
+    deps = [":arrow"],
+)
+
+cc_library(
+    name = "parquet",
+    srcs = PARQUET_SRCS,
+    hdrs = glob(
+        [
+            "cpp/src/generated/parquet_*.h",
+            "cpp/src/generated/parquet_*.tcc",
+            "cpp/src/parquet/**/*.h",
+        ],
+        exclude = [
+            "cpp/src/parquet/**/benchmark/**",
+            "cpp/src/parquet/**/test/**",
+            "cpp/src/parquet/test_util.h",
+        ],
+    ) + [":parquet_version"],
+    copts = ["-std=c++20"],
+    defines = ["PARQUET_STATIC"],
+    local_defines = [
+        "HAVE_INTTYPES_H",
+        "HAVE_NETDB_H",
+        "HAVE_NETINET_IN_H",
+        "PARQUET_THRIFT_VERSION_MAJOR=0",
+        "PARQUET_THRIFT_VERSION_MINOR=22",
+    ],
+    strip_include_prefix = "cpp/src",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":arrow",
+        "@apache_arrow_thrift//:thrift",
+        "@rapidjson",
+    ],
+)
+
+cc_library(
+    name = "dataset",
+    srcs = DATASET_SRCS,
+    hdrs = glob(
+        ["cpp/src/arrow/dataset/**/*.h"],
+        exclude = [
+            "cpp/src/arrow/dataset/**/*_test.h",
+            "cpp/src/arrow/dataset/**/test_*.h",
+        ],
+    ),
+    copts = ["-std=c++20"],
+    defines = ["ARROW_DS_STATIC"],
+    strip_include_prefix = "cpp/src",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":acero",
+        ":arrow",
+        ":parquet",
+    ],
+)

--- a/modules/apache_arrow/25.0.1/overlay/MODULE.bazel
+++ b/modules/apache_arrow/25.0.1/overlay/MODULE.bazel
@@ -1,0 +1,28 @@
+module(
+    name = "apache_arrow",
+    version = "25.0.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "aws_sdk", version = "1.11.876")
+bazel_dep(name = "azure-core-cpp", version = "1.14.1.bcr.2")
+bazel_dep(name = "azure-identity-cpp", version = "1.10.1")
+bazel_dep(name = "azure-storage-blobs-cpp", version = "12.13.0")
+bazel_dep(name = "azure-storage-files-datalake-cpp", version = "12.12.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "boost.numeric_conversion", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.predef", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.uuid", version = "1.89.0.bcr.2")
+bazel_dep(name = "bzip2", version = "1.0.8.bcr.4")
+bazel_dep(name = "lz4", version = "1.10.0.bcr.1")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rapidjson", version = "1.1.0.bcr.20250205")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "snappy", version = "1.2.2.bcr.3")
+bazel_dep(name = "xsimd", version = "14.2.0")
+bazel_dep(name = "zlib", version = "1.3.2")
+bazel_dep(name = "zstd", version = "1.5.7.bcr.1")
+
+apache_arrow_deps = use_extension("//:extensions.bzl", "apache_arrow_deps")
+use_repo(apache_arrow_deps, "apache_arrow_thrift")

--- a/modules/apache_arrow/25.0.1/overlay/extensions.bzl
+++ b/modules/apache_arrow/25.0.1/overlay/extensions.bzl
@@ -1,0 +1,16 @@
+"""The Apache Thrift version bundled by Arrow's upstream CMake build."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def _apache_arrow_deps_impl(_module_ctx):
+    http_archive(
+        name = "apache_arrow_thrift",
+        build_file = Label("//:thrift.BUILD.bazel"),
+        sha256 = "c4649c5879dd56c88f1e7a1c03e0fbfcc3b2a2872fb81616bffba5aa8a225a37",
+        strip_prefix = "thrift-0.22.0",
+        urls = ["https://github.com/apache/thrift/archive/refs/tags/v0.22.0.tar.gz"],
+    )
+
+apache_arrow_deps = module_extension(
+    implementation = _apache_arrow_deps_impl,
+)

--- a/modules/apache_arrow/25.0.1/overlay/test/BUILD.bazel
+++ b/modules/apache_arrow/25.0.1/overlay/test/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "smoke_test",
+    srcs = ["smoke_test.cc"],
+    copts = ["-std=c++20"],
+    linkstatic = True,
+    deps = [
+        "@apache_arrow",
+        "@apache_arrow//:dataset",
+        "@apache_arrow//:parquet",
+    ],
+)

--- a/modules/apache_arrow/25.0.1/overlay/test/MODULE.bazel
+++ b/modules/apache_arrow/25.0.1/overlay/test/MODULE.bazel
@@ -1,0 +1,10 @@
+bazel_dep(name = "apache_arrow", version = "25.0.1")
+bazel_dep(name = "curl", version = "8.11.0.bcr.5")
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
+
+local_path_override(
+    module_name = "apache_arrow",
+    path = "..",
+)

--- a/modules/apache_arrow/25.0.1/overlay/test/smoke_test.cc
+++ b/modules/apache_arrow/25.0.1/overlay/test/smoke_test.cc
@@ -1,0 +1,83 @@
+#include <arrow/api.h>
+#include <arrow/compute/api.h>
+#include <arrow/compute/initialize.h>
+#include <arrow/dataset/file_parquet.h>
+#include <arrow/io/api.h>
+#include <arrow/util/compression.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/arrow/writer.h>
+
+#include <iostream>
+#include <memory>
+#include <vector>
+
+int main() {
+  arrow::Int64Builder builder;
+  auto status = builder.AppendValues({1, 2, 3});
+  if (!status.ok()) {
+    std::cerr << status << '\n';
+    return 1;
+  }
+
+  auto array_result = builder.Finish();
+  if (!array_result.ok()) {
+    std::cerr << array_result.status() << '\n';
+    return 1;
+  }
+  auto values = *array_result;
+  status = arrow::compute::Initialize();
+  if (!status.ok()) {
+    std::cerr << status << '\n';
+    return 1;
+  }
+  auto sum = arrow::compute::CallFunction("add", {values, values});
+  if (!sum.ok()) {
+    std::cerr << sum.status() << '\n';
+    return 1;
+  }
+
+  auto table = arrow::Table::Make(
+      arrow::schema({arrow::field("value", arrow::int64())}), {values});
+  auto sink_result = arrow::io::BufferOutputStream::Create();
+  if (!sink_result.ok()) {
+    std::cerr << sink_result.status() << '\n';
+    return 1;
+  }
+  auto sink = *sink_result;
+  status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), sink, 3);
+  if (!status.ok()) {
+    std::cerr << status << '\n';
+    return 1;
+  }
+
+  auto buffer_result = sink->Finish();
+  if (!buffer_result.ok()) {
+    std::cerr << buffer_result.status() << '\n';
+    return 1;
+  }
+  auto source = std::make_shared<arrow::io::BufferReader>(*buffer_result);
+  auto reader_result = parquet::arrow::OpenFile(source, arrow::default_memory_pool());
+  if (!reader_result.ok()) {
+    std::cerr << reader_result.status() << '\n';
+    return 1;
+  }
+  auto reader = std::move(*reader_result);
+
+  auto restored_result = reader->ReadTable();
+  if (!restored_result.ok() || !(*restored_result)->Equals(*table)) {
+    std::cerr << "Parquet round trip failed: " << restored_result.status() << '\n';
+    return 1;
+  }
+
+  arrow::dataset::ParquetFileFormat format;
+  if (format.type_name() != "parquet" ||
+      !arrow::util::Codec::IsAvailable(arrow::Compression::ZSTD) ||
+      !arrow::util::Codec::IsAvailable(arrow::Compression::SNAPPY)) {
+    std::cerr << "Dataset format or compression codec is unavailable\n";
+    return 1;
+  }
+
+  std::cout << "Apache Arrow " << ARROW_VERSION_STRING
+            << " C++/Acero/Parquet/Dataset smoke passed\n";
+  return 0;
+}

--- a/modules/apache_arrow/25.0.1/overlay/thrift.BUILD.bazel
+++ b/modules/apache_arrow/25.0.1/overlay/thrift.BUILD.bazel
@@ -1,0 +1,68 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+write_file(
+    name = "thrift_config",
+    out = "lib/cpp/src/thrift/config.h",
+    content = [
+        "#pragma once",
+        "#define PACKAGE \"thrift\"",
+        "#define PACKAGE_NAME \"thrift\"",
+        "#define PACKAGE_TARNAME \"thrift\"",
+        "#define PACKAGE_VERSION \"0.22.0\"",
+        "#define PACKAGE_STRING \"thrift 0.22.0\"",
+        "#define PACKAGE_URL \"https://thrift.apache.org/\"",
+        "#define ARITHMETIC_RIGHT_SHIFT 1",
+        "#define SIGNED_RIGHT_SHIFT_IS 1",
+        "#define HAVE_ARPA_INET_H 1",
+        "#define HAVE_FCNTL_H 1",
+        "#define HAVE_GETHOSTBYNAME 1",
+        "#define HAVE_INTTYPES_H 1",
+        "#define HAVE_NETDB_H 1",
+        "#define HAVE_NETINET_IN_H 1",
+        "#define HAVE_POLL_H 1",
+        "#define HAVE_PTHREAD_H 1",
+        "#define HAVE_SCHED_H 1",
+        "#define HAVE_SIGNAL_H 1",
+        "#define HAVE_STDINT_H 1",
+        "#define HAVE_STRERROR_R 1",
+        "#define HAVE_STRINGS_H 1",
+        "#define HAVE_SYS_IOCTL_H 1",
+        "#define HAVE_SYS_PARAM_H 1",
+        "#define HAVE_SYS_POLL_H 1",
+        "#define HAVE_SYS_RESOURCE_H 1",
+        "#define HAVE_SYS_SELECT_H 1",
+        "#define HAVE_SYS_SOCKET_H 1",
+        "#define HAVE_SYS_STAT_H 1",
+        "#define HAVE_SYS_TIME_H 1",
+        "#define HAVE_SYS_UN_H 1",
+        "#define HAVE_UNISTD_H 1",
+    ],
+)
+
+cc_library(
+    name = "thrift",
+    srcs = [
+        "lib/cpp/src/thrift/TApplicationException.cpp",
+        "lib/cpp/src/thrift/TOutput.cpp",
+        "lib/cpp/src/thrift/protocol/TProtocol.cpp",
+        "lib/cpp/src/thrift/transport/TBufferTransports.cpp",
+        "lib/cpp/src/thrift/transport/TTransportException.cpp",
+    ],
+    hdrs = glob([
+        "lib/cpp/src/thrift/**/*.h",
+        "lib/cpp/src/thrift/**/*.tcc",
+    ]) + [":thrift_config"],
+    copts = ["-std=c++20"],
+    local_defines = select({
+        "@platforms//os:linux": ["STRERROR_R_CHAR_P"],
+        "//conditions:default": [],
+    }),
+    strip_include_prefix = "lib/cpp/src",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boost.numeric_conversion//:boost.numeric_conversion",
+        "@boost.predef//:boost.predef",
+        "@boost.uuid//:boost.uuid",
+    ],
+)

--- a/modules/apache_arrow/25.0.1/patches/use_quote_include_for_snappy.patch
+++ b/modules/apache_arrow/25.0.1/patches/use_quote_include_for_snappy.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/src/arrow/util/compression_snappy.cc b/cpp/src/arrow/util/compression_snappy.cc
+--- a/cpp/src/arrow/util/compression_snappy.cc
++++ b/cpp/src/arrow/util/compression_snappy.cc
+@@ -21,7 +21,7 @@
+ #include <cstdint>
+ #include <memory>
+
+-#include <snappy.h>
++#include "snappy.h"
+
+ #include "arrow/result.h"
+ #include "arrow/status.h"

--- a/modules/apache_arrow/25.0.1/presubmit.yml
+++ b/modules/apache_arrow/25.0.1/presubmit.yml
@@ -1,0 +1,50 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2204
+    - macos
+    - macos_arm64
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+
+tasks:
+  verify_targets:
+    name: Build Arrow C++ libraries
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@apache_arrow//:apache_arrow"
+      - "@apache_arrow//:acero"
+      - "@apache_arrow//:parquet"
+      - "@apache_arrow//:dataset"
+bcr_test_module:
+  module_path: test
+  matrix:
+    platform:
+      - debian11
+      - ubuntu2204
+      - macos
+      - macos_arm64
+    bazel:
+      - 7.x
+      - 8.x
+      - 9.x
+  tasks:
+    smoke_test:
+      name: Test Arrow and Parquet from a dependent module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//:smoke_test"
+    cloud_smoke_test:
+      name: Test optional Azure and Amazon S3 filesystems
+      platform: ubuntu2204
+      bazel: 9.x
+      test_flags:
+        - "--@apache_arrow//:with_azure"
+        - "--@apache_arrow//:with_s3"
+        - "--@curl//:ssl_lib=openssl"
+      test_targets:
+        - "//:smoke_test"

--- a/modules/apache_arrow/25.0.1/source.json
+++ b/modules/apache_arrow/25.0.1/source.json
@@ -1,0 +1,18 @@
+{
+    "integrity": "sha256-Q9XeClgfQ89josBrTc8Tuf9vzYAPAjMkWW5XgQk7xQA=",
+    "strip_prefix": "apache-arrow-25.0.1",
+    "patch_strip": 1,
+    "url": "https://github.com/apache/arrow/releases/download/apache-arrow-25.0.1/apache-arrow-25.0.1.tar.gz",
+    "overlay": {
+        "BUILD.bazel": "sha256-2cX1HqYMWmrUNMYSTDa/Ovk6Wy8YVDq/S7HieVlG7sE=",
+        "MODULE.bazel": "sha256-oajA2umpIkmxojyXvdlFQS+bCNYgfFT1FI7QkURvBDY=",
+        "extensions.bzl": "sha256-j1WU7O8c0sO6Wu0TYzoLQqD1bF3Lcv+TPJ4/9v+vUyc=",
+        "test/BUILD.bazel": "sha256-8NFiJ6W3/HPI9t/wXl9LBcgDEq0Y1ZZjpUAMYW634Sg=",
+        "test/MODULE.bazel": "sha256-PCexx55ZimhUFwruIf1O+P+cSHZ6Gb1ohgY+xvOOM5c=",
+        "test/smoke_test.cc": "sha256-XsiLKD1IXxUsgAiZb8g5c+SAboO17iOBRWSN7CBi2vo=",
+        "thrift.BUILD.bazel": "sha256-zKmEPs35cOZ/u/D/BHaeV9Tga2u8jfd3YWIfbsyC6BE="
+    },
+    "patches": {
+        "use_quote_include_for_snappy.patch": "sha256-JXo7u9kha5Tm3sPZLf3MxM7MnnrfMty0oPbePZiIoH0="
+    }
+}

--- a/modules/apache_arrow/metadata.json
+++ b/modules/apache_arrow/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://arrow.apache.org/",
+    "maintainers": [
+        {
+            "github": "zbarsky-openai",
+            "github_user_id": 185118497
+        }
+    ],
+    "repository": [
+        "github:apache/arrow"
+    ],
+    "versions": [
+        "25.0.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
## Summary

- Publish Apache Arrow C++ 25.0.1 using its stable official release archive.
- Expose public Arrow, Acero, Parquet, and Dataset targets with compression, CSV, JSON, and IPC support.
- Bundle the upstream-matched Apache Thrift release and depend on the proposed xsimd, AWS SDK, and Azure Data Lake registry additions.
- Make Azure and Linux S3 support optional build settings, and use curl's existing TLS-provider selection for cloud-enabled builds.
- Apply the existing BCR-style Snappy include portability adjustment needed for Bazel header resolution.

## Validation

- Built and ran a dependent C++ smoke test covering Arrow compute, Parquet round-tripping, Dataset integration, and compression codecs.
- Validated all four proposed modules together using a temporary local registry.
- Passed the same dependent C++ test with S3 and Azure enabled together using `--@curl//:ssl_lib=openssl`.

The AWS SDK 1.11.876, xsimd 14.2.0, and Azure Storage Files Data Lake 12.12.0 submissions must merge before this module can pass registry dependency validation independently.
