### PR TITLE
liburing: orphan maintainership

### DIFF
--- a/modules/liburing/metadata.json
+++ b/modules/liburing/metadata.json
@@ -2,10 +2,8 @@
     "homepage": "https://github.com/axboe/liburing",
     "maintainers": [
         {
-            "email": "maennich@google.com",
-            "github": "metti",
-            "github_user_id": 184796,
-            "name": "Matthias Maennich"
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
         }
     ],
     "repository": [


### PR DESCRIPTION
Set maintainer to 'No Maintainer Specified' (bcr-maintainers@bazel.build) as there is currently no active module maintainer.