### PR TITLE
Add logfmt_cpp@0.1.0

### DIFF
--- a/modules/logfmt_cpp/0.1.0/MODULE.bazel
+++ b/modules/logfmt_cpp/0.1.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "logfmt_cpp",
+    version = "0.1.0",
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/logfmt_cpp/0.1.0/presubmit.yml
+++ b/modules/logfmt_cpp/0.1.0/presubmit.yml
@@ -1,0 +1,35 @@
+matrix:
+  platform:
+    - ubuntu2404
+    - macos_arm64
+    - windows
+  bazel:
+    - 8.x
+    - 9.x
+    - rolling
+tasks:
+  verify_targets:
+    name: Verify public target
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '@logfmt_cpp//:logfmt_cpp'
+
+bcr_test_module:
+  module_path: e2e/bzlmod
+  matrix:
+    platform:
+      - ubuntu2404
+      - macos_arm64
+      - windows
+    bazel:
+      - 8.x
+      - 9.x
+      - rolling
+  tasks:
+    run_consumer_test:
+      name: Compile and run a downstream consumer
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - //:consumer_test

--- a/modules/logfmt_cpp/0.1.0/source.json
+++ b/modules/logfmt_cpp/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-7YqANsUGdSTk7UsjKs7X4rpXjOT8gQx49YrbmKpBe10=",
+    "strip_prefix": "logfmt_cpp-0.1.0",
+    "url": "https://github.com/Derham1999/logfmt_cpp/releases/download/v0.1.0/logfmt_cpp-0.1.0.tar.gz"
+}

--- a/modules/logfmt_cpp/metadata.json
+++ b/modules/logfmt_cpp/metadata.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://github.com/Derham1999/logfmt_cpp",
+    "maintainers": [
+        {
+            "github": "Derham1999",
+            "github_user_id": 149142660
+        }
+    ],
+    "repository": [
+        "github:Derham1999/logfmt_cpp"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds the first BCR release of logfmt_cpp, a dependency-free C++17 header-only library for parsing and encoding logfmt records.

The module includes a downstream Bzlmod consumer test and presubmit coverage for Linux, macOS arm64, and Windows with Bazel 8.x, 9.x, and rolling.

Source release: https://github.com/Derham1999/logfmt_cpp/releases/tag/v0.1.0

Local validation completed with Bazel 8.7.0 and 9.2.0, including resolution through the prepared registry entry.