### PR TITLE
Add OpenBlas 0.3.29

### DIFF
--- a/modules/openblas/0.3.29/MODULE.bazel
+++ b/modules/openblas/0.3.29/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "openblas",
+    version = "0.3.29",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
+
+register_toolchains("@rules_foreign_cc//toolchains:preinstalled_pkgconfig_toolchain")

--- a/modules/openblas/0.3.29/overlay/BUILD.bazel
+++ b/modules/openblas/0.3.29/overlay/BUILD.bazel
@@ -1,0 +1,60 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "bazel-*/**",
+            "BUILD",
+            "BUILD.bazel",
+            "MODULE.bazel",
+        ],
+    ),
+    visibility = ["//visibility:private"],
+)
+
+cmake(
+    name = "openblas",
+    generate_args = ["-GNinja"],
+    cache_entries = {
+        "BUILD_SHARED_LIBS": "OFF",
+        "BUILD_STATIC_LIBS": "ON",
+        "BUILD_TESTING": "OFF",
+        "BUILD_BENCHMARKS": "OFF",
+        "NOFORTRAN": "ON",
+        "DYNAMIC_ARCH": "ON",
+        "CMAKE_INSTALL_LIBDIR": "lib",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_STANDARD": "11",
+    },
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "-std=gnu11",
+            "-Wno-error",
+        ],
+    }),
+    includes = ["openblas"],
+    lib_source = ":all_srcs",
+    linkopts = select({
+        "@platforms//os:macos": [
+            "-lpthread",
+            "-ldl",
+            "-lm",
+        ],
+        "@platforms//os:linux": [
+            "-lpthread",
+            "-ldl",
+            "-lm",
+        ],
+        "//conditions:default": [],
+    }),
+    out_include_dir = "include",
+    out_static_libs = select({
+        "@platforms//os:windows": ["openblas.lib"],
+        "//conditions:default": ["libopenblas.a"],
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/modules/openblas/0.3.29/presubmit.yml
+++ b/modules/openblas/0.3.29/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+    - debian11
+    - ubuntu2204
+    - ubuntu2404
+    - macos
+    - macos_arm64
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@openblas"

--- a/modules/openblas/0.3.29/source.json
+++ b/modules/openblas/0.3.29/source.json
@@ -1,0 +1,8 @@
+{
+    "integrity": "sha256-OCQO7hsp4r3kfrtdYRYCB9xoZopUysYsB2u1AyATses=",
+    "strip_prefix": "OpenBLAS-0.3.29",
+    "url": "https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.29/OpenBLAS-0.3.29.tar.gz",
+    "overlay": {
+        "BUILD.bazel": "sha256-blNMHWqpftmE6eDb1GMwdpZaPhmJIBEpaR3tPkGuUa8="
+    }
+}

--- a/modules/openblas/metadata.json
+++ b/modules/openblas/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://www.openblas.net",
+    "maintainers": [
+        {
+            "email": "bponton@intrinsic.ai",
+            "github": "bponton-intrinsic",
+            "github_user_id": 141635050,
+            "name": "Brahayam Ponton"
+        }
+    ],
+    "repository": [
+        "github:OpenMathLib/OpenBLAS"
+    ],
+    "versions": [
+        "0.3.29"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Publish openblas@0.3.29 (https://github.com/bazelbuild/bazel-central-registry/pull/10373)

From: "https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.29/OpenBLAS-0.3.29.tar.gz