### PR TITLE
Add protobuf@36.1.bcr.1

### DIFF
--- a/modules/protobuf/36.1.bcr.1/MODULE.bazel
+++ b/modules/protobuf/36.1.bcr.1/MODULE.bazel
@@ -3,7 +3,7 @@
 
 module(
     name = "protobuf",
-    version = "36.1.bcr.1",  # Automatically updated on release
+    version = "36.1.bcr.1",
     bazel_compatibility = [">=8.0.0"],
     compatibility_level = 1,
     repo_name = "com_google_protobuf",

--- a/modules/protobuf/36.1.bcr.1/MODULE.bazel
+++ b/modules/protobuf/36.1.bcr.1/MODULE.bazel
@@ -1,0 +1,362 @@
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/protocolbuffers/protobuf/issues/14313
+
+module(
+    name = "protobuf",
+    version = "36.1.bcr.1",  # Automatically updated on release
+    bazel_compatibility = [">=8.0.0"],
+    compatibility_level = 1,
+    repo_name = "com_google_protobuf",
+)
+
+# LOWER BOUND dependency versions.
+# Bzlmod follows MVS:
+# https://bazel.build/versions/6.0.0/build/bzlmod#version-resolution
+# Thus the highest version in their module graph is resolved.
+
+bazel_dep(name = "apple_support", version = "2.3.0", repo_name = "build_bazel_apple_support")
+
+# Unused but must be pinned to avoid old broken versions
+bazel_dep(name = "rules_proto", version = "7.1.0")
+
+#ifndef PROTO2_OPENSOURCE
+# LINT.IfChange
+#endif // PROTO2_OPENSOURCE
+# protoc dependencies
+bazel_dep(name = "abseil-cpp", version = "20250512.1")
+bazel_dep(name = "rules_cc", version = "0.2.18")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
+#ifndef PROTO2_OPENSOURCE
+# LINT.ThenChange(//depot/google3/third_party/protobuf/compiler/notices.h)
+#endif // PROTO2_OPENSOURCE
+
+# other dependencies
+bazel_dep(name = "bazel_features", version = "1.33.0", repo_name = "proto_bazel_features")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "jsoncpp", version = "1.9.6.bcr.2")
+bazel_dep(name = "rules_java", version = "8.6.1")
+bazel_dep(name = "rules_jvm_external", version = "6.7")
+bazel_dep(name = "rules_kotlin", version = "2.3.20")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_pkg", version = "1.0.1")
+bazel_dep(name = "rules_python", version = "1.6.0")
+bazel_dep(name = "rules_rust", version = "0.69.0")
+
+bazel_dep(name = "rules_ruby", version = "0.20.1", dev_dependency = True)
+
+# Workaround for https://github.com/bazelbuild/bazel-central-registry/issues/4230
+# rules_fuzzing 0.5.3 is not yet available in BCR.
+bazel_dep(name = "rules_fuzzing", version = "0.5.3", dev_dependency = True)
+archive_override(
+    module_name = "rules_fuzzing",
+    integrity = "sha256-CCdEIsQ4NBbfX5gpQ+QNWBQfdJwJAIu3gEQO7OaxE+Q=",
+    strip_prefix = "rules_fuzzing-0.5.3",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.5.3.tar.gz"],
+)
+
+# Workaround for https://github.com/bazel-contrib/rules_ruby/issues/216
+# Patch rules_ruby to disable automatic attempt to install bundler. When fixed,
+# delete Disable_bundle_install.patch and single_version_override() below.
+single_version_override(
+    module_name = "rules_ruby",
+    patch_strip = 1,
+    patches = [
+        "@com_google_protobuf//:Disable_bundle_install.patch",
+    ],
+)
+
+bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+
+# Ruby toolchains
+ruby = use_extension("@rules_ruby//ruby:extensions.bzl", "ruby", dev_dependency = True)
+ruby.toolchain(
+    name = "ruby",
+    version = "system",
+)
+use_repo(ruby, "ruby")
+ruby.bundle_fetch(
+    name = "protobuf_bundle",
+    gem_checksums = {
+        "bigdecimal-3.1.9": "2ffc742031521ad69c2dfc815a98e426a230a3d22aeac1995826a75dabfad8cc",
+        "bigdecimal-3.1.9-java": "dd9b8f7c870664cd9538a1325ce385ba57a6627969177258c4f0e661a7be4456",
+        "ffi-1.17.1": "26f6b0dbd1101e6ffc09d3ca640b2a21840cc52731ad8a7ded9fb89e5fb0fc39",
+        "ffi-1.17.1-java": "2546e11f9592e2b9b6de49eb96d2a378da47b0bb8469d5cbc9881a55c0d55da7",
+        "ffi-compiler-1.3.2": "a94f3d81d12caf5c5d4ecf13980a70d0aeaa72268f3b9cc13358bcc6509184a0",
+        "power_assert-2.0.5": "63b511b85bb8ea57336d25156864498644f5bbf028699ceda27949e0125bc323",
+        "rake-13.2.1": "46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d",
+        "rake-compiler-1.1.9": "51b5c95a1ff25cabaaf92e674a2bed847ab53d66302fc8843830df46ab1f51f5",
+        "rake-compiler-dock-1.2.1": "3cc968d7ffc923c0e775b28d79a3389efb3d2b16ef52ed0298fbc97d347e5878",
+        "test-unit-3.6.7": "c342bb9f7334ea84a361b43c20b063f405c0bf3c7dbe3ff38f61a91661d29221",
+    },
+    gemfile = "//ruby:Gemfile",
+    gemfile_lock = "//ruby:Gemfile.lock",
+)
+use_repo(ruby, "protobuf_bundle", "ruby_toolchains")
+
+register_toolchains(
+    "@ruby_toolchains//:all",
+    dev_dependency = True,
+)
+
+# Define toolchains that use pre-built protoc binaries.
+prebuilt_protoc = use_extension("//bazel/private/oss/toolchains/prebuilt:protoc_extension.bzl", "protoc")
+use_repo(
+    prebuilt_protoc,
+    "prebuilt_protoc.linux_aarch_64",
+    "prebuilt_protoc.linux_ppcle_64",
+    "prebuilt_protoc.linux_s390_64",
+    "prebuilt_protoc.linux_x86_32",
+    "prebuilt_protoc.linux_x86_64",
+    "prebuilt_protoc.osx_aarch_64",
+    "prebuilt_protoc.osx_x86_64",
+    "prebuilt_protoc.win32",
+    "prebuilt_protoc.win64",
+)
+
+# This registration applies when the config_setting for prefer_prebuilt_protoc is true.
+# This is now enabled by default.
+# It can be disabled using --@protobuf//bazel/flags:prefer_prebuilt_protoc=false
+register_toolchains("//bazel/private/oss/toolchains/prebuilt:all")
+
+# From-source protobuf toolchains
+# Fallback if nothing is already registered
+register_toolchains("//bazel/private/oss/toolchains:all")
+
+SUPPORTED_PYTHON_VERSIONS = [
+    "3.10",
+    "3.11",
+    "3.12",
+    "3.13",
+    "3.14",
+]
+
+# TODO: Replace system_python with hermetic_python.
+# TODO: Remove dev_dependency once system_python is no longer used and we support
+# python/upb in Bazel.
+system_python = use_extension("//python/dist:system_python.bzl", "system_python_extension")
+system_python.find(
+    name = "system_python",
+    minimum = "3.9",
+)
+use_repo(system_python, "system_python")
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)
+
+[
+    pip.parse(
+        hub_name = "protobuf_pip_deps",
+        python_interpreter_target = "@system_python//:interpreter",
+        python_version = python_version,
+        requirements_lock = "//python:requirements.txt",
+    )
+    for python_version in SUPPORTED_PYTHON_VERSIONS
+]
+
+use_repo(pip, "protobuf_pip_deps")
+
+local_runtime_repo = use_repo_rule(
+    "@rules_python//python/local_toolchains:repos.bzl",
+    "local_runtime_repo",
+)
+
+local_runtime_toolchains_repo = use_repo_rule(
+    "@rules_python//python/local_toolchains:repos.bzl",
+    "local_runtime_toolchains_repo",
+)
+
+local_runtime_repo(
+    name = "local_python3",
+    dev_dependency = True,
+    interpreter_path = "python3",
+    on_failure = "fail",
+)
+
+local_runtime_toolchains_repo(
+    name = "local_toolchains",
+    dev_dependency = True,
+    runtimes = ["local_python3"],
+)
+
+register_toolchains(
+    "@local_toolchains//:all",
+    dev_dependency = True,
+)
+
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust", dev_dependency = True)
+
+# As of October 2025, our minimum supported Rust version is 1.79. However, we
+# use 1.85.0 here so that we can get some test coverage with Rust edition 2024.
+# Cargo and our Bazel WORKSPACE build are both still on Rust edition 2021.
+rust.toolchain(
+    edition = "2024",
+    versions = ["1.85.0"],
+)
+
+crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")
+crate.spec(
+    package = "googletest",
+    version = ">0.0.0",
+)
+crate.spec(
+    package = "linkme",
+    version = "0.3.35",
+)
+crate.spec(
+    package = "paste",
+    version = ">=1",
+)
+crate.spec(
+    package = "quote",
+    version = ">=1",
+)
+crate.spec(
+    package = "syn",
+    version = "2",
+)
+crate.from_specs()
+use_repo(crate, crate_index = "crates")
+
+# Keep this list minimal; these dependencies will be part of the common `maven` install and could affect end-user projects.
+PROTOBUF_MAVEN_ARTIFACTS = [
+    "com.google.code.findbugs:jsr305:3.0.2",
+    "com.google.code.gson:gson:2.8.9",
+    "com.google.errorprone:error_prone_annotations:2.5.1",
+    "com.google.j2objc:j2objc-annotations:2.8",
+    "com.google.guava:guava:32.0.1-jre",
+]
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.install(
+    artifacts = PROTOBUF_MAVEN_ARTIFACTS,
+    lock_file = "//:maven_install.json",
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://repo.maven.apache.org/maven2",
+    ],
+)
+
+# Use the default "maven" namespace because protobuf java targets are exposed to users
+# See https://github.com/protocolbuffers/protobuf/issues/21177
+use_repo(maven, "maven")
+
+# Temporarily pin transitive dependency for https://github.com/bazelbuild/bazel/issues/24426
+bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
+
+# Development dependencies
+protobuf_maven_dev = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
+protobuf_maven_dev.install(
+    name = "protobuf_maven_dev",
+    artifacts = PROTOBUF_MAVEN_ARTIFACTS + [
+        "com.google.caliper:caliper:1.0-beta-3",
+        "com.google.guava:guava-testlib:32.0.1-jre",
+        "com.google.testparameterinjector:test-parameter-injector:1.18",
+        "com.google.truth:truth:1.1.2",
+        "junit:junit:4.13.2",
+        "org.mockito:mockito-core:4.3.1",
+        "biz.aQute.bnd:biz.aQute.bndlib:6.4.0",
+        "info.picocli:picocli:4.6.3",
+    ],
+    lock_file = "//:maven_dev_install.json",
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://repo.maven.apache.org/maven2",
+    ],
+)
+use_repo(protobuf_maven_dev, "protobuf_maven_dev")
+
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
+bazel_dep(name = "rules_buf", version = "0.3.0", dev_dependency = True)
+bazel_dep(name = "rules_testing", version = "0.9.0", dev_dependency = True)
+bazel_dep(
+    name = "abseil-py",
+    version = "2.1.0",
+    dev_dependency = True,
+    repo_name = "com_google_absl_py",
+)
+
+# For clang-cl configuration
+cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")
+use_repo(cc_configure, "local_config_cc")
+
+# For the Lua upb implementation
+bazel_dep(name = "lua", version = "5.4.6", dev_dependency = True)
+
+# For benchmarks
+bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", dev_dependency = True)
+bazel_dep(name = "google_benchmark", version = "1.9.2", dev_dependency = True)
+
+# For testing runtime against old gencode from a previous major version.
+bazel_dep(name = "com_google_protobuf_v25", version = "25.0", dev_dependency = True)
+archive_override(
+    module_name = "com_google_protobuf_v25",
+    integrity = "sha256-e+7ZxRHWMs/3wirACU3Xcg5VAVMDnV2n4Fm8zrSIR0o=",
+    patch_strip = 1,
+    patches = [
+        "@com_google_protobuf//:patches/protobuf_v25/0001-Add-MODULE.bazel.patch",
+        "@com_google_protobuf//:patches/protobuf_v25/0002-Examples-MODULE.bazel.patch",
+        "@com_google_protobuf//:patches/protobuf_v25/0003-relative-labels.patch",
+        "@com_google_protobuf//:patches/protobuf_v25/0004-Add-utf8_range-dependency.patch",
+        "@com_google_protobuf//:patches/protobuf_v25/0005-Make-rules_ruby-a-dev-only-dependency.patch",
+        "@com_google_protobuf//:patches/protobuf_v25/0006-Add-repo_name.patch",
+        "@com_google_protobuf//:patches/protobuf_v25/0007-Java-bazel8.patch",
+        "@com_google_protobuf//:patches/protobuf_v25/0008-bazel9.patch",
+    ],
+    strip_prefix = "protobuf-25.0",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v25.0/protobuf-25.0.tar.gz"],
+)
+
+bazel_dep(name = "com_google_protobuf_previous_release", version = "33.0", dev_dependency = True)
+archive_override(
+    module_name = "com_google_protobuf_previous_release",
+    integrity = "sha256-y8U2BkcGtijc/lB77zhu8+IhTVY2V2EilvF4GqFV7gc=",
+    patch_strip = 1,
+    patches = [
+        "@com_google_protobuf//:patches/protobuf_v33/0001-Update-module-name.patch",
+    ],
+    strip_prefix = "protobuf-33.0",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.0/protobuf-33.0.tar.gz"],
+)
+
+# Register C++ toolchains for cross-compilation. These are used for compiling release binaries of
+# protoc and the Python extension. They are disabled unless --//toolchain:release=true is passed.
+register_toolchains(
+    "//toolchain:osx-x86_64-toolchain",
+    "//toolchain:osx-aarch_64-toolchain",
+    "//toolchain:linux-aarch_64-toolchain",
+    "//toolchain:linux-ppcle_64-toolchain",
+    "//toolchain:linux-s390_64-toolchain",
+    "//toolchain:linux-x86_32-toolchain",
+    "//toolchain:linux-x86_64-toolchain",
+    "//toolchain:win32-toolchain",
+    "//toolchain:win64-toolchain",
+    "//toolchain:k8-toolchain",
+)
+
+# Python headers for release
+python_headers = use_extension("//python/dist:python_downloads.bzl", "python_headers", dev_dependency = True)
+python_headers.source_archive(
+    sha256 = "c4e0cbad57c90690cb813fb4663ef670b4d0f587d8171e2c42bd4c9245bd2758",
+    version = "3.10.0",
+)
+python_headers.nuget_package(
+    cpu = "i686",
+    sha256 = "e115e102eb90ce160ab0ef7506b750a8d7ecc385bde0a496f02a54337a8bc333",
+    version = "3.10.0",
+)
+python_headers.nuget_package(
+    cpu = "x86-64",
+    sha256 = "4474c83c25625d93e772e926f95f4cd398a0abbb52793625fa30f39af3d2cc00",
+    version = "3.10.0",
+)
+use_repo(
+    python_headers,
+    "nuget_python_i686_3.10.0",
+    "nuget_python_x86-64_3.10.0",
+    "python-3.10.0",
+)
+
+bazel_dep(name = "jq.bzl", version = "0.6.1", dev_dependency = True)
+
+jq = use_extension("@jq.bzl//jq:extensions.bzl", "toolchains", dev_dependency = True)
+use_repo(jq, "jq_toolchains")

