### PR TITLE
gazelle_css@0.1.0

### DIFF
--- a/modules/gazelle_css/0.1.0/MODULE.bazel
+++ b/modules/gazelle_css/0.1.0/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "gazelle_css",
+    version = "0.1.0",
+    bazel_compatibility = [">=8.0.0"],
+)
+
+bazel_dep(name = "gazelle", version = "0.50.0")
+bazel_dep(name = "rules_go", version = "0.60.0")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.24.12")

--- a/modules/gazelle_css/0.1.0/attestations.json
+++ b/modules/gazelle_css/0.1.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/perplexityai/gazelle_css/releases/download/v0.1.0/source.json.intoto.jsonl",
+            "integrity": "sha256-2AUTMR04reNwuUUES0bqgTDGad16tTJQsuEMy/FKSH4="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/perplexityai/gazelle_css/releases/download/v0.1.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-n7cAPDRVOfAQ5eyGjFUoMKmzHTBq/h/Ku3CRSn9Z1/Q="
+        },
+        "gazelle_css-v0.1.0.tar.gz": {
+            "url": "https://github.com/perplexityai/gazelle_css/releases/download/v0.1.0/gazelle_css-v0.1.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-3Us0oM8ed0TWjJsV0kb8Sqo4G6oG9DxusXoJ+KT7zxA="
+        }
+    }
+}

--- a/modules/gazelle_css/0.1.0/patches/module_dot_bazel_version.patch
+++ b/modules/gazelle_css/0.1.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "gazelle_css",
+-    version = "0.0.0",
++    version = "0.1.0",
+     bazel_compatibility = [">=8.0.0"],
+ )
+ 
+ bazel_dep(name = "gazelle", version = "0.50.0")

--- a/modules/gazelle_css/0.1.0/presubmit.yml
+++ b/modules/gazelle_css/0.1.0/presubmit.yml
@@ -1,0 +1,13 @@
+bcr_test_module:
+  module_path: "bcr_test"
+  matrix:
+    bazel:
+      - 9.x
+      - 8.x
+  tasks:
+    verify:
+      name: Build and test gazelle_css
+      platform: ubuntu2204
+      bazel: ${{ bazel }}
+      build_targets:
+        - "@gazelle_css//css/..."

--- a/modules/gazelle_css/0.1.0/source.json
+++ b/modules/gazelle_css/0.1.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-y0PAhIZc59ZAQrNR6qYAdbEZ/HGZGRA3hQ/XVU94wgg=",
+    "strip_prefix": "gazelle_css-0.1.0",
+    "url": "https://github.com/perplexityai/gazelle_css/releases/download/v0.1.0/gazelle_css-v0.1.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-V0qGNQZ5WG4yexcdU/waTcgkkGtycNf60nQyQPUfo28="
+    },
+    "patch_strip": 1
+}

--- a/modules/gazelle_css/metadata.json
+++ b/modules/gazelle_css/metadata.json
@@ -1,0 +1,28 @@
+{
+    "homepage": "https://github.com/perplexityai/gazelle_css",
+    "maintainers": [
+        {
+            "name": "Long Ho",
+            "email": "holevietlong@gmail.com",
+            "github": "longlho",
+            "github_user_id": 198255
+        },
+        {
+            "email": "ossmaintainers@perplexity.ai",
+            "github": "pplx-oss",
+            "github_user_id": 287052873
+        },
+        {
+            "name": "Dan Morgan",
+            "github": "dan-pplx",
+            "github_user_id": 224607396
+        }
+    ],
+    "repository": [
+        "github:perplexityai/gazelle_css"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/perplexityai/gazelle_css/releases/tag/v0.1.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_