### PR TITLE
libiberty@2.42

### DIFF
--- a/modules/libiberty/2.42/MODULE.bazel
+++ b/modules/libiberty/2.42/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "libiberty",
+    version = "2.42",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/libiberty/2.42/overlay/BUILD.bazel
+++ b/modules/libiberty/2.42/overlay/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "COPYING",
+    "COPYING.LIB",
+])
+
+cc_library(
+    name = "libiberty",
+    srcs = [
+        "libiberty/cp-demangle.c",
+        "libiberty/cp-demangle.h",
+        "libiberty/rust-demangle.c",
+        "libiberty/safe-ctype.c",
+    ],
+    hdrs = [
+        "include/ansidecl.h",
+        "include/demangle.h",
+        "include/libiberty.h",
+        "include/safe-ctype.h",
+    ],
+    includes = [
+        "include",
+        "libiberty",
+    ],
+    local_defines = [
+        "HAVE_ALLOCA_H=1",
+        "HAVE_LIMITS_H=1",
+        "HAVE_STDLIB_H=1",
+        "HAVE_STRING_H=1",
+    ],
+)
+
+cc_test(
+    name = "test",
+    srcs = ["libiberty_test.c"],
+    deps = [":libiberty"],
+)

--- a/modules/libiberty/2.42/overlay/MODULE.bazel
+++ b/modules/libiberty/2.42/overlay/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "libiberty",
+    version = "2.42",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.18")

--- a/modules/libiberty/2.42/overlay/libiberty_test.c
+++ b/modules/libiberty/2.42/overlay/libiberty_test.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "demangle.h"
+
+int main(void) {
+  char* demangled = cplus_demangle_v3("_Z3foov", DMGL_PARAMS | DMGL_ANSI);
+  if (demangled == NULL) {
+    return 1;
+  }
+
+  int matches = strcmp(demangled, "foo()") == 0;
+  free(demangled);
+  return matches ? 0 : 1;
+}

--- a/modules/libiberty/2.42/presubmit.yml
+++ b/modules/libiberty/2.42/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+  bazel: [7.x, 8.x, 9.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@libiberty'
+    test_targets:
+      - '@libiberty//:test'

--- a/modules/libiberty/2.42/source.json
+++ b/modules/libiberty/2.42/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.xz",
+    "integrity": "sha256-9uTUH9X8d4sGt4kUV7NiDaXs6hAGxqSkGumYEJ+FqAA=",
+    "strip_prefix": "binutils-2.42",
+    "overlay": {
+        "BUILD.bazel": "sha256-q57p7xkiU1nIPuys1wLlj1Ozm+6NBHhaKYPCXa1rYSQ=",
+        "MODULE.bazel": "sha256-uOVNjRXDKIR4VhE3cQBmaLoCTk5skYV5u7et8bfTgVQ=",
+        "libiberty_test.c": "sha256-xsrwMigFgSg3WKWPIk3SdjAqXydGoOM6HCE3mJOMgSo="
+    }
+}

--- a/modules/libiberty/metadata.json
+++ b/modules/libiberty/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://www.gnu.org/software/binutils/",
+    "maintainers": [
+        {
+            "github": "zbarsky-openai",
+            "github_user_id": 185118497,
+            "name": "David Zbarsky"
+        }
+    ],
+    "repository": [
+        "https://ftp.gnu.org/gnu/binutils/"
+    ],
+    "versions": [
+        "2.42"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add the GNU libiberty 2.42 C and C++ demangling library with a Bazel-native build, public headers, and supported-platform presubmit coverage.