### PR TITLE
security: restrict skip_check to maintainers and validate overlay BUILD files

### DIFF
--- a/.github/workflows/skip_check.yml
+++ b/.github/workflows/skip_check.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   comment_bot:
-    if: startsWith(github.event.comment.body, '@bazel-io skip_check ')
+    if: startsWith(github.event.comment.body, '@bazel-io skip_check ') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/tools/bcr_validation.py
+++ b/tools/bcr_validation.py
@@ -68,6 +68,18 @@ class BcrValidationResult(Enum):
     FAILED = 3
 
 
+def _validate_overlay_build_files(module_dir):
+    overlay_dir = module_dir / "overlay"
+    if not overlay_dir.is_dir():
+        return BcrValidationResult.GOOD
+    build_files = list(overlay_dir.rglob("BUILD.bazel")) + list(overlay_dir.rglob("BUILD"))
+    for build_file in build_files:
+        content = build_file.read_text()
+        if 'tags = ["local"]' in content or "tags = ['local']" in content:
+            return BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW
+    return BcrValidationResult.GOOD
+
+
 RED = "\x1b[31m"
 GREEN = "\x1b[32m"
 YELLOW = "\x1b[33m"
@@ -799,6 +811,12 @@ class BcrValidator:
         self.verify_module_dot_bazel(module_name, version, "compatibility_level" not in skipped_validations)
         if "attestations" not in skipped_validations:
             self.verify_attestations(module_name, version)
+        overlay_result = _validate_overlay_build_files(self.registry.get_version_dir(module_name, version))
+        if overlay_result == BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW:
+            self.report(
+                BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW,
+                f'{module_name}@{version} overlay contains a BUILD file with tags=["local"], which requires BCR maintainer review.',
+            )
 
     def validate_metadata(self, modules):
         print_expanded_group(f"Validating metadata.json files for {modules}")
@@ -924,10 +942,7 @@ class BcrValidator:
         if source_uri not in gh_source_uris:
             self.report(
                 BcrValidationResult.FAILED,
-                (
-                    f"{module_name}@{version}: Expected source URI {source_uri}, "
-                    f"but got {', '.join(gh_source_uris)}."
-                ),
+                (f"{module_name}@{version}: Expected source URI {source_uri}, but got {', '.join(gh_source_uris)}."),
             )
             return
 

--- a/tools/test_security_fixes.py
+++ b/tools/test_security_fixes.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+tools_dir = Path(__file__).parent
+sys.path.insert(0, str(tools_dir))
+
+from bcr_validation import BcrValidationResult, _validate_overlay_build_files
+
+
+def test_skip_check_yml_has_author_association():
+    workflow = tools_dir.parent / ".github" / "workflows" / "skip_check.yml"
+    content = workflow.read_text()
+    assert "author_association" in content, "skip_check.yml missing author_association condition"
+    assert (
+        "OWNER" in content and "MEMBER" in content and "COLLABORATOR" in content
+    ), "skip_check.yml missing required permission checks"
+    print("PASS: skip_check.yml contains author_association permission check")
+
+
+def test_overlay_rejects_local_tags():
+    with tempfile.TemporaryDirectory() as tmp:
+        module_dir = Path(tmp)
+        overlay_dir = module_dir / "overlay"
+        overlay_dir.mkdir()
+        build_file = overlay_dir / "BUILD.bazel"
+        build_file.write_text('genrule(name = "x", tags = ["local"], outs = ["y"], cmd = "echo hi")')
+        result = _validate_overlay_build_files(module_dir)
+        assert (
+            result == BcrValidationResult.NEED_BCR_MAINTAINER_REVIEW
+        ), f"Expected NEED_BCR_MAINTAINER_REVIEW, got {result}"
+        print('PASS: _validate_overlay_build_files rejects tags=["local"]')
+
+
+def test_overlay_accepts_normal_build():
+    with tempfile.TemporaryDirectory() as tmp:
+        module_dir = Path(tmp)
+        overlay_dir = module_dir / "overlay"
+        overlay_dir.mkdir()
+        build_file = overlay_dir / "BUILD.bazel"
+        build_file.write_text('cc_library(name = "x", srcs = ["a.cc"])')
+        result = _validate_overlay_build_files(module_dir)
+        assert result == BcrValidationResult.GOOD, f"Expected GOOD, got {result}"
+        print("PASS: _validate_overlay_build_files accepts normal overlay BUILD files")
+
+
+def test_overlay_no_overlay_dir():
+    with tempfile.TemporaryDirectory() as tmp:
+        module_dir = Path(tmp)
+        result = _validate_overlay_build_files(module_dir)
+        assert result == BcrValidationResult.GOOD, f"Expected GOOD, got {result}"
+        print("PASS: _validate_overlay_build_files returns GOOD when no overlay dir")
+
+
+if __name__ == "__main__":
+    test_skip_check_yml_has_author_association()
+    test_overlay_rejects_local_tags()
+    test_overlay_accepts_normal_build()
+    test_overlay_no_overlay_dir()
+    print("\nAll security fix tests passed.")


### PR DESCRIPTION
## Summary

Fixes two issues:

1. Missing authorization: any GitHub user's `@bazel-io skip_check` comment could add CI-triggering labels to any PR. Now restricted to OWNER/MEMBER/COLLABORATOR.\n2. Pre-approval RCE: BCR overlay `BUILD.bazel` files with `tags=["local"]` genrules execute unsandboxed. Added validation that rejects such overlays with NEED_BCR_MAINTAINER_REVIEW.\n\n## Changes\n\n- `.github/workflows/skip_check.yml`: added `author_association` condition\n- `tools/bcr_validation.py`: added `_validate_overlay_build_files()`\n\n## Testing Plan\n\nAdded `tools/test_security_fixes.py`:\n- skip_check.yml contains author_association permission check\n- _validate_overlay_build_files rejects tags=["local"]\n- _validate_overlay_build_files accepts normal overlay BUILD files\n- _validate_overlay_build_files returns GOOD when no overlay dir\n\nAll 4 tests pass.