### PR TITLE
trec_eval@10.0

### DIFF
--- a/modules/trec_eval/10.0/MODULE.bazel
+++ b/modules/trec_eval/10.0/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "trec_eval",
+    version = "10.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "platforms", version = "1.1.0")

--- a/modules/trec_eval/10.0/overlay/BUILD.bazel
+++ b/modules/trec_eval/10.0/overlay/BUILD.bazel
@@ -1,0 +1,50 @@
+"""trec_eval: evaluation of TREC-style retrieval runs."""
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # See LICENSE.md (research, non-commercial use grant)
+
+exports_files(["LICENSE.md"])
+
+# Sources that make up the trec_eval core. `m_ndcg_p.c` is present in the
+# source tree but intentionally excluded: it is not part of upstream's
+# Makefile build and defines an unregistered duplicate measure.
+_COPTS = select({
+    "@platforms//os:windows": [],
+    "//conditions:default": [
+        "-Wno-macro-redefined",
+        "-Wno-deprecated-non-prototype",
+        "-Wno-unused-but-set-variable",
+    ],
+})
+
+_DEFINES = ['VERSIONID=\\"10.0\\"']
+
+# Library form, in case downstream modules want to link against the
+# measure/IO machinery directly.
+cc_library(
+    name = "trec_eval_lib",
+    srcs = glob(
+        include = ["*.c"],
+        exclude = [
+            "trec_eval.c",
+            "m_ndcg_p.c",
+        ],
+    ),
+    hdrs = glob(["*.h"]),
+    copts = _COPTS,
+    linkopts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-lm"],
+    }),
+)
+
+cc_binary(
+    name = "trec_eval",
+    srcs = ["trec_eval.c"],
+    copts = _COPTS,
+    local_defines = _DEFINES,
+    deps = [":trec_eval_lib"],
+)

--- a/modules/trec_eval/10.0/overlay/MODULE.bazel
+++ b/modules/trec_eval/10.0/overlay/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "trec_eval",
+    version = "10.0",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "platforms", version = "1.1.0")

