### PR TITLE
dtc@1.7.2.bcr.2

### DIFF
--- a/modules/dtc/1.7.2.bcr.2/MODULE.bazel
+++ b/modules/dtc/1.7.2.bcr.2/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "dtc",
+    version = "1.7.2.bcr.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "bison", version = "3.8.2.bcr.8")
+bazel_dep(name = "flex", version = "2.6.4.bcr.5")
+bazel_dep(name = "libyaml", version = "0.2.5")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.1", dev_dependency = True)

--- a/modules/dtc/1.7.2.bcr.2/overlay/BUILD.bazel
+++ b/modules/dtc/1.7.2.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,145 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@bison//:bison.bzl", "bison")
+load("@flex//:flex.bzl", "flex")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# Generate version header
+expand_template(
+    name = "generate_version_header",
+    out = "version_gen.h",
+    substitutions = {
+        "@VCS_TAG@": "1.7.2",
+    },
+    template = "//:version_gen.h.in",
+)
+
+# Lexer and parser generation
+flex(
+    name = "generate_dtc_lexer",
+    srcs = ["dtc-lexer.l"],
+    outs = ["dtc-lexer.lex.c"],
+    args = [
+        "-o",
+        "$(execpath dtc-lexer.lex.c)",
+        "$(execpath dtc-lexer.l)",
+    ],
+)
+
+bison(
+    name = "generate_dtc_parser",
+    srcs = ["dtc-parser.y"],
+    outs = [
+        "dtc-parser.tab.c",
+        "dtc-parser.tab.h",
+    ],
+    args = [
+        "-o",
+        "$(execpath dtc-parser.tab.c)",
+        "-d",
+        "$(execpath dtc-parser.y)",
+    ],
+)
+
+flex(
+    name = "generate_convert_dtsv0_lexer",
+    srcs = ["convert-dtsv0-lexer.l"],
+    outs = ["convert-dtsv0-lexer.lex.c"],
+    args = [
+        "-o",
+        "$(execpath convert-dtsv0-lexer.lex.c)",
+        "$(execpath convert-dtsv0-lexer.l)",
+    ],
+)
+
+# dtc util library
+cc_library(
+    name = "utils",
+    srcs = [
+        "util.c",
+    ],
+    hdrs = [
+        "util.h",
+        "version_gen.h",
+    ],
+    deps = [
+        "//libfdt",
+    ],
+)
+
+# Binaries
+cc_binary(
+    name = "dtc",
+    srcs = [
+        "checks.c",
+        "data.c",
+        "dtc.c",
+        "dtc.h",
+        "dtc-lexer.lex.c",
+        "dtc-parser.tab.c",
+        "dtc-parser.tab.h",
+        "flattree.c",
+        "fstree.c",
+        "livetree.c",
+        "srcpos.c",
+        "srcpos.h",
+        "treesource.c",
+        "yamltree.c",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":utils",
+        "@libyaml",
+    ],
+)
+
+cc_binary(
+    name = "fdtget",
+    srcs = ["fdtget.c"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":utils",
+    ],
+)
+
+cc_binary(
+    name = "fdtdump",
+    srcs = ["fdtdump.c"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":utils",
+    ],
+)
+
+cc_binary(
+    name = "fdtput",
+    srcs = ["fdtput.c"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":utils",
+    ],
+)
+
+cc_binary(
+    name = "fdtoverlay",
+    srcs = ["fdtoverlay.c"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":utils",
+    ],
+)
+
+cc_binary(
+    name = "convert-dtsv0",
+    srcs = [
+        "convert-dtsv0-lexer.lex.c",
+        "dtc.h",
+        "srcpos.c",
+        "srcpos.h",
+        "version_gen.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":utils",
+    ],
+)

--- a/modules/dtc/1.7.2.bcr.2/overlay/MODULE.bazel
+++ b/modules/dtc/1.7.2.bcr.2/overlay/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "dtc",
+    version = "1.7.2.bcr.2",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "bison", version = "3.8.2.bcr.8")
+bazel_dep(name = "flex", version = "2.6.4.bcr.5")
+bazel_dep(name = "libyaml", version = "0.2.5")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.1", dev_dependency = True)

--- a/modules/dtc/1.7.2.bcr.2/overlay/libfdt/BUILD.bazel
+++ b/modules/dtc/1.7.2.bcr.2/overlay/libfdt/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# libfdt library
+cc_library(
+    name = "fdt",
+    srcs = [
+        "fdt.c",
+        "fdt_addresses.c",
+        "fdt_check.c",
+        "fdt_empty_tree.c",
+        "fdt_overlay.c",
+        "fdt_ro.c",
+        "fdt_rw.c",
+        "fdt_strerror.c",
+        "fdt_sw.c",
+        "fdt_wip.c",
+        "libfdt_internal.h",
+    ],
+    hdrs = [
+        "fdt.h",
+        "libfdt.h",
+        "libfdt_env.h",
+    ],
+    includes = ["."],
+)
+
+alias(
+    name = "libfdt",
+    actual = "fdt",
+    visibility = ["//visibility:public"],
+)

--- a/modules/dtc/1.7.2.bcr.2/presubmit.yml
+++ b/modules/dtc/1.7.2.bcr.2/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+  platform:
+    - debian11
+    - rockylinux8
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2204_arm64
+    - ubuntu2404
+    - ubuntu2404_arm64
+
+tasks:
+  build:
+    name: Build `device tree compiler` targets
+    bazel: ${{ bazel }}
+    platform: ${{ platform }}
+    build_targets:
+      - "//..."

--- a/modules/dtc/1.7.2.bcr.2/source.json
+++ b/modules/dtc/1.7.2.bcr.2/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://www.kernel.org/pub/software/utils/dtc/dtc-1.7.2.tar.xz",
+    "integrity": "sha256-ktjKdpgFrh8XYgQjBDj+UoCPThx5RAU8nuwOZJsjdTk=",
+    "strip_prefix": "dtc-1.7.2",
+    "overlay": {
+        "BUILD.bazel": "sha256-gzrLuZd8+7TdqU27MC5clLwfxccUIk3yiRos+W8otiQ=",
+        "MODULE.bazel": "sha256-PMkg64IYD/AK/MIvAzSxcXC9yXhfJm9bvrKgCLOGMgQ=",
+        "libfdt/BUILD.bazel": "sha256-IDmmflc80Th6LPAzX7vstBNk5QcSFLjtm9cwf2XXoHQ="
+    }
+}

--- a/modules/dtc/metadata.json
+++ b/modules/dtc/metadata.json
@@ -15,7 +15,8 @@
     ],
     "versions": [
         "1.7.2",
-        "1.7.2.bcr.1"
+        "1.7.2.bcr.1",
+        "1.7.2.bcr.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This change pulls in an updated `bison` that supports older versions of Bazel.