### PR TITLE
Add azure-storage-files-datalake-cpp 12.12.0

### DIFF
--- a/modules/azure-storage-files-datalake-cpp/12.12.0/MODULE.bazel
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "azure-storage-files-datalake-cpp",
+    version = "12.12.0",
+    bazel_compatibility = [">=7.2.1"],  # need support for "overlay" directory
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "azure-storage-blobs-cpp", version = "12.13.0")
+bazel_dep(name = "googletest", version = "1.16.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.0.17")

--- a/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/BUILD.bazel
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "azure_storage_files_datalake_cpp",
+    srcs = glob([
+        "src/**/*.hpp",
+        "src/**/*.cpp",
+    ]),
+    hdrs = glob(["inc/**/*.hpp"]),
+    includes = ["inc"],
+    local_defines = ["_azure_BUILDING_SDK"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@azure-storage-blobs-cpp//:azure_storage_blobs_cpp",
+    ],
+)
+
+cc_test(
+    name = "azure_storage_files_datalake_cpp_test",
+    srcs = [
+        "test/ut/simplified_header_test.cpp",
+        # Other tests require the Azure SDK test proxy:
+        # https://github.com/Azure/azure-sdk-for-cpp/blob/main/doc/TestProxy.md
+    ],
+    linkstatic = True,
+    local_defines = ["_azure_TESTING_BUILD"],
+    deps = [
+        ":azure_storage_files_datalake_cpp",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/test/MODULE.bazel
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/test/MODULE.bazel
@@ -1,0 +1,10 @@
+bazel_dep(name = "azure-storage-files-datalake-cpp", version = "12.12.0")
+local_path_override(
+    module_name = "azure-storage-files-datalake-cpp",
+    path = "..",
+)
+
+bazel_dep(name = "azure-core-cpp", version = "1.14.1.bcr.2")
+bazel_dep(name = "curl", version = "8.11.0.bcr.5")
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+bazel_dep(name = "rules_foreign_cc", version = "0.15.1")

--- a/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/test/MODULE.bazel
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/test/MODULE.bazel
@@ -8,7 +8,6 @@ bazel_dep(name = "azure-core-cpp", version = "1.14.1.bcr.2")
 bazel_dep(name = "curl", version = "8.11.0.bcr.5")
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 bazel_dep(name = "libxml2", version = "2.15.3")
-bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
 
 single_version_override(
     module_name = "azure-core-cpp",

--- a/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/test/MODULE.bazel
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/test/MODULE.bazel
@@ -7,4 +7,12 @@ local_path_override(
 bazel_dep(name = "azure-core-cpp", version = "1.14.1.bcr.2")
 bazel_dep(name = "curl", version = "8.11.0.bcr.5")
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+bazel_dep(name = "libxml2", version = "2.15.3")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
+
+single_version_override(
+    module_name = "azure-core-cpp",
+    patch_strip = 1,
+    patches = ["//bcr_patches:azure_core_curl_visibility.patch"],
+    version = "1.14.1.bcr.2",
+)

--- a/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/test/bcr_patches/BUILD.bazel
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/test/bcr_patches/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["azure_core_curl_visibility.patch"])

--- a/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/test/bcr_patches/azure_core_curl_visibility.patch
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/overlay/test/bcr_patches/azure_core_curl_visibility.patch
@@ -1,0 +1,22 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1,3 +1,2 @@
+-load("@bazel_skylib//lib:selects.bzl", "selects")
+ load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+@@ -21,10 +20,10 @@
+ # If we're building azure_core_cpp with Curl as a transport, we must ensure curl
+ # was built with OpenSSL and not another SSL lib, as azure_core_cpp only
+ # supports OpenSSL.
+-selects.config_setting_group(
++config_setting(
+     name = "build_transport_curl_openssl",
+-    match_all = [
+-        ":build_transport_curl_setting",
+-        "@curl//:use_openssl",
+-    ],
++    flag_values = {
++        ":build_transport_curl": "true",
++        "@curl//:ssl_lib": "openssl",
++    },
+ )

--- a/modules/azure-storage-files-datalake-cpp/12.12.0/presubmit.yml
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/presubmit.yml
@@ -18,10 +18,12 @@ bcr_test_module:
         - "@azure-storage-files-datalake-cpp//:azure_storage_files_datalake_cpp"
       build_flags:
         - "--@curl//:ssl_lib=openssl"
+        - "--cxxopt=-std=c++17"
       test_targets:
         - "@azure-storage-files-datalake-cpp//:azure_storage_files_datalake_cpp_test"
       test_flags:
         - "--@curl//:ssl_lib=openssl"
+        - "--cxxopt=-std=c++17"
     verify_targets_windows:
       name: Build and test targets on Windows
       platform: windows

--- a/modules/azure-storage-files-datalake-cpp/12.12.0/presubmit.yml
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/presubmit.yml
@@ -1,0 +1,32 @@
+bcr_test_module:
+  module_path: test
+  matrix:
+    unix_platform:
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+      - ubuntu2404
+      - macos
+      - macos_arm64
+    bazel: [7.x, 8.x, 9.x, rolling]
+  tasks:
+    verify_targets_unix:
+      name: Build and test targets on Unix platforms
+      platform: ${{ unix_platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "@azure-storage-files-datalake-cpp//:azure_storage_files_datalake_cpp"
+      build_flags:
+        - "--@curl//:ssl_lib=openssl"
+      test_targets:
+        - "@azure-storage-files-datalake-cpp//:azure_storage_files_datalake_cpp_test"
+      test_flags:
+        - "--@curl//:ssl_lib=openssl"
+    verify_targets_windows:
+      name: Build and test targets on Windows
+      platform: windows
+      bazel: ${{ bazel }}
+      build_targets:
+        - "@azure-storage-files-datalake-cpp//:azure_storage_files_datalake_cpp"
+      build_flags:
+        - "--@azure-core-cpp//:build_transport_curl=false"

--- a/modules/azure-storage-files-datalake-cpp/12.12.0/source.json
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/source.json
@@ -4,7 +4,7 @@
     "strip_prefix": "azure-sdk-for-cpp-azure-storage-blobs_12.13.0/sdk/storage/azure-storage-files-datalake",
     "overlay": {
         "BUILD.bazel": "sha256-NVkSasSqDxbbAvGg2nSOzNL1NADkxTVZwwmQZLZxF4Y=",
-        "test/MODULE.bazel": "sha256-3cGAU5FusamRwJd2blnlDq5xEqYCv8byKf+ZhoKgrvE=",
+        "test/MODULE.bazel": "sha256-yX4dK3qp8rAfvYw00QwDyt3IcxrGeYZ0v34qx7w4FBA=",
         "test/bcr_patches/BUILD.bazel": "sha256-TE+3oTjzJAnr0GzqM+6kTQyjOt7KktNbDZPrMZ9+JdQ=",
         "test/bcr_patches/azure_core_curl_visibility.patch": "sha256-62hOTgQx4AAo9kn5/zxIJguWsyJG12ELhw86cdO6C10="
     }

--- a/modules/azure-storage-files-datalake-cpp/12.12.0/source.json
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/source.json
@@ -4,6 +4,8 @@
     "strip_prefix": "azure-sdk-for-cpp-azure-storage-blobs_12.13.0/sdk/storage/azure-storage-files-datalake",
     "overlay": {
         "BUILD.bazel": "sha256-NVkSasSqDxbbAvGg2nSOzNL1NADkxTVZwwmQZLZxF4Y=",
-        "test/MODULE.bazel": "sha256-PQgi1YiXpz3ARwyu7JaEZd2kPL//y/3Oj+DzWLszg90="
+        "test/MODULE.bazel": "sha256-3cGAU5FusamRwJd2blnlDq5xEqYCv8byKf+ZhoKgrvE=",
+        "test/bcr_patches/BUILD.bazel": "sha256-TE+3oTjzJAnr0GzqM+6kTQyjOt7KktNbDZPrMZ9+JdQ=",
+        "test/bcr_patches/azure_core_curl_visibility.patch": "sha256-62hOTgQx4AAo9kn5/zxIJguWsyJG12ELhw86cdO6C10="
     }
 }

--- a/modules/azure-storage-files-datalake-cpp/12.12.0/source.json
+++ b/modules/azure-storage-files-datalake-cpp/12.12.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-storage-blobs_12.13.0.tar.gz",
+    "integrity": "sha256-MAu9HWvFC4mIs92inW1idXSk8+JafgCmmG2l05ZfZ5o=",
+    "strip_prefix": "azure-sdk-for-cpp-azure-storage-blobs_12.13.0/sdk/storage/azure-storage-files-datalake",
+    "overlay": {
+        "BUILD.bazel": "sha256-NVkSasSqDxbbAvGg2nSOzNL1NADkxTVZwwmQZLZxF4Y=",
+        "test/MODULE.bazel": "sha256-PQgi1YiXpz3ARwyu7JaEZd2kPL//y/3Oj+DzWLszg90="
+    }
+}

--- a/modules/azure-storage-files-datalake-cpp/metadata.json
+++ b/modules/azure-storage-files-datalake-cpp/metadata.json
@@ -2,8 +2,8 @@
     "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-datalake",
     "maintainers": [
         {
-            "github": "zbarsky-openai",
-            "github_user_id": 185118497
+            "github": "dzbarsky",
+            "github_user_id": 1565842
         }
     ],
     "repository": [

--- a/modules/azure-storage-files-datalake-cpp/metadata.json
+++ b/modules/azure-storage-files-datalake-cpp/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-files-datalake",
+    "maintainers": [
+        {
+            "github": "zbarsky-openai",
+            "github_user_id": 185118497
+        }
+    ],
+    "repository": [
+        "github:Azure/azure-sdk-for-cpp"
+    ],
+    "versions": [
+        "12.12.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
## Summary

- Publish Azure Storage Files Data Lake C++ 12.12.0 from the same official, SHA-pinned SDK release archive already used by `azure-storage-blobs-cpp` 12.13.0.
- Expose `@azure-storage-files-datalake-cpp//:azure_storage_files_datalake_cpp` with its upstream Azure Blob dependency.
- Add the upstream simplified-header test and Linux, macOS, and Windows presubmit coverage.
- Keep Bazel 9 compatibility floors and static linking scoped to the test module and target.

## Validation

- Compiled 1,364 Bazel actions and passed the upstream `SimplifiedHeader.StorageFilesDataLake` test.
- Verified archive and overlay integrity and module-maintainer metadata.