--- a/modules/trec_eval/10.0/overlay/test/BUILD.bazel
+++ b/modules/trec_eval/10.0/overlay/test/BUILD.bazel
@@ -1,0 +1,147 @@
+"""Bazel ports of the upstream Makefile `quicktest` target.
+
+Each case runs the trec_eval binary on fixed inputs (the data files that
+ship in this `test/` directory) and diffs the output against the checked-in
+expected file, exactly mirroring `make quicktest`. Every case is its own
+test target so failures point at the specific invocation.
+"""
+
+load(":quicktest.bzl", "quicktest")
+
+quicktest(
+    name = "default",
+    expected = "out.test",
+    inputs = ["qrels.test", "results.test"],
+)
+
+quicktest(
+    name = "with_comments",
+    expected = "out.test",
+    inputs = ["qrels.test.with-comments", "results.test"],
+)
+
+quicktest(
+    name = "comment",
+    expected = "out.comment.test",
+    inputs = ["qrels.comment.test", "results.comment.test"],
+)
+
+quicktest(
+    name = "all_trec",
+    expected = "out.test.a",
+    flags = ["-m", "all_trec"],
+    inputs = ["qrels.test", "results.test"],
+)
+
+quicktest(
+    name = "all_trec_q",
+    expected = "out.test.aq",
+    flags = ["-m", "all_trec", "-q"],
+    inputs = ["qrels.test", "results.test"],
+)
+
+quicktest(
+    name = "all_trec_q_c",
+    expected = "out.test.aqc",
+    flags = ["-m", "all_trec", "-q", "-c"],
+    inputs = ["qrels.test", "results.trunc"],
+)
+
+quicktest(
+    name = "all_trec_q_c_M100",
+    expected = "out.test.aqcM",
+    flags = ["-m", "all_trec", "-q", "-c", "-M100"],
+    inputs = ["qrels.test", "results.trunc"],
+)
+
+quicktest(
+    name = "relstring_level",
+    expected = "out.test.aql",
+    flags = ["-m", "all_trec", "-mrelstring.20", "-q", "-l2"],
+    inputs = ["qrels.rel_level", "results.test"],
+)
+
+quicktest(
+    name = "prefs",
+    expected = "out.test.prefs",
+    flags = ["-m", "all_prefs", "-q", "-R", "prefs"],
+    inputs = ["prefs.test", "prefs.results.test"],
+)
+
+quicktest(
+    name = "prefs_comment",
+    expected = "out.test.prefs",
+    flags = ["-m", "all_prefs", "-q", "-R", "prefs"],
+    inputs = ["prefs.comment.test", "prefs.results.test"],
+)
+
+quicktest(
+    name = "qrels_prefs",
+    expected = "out.test.qrels_prefs",
+    flags = ["-m", "all_prefs", "-q", "-R", "qrels_prefs"],
+    inputs = ["qrels.test", "results.test"],
+)
+
+quicktest(
+    name = "qrels_jg",
+    expected = "out.test.qrels_jg",
+    flags = ["-m", "qrels_jg", "-q", "-R", "qrels_jg"],
+    inputs = ["qrels.123", "results.test"],
+)
+
+quicktest(
+    name = "qrels_jg_comments",
+    expected = "out.test.qrels_jg",
+    flags = ["-m", "qrels_jg", "-q", "-R", "qrels_jg"],
+    inputs = ["qrels.comments.123", "results.test"],
+)
+
+quicktest(
+    name = "meas_params",
+    expected = "out.test.meas_params",
+    flags = [
+        "-q",
+        "-miprec_at_recall..10,.20,.25,.75,.50",
+        "-m",
+        "P.5,7,3",
+        "-m",
+        "recall.20,2000",
+        "-m",
+        "Rprec_mult.5.0,0.2,0.35",
+        "-mutility.2,-1,0,0",
+        "-m",
+        "11pt_avg..25,.5,.75",
+        "-mndcg.1=3,2=9,4=4.5",
+        "-mndcg_cut.10,20,23.4",
+        "-msuccess.2,5,20",
+    ],
+    inputs = ["qrels.test", "results.test"],
+)
+
+quicktest(
+    name = "zscores",
+    expected = "out.test.aqZ",
+    flags = ["-q", "-m", "all_trec", "-Z"],
+    inputs = ["zscores_file", "qrels.test", "results.test"],
+)
+
+test_suite(
+    name = "quicktest",
+    tests = [
+        ":default",
+        ":with_comments",
+        ":comment",
+        ":all_trec",
+        ":all_trec_q",
+        ":all_trec_q_c",
+        ":all_trec_q_c_M100",
+        ":relstring_level",
+        ":prefs",
+        ":prefs_comment",
+        ":qrels_prefs",
+        ":qrels_jg",
+        ":qrels_jg_comments",
+        ":meas_params",
+        ":zscores",
+    ],
+)