--- a/modules/protobuf/36.1.bcr.1/patches/module_dot_bazel_version.patch
+++ b/modules/protobuf/36.1.bcr.1/patches/module_dot_bazel_version.patch
@@ -1,0 +1,11 @@
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -3,7 +3,7 @@
+ 
+ module(
+     name = "protobuf",
+-    version = "36.1",  # Automatically updated on release
++    version = "36.1.bcr.1",
+     bazel_compatibility = [">=8.0.0"],
+     compatibility_level = 1,
+     repo_name = "com_google_protobuf",

--- a/modules/protobuf/36.1.bcr.1/patches/tool_integrity.patch
+++ b/modules/protobuf/36.1.bcr.1/patches/tool_integrity.patch
@@ -1,0 +1,16 @@
+--- a/bazel/private/oss/toolchains/prebuilt/tool_integrity.bzl
++++ b/bazel/private/oss/toolchains/prebuilt/tool_integrity.bzl
+@@ -1,4 +1,13 @@
+ """Pre-computed during release"""
+ RELEASE_VERSION = "v36.1"
+ RELEASED_BINARY_INTEGRITY = {
++  "protoc-36.1-linux-aarch_64.zip": "237a68856edf1bd28b6204bddd0596c1cf46d298bc29c620012540b2e44c73e7",
++  "protoc-36.1-linux-ppcle_64.zip": "ecf722a3df8446af59c3c2f01f52978271eff396fccd48d8e793a87b551518cc",
++  "protoc-36.1-linux-s390_64.zip": "dd1bc36cd2efa7ecfa21ae03507d2e00db46f1f05e817d9bd339eb5efe6ab1e8",
++  "protoc-36.1-linux-x86_32.zip": "b8875ab09a8e9f72de78d257e250c8e7e5d041dfbded649ef5f5320c686ee994",
++  "protoc-36.1-linux-x86_64.zip": "c4bc672d9d49214dc8cafdceadf4df92182d6ca8e3ec65a56b2d7de5602669b4",
++  "protoc-36.1-osx-aarch_64.zip": "de56d57afe30c5d191b11d24ff93dd4025728d7fb43b773886b2d3613e0bdbb2",
++  "protoc-36.1-osx-x86_64.zip": "ee2c5496e4af0aa6a224894bc0f7025145260e004d890487d510725ce8b473eb",
++  "protoc-36.1-win32.zip": "9f1da00ed49ee2eab0520c354c7edbfa69f567a9247cf81a7995fe5db27ceb9e",
++  "protoc-36.1-win64.zip": "390e515cb456e6a978553bdb57baf087b054885077fd6da7f7ff0160279c07d6",
+ }

--- a/modules/protobuf/36.1.bcr.1/presubmit.yml
+++ b/modules/protobuf/36.1.bcr.1/presubmit.yml
@@ -1,0 +1,22 @@
+# LINT.IfChange(bcr_presubmit)
+bcr_test_module:
+  module_path: examples
+  matrix:
+    platform: ["debian12", "macos_arm64", "ubuntu2404", "windows"]
+    bazel: [8.x, 9.x]
+
+  tasks:
+    verify_targets:
+      name: "Verify build targets"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - '//...'
+      - '@com_google_protobuf//:protobuf'
+      - '@com_google_protobuf//:protobuf_lite'
+      - '@com_google_protobuf//:protobuf_python'
+      - '@com_google_protobuf//:protobuf_java'
+      - '@com_google_protobuf//:protoc'
+      - '@com_google_protobuf//:test_messages_proto2_cc_proto'
+      - '@com_google_protobuf//:test_messages_proto3_cc_proto'
+# LINT.ThenChange(<ROOT_DIR>/.bazelci/presubmit.yml)

--- a/modules/protobuf/36.1.bcr.1/source.json
+++ b/modules/protobuf/36.1.bcr.1/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-fYRVuwxVr6N+UbhhNvuiSUVG28h4vhcWRYRPkiqeUXo=",
+    "strip_prefix": "protobuf-36.1",
+    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v36.1/protobuf-36.1.bazel.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-MJUR2szQnFz8BQz/WUUShcR/EOETCiRHSdYfFafqCeY=",
+        "tool_integrity.patch": "sha256-BP4/R5LXM/5MmIGWnEsrJZWqAGNXm4JhF2vJtt9v7to="
+    }
+}

