### PR TITLE
onnxruntime_prebuilt@0.1.1

### DIFF
--- a/modules/onnxruntime_prebuilt/0.1.1/MODULE.bazel
+++ b/modules/onnxruntime_prebuilt/0.1.1/MODULE.bazel
@@ -1,0 +1,25 @@
+module(
+    name = "onnxruntime_prebuilt",
+    version = "0.1.1",
+)
+
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_pkg", version = "1.2.0")
+
+bazel_dep(name = "rules_python", version = "1.9.2", dev_dependency = True)
+
+# Instantiate one version so all three repository layers are exercised
+# by builds in this workspace; consumers pin their own version (and
+# default) through the same extension.
+onnxruntime = use_extension("//extensions:onnxruntime.bzl", "onnxruntime", dev_dependency = True)
+onnxruntime.download(
+    default = True,
+    version = "1.24.4",
+)
+use_repo(
+    onnxruntime,
+    "onnxruntime",
+    "onnxruntime-1.24.4-cpu",
+    "onnxruntime-1.24.4-linux-x64-gpu_cuda13",
+    "onnxruntime-gpu",
+)

--- a/modules/onnxruntime_prebuilt/0.1.1/presubmit.yml
+++ b/modules/onnxruntime_prebuilt/0.1.1/presubmit.yml
@@ -1,0 +1,21 @@
+bcr_test_module:
+  module_path: e2e
+  matrix:
+    # No macos (x86_64): recent ONNX Runtime releases ship no osx-x86_64
+    # archive, so the @onnxruntime selector has no branch for it.
+    platform: [ubuntu2204, ubuntu2404, macos_arm64, windows]
+    bazel: [8.x, 9.x]
+  tasks:
+    cpu_distribution:
+      name: Build the CPU distribution
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//:cpu_distribution"
+    gpu_distribution:
+      name: Build the GPU and versioned distributions
+      platform: ubuntu2404
+      bazel: 9.x
+      build_targets:
+        - "//:gpu_distribution"
+        - "//:versioned_distribution"

--- a/modules/onnxruntime_prebuilt/0.1.1/source.json
+++ b/modules/onnxruntime_prebuilt/0.1.1/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-qWku3F05sZ641G5DlF4CA4QD0isI9OvijfvLqULJzJE=",
+    "strip_prefix": "onnxruntime_prebuilt-0.1.1",
+    "url": "https://github.com/rimelabs/onnxruntime_prebuilt/releases/download/v0.1.1/onnxruntime_prebuilt-v0.1.1.tar.gz"
+}

--- a/modules/onnxruntime_prebuilt/metadata.json
+++ b/modules/onnxruntime_prebuilt/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/rimelabs/onnxruntime_prebuilt",
+    "maintainers": [
+        {
+            "email": "ryanli@ryanli.org",
+            "github": "ryanli",
+            "github_user_id": 148289,
+            "name": "Ryan Li"
+        }
+    ],
+    "repository": [
+        "github:rimelabs/onnxruntime_prebuilt"
+    ],
+    "versions": [
+        "0.1.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds [onnxruntime_prebuilt](https://github.com/rimelabs/onnxruntime_prebuilt) 0.1.1, a module exposing the prebuilt [ONNX Runtime](https://github.com/microsoft/onnxruntime) library distributions from GitHub releases (both the CPU `onnxruntime` and the CUDA `onnxruntime-gpu` archives) as hermetic, checksum-pinned repositories with platform-constraint dispatch.

The source archive is produced with `git archive` by the repository's release workflow and attached to the GitHub release. The presubmit runs the `e2e` test module from the archive, which downloads the CPU distribution on every platform and the GPU distribution on Linux. The matrix has no macos (x86_64) because recent ONNX Runtime releases ship no osx-x86_64 archive.