### PR TITLE
Update legacy MBO Works module metadata

### DIFF
--- a/modules/helly25_bashtest/metadata.json
+++ b/modules/helly25_bashtest/metadata.json
@@ -1,15 +1,16 @@
 {
-    "homepage": "https://github.com/helly25/bashtest",
+    "homepage": "https://github.com/mboworks/bashtest",
     "maintainers": [
         {
-            "name": "helly25",
+            "name": "M. Boerger",
             "email": "marcus.boerger@gmail.com",
             "github": "helly25",
             "github_user_id": 6420169
         }
     ],
     "repository": [
-        "github:helly25/bashtest"
+        "github:helly25/bashtest",
+        "github:mboworks/bashtest"
     ],
     "versions": [
         "0.1.0",

--- a/modules/helly25_bzl/metadata.json
+++ b/modules/helly25_bzl/metadata.json
@@ -1,15 +1,16 @@
 {
-    "homepage": "https://github.com/helly25/bzl",
+    "homepage": "https://github.com/mboworks/bzl",
     "maintainers": [
         {
-            "name": "helly25",
+            "name": "M. Boerger",
             "email": "marcus.boerger@gmail.com",
             "github": "helly25",
             "github_user_id": 6420169
         }
     ],
     "repository": [
-        "github:helly25/bzl"
+        "github:helly25/bzl",
+        "github:mboworks/bzl"
     ],
     "versions": [
         "0.1.1",

--- a/modules/helly25_mbo/metadata.json
+++ b/modules/helly25_mbo/metadata.json
@@ -1,15 +1,16 @@
 {
-    "homepage": "https://github.com/helly25/mbo",
+    "homepage": "https://github.com/mboworks/mbo",
     "maintainers": [
         {
-            "name": "helly25",
+            "name": "M. Boerger",
             "email": "marcus.boerger@gmail.com",
             "github": "helly25",
             "github_user_id": 6420169
         }
     ],
     "repository": [
-        "github:helly25/mbo"
+        "github:helly25/mbo",
+        "github:mboworks/mbo"
     ],
     "versions": [
         "0.4.0-rc.1",

--- a/modules/helly25_proto/metadata.json
+++ b/modules/helly25_proto/metadata.json
@@ -1,15 +1,16 @@
 {
-    "homepage": "https://github.com/helly25/proto",
+    "homepage": "https://github.com/mboworks/proto",
     "maintainers": [
         {
-            "name": "helly25",
+            "name": "M. Boerger",
             "email": "marcus.boerger@gmail.com",
             "github": "helly25",
             "github_user_id": 6420169
         }
     ],
     "repository": [
-        "github:helly25/proto"
+        "github:helly25/proto",
+        "github:mboworks/proto"
     ],
     "versions": [
         "0.6.1",


### PR DESCRIPTION
## Summary

Update the Bazel Central Registry metadata for every historical `helly25_*`
module whose canonical source repository has moved to the MBO Works
organization:

- `helly25_bzl` → `mboworks/bzl`
- `helly25_bashtest` → `mboworks/bashtest`
- `helly25_mbo` → `mboworks/mbo`
- `helly25_proto` → `mboworks/proto`

For each historical module, this PR:

- points the homepage at the canonical `mboworks` repository;
- retains the old `github:helly25/...` repository entry so historical source
  archives remain allowed;
- adds the corresponding `github:mboworks/...` repository entry; and
- updates the informational maintainer display name to `M. Boerger` while
  retaining the existing GitHub identity and numeric user ID.

## Repository-transfer scope

All seven repositories in this transfer project now live under `mboworks`:

- `helly25/bzl` → `mboworks/bzl`
- `helly25/bashtest` → `mboworks/bashtest`
- `helly25/mbo` → `mboworks/mbo`
- `helly25/proto` → `mboworks/proto`
- `helly25/carve` → `mboworks/carve`
- `helly25/xff` → `mboworks/xff`
- `helly25/coderef` → `mboworks/coderef`

Only the first four have historical BCR module records and therefore require
changes in this PR. Carve and Xff have no historical BCR modules, and Coderef
is not a Bazel module.

## BCR scope

This is a metadata-only update to the four historical modules. It does not
rename modules or change version lists, version directories, archive URLs,
checksums, or yanked-version state. Historical versions remain under their
existing `helly25_*` module names and are not copied to the new names.

Successor releases use distinct `mboworks_*` module names and are handled by
separate release submissions:

- `mboworks_bzl@0.5.1`, `mboworks_bashtest@0.6.1`, and
  `mboworks_mbo@0.14.0` are public in the BCR.
- `mboworks_proto@1.2.2` is published as a GitHub prerelease. Its first BCR
  submission is [#10322](https://github.com/bazelbuild/bazel-central-registry/pull/10322),
  which is open and awaiting BCR maintainer review.
- Carve has not yet made its first release.
- Xff has GitHub binary releases (currently through `v0.2.0`) but is not
  published as a BCR module.
- Coderef is not a Bazel module and has no BCR publication work.

No successor release is added or modified by this PR.