--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -199,7 +199,8 @@
         "36.0-rc2",
         "36.0",
         "36.0.bcr.1",
-        "36.1"
+        "36.1",
+	"36.1.bcr.1"
     ],
     "yanked_versions": {
         "3.19.0": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)",

--- a/modules/protobuf/metadata.json
+++ b/modules/protobuf/metadata.json
@@ -200,7 +200,7 @@
         "36.0",
         "36.0.bcr.1",
         "36.1",
-	"36.1.bcr.1"
+        "36.1.bcr.1"
     ],
     "yanked_versions": {
         "3.19.0": "CVE-2022-3171 (https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)",


### PR DESCRIPTION
BCR is still broken for 36.1(https://github.com/protocolbuffers/protobuf/issues/29537), doing another hot fix similar to https://github.com/bazelbuild/bazel-central-registry/pull/10223.

```
# 1. Linux AArch64 (ARM64)
curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v36.1/protoc-36.1-linux-aarch_64.zip | sha256sum
# 237a68856edf1bd28b6204bddd0596c1cf46d298bc29c620012540b2e44c73e7  -

# 2. Linux PPC64LE
curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v36.1/protoc-36.1-linux-ppcle_64.zip | sha256sum
# ecf722a3df8446af59c3c2f01f52978271eff396fccd48d8e793a87b551518cc  -

# 3. Linux s390x
curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v36.1/protoc-36.1-linux-s390_64.zip | sha256sum
# dd1bc36cd2efa7ecfa21ae03507d2e00db46f1f05e817d9bd339eb5efe6ab1e8  -

# 4. Linux x86 (32-bit)
curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v36.1/protoc-36.1-linux-x86_32.zip | sha256sum
# b8875ab09a8e9f72de78d257e250c8e7e5d041dfbded649ef5f5320c686ee994  -

# 5. Linux x86_64 (64-bit)
curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v36.1/protoc-36.1-linux-x86_64.zip | sha256sum
# c4bc672d9d49214dc8cafdceadf4df92182d6ca8e3ec65a56b2d7de5602669b4  -

# 6. macOS Apple Silicon (AArch64 / M1/M2/M3/M4)
curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v36.1/protoc-36.1-osx-aarch_64.zip | sha256sum
# de56d57afe30c5d191b11d24ff93dd4025728d7fb43b773886b2d3613e0bdbb2  -

# 7. macOS Intel (x86_64)
curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v36.1/protoc-36.1-osx-x86_64.zip | sha256sum
# ee2c5496e4af0aa6a224894bc0f7025145260e004d890487d510725ce8b473eb  -

# 8. Windows (32-bit)
curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v36.1/protoc-36.1-win32.zip | sha256sum
# 9f1da00ed49ee2eab0520c354c7edbfa69f567a9247cf81a7995fe5db27ceb9e  -

# 9. Windows (64-bit)
curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v36.1/protoc-36.1-win64.zip | sha256sum
# 390e515cb456e6a978553bdb57baf087b054885077fd6da7f7ff0160279c07d6  -
```

```
openssl dgst -sha256 -binary modules/protobuf/36.1.bcr.1/patches/tool_integrity.patch \
  | openssl base64 -A | awk '{print "sha256-" $1}'
# Output: sha256-BP4/R5LXM/5MmIGWnEsrJZWqAGNXm4JhF2vJtt9v7to=

openssl dgst -sha256 -binary modules/protobuf/36.1.bcr.1/patches/module_dot_bazel_version.patch \
  | openssl base64 -A | awk '{print "sha256-" $1}'
# Output: sha256-MJUR2szQnFz8BQz/WUUShcR/EOETCiRHSdYfFafqCeY=
```