### PR TITLE
libsais@2.10.4

### DIFF
--- a/modules/libsais/2.10.4/MODULE.bazel
+++ b/modules/libsais/2.10.4/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "libsais",
+    version = "2.10.4",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/libsais/2.10.4/overlay/BUILD.bazel
+++ b/modules/libsais/2.10.4/overlay/BUILD.bazel
@@ -1,0 +1,57 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "libsais",
+    srcs = ["src/libsais.c"],
+    hdrs = ["include/libsais.h"],
+    includes = ["include"],
+)
+
+cc_library(
+    name = "libsais16",
+    srcs = ["src/libsais16.c"],
+    hdrs = ["include/libsais16.h"],
+    includes = ["include"],
+)
+
+cc_library(
+    name = "libsais64",
+    srcs = ["src/libsais64.c"],
+    hdrs = ["include/libsais64.h"],
+    includes = ["include"],
+    deps = [":libsais"],
+)
+
+cc_library(
+    name = "libsais16x64",
+    srcs = ["src/libsais16x64.c"],
+    hdrs = ["include/libsais16x64.h"],
+    includes = ["include"],
+    deps = [":libsais16"],
+)
+
+cc_test(
+    name = "libsais_test",
+    srcs = ["test/libsais_test.c"],
+    deps = [":libsais"],
+)
+
+cc_test(
+    name = "libsais16_test",
+    srcs = ["test/libsais16_test.c"],
+    deps = [":libsais16"],
+)
+
+cc_test(
+    name = "libsais64_test",
+    srcs = ["test/libsais64_test.c"],
+    deps = [":libsais64"],
+)
+
+cc_test(
+    name = "libsais16x64_test",
+    srcs = ["test/libsais16x64_test.c"],
+    deps = [":libsais16x64"],
+)

