### PR TITLE
Add libjxl@0.12.0.bcr.1 for Bazel 8.5 compatibility

### DIFF
--- a/modules/libjxl/0.12.0.bcr.1/MODULE.bazel
+++ b/modules/libjxl/0.12.0.bcr.1/MODULE.bazel
@@ -1,0 +1,17 @@
+module(
+    name = "libjxl",
+    version = "0.12.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "brotli", version = "1.2.0.bcr.3")
+bazel_dep(name = "giflib", version = "5.2.1.bcr.1")
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+bazel_dep(name = "highway", version = "1.4.0.bcr.1")
+bazel_dep(name = "libjpeg_turbo", version = "3.1.3.bcr.6")
+bazel_dep(name = "libpng", version = "1.6.58")
+bazel_dep(name = "libwebp", version = "1.6.0")
+bazel_dep(name = "openexr", version = "3.4.15")
+bazel_dep(name = "rules_cc", version = "0.2.18")
+bazel_dep(name = "skcms", version = "20250916.0.bcr.2")

--- a/modules/libjxl/0.12.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/libjxl/0.12.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,40 @@
+package(default_visibility = ["//:__subpackages__"])
+
+filegroup(
+    name = "testdata",
+    srcs = glob(
+        [
+            "testdata/**/*.gif",
+            "testdata/**/*.icc",
+            "testdata/**/*.jpg",
+            "testdata/**/*.jxl",
+            "testdata/**/*.pam",
+            "testdata/**/*.pfm",
+            "testdata/**/*.pgm",
+            "testdata/**/*.png",
+            "testdata/**/*.pnm",
+            "testdata/**/*.ppm",
+            "testdata/**/*.y4m",
+            "testdata/position_encoding/*.txt",
+        ],
+        allow_empty = True,
+    ),
+)
+
+alias(
+    name = "jxl",
+    actual = "//lib:jpegxl",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libjxl",
+    actual = ":jxl",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "jxl_threads",
+    actual = "//lib:jpegxl_threads",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libjxl/0.12.0.bcr.1/overlay/lib/BUILD
+++ b/modules/libjxl/0.12.0.bcr.1/overlay/lib/BUILD
@@ -1,0 +1,251 @@
+# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+# Load sources/headers/tests lists.
+load(
+    "jxl_lists.bzl",
+    "libjxl_base_sources",
+    "libjxl_cms_sources",
+    "libjxl_codec_apng_sources",
+    "libjxl_codec_exr_sources",
+    "libjxl_codec_gif_sources",
+    "libjxl_codec_jpg_sources",
+    "libjxl_codec_jxl_sources",
+    "libjxl_codec_npy_sources",
+    "libjxl_codec_pgx_sources",
+    "libjxl_codec_pnm_sources",
+    "libjxl_dec_box_sources",
+    "libjxl_dec_jpeg_sources",
+    "libjxl_dec_sources",
+    "libjxl_enc_sources",
+    "libjxl_extras_for_tools_sources",
+    "libjxl_extras_sources",
+    # "libjxl_gbench_sources",
+    "libjxl_major_version",
+    "libjxl_minor_version",
+    "libjxl_patch_version",
+    "libjxl_public_headers",
+    "libjxl_testlib_files",
+    "libjxl_tests",
+    "libjxl_threads_public_headers",
+    "libjxl_threads_sources",
+)
+load(
+    "jxl_vars.bzl",
+    "libjxl_deps_brotli",
+    "libjxl_deps_exr",
+    "libjxl_deps_gif",
+    "libjxl_deps_gtest",
+    "libjxl_deps_hwy",
+    "libjxl_deps_hwy_nanobenchmark",
+    "libjxl_deps_hwy_test_util",
+    "libjxl_deps_jpeg",
+    "libjxl_deps_png",
+    "libjxl_deps_runfiles",
+    "libjxl_deps_skcms",
+    # "libjxl_deps_testdata",
+    # "libjxl_deps_webp",
+    "libjxl_root_package",
+    "libjxl_test_shards",
+    "libjxl_test_timeouts",
+)
+
+DEFAULT_VISIBILITY = ["//:__subpackages__"]
+
+DEFAULT_COMPATIBILITY = []
+
+INCLUDES_DIR = "include"
+
+package(
+    default_visibility = DEFAULT_VISIBILITY,
+)
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+EXPORT_TEMPLATE = """
+#ifndef @_EXPORT_H
+#define @_EXPORT_H
+
+#define @_EXPORT
+#define @_NO_EXPORT
+
+#ifndef @_DEPRECATED
+#  define @_DEPRECATED __attribute__ ((__deprecated__))
+#endif
+
+#endif
+"""
+
+JXL_EXPORT_H = INCLUDES_DIR + "/jxl/jxl_export.h"
+
+genrule(
+    name = "create_jxl_export",
+    outs = [JXL_EXPORT_H],
+    cmd = "echo '" + EXPORT_TEMPLATE.replace("@", "JXL") + "' > $@",
+    compatible_with = DEFAULT_COMPATIBILITY,
+)
+
+JXL_CMS_EXPORT_H = INCLUDES_DIR + "/jxl/jxl_cms_export.h"
+
+genrule(
+    name = "create_jxl_cms_export",
+    outs = [JXL_CMS_EXPORT_H],
+    cmd = "echo '" + EXPORT_TEMPLATE.replace("@", "JXL_CMS") + "' > $@",
+    compatible_with = DEFAULT_COMPATIBILITY,
+)
+
+JXL_THREADS_EXPORT_H = INCLUDES_DIR + "/jxl/jxl_threads_export.h"
+
+genrule(
+    name = "create_jxl_threads_export",
+    outs = [JXL_THREADS_EXPORT_H],
+    cmd = "echo '" + EXPORT_TEMPLATE.replace("@", "JXL_THREADS") + "' > $@",
+    compatible_with = DEFAULT_COMPATIBILITY,
+)
+
+JXL_VERSION_H = INCLUDES_DIR + "/jxl/version.h"
+
+expand_template(
+    name = "expand_jxl_version",
+    out = JXL_VERSION_H,
+    compatible_with = DEFAULT_COMPATIBILITY,
+    substitutions = {
+        "@JPEGXL_MAJOR_VERSION@": str(libjxl_major_version),
+        "@JPEGXL_MINOR_VERSION@": str(libjxl_minor_version),
+        "@JPEGXL_PATCH_VERSION@": str(libjxl_patch_version),
+    },
+    template = "jxl/version.h.in",
+)
+
+cc_library(
+    name = "jxl_version",
+    hdrs = [JXL_VERSION_H],
+    compatible_with = DEFAULT_COMPATIBILITY,
+    strip_include_prefix = INCLUDES_DIR,
+)
+
+cc_library(
+    name = "includes",
+    hdrs = libjxl_public_headers + [
+        JXL_EXPORT_H,
+        JXL_CMS_EXPORT_H,
+    ],
+    compatible_with = DEFAULT_COMPATIBILITY,
+    strip_include_prefix = INCLUDES_DIR,
+    deps = [":jxl_version"],
+)
+
+cc_library(
+    name = "base",
+    srcs = [path for path in libjxl_base_sources if path.endswith(".cc")],
+    hdrs = [path for path in libjxl_base_sources if path.endswith(".h")],
+    compatible_with = DEFAULT_COMPATIBILITY,
+    deps = [
+        ":includes",
+    ] + libjxl_deps_hwy,
+)
+
+cc_library(
+    name = "jpegxl",
+    srcs = libjxl_dec_sources + libjxl_dec_box_sources + libjxl_dec_jpeg_sources + libjxl_enc_sources + libjxl_cms_sources,
+    compatible_with = DEFAULT_COMPATIBILITY,
+    defines = [
+        "JPEGXL_ENABLE_SKCMS=1",
+    ],
+    deps = [
+        ":base",
+        ":includes",
+    ] + libjxl_deps_brotli + libjxl_deps_hwy + libjxl_deps_skcms,
+)
+
+cc_library(
+    name = "jpegxl_private",
+    hdrs = [
+        path
+        for path in libjxl_dec_sources + libjxl_dec_box_sources + libjxl_dec_jpeg_sources + libjxl_enc_sources + libjxl_cms_sources
+        if path.endswith(".h") and not path.endswith("-inl.h")
+    ],
+    compatible_with = DEFAULT_COMPATIBILITY,
+    deps = [":jpegxl"],
+)
+
+cc_library(
+    name = "jpegxl_threads",
+    srcs = libjxl_threads_sources,
+    hdrs = libjxl_threads_public_headers + [JXL_THREADS_EXPORT_H],
+    compatible_with = DEFAULT_COMPATIBILITY,
+    strip_include_prefix = INCLUDES_DIR,
+    deps = [":includes"],
+)
+
+CODEC_FILES = libjxl_codec_apng_sources + libjxl_codec_exr_sources + libjxl_codec_gif_sources + libjxl_codec_jpg_sources + libjxl_codec_jxl_sources + libjxl_codec_npy_sources + libjxl_codec_pgx_sources + libjxl_codec_pnm_sources
+
+CODEC_SRCS = [path for path in CODEC_FILES if path.endswith(".cc")]
+
+CODEC_HDRS = [path for path in CODEC_FILES if path.endswith(".h")]
+
+# TODO(eustas): build codecs separately?
+cc_library(
+    name = "jpegxl_extras",
+    srcs = libjxl_extras_sources + libjxl_extras_for_tools_sources + CODEC_SRCS,
+    hdrs = CODEC_HDRS,
+    compatible_with = DEFAULT_COMPATIBILITY,
+    defines = [
+        "JPEGXL_ENABLE_APNG=1",
+        "JPEGXL_ENABLE_EXR=1",
+        "JPEGXL_ENABLE_GIF=1",
+        "JPEGXL_ENABLE_JPEG=1",
+    ],
+    deps = [
+        ":jpegxl_private",
+        ":jpegxl_threads",
+        ":jxl_version",
+    ] + libjxl_deps_exr + libjxl_deps_gif + libjxl_deps_jpeg + libjxl_deps_png,
+)
+
+TESTLIB_FILES = libjxl_testlib_files
+
+cc_library(
+    name = "test_utils",
+    testonly = 1,
+    srcs = [path for path in TESTLIB_FILES if not path.endswith(".h")],
+    hdrs = [path for path in TESTLIB_FILES if path.endswith(".h")],
+    compatible_with = DEFAULT_COMPATIBILITY,
+    defines = [
+        'JPEGXL_ROOT_PACKAGE=\'"' + libjxl_root_package + '"\'',
+    ],
+    deps = [
+        ":jpegxl_extras",
+        ":jpegxl_private",
+    ] + libjxl_deps_runfiles,
+)
+
+TESTS = [path.partition(".")[0] for path in libjxl_tests]
+
+[
+    cc_test(
+        name = test,
+        timeout = libjxl_test_timeouts.get(test, "moderate"),
+        srcs = [
+            test + ".cc",
+            "jxl/testing.h",
+        ],
+        data = ["//:testdata"],
+        shard_count = libjxl_test_shards.get(test, 1),
+        deps = [
+            ":jpegxl_extras",
+            ":jpegxl_private",
+            ":jpegxl_threads",
+            ":test_utils",
+        ] + libjxl_deps_gtest + libjxl_deps_hwy_test_util + libjxl_deps_hwy_nanobenchmark,
+    )
+    for test in TESTS
+]

--- a/modules/libjxl/0.12.0.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/libjxl/0.12.0.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,38 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +0,0 @@
+-# Copyright (c) the JPEG XL Project Authors. All rights reserved.
+-#
+-# Use of this source code is governed by a BSD-style
+-# license that can be found in the LICENSE file.
+-
+-"""JPEG XL reference implementation"""
+-
+@@ -10 +3,2 @@
+-    repo_name = "libjxl",
++    version = "0.12.0.bcr.1",
++    bazel_compatibility = [">=7.2.1"],
+@@ -14 +8 @@
+-bazel_dep(name = "brotli", version = "1.1.0")
++bazel_dep(name = "brotli", version = "1.2.0.bcr.3")
+@@ -16,3 +10,4 @@
+-bazel_dep(name = "googletest", version = "1.14.0")
+-bazel_dep(name = "libjpeg_turbo", version = "2.1.91")
+-bazel_dep(name = "libpng", version = "1.6.50.bcr.1")
++bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
++bazel_dep(name = "highway", version = "1.4.0.bcr.1")
++bazel_dep(name = "libjpeg_turbo", version = "3.1.3.bcr.6")
++bazel_dep(name = "libpng", version = "1.6.58")
+@@ -20,9 +15,3 @@
+-bazel_dep(name = "openexr", version = "3.2.1")
+-bazel_dep(name = "skcms", version = "20250916.0")
+-
+-# Requires patching `MODULE.bazel` and `BUILD` files
+-bazel_dep(name = "highway", version = "1.2.0")
+-local_path_override(
+-    module_name = "highway",
+-    path = "third_party/highway",
+-)
++bazel_dep(name = "openexr", version = "3.4.15")
++bazel_dep(name = "rules_cc", version = "0.2.18")
++bazel_dep(name = "skcms", version = "20250916.0.bcr.2")

--- a/modules/libjxl/0.12.0.bcr.1/presubmit.yml
+++ b/modules/libjxl/0.12.0.bcr.1/presubmit.yml
@@ -1,0 +1,22 @@
+matrix:
+  platform:
+    - ubuntu2404
+    - ubuntu2404_arm64
+    - macos_arm64
+  bazel:
+    - 8.5.0
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Build upstream JPEG XL targets and run original codec tests
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@libjxl//:libjxl'
+      - '@libjxl//:jxl'
+      - '@libjxl//:jxl_threads'
+    test_targets:
+      - '@libjxl//lib:jxl/bits_test'
+      - '@libjxl//lib:jxl/alpha_test'
+      - '@libjxl//lib:jxl/enc_external_image_test'

--- a/modules/libjxl/0.12.0.bcr.1/source.json
+++ b/modules/libjxl/0.12.0.bcr.1/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://github.com/libjxl/libjxl/archive/refs/tags/v0.12.0.tar.gz",
+    "integrity": "sha256-A+m+aaML5AEfVZ2nUyi2186orZIfq/vVUc4Qv0XNyZI=",
+    "strip_prefix": "libjxl-0.12.0",
+    "patch_strip": 1,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-Ga0FJdKa9dmr4rtVi+C/1ovrWw2vntL76GVlAvMxUi0="
+    },
+    "overlay": {
+        "BUILD.bazel": "sha256-ait1JAd3t4xj69YJWOHkUaQO+WsB8iwe8ZQUO1AhHGA=",
+        "lib/BUILD": "sha256-QMOouS/VIXb2cz1+xaKoeBgkF23GXvlfpSO/j/c1aAg="
+    }
+}

--- a/modules/libjxl/metadata.json
+++ b/modules/libjxl/metadata.json
@@ -12,7 +12,8 @@
         "github:libjxl/libjxl"
     ],
     "versions": [
-        "0.12.0"
+        "0.12.0",
+        "0.12.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds `libjxl@0.12.0.bcr.1` as a separate prerequisite for #10256. It lowers the GoogleTest minimum to `1.17.0.bcr.2`, avoiding the conflicting Abseil compatibility levels introduced by GoogleTest 1.18 on Bazel 8.5. GoogleTest remains available to consumers of JPEG XL's existing tests. It also uses the Brotli and skcms GCC 8 fixes merged in #10270.

The JPEG XL archive, build overlays, build targets, and three upstream tests are unchanged. Presubmit adds Bazel 8.5.0 alongside 8.x/9.x on Ubuntu x86_64, Ubuntu ARM64, and macOS ARM64.