### PR TITLE
Add thrift 0.22.0 C++ compact-protocol runtime

### DIFF
--- a/modules/thrift/0.22.0/MODULE.bazel
+++ b/modules/thrift/0.22.0/MODULE.bazel
@@ -1,0 +1,13 @@
+module(
+    name = "thrift",
+    version = "0.22.0",
+    bazel_compatibility = [">=7.6.0"],
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "boost.numeric_conversion", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.predef", version = "1.89.0.bcr.2")
+bazel_dep(name = "boost.uuid", version = "1.89.0.bcr.2")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/thrift/0.22.0/README.md
+++ b/modules/thrift/0.22.0/README.md
@@ -1,0 +1,6 @@
+# Apache Thrift C++
+
+The public `@thrift//:thrift` target provides the Apache Thrift C++ runtime,
+including the compact protocol and in-memory transport used by Apache Parquet.
+
+The Thrift compiler, nonblocking server, and SSL transports are not included.

--- a/modules/thrift/0.22.0/overlay/BUILD.bazel
+++ b/modules/thrift/0.22.0/overlay/BUILD.bazel
@@ -1,0 +1,68 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+write_file(
+    name = "thrift_config",
+    out = "lib/cpp/src/thrift/config.h",
+    content = [
+        "#pragma once",
+        "#define PACKAGE \"thrift\"",
+        "#define PACKAGE_NAME \"thrift\"",
+        "#define PACKAGE_TARNAME \"thrift\"",
+        "#define PACKAGE_VERSION \"0.22.0\"",
+        "#define PACKAGE_STRING \"thrift 0.22.0\"",
+        "#define PACKAGE_URL \"https://thrift.apache.org/\"",
+        "#define ARITHMETIC_RIGHT_SHIFT 1",
+        "#define SIGNED_RIGHT_SHIFT_IS 1",
+        "#define HAVE_ARPA_INET_H 1",
+        "#define HAVE_FCNTL_H 1",
+        "#define HAVE_GETHOSTBYNAME 1",
+        "#define HAVE_INTTYPES_H 1",
+        "#define HAVE_NETDB_H 1",
+        "#define HAVE_NETINET_IN_H 1",
+        "#define HAVE_POLL_H 1",
+        "#define HAVE_PTHREAD_H 1",
+        "#define HAVE_SCHED_H 1",
+        "#define HAVE_SIGNAL_H 1",
+        "#define HAVE_STDINT_H 1",
+        "#define HAVE_STRERROR_R 1",
+        "#define HAVE_STRINGS_H 1",
+        "#define HAVE_SYS_IOCTL_H 1",
+        "#define HAVE_SYS_PARAM_H 1",
+        "#define HAVE_SYS_POLL_H 1",
+        "#define HAVE_SYS_RESOURCE_H 1",
+        "#define HAVE_SYS_SELECT_H 1",
+        "#define HAVE_SYS_SOCKET_H 1",
+        "#define HAVE_SYS_STAT_H 1",
+        "#define HAVE_SYS_TIME_H 1",
+        "#define HAVE_SYS_UN_H 1",
+        "#define HAVE_UNISTD_H 1",
+    ],
+)
+
+cc_library(
+    name = "thrift",
+    srcs = [
+        "lib/cpp/src/thrift/TApplicationException.cpp",
+        "lib/cpp/src/thrift/TOutput.cpp",
+        "lib/cpp/src/thrift/protocol/TProtocol.cpp",
+        "lib/cpp/src/thrift/transport/TBufferTransports.cpp",
+        "lib/cpp/src/thrift/transport/TTransportException.cpp",
+    ],
+    hdrs = glob([
+        "lib/cpp/src/thrift/**/*.h",
+        "lib/cpp/src/thrift/**/*.tcc",
+    ]) + [":thrift_config"],
+    copts = ["-std=c++20"],
+    local_defines = select({
+        "@platforms//os:linux": ["STRERROR_R_CHAR_P"],
+        "//conditions:default": [],
+    }),
+    strip_include_prefix = "lib/cpp/src",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boost.numeric_conversion//:boost.numeric_conversion",
+        "@boost.predef//:boost.predef",
+        "@boost.uuid//:boost.uuid",
+    ],
+)

