### PR TITLE
bazel_lib@3.7.2

### DIFF
--- a/modules/bazel_lib/3.7.2/MODULE.bazel
+++ b/modules/bazel_lib/3.7.2/MODULE.bazel
@@ -1,0 +1,86 @@
+module(
+    name = "bazel_lib",
+    bazel_compatibility = [">=6.0.0"],
+    compatibility_level = 1,
+    version = "3.7.2",
+)
+
+# Lower-bounds (minimum) versions for direct runtime dependencies
+bazel_dep(name = "bazel_features", version = "1.9.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_shell", version = "0.4.1")
+
+bazel_lib_toolchains = use_extension("@bazel_lib//lib:extensions.bzl", "toolchains")
+bazel_lib_toolchains.copy_directory()
+bazel_lib_toolchains.copy_to_directory()
+bazel_lib_toolchains.coreutils()
+bazel_lib_toolchains.zstd()
+bazel_lib_toolchains.expand_template()
+bazel_lib_toolchains.spawn_binary()
+bazel_lib_toolchains.bats()
+use_repo(bazel_lib_toolchains, "bats_toolchains", "copy_directory_toolchains", "copy_to_directory_toolchains", "coreutils_toolchains", "expand_template_toolchains", "spawn_binary_toolchains", "zstd_toolchains")
+
+register_toolchains(
+    "@copy_directory_toolchains//:all",
+    "@copy_to_directory_toolchains//:all",
+    "@coreutils_toolchains//:all",
+    "@expand_template_toolchains//:all",
+    "@spawn_binary_toolchains//:all",
+    "@bats_toolchains//:all",
+    "@zstd_toolchains//:all",
+)
+
+####### Dev dependencies ########
+
+# To allow /tools to be built from source
+# NOTE: when publishing to BCR, we patch this to be dev_dependency, as we publish pre-built binaries
+# along with our releases.
+IS_RELEASE = True
+
+bazel_dep(
+    name = "gazelle",
+    version = "0.52.2",
+    dev_dependency = IS_RELEASE,
+)
+bazel_dep(
+    name = "rules_go",
+    version = "0.62.0",
+    dev_dependency = IS_RELEASE,
+    repo_name = "io_bazel_rules_go",
+)
+
+go_sdk = use_extension(
+    "@io_bazel_rules_go//go:extensions.bzl",
+    "go_sdk",
+    dev_dependency = IS_RELEASE,
+)
+go_sdk.from_file(go_mod = "//:go.mod")
+
+go_deps = use_extension(
+    "@gazelle//:extensions.bzl",
+    "go_deps",
+    dev_dependency = IS_RELEASE,
+)
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_bmatcuk_doublestar_v4",
+    "org_golang_x_exp",
+    "org_golang_x_sys",
+)
+
+host = use_extension("@bazel_lib//lib:extensions.bzl", "host", dev_dependency = True)
+host.host()
+use_repo(host, "bazel_lib_host")
+
+host_platform = use_extension("@platforms//host:extension.bzl", "host_platform")
+use_repo(host_platform, "host_platform")
+
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.2", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.3", dev_dependency = True)
+bazel_dep(name = "external_test_repo", dev_dependency = True)
+local_path_override(
+    module_name = "external_test_repo",
+    path = "./lib/tests/external_test_repo",
+)

--- a/modules/bazel_lib/3.7.2/attestations.json
+++ b/modules/bazel_lib/3.7.2/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.7.2/source.json.intoto.jsonl",
+            "integrity": "sha256-Q+hMITbsyUmqX1EuUakEZm2nVsIzHwXQD7ulwMNL9JI="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.7.2/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-PwoRIYpCrGuNrT+h3b7RhT/FCnSxsBNHWhY4Sq7+xLI="
+        },
+        "bazel-lib-v3.7.2.tar.gz": {
+            "url": "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.7.2/bazel-lib-v3.7.2.tar.gz.intoto.jsonl",
+            "integrity": "sha256-RHe90+hp6jwQSIDpEmJrBa6hVbq0sUTfi16TTpzbbPk="
+        }
+    }
+}

--- a/modules/bazel_lib/3.7.2/patches/go_dev_dep.patch
+++ b/modules/bazel_lib/3.7.2/patches/go_dev_dep.patch
@@ -1,0 +1,13 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index eec026a..4854935 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -33,7 +33,7 @@ register_toolchains(
+ # To allow /tools to be built from source
+ # NOTE: when publishing to BCR, we patch this to be dev_dependency, as we publish pre-built binaries
+ # along with our releases.
+-IS_RELEASE = False
++IS_RELEASE = True
+
+ bazel_dep(
+     name = "gazelle",

--- a/modules/bazel_lib/3.7.2/patches/module_dot_bazel_version.patch
+++ b/modules/bazel_lib/3.7.2/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,8 +1,9 @@
+ module(
+     name = "bazel_lib",
+     bazel_compatibility = [">=6.0.0"],
+     compatibility_level = 1,
++    version = "3.7.2",
+ )
+ 
+ # Lower-bounds (minimum) versions for direct runtime dependencies
+ bazel_dep(name = "bazel_features", version = "1.9.0")

--- a/modules/bazel_lib/3.7.2/presubmit.yml
+++ b/modules/bazel_lib/3.7.2/presubmit.yml
@@ -1,0 +1,16 @@
+bcr_test_module:
+  module_path: "e2e/smoke"
+  matrix:
+    platform: ["debian11", "macos", "ubuntu2204", "windows"]
+    bazel:
+      - 7.x
+      - 8.x
+      - 9.x
+      - rolling
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/bazel_lib/3.7.2/source.json
+++ b/modules/bazel_lib/3.7.2/source.json
@@ -1,0 +1,11 @@
+{
+    "integrity": "sha256-x1+MN1+fLHOlZduhiPkaTo18oW3SthUtOIbCa78cZTI=",
+    "strip_prefix": "bazel-lib-3.7.2",
+    "docs_url": "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.7.2/bazel-lib-v3.7.2.docs.tar.gz",
+    "url": "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.7.2/bazel-lib-v3.7.2.tar.gz",
+    "patches": {
+        "go_dev_dep.patch": "sha256-boWp7svEiLDFXEIg6hq70JcTom4rYFNzvwfpCPrusDw=",
+        "module_dot_bazel_version.patch": "sha256-fTTM8Or2usOzP99CbwztvLtty9uXiSzygA9IRFXoAWg="
+    },
+    "patch_strip": 1
+}

--- a/modules/bazel_lib/metadata.json
+++ b/modules/bazel_lib/metadata.json
@@ -3,13 +3,13 @@
     "maintainers": [
         {
             "name": "Alex Eagle",
-            "email": "alex@aspect.build",
+            "email": "eagle@post.harvard.edu",
             "github": "alexeagle",
             "github_user_id": 47395
         },
         {
             "name": "Derek Cormier",
-            "email": "derek@aspect.build",
+            "email": "derek.m.cormier@gmail.com",
             "github": "kormide",
             "github_user_id": 4948761
         },
@@ -18,6 +18,12 @@
             "github": "fmeum",
             "name": "Fabian Meumertzheim",
             "github_user_id": 4312191
+        },
+        {
+            "name": "Jason Bedard",
+            "email": "jason@aspect.build",
+            "github": "jbedard",
+            "github_user_id": 89246
         }
     ],
     "repository": [
@@ -38,7 +44,8 @@
         "3.5.0",
         "3.6.0",
         "3.7.0",
-        "3.7.1"
+        "3.7.1",
+        "3.7.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/bazel-contrib/bazel-lib/releases/tag/v3.7.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_