### PR TITLE
gdk-pixbuf@2.44.4.bcr.1

### DIFF
--- a/modules/gdk-pixbuf/2.44.4.bcr.1/MODULE.bazel
+++ b/modules/gdk-pixbuf/2.44.4.bcr.1/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "gdk-pixbuf",
+    version = "2.44.4.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_autoconf", version = "0.0.15")
+bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "glib", version = "2.82.2.bcr.7")
+bazel_dep(name = "libjpeg_turbo", version = "3.1.3.bcr.1")
+bazel_dep(name = "libpng", version = "1.6.53")

--- a/modules/gdk-pixbuf/2.44.4.bcr.1/README.md
+++ b/modules/gdk-pixbuf/2.44.4.bcr.1/README.md
@@ -1,0 +1,9 @@
+# Optional built-in SVG loading
+
+The default library retains the existing raster loaders. To add static SVG
+loading, build with `--@gdk-pixbuf//:builtin_svg` and link both the renderer and
+`@librsvg//:pixbuf_loader` into the final binary. This flag enables the static
+registration calls; without those linked implementations the link fails.
+`@gdk-pixbuf//gdk-pixbuf:headers` allows adapters to consume the public API
+without depending on the implementation, avoiding a dependency cycle.
+The librsvg module contains a complete decode test of this integration.

