### PR TITLE
Add rules_cyclone@0.1.0

### DIFF
--- a/modules/rules_cyclone/0.1.0/MODULE.bazel
+++ b/modules/rules_cyclone/0.1.0/MODULE.bazel
@@ -1,0 +1,24 @@
+"""rules_cyclone — Cyclone Core 的 Bazel 规则包。
+
+把确定性 XiL 测试变成 bazel test 的一等公民：
+一条 bazel_dep 接入，cyclone_test 与单元测试共用同一张构建图、
+同一个远程缓存、同一个 CI 看板。
+"""
+
+module(
+    name = "rules_cyclone",
+    version = "0.1.0",
+)
+
+# 平台约束标签（@platforms//os:linux 等，tools/toolchain.bzl 的
+# exec_compatible_with 使用）。运行期无其他第三方依赖。
+bazel_dep(name = "platforms", version = "0.0.11")
+
+# 工具链二进制下载（cyclone_repositories 在此声明各平台 CLI 仓库，惰性拉取）
+cyclone = use_extension("//tools:extensions.bzl", "cyclone")
+use_repo(cyclone, "cyclone_cli_linux_amd64", "cyclone_cli_linux_arm64", "cyclone_cli_darwin_arm64")
+
+# 默认注册三平台 CLI 工具链：bzlmod 下依赖模块的 register_toolchains 对整张
+# 构建图生效，使用方一条 bazel_dep 即接入（首次解析按宿主平台惰性下载 CLI）。
+# 本地开发可像 examples/ 的 shim 流一样注册自己的工具链——根模块注册优先。
+register_toolchains("//tools:all")

--- a/modules/rules_cyclone/0.1.0/presubmit.yml
+++ b/modules/rules_cyclone/0.1.0/presubmit.yml
@@ -1,0 +1,18 @@
+# rules_cyclone 的 BCR presubmit。
+# 平台约束：runner.sh 是 bash（无 Windows）；预编译 CLI 只有
+# linux-amd64 / linux-arm64 / darwin-arm64 三平台——
+# BCR CI 的 linux arm64 不在标准矩阵，故选 ubuntu（amd64）+ macos_arm64。
+# 注意：examples 的用例会触发 CLI 下载（~33MB，GitHub Release 匿名可拉）；
+# macOS 首跑有一次性安全评估 ~20s，small 测试 60s 超时内可完成。
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["ubuntu2204", "ubuntu2404", "macos_arm64"]
+    bazel: [7.x, 8.x, 9.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/rules_cyclone/0.1.0/source.json
+++ b/modules/rules_cyclone/0.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-Dg/7qhpZvurDoPzfmeSg4LinE/9TSIbYC+WCKfP63Bw=",
+    "strip_prefix": "rules_cyclone-0.1.0",
+    "url": "https://github.com/cyclone-core/rules-cyclone/releases/download/v0.1.0/rules_cyclone-0.1.0.tar.gz"
+}

--- a/modules/rules_cyclone/0.1.0/source.json
+++ b/modules/rules_cyclone/0.1.0/source.json
@@ -1,5 +1,5 @@
 {
-    "integrity": "sha256-Dg/7qhpZvurDoPzfmeSg4LinE/9TSIbYC+WCKfP63Bw=",
+    "integrity": "sha256-eLrAosGcLU2V4zmtTy64KNQ4zzlIZQgPhrLMmFQ02Os=",
     "strip_prefix": "rules_cyclone-0.1.0",
     "url": "https://github.com/cyclone-core/rules-cyclone/releases/download/v0.1.0/rules_cyclone-0.1.0.tar.gz"
 }

--- a/modules/rules_cyclone/metadata.json
+++ b/modules/rules_cyclone/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/cyclone-core/rules-cyclone",
+    "maintainers": [
+        {
+            "email": "caojian258@icloud.com",
+            "github": "cyclone-core",
+            "github_user_id": 325211290,
+            "name": "Cyclone Core"
+        }
+    ],
+    "repository": [
+        "github:cyclone-core/rules-cyclone"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Adds rules_cyclone 0.1.0 — Bazel rules for the Cyclone Core deterministic XiL test engine.                                            
                                                                                                                                           
     cyclone_test becomes a first-class bazel test: exit-code contract, JUnit output                                                       
     with case_hash/seed/log-digest properties for CI traceability, and an evidence                                                        
     chain under TEST_UNDECLARED_OUTPUTS_DIR.                                                                                              
                                                                                                                                           
     Precompiled CLI toolchains (darwin-arm64 / linux-amd64 / linux-arm64) are                                                             
     downloaded lazily from the module's own GitHub Release with sha256-pinned                                                             
     integrity. The source archive is a git-archive release asset (stable bytes,                                                           
     gzip -n), not the auto-generated GitHub archive.                                                                                      
                                                                                                                                           
     presubmit runs the bundled examples/ test module on                                                                                   
     ubuntu2204/ubuntu2404/macos_arm64 with Bazel 7.x/8.x/9.x. The test runner is                                                          
     bash, so no Windows. Note: on a virgin macOS machine the first execution of the                                                       
     downloaded onedir CLI tree pays a one-time Gatekeeper assessment that can                                                             
     exceed 60s, so test targets are size=medium. 