### PR TITLE
Publish wpilib_toolchains@2027-1.bcr1

### DIFF
--- a/modules/wpilib_toolchains/2027-1.bcr1/MODULE.bazel
+++ b/modules/wpilib_toolchains/2027-1.bcr1/MODULE.bazel
@@ -1,0 +1,43 @@
+module(
+    name = "wpilib_toolchains",
+    version = "2027-1.bcr1",
+)
+
+bazel_dep(name = "platforms", version = "0.0.9")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
+
+deps = use_extension("//:maven_deps.bzl", "deps")
+use_repo(
+    deps,
+    "gcc_systemcore_debug_linux",
+    "gcc_systemcore_debug_linuxaarch64",
+    "gcc_systemcore_debug_macos",
+    "gcc_systemcore_debug_macosarm",
+    "gcc_systemcore_debug_win",
+    "gcc_systemcore_linux",
+    "gcc_systemcore_linuxaarch64",
+    "gcc_systemcore_macos",
+    "gcc_systemcore_macosarm",
+    "gcc_systemcore_win",
+    "gcc_trixie64_linux",
+    "gcc_trixie64_linuxaarch64",
+    "gcc_trixie64_macos",
+    "gcc_trixie64_macosarm",
+    "gcc_trixie64_win",
+)
+
+cfg = use_extension("@wpilib_toolchains//:extensions.bzl", "cfg")
+use_repo(cfg, "local_systemcore", "local_systemcore_debug", "local_trixie64")
+
+register_toolchains(
+    "@local_trixie64//:macos",
+    "@local_trixie64//:linux",
+    "@local_trixie64//:windows",
+    "@local_systemcore//:macos",
+    "@local_systemcore//:linux",
+    "@local_systemcore//:windows",
+    "@local_systemcore_debug//:macos",
+    "@local_systemcore_debug//:linux",
+    "@local_systemcore_debug//:windows",
+)

--- a/modules/wpilib_toolchains/2027-1.bcr1/patches/config_setting_visibility.patch
+++ b/modules/wpilib_toolchains/2027-1.bcr1/patches/config_setting_visibility.patch
@@ -1,0 +1,10 @@
+--- a/constraints/combined/BUILD.bazel
++++ b/constraints/combined/BUILD.bazel
+@@ -1,5 +1,7 @@
+ load("@bazel_skylib//lib:selects.bzl", "selects")
+ 
++package(default_visibility = ["//visibility:public"])
++
+ selects.config_setting_group(
+     name = "is_cross_compiler",
+     match_any = [

--- a/modules/wpilib_toolchains/2027-1.bcr1/presubmit.yml
+++ b/modules/wpilib_toolchains/2027-1.bcr1/presubmit.yml
@@ -1,0 +1,26 @@
+matrix:
+  platform: ["debian13", "macos", "windows"]
+  bazel: ["7.x", "8.x", "9.x"]
+
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - "@wpilib_toolchains//..."
+
+bcr_test_module:
+  module_path: "tests"
+  matrix:
+    # googletest 1.14.0, which tests/MODULE.bazel pins, uses bare cc_library and
+    # so does not load under Bazel 9. Bump it upstream to widen this matrix.
+    platform: ["debian13", "macos", "windows"]
+    bazel: ["7.x", "8.x"]
+  tasks:
+    verify_targets:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+      - "//:main"
+      test_targets:
+      - "//:test"

--- a/modules/wpilib_toolchains/2027-1.bcr1/source.json
+++ b/modules/wpilib_toolchains/2027-1.bcr1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-t9pasV154Izb6xAllG7XI7lYljVP1jhNTQtoG2l6t6Y=",
+    "patch_strip": 1,
+    "patches": {
+        "config_setting_visibility.patch": "sha256-dJBlIciZ3+ff29rdHjUlm57pmyTXL85cWeaVys3jyz0="
+    },
+    "strip_prefix": "",
+    "url": "https://github.com/wpilibsuite/bazel_wpilib_toolchains/releases/download/2027-1.bcr1/wpilib_toolchains-2027-1.bcr1.tar.gz"
+}

--- a/modules/wpilib_toolchains/metadata.json
+++ b/modules/wpilib_toolchains/metadata.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "https://github.com/wpilibsuite/bazel_wpilib_toolchains",
+    "maintainers": [
+        {
+            "github": "pjreiniger",
+            "github_user_id": 10381694,
+            "name": "PJ Reiniger"
+        },
+        {
+            "github": "PeterJohnson",
+            "github_user_id": 297126,
+            "name": "Peter Johnson"
+        },
+        {
+            "github": "AustinSchuh",
+            "github_user_id": 294043,
+            "name": "Austin Schuh"
+        }
+    ],
+    "repository": [
+        "github:wpilibsuite/bazel_wpilib_toolchains"
+    ],
+    "versions": [
+        "2027-1.bcr1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds the WPILib Bazel toolchains module (`wpilib_toolchains`) to the registry.

Sources are the [2027-1.bcr1 release](https://github.com/wpilibsuite/bazel_wpilib_toolchains/releases/tag/2027-1.bcr1) of `wpilibsuite/bazel_wpilib_toolchains`. The `.bcr/` templates and `publish-to-bcr` workflow are still in review upstream ([wpilibsuite/bazel_wpilib_toolchains#43](https://github.com/wpilibsuite/bazel_wpilib_toolchains/pull/43)), so this first entry is hand-generated from those templates; subsequent releases will be published automatically.

Verified locally against Bazel 8.5.0 — `bazel build //...` in the module and `bazel test //:main //:test` in the `tests` module both pass — and `tools/bcr_validation.py --check wpilib_toolchains@2027-1.bcr1` reports no failures.