--- a/modules/gdk-pixbuf/2.44.4.bcr.1/overlay/BUILD.bazel
+++ b/modules/gdk-pixbuf/2.44.4.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+alias(
+    name = "gdk-pixbuf",
+    actual = "//gdk-pixbuf",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "config",
+    hdrs = ["config.h"],
+    defines = select({
+        "@platforms//os:linux": ["OS_LINUX=1"],
+        "@platforms//os:macos": ["OS_DARWIN=1"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//:__subpackages__"],
+    deps = ["@rules_autoconf//:config"],
+)
+
+# The final binary must also link the librsvg adapter and renderer. Keeping this
+# opt-in avoids a Rust dependency for applications that only need raster images.
+bool_flag(
+    name = "builtin_svg",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "with_builtin_svg",
+    flag_values = {":builtin_svg": "true"},
+    visibility = ["//gdk-pixbuf:__pkg__"],
+)

--- a/modules/gdk-pixbuf/2.44.4.bcr.1/overlay/config.h
+++ b/modules/gdk-pixbuf/2.44.4.bcr.1/overlay/config.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <rules_autoconf/config.h>
+
+#define GETTEXT_PACKAGE "gdk-pixbuf"
+

--- a/modules/gdk-pixbuf/2.44.4.bcr.1/overlay/gdk-pixbuf/BUILD.bazel
+++ b/modules/gdk-pixbuf/2.44.4.bcr.1/overlay/gdk-pixbuf/BUILD.bazel
@@ -1,0 +1,147 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@glib//gobject:gobject.bzl", "genmarshal", "mkenums")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# Public API headers that are installed for consumers.
+PUBLIC_API_HEADERS = [
+    "gdk-pixbuf.h",
+    "gdk-pixbuf-animation.h",
+    "gdk-pixbuf-core.h",
+    "gdk-pixbuf-io.h",
+    "gdk-pixbuf-loader.h",
+    "gdk-pixbuf-macros.h",
+    "gdk-pixbuf-simple-anim.h",
+    "gdk-pixbuf-transform.h",
+]
+
+expand_template(
+    name = "gdk_pixbuf_features_h",
+    out = "gdk-pixbuf-features.h",
+    substitutions = {
+        "@GDK_PIXBUF_MAJOR@": "2",
+        "@GDK_PIXBUF_MINOR@": "44",
+        "@GDK_PIXBUF_MICRO@": "4",
+        "@GDK_PIXBUF_VERSION@": "2.44.4",
+    },
+    template = "gdk-pixbuf-features.h.in",
+)
+
+mkenums(
+    name = "gdk_pixbuf_enum_types_c",
+    srcs = PUBLIC_API_HEADERS,
+    out = "gdk-pixbuf-enum-types.c",
+    template = "gdk-pixbuf-enum-types.c.template",
+)
+
+mkenums(
+    name = "gdk_pixbuf_enum_types_h",
+    srcs = PUBLIC_API_HEADERS,
+    out = "gdk-pixbuf-enum-types.h",
+    template = "gdk-pixbuf-enum-types.h.template",
+)
+
+genmarshal(
+    name = "gdk_pixbuf_marshal",
+    src = "gdk-pixbuf-marshal.list",
+    out_body = "gdk-pixbuf-marshal.c",
+    out_header = "gdk-pixbuf-marshal.h",
+    prefix = "_gdk_pixbuf_marshal",
+)
+
+cc_library(
+    name = "gdk-pixbuf",
+    srcs = [
+        "gdk-pixbuf.c",
+        "gdk-pixbuf-animation.c",
+        "gdk-pixbuf-buffer-queue.c",
+        "gdk-pixbuf-buffer-queue-private.h",
+        "gdk-pixbuf-data.c",
+        "gdk-pixbuf-enum-types.c",
+        "gdk-pixbuf-io.c",
+        "gdk-pixbuf-loader.c",
+        "gdk-pixbuf-marshal.c",
+        "gdk-pixbuf-private.h",
+        "gdk-pixbuf-scale.c",
+        "gdk-pixbuf-scaled-anim.c",
+        "gdk-pixbuf-scaled-anim.h",
+        "gdk-pixbuf-simple-anim.c",
+        "gdk-pixbuf-util.c",
+        "gdk-pixdata.c",
+        "io-ani.c",
+        "io-ani-animation.c",
+        "io-ani-animation.h",
+        "io-bmp.c",
+        "io-gif.c",
+        "io-gif-animation.c",
+        "io-gif-animation.h",
+        "io-ico.c",
+        "io-jpeg.c",
+        "io-png.c",
+        "io-pnm.c",
+        "io-tga.c",
+        "io-xbm.c",
+        "io-xpm.c",
+        "lzw.c",
+        "lzw.h",
+        "pixops/pixops.c",
+        "pixops/pixops.h",
+        "xpm-color-table.h",
+    ],
+    copts = [
+        "-DGDK_PIXBUF_LOCALEDIR=\\\"share/locale\\\"",
+    ],
+    include_prefix = "gdk-pixbuf",
+    includes = ["."],
+    local_defines = [
+        "GDK_PIXBUF_COMPILATION",
+        "GDK_PIXBUF_ENABLE_BACKEND",
+        "HAVE_CONFIG_H",
+        "INCLUDE_ani",
+        "INCLUDE_bmp",
+        "INCLUDE_gif",
+        "INCLUDE_ico",
+        "INCLUDE_jpeg",
+        "INCLUDE_png",
+        "INCLUDE_pnm",
+        "INCLUDE_tga",
+        "INCLUDE_xbm",
+        "INCLUDE_xpm",
+    ] + select({
+        "//:with_builtin_svg": ["INCLUDE_svg"],
+        "//conditions:default": [],
+    }),
+    textual_hdrs = [
+        "fallback-c89.c",
+        "gdk-pixbuf-marshal.list",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":headers",
+        "//:config",
+        "@glib//gio",
+        "@glib//glib",
+        "@glib//gmodule",
+        "@glib//gobject",
+        "@libjpeg_turbo//:jpeg",
+        "@libpng//:png",
+    ],
+)
+
+# Separate declarations keep the statically linked SVG renderer independent of
+# the GdkPixbuf implementation.
+cc_library(
+    name = "headers",
+    hdrs = PUBLIC_API_HEADERS + [
+        "gdk-pixbuf-enum-types.h",
+        "gdk-pixbuf-features.h",
+        "gdk-pixbuf-marshal.h",
+        "gdk-pixdata.h",
+    ],
+    include_prefix = "gdk-pixbuf",
+    includes = ["."],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@glib//gio",
+        "@glib//gobject",
+    ],
+)

--- a/modules/gdk-pixbuf/2.44.4.bcr.1/overlay/tests/BUILD.bazel
+++ b/modules/gdk-pixbuf/2.44.4.bcr.1/overlay/tests/BUILD.bazel
@@ -1,0 +1,90 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+TESTS = [
+    "animation",
+    "pixbuf-area-updated",
+    "pixbuf-composite",
+    "pixbuf-construction",
+    "pixbuf-dpi",
+    "pixbuf-fail",
+    "pixbuf-gif",
+    "pixbuf-gif-circular-table",
+    "pixbuf-icon-serialize",
+    "pixbuf-icc",
+    "pixbuf-jpeg",
+    "pixbuf-randomly-modified",
+    "pixbuf-readonly-to-mutable",
+    "pixbuf-reftest",
+    "pixbuf-save",
+    "pixbuf-scale",
+    "pixbuf-scale-two-step",
+    "pixbuf-short-gif-write",
+    "pixbuf-stream",
+    "pixbuf-threads",
+]
+
+TEST_DATA = glob([
+    "*.ani",
+    "*.bmp",
+    "*.gif",
+    "*.jpeg",
+    "*.jpg",
+    "*.pixdata",
+    "*.png",
+    "*.tiff",
+    "test-images/**",
+])
+
+[
+    cc_test(
+        name = test_name,
+        srcs = [
+            test_name + ".c",
+            "test-common.c",
+            "test-common.h",
+        ],
+        data = TEST_DATA,
+        defines = ["HAVE_CONFIG_H"],
+        env = {
+            "G_TEST_SRCDIR": "tests",
+            "G_TEST_BUILDDIR": ".",
+        },
+        linkstatic = True,
+        deps = [
+            "//:config",
+            "//gdk-pixbuf",
+        ],
+    )
+    for test_name in TESTS
+]
+
+cc_test(
+    name = "pixbuf-lowmem",
+    srcs = [
+        "pixbuf-lowmem.c",
+    ],
+    args = [
+        "16777216",
+        "tests/test-image.png",
+    ],
+    data = TEST_DATA,
+    defines = ["HAVE_CONFIG_H"],
+    linkstatic = True,
+    deps = [
+        "//:config",
+        "//gdk-pixbuf",
+    ],
+)
+
+cc_test(
+    name = "pixbuf-save-ref",
+    srcs = ["pixbuf-save-ref.c"],
+    args = ["tests/test-image.png"],
+    data = TEST_DATA,
+    defines = ["HAVE_CONFIG_H"],
+    linkstatic = True,
+    deps = [
+        "//:config",
+        "//gdk-pixbuf",
+    ],
+)

--- a/modules/gdk-pixbuf/2.44.4.bcr.1/patches/builtin_svg.patch
+++ b/modules/gdk-pixbuf/2.44.4.bcr.1/patches/builtin_svg.patch
@@ -1,0 +1,31 @@
+diff --git a/gdk-pixbuf/gdk-pixbuf-io.c b/gdk-pixbuf/gdk-pixbuf-io.c
+--- a/gdk-pixbuf/gdk-pixbuf-io.c
++++ b/gdk-pixbuf/gdk-pixbuf-io.c
+@@ -609,6 +609,9 @@
+ #ifdef INCLUDE_ani
+         load_one_builtin_module (ani);
+ #endif
++#ifdef INCLUDE_svg
++        load_one_builtin_module (svg);
++#endif
+ #ifdef INCLUDE_png
+         load_one_builtin_module (png);
+ #endif
+@@ -714,6 +717,7 @@
+   extern void _gdk_pixbuf__##type##_fill_info   (GdkPixbufFormat *info);   \
+   extern void _gdk_pixbuf__##type##_fill_vtable (GdkPixbufModule *module)
+ 
++module (svg);
+ module (png);
+ module (jpeg);
+ module (gif);
+@@ -824,6 +828,9 @@
+ 	try_module (wbmp,android_wbmp);
+ 	try_module (heif,android_heif);
+ #endif
++#ifdef INCLUDE_svg
++        try_module (svg,svg);
++#endif
+ #ifdef INCLUDE_png
+         try_module (png,png);
+ #endif

--- a/modules/gdk-pixbuf/2.44.4.bcr.1/patches/fix_test_include.patch
+++ b/modules/gdk-pixbuf/2.44.4.bcr.1/patches/fix_test_include.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/pixbuf-composite.c b/tests/pixbuf-composite.c
+index 14968c49..ececb644 100644
+--- a/tests/pixbuf-composite.c
++++ b/tests/pixbuf-composite.c
+@@ -18,7 +18,7 @@
+  * Author: Matthias Clasen
+  */
+ 
+-#include <gdk-pixbuf.h>
++#include <gdk-pixbuf/gdk-pixbuf.h>
+ #include "test-common.h"
+ 
+ static void

--- a/modules/gdk-pixbuf/2.44.4.bcr.1/presubmit.yml
+++ b/modules/gdk-pixbuf/2.44.4.bcr.1/presubmit.yml
@@ -1,0 +1,16 @@
+bcr_test_module:
+  module_path: ""
+  matrix:
+    platform:
+      - debian10
+      - debian11
+      - ubuntu2004
+      - ubuntu2204
+    bazel: [7.x, 8.x, rolling]
+  tasks:
+    run_test_module:
+      name: Run test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "@gdk-pixbuf//..."

--- a/modules/gdk-pixbuf/2.44.4.bcr.1/source.json
+++ b/modules/gdk-pixbuf/2.44.4.bcr.1/source.json
@@ -1,0 +1,16 @@
+{
+    "url": "https://download.gnome.org/sources/gdk-pixbuf/2.44/gdk-pixbuf-2.44.4.tar.xz",
+    "strip_prefix": "gdk-pixbuf-2.44.4",
+    "overlay": {
+        "BUILD.bazel": "sha256-gWZdHDEEs63GKFVG2hZcXHwvfbT4ZMiKavZTICNwzJA=",
+        "config.h": "sha256-A55vUfAO5Z1w24rnn79Bz0yfl5CmWAA59EURZp9TTcE=",
+        "gdk-pixbuf/BUILD.bazel": "sha256-q7HloiJV26yhnAezTERdcULOzkO+wLdbIBWCJMAIxtE=",
+        "tests/BUILD.bazel": "sha256-Ajktjkd7LUKk42SasO84IkxlrMrFufU+ZH6dRIGcnBI="
+    },
+    "patch_strip": "1",
+    "patches": {
+        "fix_test_include.patch": "sha256-6Y26V41/hAnlnMZAkDaXBmJ0S8Bt79LTrp3JlyeRCsQ=",
+        "builtin_svg.patch": "sha256-f08XKv7RkneEqWOpS1U7/Gmi0cLCMJYpbfR00CDJiIk="
+    },
+    "integrity": "sha256-k6Gqw/FCeuc0Vzl1gqLDjQSWOKgBeIzL1fSMpge9vRc="
+}

--- a/modules/gdk-pixbuf/metadata.json
+++ b/modules/gdk-pixbuf/metadata.json
@@ -12,7 +12,8 @@
         "https://download.gnome.org/sources/gdk-pixbuf"
     ],
     "versions": [
-        "2.44.4"
+        "2.44.4",
+        "2.44.4.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Separate public headers and add opt-in registration for a statically linked SVG loader. SVG support remains disabled by default.

Split from #10410 into a PR containing only `modules/gdk-pixbuf`. Module files are unchanged from that submission.

Validation: BCR source-archive, patch, overlay, MODULE.bazel, and metadata checks passed locally. The module files match #10410 byte for byte; its build/test results are documented there. Module builds were not rerun for this split.

Prepared with Codex.

-zbarskybot
