### PR TITLE
simdutf@7.3.6

### DIFF
--- a/modules/simdutf/7.3.6/MODULE.bazel
+++ b/modules/simdutf/7.3.6/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdutf",
+    version = "7.3.6",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.17")

--- a/modules/simdutf/7.3.6/overlay/BUILD.bazel
+++ b/modules/simdutf/7.3.6/overlay/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_library(
+    name = "simdutf",
+    srcs = ["simdutf.cpp"],
+    hdrs = ["simdutf.h"],
+    copts = ["-std=c++20"],
+    includes = ["."],
+    textual_hdrs = ["simdutf.cpp"],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "test",
+    srcs = ["amalgamation_demo.cpp"],
+    deps = [":simdutf"],
+)

--- a/modules/simdutf/7.3.6/overlay/MODULE.bazel
+++ b/modules/simdutf/7.3.6/overlay/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "simdutf",
+    version = "7.3.6",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.17")

--- a/modules/simdutf/7.3.6/presubmit.yml
+++ b/modules/simdutf/7.3.6/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+    - windows
+  bazel: [7.x, 8.x, 9.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@simdutf'
+    test_targets:
+      - '@simdutf//:test'

--- a/modules/simdutf/7.3.6/source.json
+++ b/modules/simdutf/7.3.6/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-5cAG1fjawE5cRDDtSh4sqyPwuIWWTDpEKj65CDFauqA=",
+    "url": "https://github.com/simdutf/simdutf/releases/download/v7.3.6/singleheader.zip",
+    "patch_strip": 1,
+    "patches": {},
+    "overlay": {
+        "BUILD.bazel": "sha256-HMc+6zS9OFFpxvAX/By2eI9HcEuhJyFh7a0T7GDaABY=",
+        "MODULE.bazel": "sha256-EVxL5473oSe9Fy/Hh43gHWjqkCsn8bMwXCjYbL7ImWU="
+    }
+}

--- a/modules/simdutf/metadata.json
+++ b/modules/simdutf/metadata.json
@@ -18,6 +18,7 @@
         "github:simdutf/simdutf"
     ],
     "versions": [
+        "7.3.6",
         "7.7.0"
     ],
     "yanked_versions": {}


### PR DESCRIPTION
Add simdutf 7.3.6 using the upstream single-header release and the existing simdutf build, test, and supported-platform configuration.