### PR TITLE
Add mercurial.bzl module

### DIFF
--- a/modules/mercurial.bzl/metadata.json
+++ b/modules/mercurial.bzl/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/willstranton/mercurial.bzl",
+    "maintainers": [
+       {
+            "email": "2659963+willstranton@users.noreply.github.com",
+            "github": "willstranton",
+            "github_user_id": 2659963,
+            "name": "willstranton"
+       }
+    ],
+    "repository": [
+        "github:willstranton/mercurial.bzl"
+    ],
+    "versions": [
+        "v0.0.1alpha1"
+    ],
+    "yanked_versions": {}
+}

--- a/modules/mercurial.bzl/v0.0.1alpha1/MODULE.bazel
+++ b/modules/mercurial.bzl/v0.0.1alpha1/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "mercurial.bzl",
+    version = "v0.0.1alpha1",
+    compatibility_level = 0,
+)

--- a/modules/mercurial.bzl/v0.0.1alpha1/patches/module_dot_bazel_version.patch
+++ b/modules/mercurial.bzl/v0.0.1alpha1/patches/module_dot_bazel_version.patch
@@ -1,0 +1,8 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,3 +1,5 @@
+ module(
+     name = "mercurial.bzl",
++    version = "v0.0.1alpha1",
++    compatibility_level = 0,
+ )

--- a/modules/mercurial.bzl/v0.0.1alpha1/presubmit.yml
+++ b/modules/mercurial.bzl/v0.0.1alpha1/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  - windows
+  bazel:
+  - 9.x
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@mercurial.bzl:mercurial.bzl'

--- a/modules/mercurial.bzl/v0.0.1alpha1/presubmit.yml
+++ b/modules/mercurial.bzl/v0.0.1alpha1/presubmit.yml
@@ -15,4 +15,4 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_targets:
-    - '@mercurial.bzl:mercurial.bzl'
+    - '@mercurial.bzl//...'

--- a/modules/mercurial.bzl/v0.0.1alpha1/source.json
+++ b/modules/mercurial.bzl/v0.0.1alpha1/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/willstranton/mercurial.bzl/archive/refs/tags/v0.0.1alpha1.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-QRfK9p6pHa0jp/yuIQpqMvBBg9lrwaZPaJs+9lT6NE4="
+    },
+    "integrity": "sha256-nwxbfUhWuDa02+v30kQri0pXpB6PXaxObtJ5qaqFsug=",
+    "strip_prefix": "mercurial.bzl-0.0.1alpha1"
+}


### PR DESCRIPTION
The mercurial.bzl module allows external repositories that are mercurial repositories.  Similar to `git_repository` which is for git repositories.  `mercurial_repository` is for Mercurial repositories.

Fixes #9740