### PR TITLE
rules_latex@0.6.1

### DIFF
--- a/modules/rules_latex/0.6.1/MODULE.bazel
+++ b/modules/rules_latex/0.6.1/MODULE.bazel
@@ -1,0 +1,44 @@
+"""rules_latex - Bazel rules for building LaTeX documents with Tectonic.
+
+See https://github.com/nicklambourne/rules_latex for details.
+"""
+
+module(
+    name = "rules_latex",
+    version = "0.6.1",
+    compatibility_level = 1,
+)
+
+# Standard dependencies.
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+
+# Stardoc generates the Markdown that backs the user guide at
+# https://nicklambourne.github.io/rules_latex/. Marked as a dev-only
+# dependency because consumers of rules_latex don't need it; only
+# our own //docs:* targets do.
+bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.5.0", dev_dependency = True)
+
+# Module extension that registers the tectonic toolchain repos.
+tectonic = use_extension("//latex/toolchain:extensions.bzl", "tectonic")
+tectonic.toolchain()
+use_repo(
+    tectonic,
+    "rules_latex_tectonic_toolchains",
+    # Per-platform repos that hold the downloaded tectonic binaries.
+    "rules_latex_tectonic_linux_aarch64",
+    "rules_latex_tectonic_linux_x86_64",
+    "rules_latex_tectonic_macos_aarch64",
+    "rules_latex_tectonic_macos_x86_64",
+)
+
+register_toolchains("@rules_latex_tectonic_toolchains//:all")
+
+# Module extension that vendors PDF.js for latex_live. Always
+# materialised so the rule's default _pdfjs_lib / _pdfjs_worker
+# attributes resolve cleanly; the actual ~10 MB download only happens
+# when something in the build graph references the @rules_latex_pdfjs
+# repo (i.e. when a latex_live target is built).
+pdfjs = use_extension("//latex/web:extensions.bzl", "pdfjs")
+use_repo(pdfjs, "rules_latex_pdfjs")

--- a/modules/rules_latex/0.6.1/attestations.json
+++ b/modules/rules_latex/0.6.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/nicklambourne/rules_latex/releases/download/v0.6.1/source.json.intoto.jsonl",
+            "integrity": "sha256-9dfSNTIyGp/us0hjWrWrOH3F0PGRc9lIls7w8627emc="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/nicklambourne/rules_latex/releases/download/v0.6.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-0Sq972YQxmJrXAcRoK2dn4vYcjQ5+Nrw/7/neASsL10="
+        },
+        "rules_latex-0.6.1.tar.gz": {
+            "url": "https://github.com/nicklambourne/rules_latex/releases/download/v0.6.1/rules_latex-0.6.1.tar.gz.intoto.jsonl",
+            "integrity": "sha256-JfG3VgKrUj6AKkpBxpnVpuko6r37vkEmzNnE1K2YWzE="
+        }
+    }
+}

--- a/modules/rules_latex/0.6.1/presubmit.yml
+++ b/modules/rules_latex/0.6.1/presubmit.yml
@@ -1,0 +1,31 @@
+# BCR presubmit configuration.
+#
+# When the BCR receives our submission PR, it runs this presubmit
+# against a copy of our test module. The test module exercises the
+# rules through Bzlmod against the published version of rules_latex
+# being submitted. If the test module fails, the PR is blocked.
+#
+# Our test module is `examples/` — a Bzlmod workspace that consumes
+# rules_latex via bazel_dep. It contains six sub-packages (hello,
+# letter, cv, paper, thesis, beamer) covering the main document
+# shapes. We exercise the smallest ones in presubmit; the rest are
+# covered in the project's own CI.
+
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["ubuntu2204", "macos", "macos_arm64"]
+    # Exercise both Bazel 8 and 9 across the platform matrix.
+    bazel: [8.x, 9.x]
+  tasks:
+    run_tests:
+      name: "Build and test hello example"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//hello:hello"
+        - "//hello:hello_offline"
+        - "//letter:letter"
+      test_targets:
+        - "//hello:hello_compiles"
+        - "//letter:letter_compiles"

--- a/modules/rules_latex/0.6.1/source.json
+++ b/modules/rules_latex/0.6.1/source.json
@@ -1,0 +1,6 @@
+{
+    "integrity": "sha256-6r5SmtEH4fGF9eN0nR6N6x3hD6OD4CNAhMFxwC6jPto=",
+    "strip_prefix": "rules_latex-0.6.1",
+    "url": "https://github.com/nicklambourne/rules_latex/releases/download/v0.6.1/rules_latex-0.6.1.tar.gz",
+    "docs_url": "https://github.com/nicklambourne/rules_latex/releases/download/v0.6.1/rules_latex-0.6.1.docs.tar.gz"
+}

--- a/modules/rules_latex/metadata.json
+++ b/modules/rules_latex/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/nicklambourne/rules_latex",
+    "maintainers": [
+        {
+            "name": "Nicholas Lambourne",
+            "email": "dev@ndl.au",
+            "github": "nicklambourne",
+            "github_user_id": 9084563
+        }
+    ],
+    "repository": [
+        "github:nicklambourne/rules_latex"
+    ],
+    "versions": [
+        "0.6.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/nicklambourne/rules_latex/releases/tag/v0.6.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_

Hey BCR maintainers, just picking this up again after I got distracted during some past attempts (https://github.com/bazelbuild/bazel-central-registry/pull/8986, https://github.com/bazelbuild/bazel-central-registry/pull/8981) - apologies for another PR but this one cleans up some issues that surfaced with the last one around a CTAN pin and represents the current (and more stable) rules_latex. 

This is my first time contributing to BCR, so hoping that I've ticked the right boxes, but please let me know if there's anything I need to fix / update. Thank you ❤️  