### PR TITLE
mboworks_proto@1.2.2

### DIFF
--- a/modules/mboworks_proto/1.2.2/MODULE.bazel
+++ b/modules/mboworks_proto/1.2.2/MODULE.bazel
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) M. Boerger, the MBO Works authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module mboworks/proto."""
+
+module(
+    name = "mboworks_proto",
+    version = "1.2.2",
+)
+
+# For local development we include LLVM, Hedron-Compile-Commands, etc.
+# For bazelmod usage these have to be provided by the main module - if necessary.
+# include("//bazelmod:dev.MODULE.bazel")
+
+# include("//bazelmod:llvm.MODULE.bazel")
+
+# `repo_name`s preserve the WORKSPACE-era aliases that this repo's BUILD files
+# still reference (`@com_google_absl`, `@com_googlesource_code_re2`,
+# `@com_google_googletest`, `@com_google_protobuf`).
+bazel_dep(name = "bazel_skylib", version = "1.9.2")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+
+# RE2's release metadata still selects compatibility-level-1 Abseil. Patch the
+# dependency to this module's compatibility-level-0 Abseil until RE2 publishes
+# compatible BCR metadata. The release archive is used because the BCR MODULE
+# differs from the upstream archive and cannot be patched through a plain
+# single_version_override.
+archive_override(
+    module_name = "re2",
+    integrity = "sha256-x7Gnp8aNLXz400PcVmVcG1qMiq3twBfbRT1MHYkTuEQ=",
+    patch_strip = 1,
+    patches = ["//bazelmod:re2-2025-11-05-abseil.patch"],
+    strip_prefix = "re2-2025-11-05",
+    urls = ["https://github.com/google/re2/releases/download/2025-11-05/re2-2025-11-05.zip"],
+)
+
+single_version_override(
+    module_name = "protobuf",
+    patch_strip = 1,
+    patches = ["//bazelmod:protobuf-35.0-abseil.patch"],
+    version = "35.0",
+)
+
+bazel_dep(name = "abseil-cpp", version = "20260817.0", repo_name = "com_google_absl")
+bazel_dep(name = "re2", version = "2025-11-05.bcr.1", repo_name = "com_googlesource_code_re2")
+bazel_dep(name = "googletest", version = "1.18.0.bcr.1", repo_name = "com_google_googletest")
+
+# Default to protobuf 35.0, the version selected by the combined GoogleTest and
+# Abseil graph. The `proto_version` CI matrix continues to exercise its declared
+# roots under Bazel's normal minimum-version selection.
+bazel_dep(name = "protobuf", version = "35.0", repo_name = "com_google_protobuf")
+
+# Transitive-compat shim (not used by any first-party code): protobuf pulls
+# rules_android -> rules_go 0.51.0-rc2, which `register_toolchains`es
+# `@go_toolchains//:all` globally. That old rules_go imports the legacy `CcInfo`
+# symbol that rules_cc 0.2.x removed, so on Bazel 9 it fails to load and breaks
+# C++ toolchain resolution for every target. Force a current rules_go via MVS;
+# its own deps all sit below our pins, so it adds nothing else. Drop once
+# protobuf's transitive rules_go is new enough on its own.
+bazel_dep(name = "rules_go", version = "0.63.0")
+
+# Same class of fix for the other Bazel-9-incompatible toolchain protobuf pulls:
+# rules_android. Its `@androidsdk//:all` toolchain registration makes Bazel load
+# rules_android's `attrs.bzl` during C++ toolchain resolution on any host with an
+# Android SDK (CI runners, the BCR presubmit). The pinned rules_android (0.6.4)
+# imports the legacy `CcInfo` removed in rules_cc 0.2.x, so it fails to compile on
+# Bazel 9. Force a current rules_android via MVS. (`.bazelrc` blanks ANDROID_HOME
+# for our own builds; this shim is what fixes downstream consumers, which never
+# see our `.bazelrc` -- e.g. the BCR presubmit.)
+bazel_dep(name = "rules_android", version = "0.7.3")

--- a/modules/mboworks_proto/1.2.2/presubmit.yml
+++ b/modules/mboworks_proto/1.2.2/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  # Bazel 7.x is intentionally absent: the pinned protobuf (34.1) no longer
+  # analyzes on Bazel 7.x, so the module's floor is Bazel 8.
+  bazel:
+    - 8.x
+    - 9.x
+  platform:
+    - ubuntu2404
+    - macos_arm64
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--cxxopt=-std=c++20"
+    #bazel query 'kind(cc_binary,//...) - rdeps(//mbo/mope:mope,//...)'
+    build_targets:
+      - "@mboworks_proto//mbo/proto:matchers_test"
+      - "@mboworks_proto//mbo/proto:parse_text_proto_test"

--- a/modules/mboworks_proto/1.2.2/source.json
+++ b/modules/mboworks_proto/1.2.2/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-RSz5FcLulFCJGq23A9vlOSetw1R/HQRujtOWYbhbxu0=",
+    "strip_prefix": "proto-1.2.2",
+    "url": "https://github.com/mboworks/proto/releases/download/1.2.2/proto-1.2.2.tar.gz"
+}

--- a/modules/mboworks_proto/metadata.json
+++ b/modules/mboworks_proto/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/mboworks/proto",
+    "maintainers": [
+        {
+            "name": "helly25",
+            "email": "marcus.boerger@gmail.com",
+            "github": "helly25",
+            "github_user_id": 6420169
+        }
+    ],
+    "repository": [
+        "github:mboworks/proto"
+    ],
+    "versions": [
+        "1.2.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/mboworks/proto/releases/tag/1.2.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_