### PR TITLE
Circe 1.0.1

### DIFF
--- a/modules/circe/1.0.1/MODULE.bazel
+++ b/modules/circe/1.0.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "circe",
+    version = "1.0.1",
+)
+
+bazel_dep(name = "apple_support", version = "2.2.0", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "rules_apple", version = "4.5.3", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_swift", version = "3.6.1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_xcodeproj", version = "4.1.0", dev_dependency = True)

--- a/modules/circe/1.0.1/presubmit.yml
+++ b/modules/circe/1.0.1/presubmit.yml
@@ -1,0 +1,11 @@
+matrix:
+  bazel:
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: macos_arm64
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@circe//Circe:Circe'

--- a/modules/circe/1.0.1/source.json
+++ b/modules/circe/1.0.1/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/xiemotongye/circe/releases/download/1.0.1/circe-1.0.1.tar.gz",
+    "integrity": "sha256-Lnmera1b0ZmaW+KGFo87hdTA0TFxxQ+77gR8u4UnSBI=",
+    "strip_prefix": "circe-1.0.1"
+}

--- a/modules/circe/metadata.json
+++ b/modules/circe/metadata.json
@@ -12,7 +12,8 @@
         "github:xiemotongye/circe"
     ],
     "versions": [
-        "1.0.0"
+        "1.0.0",
+        "1.0.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
## Description

Update `circe` from `1.0.0` to `1.0.1`.

Circe provides Bazel rules for converting pre-built arm64 iOS device binaries into arm64 iOS Simulator-compatible binaries. This patch release improves framework conversion compatibility with Xcode 27.

## Changes

- Fix framework conversion failures with Xcode 27 caused by symlinked framework root files such as `Info.plist`.
- Materialize framework root files in the same action as binary conversion and signing.
- Omit the imported device `_CodeSignature` after conversion, since the original signature is invalidated when the Mach-O binary is rewritten.
- Preserve lightweight symlink handling for non-root framework files.
- Handle nested frameworks by converting their binaries in the correct order.
- Improve framework binary detection.
- Update the module version and README examples to `1.0.1`.
- Add attribution to the original [arm64-to-sim](https://bogo.wtf/arm64-to-sim.html) project.