### PR TITLE
libde265@1.1.1

### DIFF
--- a/modules/libde265/1.1.1/MODULE.bazel
+++ b/modules/libde265/1.1.1/MODULE.bazel
@@ -1,0 +1,12 @@
+"""https://github.com/strukturag/libde265/"""
+
+module(
+    name = "libde265",
+    version = "1.1.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "rules_cc_autoconf", version = "0.8.0")

--- a/modules/libde265/1.1.1/overlay/BUILD.bazel
+++ b/modules/libde265/1.1.1/overlay/BUILD.bazel
@@ -1,0 +1,385 @@
+"""https://github.com/strukturag/libde265/"""
+
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc_autoconf//autoconf:autoconf.bzl", "autoconf")
+load("@rules_cc_autoconf//autoconf:autoconf_hdr.bzl", "autoconf_hdr")
+load("@rules_cc_autoconf//autoconf:checks.bzl", "checks")
+load("@rules_cc_autoconf//autoconf:package_info.bzl", "package_info")
+
+# ===== Flags =================================================================
+
+# DE265_LOG_LEVEL (CMakeLists.txt:114-130)
+string_flag(
+    name = "log_level",
+    build_setting_default = "error",
+    values = [
+        "error",
+        "info",
+        "debug",
+        "trace",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "log_level_error",
+    flag_values = {":log_level": "error"},
+)
+
+config_setting(
+    name = "log_level_info",
+    flag_values = {":log_level": "info"},
+)
+
+config_setting(
+    name = "log_level_debug",
+    flag_values = {":log_level": "debug"},
+)
+
+config_setting(
+    name = "log_level_trace",
+    flag_values = {":log_level": "trace"},
+)
+
+# ===== Generated headers =====================================================
+
+# de265-version.h (replaces cmake configure_file of libde265/de265-version.h.in)
+# Version 1.1.1 -> BCD: 0x01010100
+write_file(
+    name = "_de265_version_h",
+    out = "libde265/de265-version.h",
+    content = [
+        "#ifndef LIBDE265_VERSION_H",
+        "#define LIBDE265_VERSION_H",
+        "#define LIBDE265_NUMERIC_VERSION 0x01010100",
+        '#define LIBDE265_VERSION "1.1.1"',
+        "#endif",
+    ],
+)
+
+package_info(
+    name = "package",
+    module_bazel = "MODULE.bazel",
+    strip_bcr_version = True,
+    visibility = ["//:__subpackages__"],
+)
+
+# config.hin template (replaces cmake/config.h.in)
+write_file(
+    name = "_config_hin",
+    out = "config.hin",
+    content = [
+        "#undef HAVE_MALLOC_H",
+        "#undef HAVE_POSIX_MEMALIGN",
+        "#undef HAVE_SSE4_1",
+        "#undef HAVE_AVX2",
+        "#undef HAVE_AVX512",
+        "#undef HAVE_ARM32",
+        "#undef HAVE_ARM64",
+        "#undef HAVE_NEON",
+    ],
+)
+
+# ===== Autoconf configuration ================================================
+
+autoconf(
+    name = "autoconf",
+    checks = [
+                 # CHECK_INCLUDE_FILE(malloc.h) (CMakeLists.txt:73)
+                 checks.AC_CHECK_HEADER(
+                     "malloc.h",
+                     define = "HAVE_MALLOC_H",
+                 ),
+
+                 # CHECK_FUNCTION_EXISTS(posix_memalign) (CMakeLists.txt:74)
+                 checks.AC_TRY_LINK(
+                     code = """\
+#include <stdlib.h>
+int main(void) {
+    void *p;
+    posix_memalign(&p, 16, 64);
+    return 0;
+}
+""",
+                     define = "HAVE_POSIX_MEMALIGN",
+                 ),
+             ] +
+             # x86 acceleration (CMakeLists.txt)
+             select({
+                 "@platforms//cpu:x86_64": [
+                     checks.AC_DEFINE("HAVE_SSE4_1", 1),
+                     checks.AC_DEFINE("HAVE_AVX2", 1),
+                     checks.AC_DEFINE("HAVE_AVX512", 1),
+                 ],
+                 "//conditions:default": [],
+             }) +
+             # ARM (CMakeLists.txt)
+             select({
+                 "@platforms//cpu:arm": [checks.AC_DEFINE("HAVE_ARM32", 1)],
+                 "@platforms//cpu:arm64": [checks.AC_DEFINE("HAVE_ARM64", 1)],
+                 "//conditions:default": [],
+             }),
+)
+
+# config.h (CMakeLists.txt:115)
+autoconf_hdr(
+    name = "config_h",
+    out = "config.h",
+    template = ":_config_hin",
+    deps = [":autoconf"],
+)
+
+# ===== Internal headers (breaks circular dep with arch-specific targets) =====
+
+cc_library(
+    name = "_de265_hdrs",
+    hdrs = [
+        "libde265/acceleration.h",
+        "libde265/alloc_pool.h",
+        "libde265/bitstream.h",
+        "libde265/cabac.h",
+        "libde265/contextmodel.h",
+        "libde265/de265.h",
+        "libde265/deblock.h",
+        "libde265/decctx.h",
+        "libde265/dpb.h",
+        "libde265/fallback.h",
+        "libde265/fallback-dct.h",
+        "libde265/fallback-deblk.h",
+        "libde265/fallback-intrapred.h",
+        "libde265/fallback-motion.h",
+        "libde265/image.h",
+        "libde265/image-io.h",
+        "libde265/intrapred.h",
+        "libde265/md5.h",
+        "libde265/motion.h",
+        "libde265/nal.h",
+        "libde265/nal-parser.h",
+        "libde265/pps.h",
+        "libde265/quality.h",
+        "libde265/refpic.h",
+        "libde265/sao.h",
+        "libde265/scan.h",
+        "libde265/sei.h",
+        "libde265/slice.h",
+        "libde265/sps.h",
+        "libde265/threads.h",
+    ] + select({
+        "@platforms//os:windows": [
+            "extra/win32cond.c",
+            "extra/win32cond.h",
+        ],
+        "//conditions:default": [],
+    }) + [
+        "libde265/transform.h",
+        "libde265/util.h",
+        "libde265/visualize.h",
+        "libde265/vps.h",
+        "libde265/vui.h",
+        ":_de265_version_h",
+        ":config_h",
+    ],
+    includes = [
+        ".",
+        "libde265",
+    ],
+)
+
+# ===== Architecture-specific acceleration ====================================
+
+# Compile CPU dispatch without SIMD flags; it must run before the runtime checks.
+cc_library(
+    name = "x86",
+    srcs = ["libde265/x86/sse.cc"],
+    hdrs = ["libde265/x86/sse.h"],
+    local_defines = ["HAVE_CONFIG_H"],
+    target_compatible_with = ["@platforms//cpu:x86_64"],
+    deps = [
+        ":_de265_hdrs",
+        ":x86_avx2",
+        ":x86_avx512",
+        ":x86_sse",
+    ],
+)
+
+cc_library(
+    name = "x86_sse",
+    srcs = [
+        "libde265/x86/sse-dct.cc",
+        "libde265/x86/sse-deblk.cc",
+        "libde265/x86/sse-intrapred.cc",
+        "libde265/x86/sse-motion.cc",
+    ],
+    hdrs = [
+        "libde265/x86/sse-dct.h",
+        "libde265/x86/sse-deblk.h",
+        "libde265/x86/sse-intrapred.h",
+        "libde265/x86/sse-motion.h",
+    ],
+    copts = select({
+        "@rules_cc//cc/compiler:msvc-cl": ["/W0"],
+        "//conditions:default": [
+            "-msse4.1",
+            "-w",
+        ],
+    }),
+    local_defines = ["HAVE_CONFIG_H"],
+    target_compatible_with = ["@platforms//cpu:x86_64"],
+    deps = [":_de265_hdrs"],
+)
+
+cc_library(
+    name = "_x86_transform_tables",
+    hdrs = ["libde265/x86/transform-dct-tables.h"],
+)
+
+cc_library(
+    name = "x86_avx2",
+    srcs = ["libde265/x86/transform-avx2.cc"],
+    hdrs = ["libde265/x86/transform-avx2.h"],
+    copts = select({
+        "@rules_cc//cc/compiler:msvc-cl": ["/arch:AVX2"],
+        "//conditions:default": ["-mavx2"],
+    }),
+    local_defines = ["HAVE_CONFIG_H"],
+    target_compatible_with = ["@platforms//cpu:x86_64"],
+    deps = [
+        ":_de265_hdrs",
+        ":_x86_transform_tables",
+    ],
+)
+
+cc_library(
+    name = "x86_avx512",
+    srcs = ["libde265/x86/transform-avx512.cc"],
+    hdrs = ["libde265/x86/transform-avx512.h"],
+    copts = select({
+        "@rules_cc//cc/compiler:msvc-cl": ["/arch:AVX512"],
+        "//conditions:default": [
+            "-mavx512f",
+            "-mavx512bw",
+        ],
+    }),
+    local_defines = ["HAVE_CONFIG_H"],
+    target_compatible_with = ["@platforms//cpu:x86_64"],
+    deps = [
+        ":_de265_hdrs",
+        ":_x86_transform_tables",
+    ],
+)
+
+# The upstream ARM target is now specific to 32-bit ARM.
+cc_library(
+    name = "arm",
+    srcs = ["libde265/arm32/arm.cc"],
+    hdrs = ["libde265/arm32/arm.h"],
+    copts = select({
+        "@rules_cc//cc/compiler:msvc-cl": ["/W0"],
+        "//conditions:default": ["-w"],
+    }),
+    local_defines = ["HAVE_CONFIG_H"],
+    target_compatible_with = ["@platforms//cpu:arm"],
+    deps = [":_de265_hdrs"],
+)
+
+# ===== Library ===============================================================
+
+alias(
+    name = "libde265",
+    actual = ":de265",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "de265",
+    srcs = [
+        # libde265_sources (libde265/CMakeLists.txt:3-36)
+        "libde265/alloc_pool.cc",
+        "libde265/bitstream.cc",
+        "libde265/cabac.cc",
+        "libde265/contextmodel.cc",
+        "libde265/de265.cc",
+        "libde265/deblock.cc",
+        "libde265/decctx.cc",
+        "libde265/dpb.cc",
+        "libde265/fallback-dct.cc",
+        "libde265/fallback-deblk.cc",
+        "libde265/fallback-intrapred.cc",
+        "libde265/fallback-motion.cc",
+        "libde265/fallback.cc",
+        "libde265/image-io.cc",
+        "libde265/image.cc",
+        "libde265/intrapred.cc",
+        "libde265/md5.cc",
+        "libde265/motion.cc",
+        "libde265/nal-parser.cc",
+        "libde265/nal.cc",
+        "libde265/pps.cc",
+        "libde265/quality.cc",
+        "libde265/refpic.cc",
+        "libde265/sao.cc",
+        "libde265/scan.cc",
+        "libde265/sei.cc",
+        "libde265/slice.cc",
+        "libde265/sps.cc",
+        "libde265/threads.cc",
+        "libde265/transform.cc",
+        "libde265/util.cc",
+        "libde265/visualize.cc",
+        "libde265/vps.cc",
+        "libde265/vui.cc",
+    ],
+    copts = select({
+        "@rules_cc//cc/compiler:msvc-cl": [
+            "/std:c++17",
+            "/W0",
+        ],
+        "//conditions:default": [
+            "-std=c++17",
+            "-w",
+        ],
+    }),
+    defines = ["LIBDE265_STATIC_BUILD"],
+    linkopts = select({
+        "@platforms//os:linux": [
+            "-lm",
+            "-lpthread",
+        ],
+        "//conditions:default": [],
+    }),
+    local_defines = [
+        "HAVE_CONFIG_H",
+        "LIBDE265_EXPORTS",
+    ] +
+    # DE265_LOG_LEVEL (CMakeLists.txt:122-130)
+    select({
+        ":log_level_debug": [
+            "DE265_LOG_ERROR",
+            "DE265_LOG_INFO",
+            "DE265_LOG_DEBUG",
+        ],
+        ":log_level_error": ["DE265_LOG_ERROR"],
+        ":log_level_info": [
+            "DE265_LOG_ERROR",
+            "DE265_LOG_INFO",
+        ],
+        ":log_level_trace": [
+            "DE265_LOG_ERROR",
+            "DE265_LOG_INFO",
+            "DE265_LOG_DEBUG",
+            "DE265_LOG_TRACE",
+        ],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":_de265_hdrs"] +
+           select({
+               "@platforms//cpu:x86_64": [":x86"],
+               "//conditions:default": [],
+           }) +
+           select({
+               "@platforms//cpu:arm": [":arm"],
+               "//conditions:default": [],
+           }),
+)

--- a/modules/libde265/1.1.1/overlay/MODULE.bazel
+++ b/modules/libde265/1.1.1/overlay/MODULE.bazel
@@ -1,0 +1,12 @@
+"""https://github.com/strukturag/libde265/"""
+
+module(
+    name = "libde265",
+    version = "1.1.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.4")
+bazel_dep(name = "rules_cc_autoconf", version = "0.8.0")

--- a/modules/libde265/1.1.1/overlay/tests/BUILD.bazel
+++ b/modules/libde265/1.1.1/overlay/tests/BUILD.bazel
@@ -1,0 +1,40 @@
+"""Smoke tests for libde265."""
+
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_cc_autoconf//autoconf:autoconf_hdr.bzl", "autoconf_hdr")
+
+write_file(
+    name = "version_check_h_in",
+    out = "version_check.h.in",
+    content = [
+        "#ifndef VERSION_CHECK_H_",
+        "#define VERSION_CHECK_H_",
+        "#undef PACKAGE_VERSION",
+        "#endif",
+    ],
+)
+
+autoconf_hdr(
+    name = "version_check_h",
+    out = "version_check.h",
+    template = "version_check.h.in",
+    deps = ["//:package"],
+)
+
+cc_library(
+    name = "version_check",
+    testonly = True,
+    hdrs = [":version_check_h"],
+    includes = ["."],
+)
+
+cc_test(
+    name = "api_test",
+    srcs = ["api_test.cc"],
+    deps = [
+        ":version_check",
+        "//:de265",
+    ],
+)

--- a/modules/libde265/1.1.1/overlay/tests/api_test.cc
+++ b/modules/libde265/1.1.1/overlay/tests/api_test.cc
@@ -1,0 +1,75 @@
+#include <libde265/de265.h>
+#include <libde265/de265-version.h>
+#include "version_check.h"
+
+#undef NDEBUG
+#include <cassert>
+#include <cstring>
+
+// One 16x16 black HEVC frame, encoded by FFmpeg with libx265 and info=0.
+constexpr unsigned char kBlackFrame[] = {
+    0x00, 0x00, 0x00, 0x01, 0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60,
+    0x00, 0x00, 0x03, 0x00, 0x90, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00,
+    0x1e, 0x95, 0x98, 0x09, 0x00, 0x00, 0x00, 0x01, 0x42, 0x01, 0x01, 0x01,
+    0x60, 0x00, 0x00, 0x03, 0x00, 0x90, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03,
+    0x00, 0x1e, 0xa0, 0x88, 0x45, 0x96, 0x56, 0x6a, 0xbc, 0xaf, 0x01, 0x68,
+    0x08, 0x00, 0x00, 0x03, 0x00, 0x08, 0x00, 0x00, 0x03, 0x00, 0xc8, 0x40,
+    0x00, 0x00, 0x00, 0x01, 0x44, 0x01, 0xc1, 0x73, 0xd0, 0x89, 0x00, 0x00,
+    0x01, 0x28, 0x01, 0xaf, 0x1d, 0x80, 0xee, 0x23, 0x8f, 0xff, 0x5e, 0x8f,
+};
+
+int main() {
+    // LIBDE265_VERSION is derived from write_file in BUILD.bazel.
+    // PACKAGE_VERSION is derived from MODULE.bazel via package_info.
+    // If these differ, the BUILD.bazel version is out of sync.
+    assert(strcmp(LIBDE265_VERSION, PACKAGE_VERSION) == 0);
+    assert(strcmp(de265_get_version(), PACKAGE_VERSION) == 0);
+    assert(de265_get_version_number() == LIBDE265_NUMERIC_VERSION);
+
+    // Error text API
+    assert(de265_get_error_text(DE265_OK) != nullptr);
+    assert(de265_isOK(DE265_OK));
+    assert(!de265_isOK(DE265_ERROR_OUT_OF_MEMORY));
+
+    // Decoder lifecycle
+    de265_decoder_context* ctx = de265_new_decoder();
+    assert(ctx != nullptr);
+
+    // Pushing empty data should not crash
+    de265_error err = de265_flush_data(ctx);
+    assert(de265_isOK(err));
+
+    // No image available without input
+    const de265_image* img = de265_get_next_picture(ctx);
+    assert(img == nullptr);
+
+    de265_reset(ctx);
+    assert(de265_isOK(de265_push_data(ctx, kBlackFrame, sizeof(kBlackFrame), 0, nullptr)));
+    assert(de265_isOK(de265_flush_data(ctx)));
+    int more = 1;
+    while (more && (img = de265_peek_next_picture(ctx)) == nullptr) {
+        assert(de265_decode(ctx, &more) == DE265_OK);
+    }
+    img = de265_peek_next_picture(ctx);
+    assert(img != nullptr);
+    for (int channel = 0; channel < 3; ++channel) {
+        const int size = channel == 0 ? 16 : 8;
+        const int pixel = channel == 0 ? 16 : 128;
+        assert(de265_get_image_width(img, channel) == size);
+        assert(de265_get_image_height(img, channel) == size);
+        int stride;
+        const uint8_t* plane = de265_get_image_plane(img, channel, &stride);
+        assert(plane != nullptr);
+        for (int y = 0; y < size; ++y) {
+            for (int x = 0; x < size; ++x) {
+                assert(plane[y * stride + x] == pixel);
+            }
+        }
+    }
+    de265_release_next_picture(ctx);
+
+    err = de265_free_decoder(ctx);
+    assert(de265_isOK(err));
+
+    return 0;
+}

--- a/modules/libde265/1.1.1/presubmit.yml
+++ b/modules/libde265/1.1.1/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+    - debian10
+    - macos_arm64
+    - rockylinux8
+    - ubuntu2004
+    - ubuntu2004_arm64
+    - windows
+  bazel: ["7.x", "8.x", "9.x"]
+tasks:
+  verify_targets:
+    name: "Run test module"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - "@libde265//..."
+    test_targets:
+    - "@libde265//..."

--- a/modules/libde265/1.1.1/source.json
+++ b/modules/libde265/1.1.1/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/strukturag/libde265/releases/download/v1.1.1/libde265-1.1.1.tar.gz",
+    "integrity": "sha256-/UipJ+lO10/Hzogp0iK52Fmfy/6LZEi6ZnBbq8Vqshk=",
+    "strip_prefix": "libde265-1.1.1",
+    "overlay": {
+        "BUILD.bazel": "sha256-jirEaNlfxk+t8BHNdayHkof0ClW4b81TMQFVxZZM3Ng=",
+        "MODULE.bazel": "sha256-Vbpisud+F8y3I/gOKaTdq4ze3KZOHQwbEic58Clavbs=",
+        "tests/BUILD.bazel": "sha256-zB8Y3JjvhCCI7HtPzUGZfjD7Fjuhxas8arP43TQXUAQ=",
+        "tests/api_test.cc": "sha256-Zl5h5nsvyOi5Nsjyc6ySDNCeQ4Qsnia3MgRHIXCMPkk="
+    }
+}

--- a/modules/libde265/metadata.json
+++ b/modules/libde265/metadata.json
@@ -12,7 +12,8 @@
         "github:strukturag/libde265"
     ],
     "versions": [
-        "1.0.18"
+        "1.0.18",
+        "1.1.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Add the upstream libde265 1.1.1 release. Update the Bazel overlay for the
new decoder sources and x86 kernels, keeping CPU dispatch separate from
the ISA-specific compilation flags. Extend the API smoke test to verify
the runtime version and decode a small HEVC frame.
