### PR TITLE
mboworks_bzl@0.5.1

### DIFF
--- a/modules/mboworks_bzl/0.5.1/MODULE.bazel
+++ b/modules/mboworks_bzl/0.5.1/MODULE.bazel
@@ -1,0 +1,22 @@
+# Copyright 2025 M. Boerger and the MBO Works authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module mboworks_bzl."""
+
+module(
+    name = "mboworks_bzl",
+    version = "0.5.1",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/modules/mboworks_bzl/0.5.1/presubmit.yml
+++ b/modules/mboworks_bzl/0.5.1/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+  platform:
+    - ubuntu2404
+    - macos_arm64
+    - windows
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@mboworks_bzl//bzl/..."

--- a/modules/mboworks_bzl/0.5.1/source.json
+++ b/modules/mboworks_bzl/0.5.1/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-DFHtvTo7aev/WbX/7EEaOrjLE3qEW5u6mANzjNe9XCg=",
+    "strip_prefix": "bzl-0.5.1",
+    "url": "https://github.com/mboworks/bzl/releases/download/0.5.1/bzl-0.5.1.tar.gz"
+}

--- a/modules/mboworks_bzl/metadata.json
+++ b/modules/mboworks_bzl/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/mboworks/bzl",
+    "maintainers": [
+        {
+            "name": "M. Boerger",
+            "email": "marcus.boerger@gmail.com",
+            "github": "helly25",
+            "github_user_id": 6420169
+        }
+    ],
+    "repository": [
+        "github:mboworks/bzl"
+    ],
+    "versions": [
+        "0.5.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/mboworks/bzl/releases/tag/0.5.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_