--- a/modules/trec_eval/10.0/overlay/test/MODULE.bazel
+++ b/modules/trec_eval/10.0/overlay/test/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "trec_eval_tests",
+    version = "0",
+)
+
+bazel_dep(name = "trec_eval", version = "10.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/modules/trec_eval/10.0/overlay/test/quicktest.bzl
+++ b/modules/trec_eval/10.0/overlay/test/quicktest.bzl
@@ -1,0 +1,33 @@
+"""Helper for porting the upstream Makefile `quicktest` cases to Bazel."""
+
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+
+def quicktest(name, expected, flags = [], inputs = []):
+    """One quicktest case: generate trec_eval output, then diff it.
+
+    Runs `trec_eval <flags> <inputs>` and compares stdout against `expected`,
+    mirroring a single `... | diff - <expected>` line of `make quicktest`.
+
+    Args:
+        name: test target name.
+        expected: checked-in golden file to compare against.
+        flags: trec_eval command-line flags, one token per list element.
+        inputs: input data files, appended after the flags in order.
+    """
+    refs = ["$(execpath {})".format(f) for f in inputs]
+    native.genrule(
+        name = name + "_gen",
+        srcs = inputs,
+        outs = [name + ".actual"],
+        tools = ["@trec_eval//:trec_eval"],
+        cmd = "$(execpath @trec_eval//:trec_eval) {} {} > $@".format(
+            " ".join(flags),
+            " ".join(refs),
+        ),
+        testonly = True,
+    )
+    diff_test(
+        name = name,
+        file1 = expected,
+        file2 = name + ".actual",
+    )

--- a/modules/trec_eval/10.0/patches/m_rbp_init_minmax.patch
+++ b/modules/trec_eval/10.0/patches/m_rbp_init_minmax.patch
@@ -1,0 +1,20 @@
+Initialize rbp's min/max before the gain-normalization loop.
+
+Upstream leaves `min` and `max` uninitialized, so the normalization
+comparison reads stack garbage. Unoptimized builds happen to compute the
+correct result (and produced the golden test files), but optimized builds
+read different garbage and emit wrong rbp values. Seed both from the first
+gain so the result is correct regardless of compiler optimization level.
+
+--- a/m_rbp.c
++++ b/m_rbp.c
+@@ -68,6 +68,9 @@
+     /* normalize gains to [0,1], per email conversation with Alistair Moffat */
+     /* Note we don't care whether there is a relevance value with gain 1, only
+        that the gains all lie between 0 and 1 inclusive. */
++    min = max = 0.0;
++    if (gains.num_gains > 0)
++        min = max = gains.rel_gains[0].gain;
+     for (i = 0; i < gains.num_gains; i++) {
+         if (gains.rel_gains[i].gain < min)
+             min = gains.rel_gains[i].gain;

--- a/modules/trec_eval/10.0/presubmit.yml
+++ b/modules/trec_eval/10.0/presubmit.yml
@@ -1,0 +1,37 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+  - 8.x
+  - rolling
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@trec_eval//:trec_eval'
+    - '@trec_eval//:trec_eval_lib'
+bcr_test_module:
+  module_path: test
+  matrix:
+    platform:
+    - debian11
+    - ubuntu2204
+    - macos
+    - macos_arm64
+    bazel:
+    - 7.x
+    - 8.x
+    - rolling
+  tasks:
+    run_quicktest:
+      name: Run quicktest
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+      - '//:quicktest'

--- a/modules/trec_eval/10.0/source.json
+++ b/modules/trec_eval/10.0/source.json
@@ -1,0 +1,16 @@
+{
+    "url": "https://github.com/usnistgov/trec_eval/archive/refs/tags/v10.0.tar.gz",
+    "integrity": "sha256-PtwgTAubjY/d0Cx5doghPcdxgO5pbRSkpmz7MugsEFE=",
+    "strip_prefix": "trec_eval-10.0",
+    "patches": {
+        "m_rbp_init_minmax.patch": "sha256-iOed1+GyBXEvS1+O2TTI2v3S+BaLNMK9oKrAEYsaIlo="
+    },
+    "patch_strip": 1,
+    "overlay": {
+        "BUILD.bazel": "sha256-9IEgGWtz2m0MaauHATU27XPFYBnsKmYJo2ohh+J+zhU=",
+        "MODULE.bazel": "sha256-Z0oXXsLO1L0JiOkYgYLD0htwqQUMtmeYezwov9n5q9U=",
+        "test/BUILD.bazel": "sha256-w7K3jgGwZ3ob894PRLYnkFN41DOBrqgMqg+B548bISI=",
+        "test/MODULE.bazel": "sha256-6GF5/t/KSZNTs5mzXSjfsHDYd3Ccwp4dAGV5xk4IIxY=",
+        "test/quicktest.bzl": "sha256-DQgASLnDatF4K8TeM0Od3pk2bBUFINH2uQT+Xagzd14="
+    }
+}

--- a/modules/trec_eval/metadata.json
+++ b/modules/trec_eval/metadata.json
@@ -12,7 +12,8 @@
         "github:usnistgov/trec_eval"
     ],
     "versions": [
-        "10.0-rc3"
+        "10.0-rc3",
+        "10.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Add `trec_eval@10.0` (upstream tag `v10.0`).

Copied from `10.0-rc3` with version strings bumped in `MODULE.bazel`, the overlay module files, and `VERSIONID` in `overlay/BUILD.bazel`.

Notes:
- All `.c`/`.h` sources are byte-identical between `10.0-rc3` and `v10.0`; only `Makefile`, `CHANGELOG`, and the GitHub workflow changed. The overlay therefore needed no changes.
- The `m_rbp` uninitialized min/max bug is still present upstream in 10.0, so `patches/m_rbp_init_minmax.patch` is carried over unchanged and still applies cleanly.
- Verified locally against the real 10.0 sources: 15/15 quicktests pass.
- The v10.0 release has no attached assets, so the source URL is the Git tag archive.

@bazel-io skip_check unstable_url