### PR TITLE
libsais@2.10.4.bcr.1

### DIFF
--- a/modules/libsais/2.10.4.bcr.1/MODULE.bazel
+++ b/modules/libsais/2.10.4.bcr.1/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "libsais",
+    version = "2.10.4.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/libsais/2.10.4.bcr.1/overlay/BUILD.bazel
+++ b/modules/libsais/2.10.4.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,145 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+# Counterpart of the LIBSAIS_USE_OPENMP option of the CMake build, off by
+# default as well. Enable it with --@libsais//:openmp.
+bool_flag(
+    name = "openmp",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "openmp_requested",
+    flag_values = {":openmp": "True"},
+)
+
+selects.config_setting_group(
+    name = "openmp_msvc_like",
+    match_all = [
+        ":openmp_requested",
+        ":msvc_like",
+    ],
+)
+
+selects.config_setting_group(
+    name = "openmp_gcc_like",
+    match_all = [
+        ":openmp_requested",
+        ":gcc_like",
+    ],
+)
+
+selects.config_setting_group(
+    name = "msvc_like",
+    match_any = [
+        "@rules_cc//cc/compiler:clang-cl",
+        "@rules_cc//cc/compiler:msvc-cl",
+    ],
+)
+
+selects.config_setting_group(
+    name = "gcc_like",
+    match_any = [
+        "@rules_cc//cc/compiler:clang",
+        "@rules_cc//cc/compiler:gcc",
+        "@rules_cc//cc/compiler:mingw-gcc",
+    ],
+)
+
+OPENMP_COPTS = select({
+    ":openmp_msvc_like": ["/openmp"],
+    ":openmp_gcc_like": ["-fopenmp"],
+    "//conditions:default": [],
+})
+
+# LIBSAIS_OPENMP gates the *_omp declarations in the public headers, so, like
+# the PUBLIC compile definition in the CMake build, it has to reach dependents.
+OPENMP_DEFINES = select({
+    ":openmp_msvc_like": ["LIBSAIS_OPENMP"],
+    ":openmp_gcc_like": ["LIBSAIS_OPENMP"],
+    "//conditions:default": [],
+})
+
+# MSVC and clang-cl link the OpenMP runtime on their own.
+OPENMP_LINKOPTS = select({
+    ":openmp_gcc_like": ["-fopenmp"],
+    "//conditions:default": [],
+})
+
+# Each library corresponds to one of the four API variants, combining the
+# symbol width of the input string with the width of the output arrays.
+# The 64-bit variants delegate to their 32-bit counterpart for inputs that
+# fit into int32_t, hence the dependency between them.
+
+# uint8_t input, int32_t output.
+cc_library(
+    name = "libsais",
+    srcs = ["src/libsais.c"],
+    hdrs = ["include/libsais.h"],
+    copts = OPENMP_COPTS,
+    defines = OPENMP_DEFINES,
+    includes = ["include"],
+    linkopts = OPENMP_LINKOPTS,
+)
+
+# uint16_t input, int32_t output.
+cc_library(
+    name = "libsais16",
+    srcs = ["src/libsais16.c"],
+    hdrs = ["include/libsais16.h"],
+    copts = OPENMP_COPTS,
+    defines = OPENMP_DEFINES,
+    includes = ["include"],
+    linkopts = OPENMP_LINKOPTS,
+)
+
+# uint8_t input, int64_t output.
+cc_library(
+    name = "libsais64",
+    srcs = ["src/libsais64.c"],
+    hdrs = ["include/libsais64.h"],
+    copts = OPENMP_COPTS,
+    defines = OPENMP_DEFINES,
+    includes = ["include"],
+    linkopts = OPENMP_LINKOPTS,
+    deps = [":libsais"],
+)
+
+# uint16_t input, int64_t output.
+cc_library(
+    name = "libsais16x64",
+    srcs = ["src/libsais16x64.c"],
+    hdrs = ["include/libsais16x64.h"],
+    copts = OPENMP_COPTS,
+    defines = OPENMP_DEFINES,
+    includes = ["include"],
+    linkopts = OPENMP_LINKOPTS,
+    deps = [":libsais16"],
+)
+
+cc_test(
+    name = "libsais_test",
+    srcs = ["test/libsais_test.c"],
+    deps = [":libsais"],
+)
+
+cc_test(
+    name = "libsais16_test",
+    srcs = ["test/libsais16_test.c"],
+    deps = [":libsais16"],
+)
+
+cc_test(
+    name = "libsais64_test",
+    srcs = ["test/libsais64_test.c"],
+    deps = [":libsais64"],
+)
+
+cc_test(
+    name = "libsais16x64_test",
+    srcs = ["test/libsais16x64_test.c"],
+    deps = [":libsais16x64"],
+)