--- a/modules/libsais/2.10.4/overlay/MODULE.bazel
+++ b/modules/libsais/2.10.4/overlay/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "libsais",
+    version = "2.10.4",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/libsais/2.10.4/overlay/test/libsais16_test.c
+++ b/modules/libsais/2.10.4/overlay/test/libsais16_test.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+
+#include "libsais16.h"
+
+/* Suffixes of "banana" in lexicographic order:
+   a, ana, anana, banana, na, nana */
+static const int32_t kExpected[6] = {5, 3, 1, 0, 4, 2};
+
+int main(void) {
+    const uint16_t text[6] = {'b', 'a', 'n', 'a', 'n', 'a'};
+    int32_t n = 6;
+    int32_t sa[6];
+
+    if (libsais16(text, sa, n, 0, NULL) != 0) {
+        fprintf(stderr, "libsais16 failed\n");
+        return 1;
+    }
+
+    for (int32_t i = 0; i < n; i += 1) {
+        if (sa[i] != kExpected[i]) {
+            fprintf(stderr, "SA[%d] = %d, expected %d\n", i, sa[i], kExpected[i]);
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/modules/libsais/2.10.4/overlay/test/libsais16x64_test.c
+++ b/modules/libsais/2.10.4/overlay/test/libsais16x64_test.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+
+#include "libsais16x64.h"
+
+/* Suffixes of "banana" in lexicographic order:
+   a, ana, anana, banana, na, nana */
+static const int64_t kExpected[6] = {5, 3, 1, 0, 4, 2};
+
+int main(void) {
+    const uint16_t text[6] = {'b', 'a', 'n', 'a', 'n', 'a'};
+    int64_t n = 6;
+    int64_t sa[6];
+
+    if (libsais16x64(text, sa, n, 0, NULL) != 0) {
+        fprintf(stderr, "libsais16x64 failed\n");
+        return 1;
+    }
+
+    for (int64_t i = 0; i < n; i += 1) {
+        if (sa[i] != kExpected[i]) {
+            fprintf(stderr, "SA[%lld] = %lld, expected %lld\n", (long long)i, (long long)sa[i], (long long)kExpected[i]);
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/modules/libsais/2.10.4/overlay/test/libsais64_test.c
+++ b/modules/libsais/2.10.4/overlay/test/libsais64_test.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "libsais64.h"
+
+/* Suffixes of "banana" in lexicographic order:
+   a, ana, anana, banana, na, nana */
+static const int64_t kExpected[6] = {5, 3, 1, 0, 4, 2};
+
+int main(void) {
+    const char * text = "banana";
+    int64_t n = (int64_t)strlen(text);
+    int64_t sa[6];
+
+    if (libsais64((const uint8_t *)text, sa, n, 0, NULL) != 0) {
+        fprintf(stderr, "libsais64 failed\n");
+        return 1;
+    }
+
+    for (int64_t i = 0; i < n; i += 1) {
+        if (sa[i] != kExpected[i]) {
+            fprintf(stderr, "SA[%lld] = %lld, expected %lld\n", (long long)i, (long long)sa[i], (long long)kExpected[i]);
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/modules/libsais/2.10.4/overlay/test/libsais_test.c
+++ b/modules/libsais/2.10.4/overlay/test/libsais_test.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "libsais.h"
+
+/* Suffixes of "banana" in lexicographic order:
+   a, ana, anana, banana, na, nana */
+static const int32_t kExpected[6] = {5, 3, 1, 0, 4, 2};
+
+int main(void) {
+    const char * text = "banana";
+    int32_t n = (int32_t)strlen(text);
+    int32_t sa[6];
+
+    if (libsais((const uint8_t *)text, sa, n, 0, NULL) != 0) {
+        fprintf(stderr, "libsais failed\n");
+        return 1;
+    }
+
+    for (int32_t i = 0; i < n; i += 1) {
+        if (sa[i] != kExpected[i]) {
+            fprintf(stderr, "SA[%d] = %d, expected %d\n", i, sa[i], kExpected[i]);
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/modules/libsais/2.10.4/presubmit.yml
+++ b/modules/libsais/2.10.4/presubmit.yml
@@ -1,0 +1,22 @@
+matrix:
+  bazel: [7.x, 8.x, 9.x, rolling]
+  platform:
+    - debian11
+    - ubuntu2204
+    - macos_arm64
+    - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--features=parse_headers'
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - "@libsais//:libsais"
+      - "@libsais//:libsais16"
+      - "@libsais//:libsais64"
+      - "@libsais//:libsais16x64"
+    test_targets:
+      - "@libsais//:all"

--- a/modules/libsais/2.10.4/source.json
+++ b/modules/libsais/2.10.4/source.json
@@ -1,0 +1,13 @@
+{
+    "integrity": "sha256-lKqI+eKfiBIhTs+mtV9dyhTH2KQnQJwGL3NKYcpMaTE=",
+    "overlay": {
+        "BUILD.bazel": "sha256-ISXtbuEs583Ey+75vGAlEK3aaXV6QZfWTqZlyWUy46M=",
+        "MODULE.bazel": "sha256-ueVfOt20pvrvspp4WCxCtg1hSA9kslWM3FmuKVmF+Tk=",
+        "test/libsais16_test.c": "sha256-2lvrHD+P+oIxyF01W4/vAR8ZV023JqsgVCKg62K6+qk=",
+        "test/libsais16x64_test.c": "sha256-rz1GxOFLyauGz1hR1qpAlRuxUjNx+ksDb4Yxi9YpW/A=",
+        "test/libsais64_test.c": "sha256-MaKgIA+vZdLmouVJf1Joth+7JjQN/4EXASnPS69MxBY=",
+        "test/libsais_test.c": "sha256-tDKrL+KP4CAZAQ0SgpSb3F6KPFrcF/5pafEttb80PS4="
+    },
+    "strip_prefix": "libsais-2.10.4",
+    "url": "https://github.com/IlyaGrebnov/libsais/archive/refs/tags/v2.10.4.tar.gz"
+}

--- a/modules/libsais/metadata.json
+++ b/modules/libsais/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/IlyaGrebnov/libsais",
+    "maintainers": [
+        {
+            "email": "byvoid@byvoid.com",
+            "github": "BYVoid",
+            "github_user_id": 245270,
+            "name": "Carbo Kuo"
+        }
+    ],
+    "repository": [
+        "github:IlyaGrebnov/libsais"
+    ],
+    "versions": [
+        "2.10.4"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add [libsais](https://github.com/IlyaGrebnov/libsais) 2.10.4 — a library for fast linear-time construction of suffix arrays, LCP arrays, BWT and inverse BWT.

The upstream project is CMake-based, so this module ships an overlay `BUILD.bazel` and `MODULE.bazel`. Each of the four upstream sources gets its own target, matching the four variants of the API (8/16-bit symbols × 32/64-bit indices):

- `@libsais//:libsais` — `uint8_t` input, `int32_t` suffix array
- `@libsais//:libsais16` — `uint16_t` input, `int32_t` suffix array
- `@libsais//:libsais64` — `uint8_t` input, `int64_t` suffix array (depends on `:libsais`, which it delegates to for inputs below `INT32_MAX`)
- `@libsais//:libsais16x64` — `uint16_t` input, `int64_t` suffix array (depends on `:libsais16` for the same reason)

The `--@libsais//:openmp` flag mirrors the `LIBSAIS_USE_OPENMP` CMake option and is off by default in the same way; it adds `-fopenmp` (`/openmp` on MSVC and clang-cl) and propagates the `LIBSAIS_OPENMP` definition to dependents, which the `*_omp` declarations in the public headers are guarded by.

Upstream ships no tests, so the overlay adds one `cc_test` per target under `test/`, each linking only its own library and checking the suffix array of `"banana"`. They run in presubmit via `test_targets: "@libsais//:all"`, and pass locally along with `tools/bcr_validation.py --check libsais@2.10.4`, which reports no issues other than the unstable URL below.

Upstream publishes no release archive assets for `v2.10.4`, only the auto-generated tag tarball, so the URL stability check cannot be satisfied.

The same build files are proposed upstream in IlyaGrebnov/libsais#37; if that lands, the overlay here can be dropped in a future version.

@bazel-io skip_check unstable_url