--- a/modules/thrift/0.22.0/overlay/test/BUILD.bazel
+++ b/modules/thrift/0.22.0/overlay/test/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "smoke_test",
+    srcs = ["smoke_test.cc"],
+    copts = ["-std=c++20"],
+    deps = ["@thrift"],
+)

--- a/modules/thrift/0.22.0/overlay/test/MODULE.bazel
+++ b/modules/thrift/0.22.0/overlay/test/MODULE.bazel
@@ -1,0 +1,6 @@
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "thrift", version = "0.22.0")
+local_path_override(
+    module_name = "thrift",
+    path = "..",
+)

--- a/modules/thrift/0.22.0/overlay/test/smoke_test.cc
+++ b/modules/thrift/0.22.0/overlay/test/smoke_test.cc
@@ -1,0 +1,24 @@
+#include <thrift/TConfiguration.h>
+#include <thrift/protocol/TCompactProtocol.h>
+#include <thrift/transport/TBufferTransports.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+int main() {
+  auto configuration = std::make_shared<apache::thrift::TConfiguration>();
+  auto transport =
+      std::make_shared<apache::thrift::transport::TMemoryBuffer>(configuration);
+  apache::thrift::protocol::TCompactProtocol protocol(transport);
+
+  protocol.writeI32(42);
+  protocol.writeString("apache-thrift");
+
+  std::int32_t number = 0;
+  std::string text;
+  protocol.readI32(number);
+  protocol.readString(text);
+
+  return number == 42 && text == "apache-thrift" ? 0 : 1;
+}

--- a/modules/thrift/0.22.0/presubmit.yml
+++ b/modules/thrift/0.22.0/presubmit.yml
@@ -1,0 +1,38 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2204
+    - macos
+    - macos_arm64
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+
+tasks:
+  verify_targets:
+    name: Build Apache Thrift C++ runtime
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@thrift//:thrift"
+
+bcr_test_module:
+  module_path: test
+  matrix:
+    platform:
+      - debian11
+      - ubuntu2204
+      - macos
+      - macos_arm64
+    bazel:
+      - 7.x
+      - 8.x
+      - 9.x
+  tasks:
+    smoke_test:
+      name: Test Apache Thrift compact-protocol serialization
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//:smoke_test"

--- a/modules/thrift/0.22.0/source.json
+++ b/modules/thrift/0.22.0/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz",
+    "integrity": "sha256-eUoORVeHlg2fJ6uSw4402ifo3u2npdsOWdxkoA34oeU=",
+    "strip_prefix": "thrift-0.22.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-zKmEPs35cOZ/u/D/BHaeV9Tga2u8jfd3YWIfbsyC6BE=",
+        "test/BUILD.bazel": "sha256-QkqDAa6y1KO8Iw0ajuEC8Jxytm/E9Yaw1KVMpcEQGDQ=",
+        "test/MODULE.bazel": "sha256-dQ2Oy+lh0Tz82Zj8/hKOk6At+jCCUoZdawa2K7khzRs=",
+        "test/smoke_test.cc": "sha256-KhBN0/a2OuXcfI9Vp8GPlRitk3+fciNikDoiWxWrYPg="
+    }
+}

--- a/modules/thrift/metadata.json
+++ b/modules/thrift/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://thrift.apache.org/",
+    "maintainers": [
+        {
+            "github": "dzbarsky",
+            "github_user_id": 1565842
+        }
+    ],
+    "repository": [
+        "github:apache/thrift",
+        "https://archive.apache.org/dist/thrift"
+    ],
+    "versions": [
+        "0.22.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
## Summary

- Publish Apache Thrift 0.22.0 from its official, stable Apache release archive.
- Expose `@thrift//:thrift` with the C++ compact protocol and in-memory transport required by Apache Arrow and Parquet.
- Add a dependent C++ compact-protocol serialization test on Linux and macOS with Bazel 7.x, 8.x, and 9.x.

## Validation

- Verified the official archive against the SHA-256 selected by Apache Arrow 25.0.1.
- Passed BCR source URL, archive integrity, module metadata, overlay integrity, and presubmit validation.
- Ran the dependent C++ compact-protocol serialization test with Bazel 9 and remote Linux execution.

Apache Arrow integration: https://github.com/bazelbuild/bazel-central-registry/pull/10189