--- a/modules/libsais/2.10.4.bcr.1/overlay/MODULE.bazel
+++ b/modules/libsais/2.10.4.bcr.1/overlay/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "libsais",
+    version = "2.10.4.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/modules/libsais/2.10.4.bcr.1/overlay/test/libsais16_test.c
+++ b/modules/libsais/2.10.4.bcr.1/overlay/test/libsais16_test.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+
+#include "libsais16.h"
+
+/* Suffixes of "banana" in lexicographic order:
+   a, ana, anana, banana, na, nana */
+static const int32_t kExpected[6] = {5, 3, 1, 0, 4, 2};
+
+static int check(const char * name, const int32_t * sa, int32_t n) {
+    for (int32_t i = 0; i < n; i += 1) {
+        if (sa[i] != kExpected[i]) {
+            fprintf(stderr, "%s: SA[%d] = %d, expected %d\n", name, i, sa[i], kExpected[i]);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int main(void) {
+    const uint16_t text[6] = {'b', 'a', 'n', 'a', 'n', 'a'};
+    int32_t n = 6;
+    int32_t sa[6];
+
+    if (libsais16(text, sa, n, 0, NULL) != 0) {
+        fprintf(stderr, "libsais16 failed\n");
+        return 1;
+    }
+
+    if (check("libsais16", sa, n) != 0) {
+        return 1;
+    }
+
+#if defined(LIBSAIS_OPENMP)
+    if (libsais16_omp(text, sa, n, 0, NULL, 2) != 0) {
+        fprintf(stderr, "libsais16_omp failed\n");
+        return 1;
+    }
+
+    if (check("libsais16_omp", sa, n) != 0) {
+        return 1;
+    }
+#endif
+
+    return 0;
+}

--- a/modules/libsais/2.10.4.bcr.1/overlay/test/libsais16x64_test.c
+++ b/modules/libsais/2.10.4.bcr.1/overlay/test/libsais16x64_test.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+
+#include "libsais16x64.h"
+
+/* Suffixes of "banana" in lexicographic order:
+   a, ana, anana, banana, na, nana */
+static const int64_t kExpected[6] = {5, 3, 1, 0, 4, 2};
+
+static int check(const char * name, const int64_t * sa, int64_t n) {
+    for (int64_t i = 0; i < n; i += 1) {
+        if (sa[i] != kExpected[i]) {
+            fprintf(stderr, "%s: SA[%lld] = %lld, expected %lld\n", name, (long long)i, (long long)sa[i], (long long)kExpected[i]);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int main(void) {
+    const uint16_t text[6] = {'b', 'a', 'n', 'a', 'n', 'a'};
+    int64_t n = 6;
+    int64_t sa[6];
+
+    if (libsais16x64(text, sa, n, 0, NULL) != 0) {
+        fprintf(stderr, "libsais16x64 failed\n");
+        return 1;
+    }
+
+    if (check("libsais16x64", sa, n) != 0) {
+        return 1;
+    }
+
+#if defined(LIBSAIS_OPENMP)
+    if (libsais16x64_omp(text, sa, n, 0, NULL, 2) != 0) {
+        fprintf(stderr, "libsais16x64_omp failed\n");
+        return 1;
+    }
+
+    if (check("libsais16x64_omp", sa, n) != 0) {
+        return 1;
+    }
+#endif
+
+    return 0;
+}

--- a/modules/libsais/2.10.4.bcr.1/overlay/test/libsais64_test.c
+++ b/modules/libsais/2.10.4.bcr.1/overlay/test/libsais64_test.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "libsais64.h"
+
+/* Suffixes of "banana" in lexicographic order:
+   a, ana, anana, banana, na, nana */
+static const int64_t kExpected[6] = {5, 3, 1, 0, 4, 2};
+
+static int check(const char * name, const int64_t * sa, int64_t n) {
+    for (int64_t i = 0; i < n; i += 1) {
+        if (sa[i] != kExpected[i]) {
+            fprintf(stderr, "%s: SA[%lld] = %lld, expected %lld\n", name, (long long)i, (long long)sa[i], (long long)kExpected[i]);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int main(void) {
+    const char * text = "banana";
+    int64_t n = (int64_t)strlen(text);
+    int64_t sa[6];
+
+    if (libsais64((const uint8_t *)text, sa, n, 0, NULL) != 0) {
+        fprintf(stderr, "libsais64 failed\n");
+        return 1;
+    }
+
+    if (check("libsais64", sa, n) != 0) {
+        return 1;
+    }
+
+#if defined(LIBSAIS_OPENMP)
+    if (libsais64_omp((const uint8_t *)text, sa, n, 0, NULL, 2) != 0) {
+        fprintf(stderr, "libsais64_omp failed\n");
+        return 1;
+    }
+
+    if (check("libsais64_omp", sa, n) != 0) {
+        return 1;
+    }
+#endif
+
+    return 0;
+}

--- a/modules/libsais/2.10.4.bcr.1/overlay/test/libsais_test.c
+++ b/modules/libsais/2.10.4.bcr.1/overlay/test/libsais_test.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "libsais.h"
+
+/* Suffixes of "banana" in lexicographic order:
+   a, ana, anana, banana, na, nana */
+static const int32_t kExpected[6] = {5, 3, 1, 0, 4, 2};
+
+static int check(const char * name, const int32_t * sa, int32_t n) {
+    for (int32_t i = 0; i < n; i += 1) {
+        if (sa[i] != kExpected[i]) {
+            fprintf(stderr, "%s: SA[%d] = %d, expected %d\n", name, i, sa[i], kExpected[i]);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int main(void) {
+    const char * text = "banana";
+    int32_t n = (int32_t)strlen(text);
+    int32_t sa[6];
+
+    if (libsais((const uint8_t *)text, sa, n, 0, NULL) != 0) {
+        fprintf(stderr, "libsais failed\n");
+        return 1;
+    }
+
+    if (check("libsais", sa, n) != 0) {
+        return 1;
+    }
+
+#if defined(LIBSAIS_OPENMP)
+    if (libsais_omp((const uint8_t *)text, sa, n, 0, NULL, 2) != 0) {
+        fprintf(stderr, "libsais_omp failed\n");
+        return 1;
+    }
+
+    if (check("libsais_omp", sa, n) != 0) {
+        return 1;
+    }
+#endif
+
+    return 0;
+}

--- a/modules/libsais/2.10.4.bcr.1/presubmit.yml
+++ b/modules/libsais/2.10.4.bcr.1/presubmit.yml
@@ -1,0 +1,42 @@
+matrix:
+  bazel: [7.x, 8.x, 9.x, rolling]
+  platform:
+    - debian11
+    - ubuntu2204
+    - macos_arm64
+    - windows
+  # Apple clang ships without OpenMP support, so macOS is left out below.
+  openmp_platform:
+    - debian11
+    - ubuntu2204
+    - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--features=parse_headers'
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - "@libsais//:libsais"
+      - "@libsais//:libsais16"
+      - "@libsais//:libsais64"
+      - "@libsais//:libsais16x64"
+    test_targets:
+      - "@libsais//:all"
+  verify_targets_openmp:
+    name: Verify build targets with OpenMP
+    platform: ${{ openmp_platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - '--@libsais//:openmp'
+      - '--features=parse_headers'
+      - '--process_headers_in_dependencies'
+    build_targets:
+      - "@libsais//:libsais"
+      - "@libsais//:libsais16"
+      - "@libsais//:libsais64"
+      - "@libsais//:libsais16x64"
+    test_targets:
+      - "@libsais//:all"

--- a/modules/libsais/2.10.4.bcr.1/source.json
+++ b/modules/libsais/2.10.4.bcr.1/source.json
@@ -1,0 +1,13 @@
+{
+    "integrity": "sha256-lKqI+eKfiBIhTs+mtV9dyhTH2KQnQJwGL3NKYcpMaTE=",
+    "overlay": {
+        "BUILD.bazel": "sha256-evXbIXbD978c7B6D28MN/Rgh9Ex4JSOBsUYb66XYvpQ=",
+        "MODULE.bazel": "sha256-eVBHC4vh4Bx8V7+4e+d9cF4sP/1J+Pf+LFtScjfxRmk=",
+        "test/libsais16_test.c": "sha256-9TWF0ihOGjFUsSu+yHlKbSedp063XoSlT8WF4kFHzpg=",
+        "test/libsais16x64_test.c": "sha256-4TuxoMnYs7jDJbV/m9fvyJGguoRZH1gGeuiNYR/okEk=",
+        "test/libsais64_test.c": "sha256-DRMihobgGxGnggowhaWxPWPcgL5sc82T0O6N3ODTXJI=",
+        "test/libsais_test.c": "sha256-9Iycfu6Wd6czfCaGdZom1UPHm4EgjttSTeGGSCfwpRU="
+    },
+    "strip_prefix": "libsais-2.10.4",
+    "url": "https://github.com/IlyaGrebnov/libsais/archive/refs/tags/v2.10.4.tar.gz"
+}

--- a/modules/libsais/metadata.json
+++ b/modules/libsais/metadata.json
@@ -12,7 +12,8 @@
         "github:IlyaGrebnov/libsais"
     ],
     "versions": [
-        "2.10.4"
+        "2.10.4",
+        "2.10.4.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds an OpenMP option to the libsais overlay, which 2.10.4 was missing.

In 2.10.4 the overlay had no counterpart to the `LIBSAIS_USE_OPENMP` option of the upstream CMake build, so enabling OpenMP required consumers to pass global `--copt`/`--linkopt` flags, which apply to every dependency in the build. This version adds the flag to the overlay instead:

```sh
bazel build <your target> --@libsais//:openmp
```

It adds `-fopenmp` (`/openmp` on MSVC and clang-cl) to the compile and link commands and defines `LIBSAIS_OPENMP`. Upstream declares that definition as `PUBLIC` in CMake, so the overlay uses the propagating `defines` attribute: the `*_omp` declarations in the public headers are guarded by it, and dependents need to see them. It is off by default, as upstream is.

The tests now also run the `*_omp` entry point with two threads when the flag is set, and a `verify_targets_openmp` task builds and tests everything with `--@libsais//:openmp`. That task skips macOS, since Apple clang ships without OpenMP support. libsais only uses `barrier`, `master`, `parallel num_threads` and `parallel for schedule(static)`, all of which are within the OpenMP 2.0 subset that MSVC implements, so Windows is covered.

Apart from that, the archive and the four targets are unchanged from 2.10.4. The new `bazel_skylib` dependency is used for the `bool_flag` and the `config_setting_group`s that combine the flag with the compiler.

Verified with `bazel test @libsais//...` against a local registry, and with `bazel cquery --output=build` with and without the flag, to confirm the flags and the define are applied only when it is set. The OpenMP configuration itself cannot be built on this machine, so the `verify_targets_openmp` task is the first real check of it; the tests' OpenMP branch was at least compiled here with `-DLIBSAIS_OPENMP` against the upstream headers.

The same build files are proposed upstream in IlyaGrebnov/libsais#37; if that lands, the overlay can be dropped in a future version.

@bazel-io skip_check unstable_url