### PR TITLE
pango@1.56.3

### DIFF
--- a/modules/pango/1.56.3/MODULE.bazel
+++ b/modules/pango/1.56.3/MODULE.bazel
@@ -1,0 +1,19 @@
+module(
+    name = "pango",
+    version = "1.56.3",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "cairo", version = "1.18.4.bcr.1")
+bazel_dep(name = "fontconfig", version = "2.16.0")
+bazel_dep(name = "freetype", version = "2.14.1.bcr.1")
+bazel_dep(name = "fribidi", version = "1.0.16")
+bazel_dep(name = "glib", version = "2.82.2.bcr.10")
+bazel_dep(name = "harfbuzz", version = "14.1.0")
+bazel_dep(name = "libdatrie", version = "0.2.13")
+bazel_dep(name = "libpng", version = "1.6.44")
+bazel_dep(name = "libthai", version = "0.1.29")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.8")

--- a/modules/pango/1.56.3/README.md
+++ b/modules/pango/1.56.3/README.md
@@ -1,0 +1,76 @@
+# Pango 1.56.3
+
+Bazel-native Linux build of upstream Pango 1.56.3, licensed LGPL-2.1-or-later.
+The release's `COPYING` file and copyright notices are retained.
+
+## Targets
+
+Add `bazel_dep(name = "pango", version = "1.56.3")` to `MODULE.bazel`.
+
+The HarfBuzz/ICU dependencies require C++17 or newer. With a toolchain that
+defaults to an older standard (including Bazel 7's default Linux toolchain), add
+this to your project's `.bazelrc`:
+
+```text
+build --cxxopt=-std=c++17
+```
+
+| Target | Purpose / output |
+| --- | --- |
+| `@pango` or `@pango//:pango` | Core `cc_library`; include `<pango/pango.h>` |
+| `@pango//:pangoft2` | FreeType/fontconfig `cc_library` |
+| `@pango//:pangocairo` | Cairo `cc_library` |
+| `@pango//:pango_shared` | `libpango-1.0.so.0` |
+| `@pango//:pangoft2_shared` | `libpangoft2-1.0.so.0` |
+| `@pango//:pangocairo_shared` | `libpangocairo-1.0.so.0` |
+
+C/C++ consumers can link the `cc_library` targets statically or use the explicit
+shared targets through `cc_shared_library.dynamic_deps`. The explicit shared
+libraries own dependency implementations once: core Pango contains the common
+text stack; FT2 depends dynamically on core; PangoCairo depends on both and
+contains Cairo/Pixman. FFI consumers using GLib/GObject or fontconfig APIs should
+resolve those functions from `pango_shared` to keep objects in the same native
+stack. Standard C/C++ runtime libraries come from the execution platform.
+
+## Loading from runfiles
+
+For a Python binary, pass a runfiles path and declare the shared target as data:
+
+```starlark
+args = ["$(rlocationpath @pango//:pangocairo_shared)"],
+data = ["@pango//:pangocairo_shared"],
+deps = ["@rules_python//python/runfiles"],
+```
+
+```python
+import ctypes
+import os
+import sys
+from python.runfiles import runfiles
+
+library_path = runfiles.Create().Rlocation(sys.argv[1])
+library = ctypes.CDLL(library_path, mode=os.RTLD_NOW | os.RTLD_LOCAL)
+```
+
+The same resolved path works with `ffi.dlopen`. Bazel supplies transitive shared
+library runfiles. Use `rlocationpath` rather than hard-coding repository names.
+When materializing runfiles, preserve file identity (for example, `cp -aL`),
+or copy the three `.so.0` files together into one directory. SONAMEs and `$ORIGIN`
+search paths support that layout. Avoid loading separate copies through both a
+canonical path and a `_solib` alias. No host Pango or `LD_LIBRARY_PATH` is needed.
+
+## Fonts and Thai dictionaries
+
+Consumers supply font files and fontconfig configuration as runtime inputs.
+For hermetic rendering, package them in runfiles and initialize an explicit
+fontconfig configuration. The test module demonstrates `FcConfigAppFontAddFile`
+and `pango_fc_font_map_set_config` with bundled fonts and no host font discovery.
+
+Thai word breaking uses libthai's embedded dictionary by default, including
+after relocation. To override it, add `@libthai//:dictionary` to `data`, resolve
+its runfiles path, and set `LIBTHAI_DICTDIR` to the parent directory before the
+first layout call. This requires a direct `libthai` dependency. An unusable
+override falls back to the embedded dictionary.
+
+This initial port supports Linux with the FreeType/fontconfig and Cairo
+backends. Xft, native macOS/Windows backends, and introspection are not included.

--- a/modules/pango/1.56.3/overlay/BUILD.bazel
+++ b/modules/pango/1.56.3/overlay/BUILD.bazel
@@ -1,0 +1,287 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@glib//gobject:gobject.bzl", "mkenums")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+
+# Source and installed-header lists from pango/meson.build, Pango 1.56.3.
+CORE_HEADERS = [
+    "pango/pango.h",
+    "pango/pango-attributes.h",
+    "pango/pango-bidi-type.h",
+    "pango/pango-break.h",
+    "pango/pango-color.h",
+    "pango/pango-context.h",
+    "pango/pango-coverage.h",
+    "pango/pango-direction.h",
+    "pango/pango-engine.h",
+    "pango/pango-font.h",
+    "pango/pango-fontmap.h",
+    "pango/pango-fontset.h",
+    "pango/pango-fontset-simple.h",
+    "pango/pango-glyph.h",
+    "pango/pango-glyph-item.h",
+    "pango/pango-gravity.h",
+    "pango/pango-item.h",
+    "pango/pango-language.h",
+    "pango/pango-layout.h",
+    "pango/pango-matrix.h",
+    "pango/pango-markup.h",
+    "pango/pango-modules.h",
+    "pango/pango-renderer.h",
+    "pango/pango-script.h",
+    "pango/pango-tabs.h",
+    "pango/pango-types.h",
+    "pango/pango-utils.h",
+]
+
+expand_template(
+    name = "pango_features",
+    out = "pango/pango-features.h",
+    substitutions = {
+        "#mesondefine PANGO_VERSION_MAJOR": "#define PANGO_VERSION_MAJOR 1",
+        "#mesondefine PANGO_VERSION_MINOR": "#define PANGO_VERSION_MINOR 56",
+        "#mesondefine PANGO_VERSION_MICRO": "#define PANGO_VERSION_MICRO 3",
+        "@PANGO_VERSION_MAJOR@": "1",
+        "@PANGO_VERSION_MINOR@": "56",
+        "@PANGO_VERSION_MICRO@": "3",
+    },
+    template = "pango/pango-features.h.meson",
+)
+
+[mkenums(
+    name = "pango_enum_types_" + ext,
+    srcs = CORE_HEADERS,
+    out = "pango/pango-enum-types." + ext,
+    template = "pango/pango-enum-types." + ext + ".template",
+) for ext in [
+    "c",
+    "h",
+]]
+
+# Private headers shared between upstream compilation units. Keep config.h
+# private to Pango so it cannot shadow a consumer's configuration header.
+PRIVATE_HEADERS = glob(["pango/**/*.h"]) + ["config.h"]
+
+# break.c includes these script-specific implementations directly.
+INCLUDED_SOURCES = glob(["pango/break-*.c"]) + ["pango/emoji_presentation_scanner.c"]
+
+LOCAL_DEFINES = [
+    "_GNU_SOURCE",
+    "_POSIX_C_SOURCE=200809L",
+    "_POSIX_THREAD_SAFE_FUNCTIONS",
+    "PANGO_COMPILATION",
+    "PANGO_DISABLE_DEPRECATION_WARNINGS",
+    "G_LOG_DOMAIN='\"Pango\"'",
+    "G_LOG_USE_STRUCTURED=1",
+    # Legacy module/config lookups are unused by the built-in font backends.
+    "SYSCONFDIR='\"/nonexistent\"'",
+    "LIBDIR='\"/nonexistent\"'",
+]
+
+LINUX_ONLY = select({
+    "@platforms//os:linux": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})
+
+# Unlike includes, this compiler search path stays private to Pango.
+# Propagating the repository root would expose config.h to dependents.
+REPO_ROOT = package_relative_label(":BUILD.bazel").workspace_root or "."
+
+NATIVE_DEPS = [
+    "@fontconfig//:fontconfig",
+    "@freetype//:freetype",
+    "@fribidi//:fribidi",
+    "@glib//gio:gio",
+    "@glib//glib:glib",
+    "@glib//gobject:gobject",
+    "@harfbuzz//:harfbuzz",
+    "@libdatrie//:datrie",
+    "@libpng//:libpng",
+    "@libthai//:thai",
+    "@zlib//:zlib",
+]
+
+cc_library(
+    name = "pango",
+    srcs = [
+        "pango/break.c",
+        "pango/ellipsize.c",
+        "pango/fonts.c",
+        "pango/glyphstring.c",
+        "pango/itemize.c",
+        "pango/json/gtkjsonparser.c",
+        "pango/json/gtkjsonprinter.c",
+        "pango/modules.c",
+        "pango/pango-attributes.c",
+        "pango/pango-bidi-type.c",
+        "pango/pango-color.c",
+        "pango/pango-context.c",
+        "pango/pango-coverage.c",
+        "pango/pango-emoji.c",
+        "pango/pango-engine.c",
+        "pango/pango-fontmap.c",
+        "pango/pango-fontset.c",
+        "pango/pango-fontset-simple.c",
+        "pango/pango-glyph-item.c",
+        "pango/pango-gravity.c",
+        "pango/pango-item.c",
+        "pango/pango-language.c",
+        "pango/pango-layout.c",
+        "pango/pango-markup.c",
+        "pango/pango-matrix.c",
+        "pango/pango-renderer.c",
+        "pango/pango-script.c",
+        "pango/pango-tabs.c",
+        "pango/pango-utils.c",
+        "pango/reorder-items.c",
+        "pango/serializer.c",
+        "pango/shape.c",
+    ] + PRIVATE_HEADERS + [":pango_enum_types_c"],
+    hdrs = CORE_HEADERS + [
+        "pango/pango-version-macros.h",
+        ":pango_enum_types_h",
+        ":pango_features",
+    ],
+    copts = [
+        "-std=gnu11",
+        "-fno-strict-aliasing",
+        "-I" + REPO_ROOT,
+    ],
+    include_prefix = "pango",
+    includes = ["pango"],
+    # HarfBuzz 14.1.0 puts hb-unicode.cc in harfbuzz-subset, after the
+    # archive containing hb-glib.cc. Force this dependency into the link
+    # before archive scanning so static consumers also resolve it.
+    linkopts = [
+        "-lm",
+        "-Wl,-u,hb_glib_get_unicode_funcs",
+    ],
+    # Dynamic consumers use the explicit cc_shared_library graph below;
+    # automatic shared variants of dependencies are not all self-contained.
+    linkstatic = True,
+    local_defines = LOCAL_DEFINES,
+    strip_include_prefix = "pango",
+    target_compatible_with = LINUX_ONLY,
+    textual_hdrs = INCLUDED_SOURCES,
+    visibility = ["//visibility:public"],
+    deps = NATIVE_DEPS,
+)
+
+cc_library(
+    name = "pangoft2",
+    srcs = [
+        "pango/pango-ot-buffer.c",
+        "pango/pango-ot-info.c",
+        "pango/pango-ot-ruleset.c",
+        "pango/pango-ot-tag.c",
+        "pango/pango-trace.c",
+        "pango/pangofc-decoder.c",
+        "pango/pangofc-font.c",
+        "pango/pangofc-fontmap.c",
+        "pango/pangoft2.c",
+        "pango/pangoft2-fontmap.c",
+        "pango/pangoft2-render.c",
+    ] + PRIVATE_HEADERS,
+    hdrs = [
+        "pango/pango-ot.h",
+        "pango/pangofc-decoder.h",
+        "pango/pangofc-font.h",
+        "pango/pangofc-fontmap.h",
+        "pango/pangoft2.h",
+    ],
+    copts = [
+        "-std=gnu11",
+        "-fno-strict-aliasing",
+        "-I" + REPO_ROOT,
+    ],
+    include_prefix = "pango",
+    includes = ["pango"],
+    linkstatic = True,
+    local_defines = LOCAL_DEFINES,
+    strip_include_prefix = "pango",
+    target_compatible_with = LINUX_ONLY,
+    visibility = ["//visibility:public"],
+    deps = [":pango"],
+)
+
+cc_library(
+    name = "pangocairo",
+    srcs = [
+        "pango/pangocairo-context.c",
+        "pango/pangocairo-fcfont.c",
+        "pango/pangocairo-fcfontmap.c",
+        "pango/pangocairo-font.c",
+        "pango/pangocairo-fontmap.c",
+        "pango/pangocairo-render.c",
+    ] + PRIVATE_HEADERS,
+    hdrs = ["pango/pangocairo.h"],
+    copts = [
+        "-std=gnu11",
+        "-fno-strict-aliasing",
+        "-I" + REPO_ROOT,
+    ],
+    include_prefix = "pango",
+    includes = ["pango"],
+    linkstatic = True,
+    local_defines = LOCAL_DEFINES,
+    strip_include_prefix = "pango",
+    target_compatible_with = LINUX_ONLY,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":pangoft2",
+        "@cairo",
+    ],
+)
+
+# Export these dependency roots from the core DSO, not just :pango. Cairo
+# also depends on Fontconfig/FreeType/PNG/zlib; cc_shared_library rejects those
+# shared dependencies as "linked statically but not exported" without the roots.
+# Whole-archive linking also retains their public APIs for explicit dlopen users.
+# This gives all three DSOs one GLib/GObject registry and other native globals.
+cc_shared_library(
+    name = "pango_shared",
+    shared_lib_name = "libpango-1.0.so.0",
+    target_compatible_with = LINUX_ONLY,
+    # shared_lib_name sets the filename, but the tested Linux toolchain does
+    # not emit DT_SONAME for a custom output name. Keep the stable ABI name.
+    user_link_flags = ["-Wl,-soname,libpango-1.0.so.0"],
+    visibility = ["//visibility:public"],
+    deps = [":pango"] + NATIVE_DEPS,
+)
+
+cc_shared_library(
+    name = "pangoft2_shared",
+    dynamic_deps = [":pango_shared"],
+    shared_lib_name = "libpangoft2-1.0.so.0",
+    target_compatible_with = LINUX_ONLY,
+    user_link_flags = [
+        "-Wl,-soname,libpangoft2-1.0.so.0",
+        # Bazel's _solib runpaths do not cover the three DSOs copied together.
+        "-Wl,-rpath,$ORIGIN",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":pangoft2"],
+)
+
+cc_shared_library(
+    name = "pangocairo_shared",
+    dynamic_deps = [
+        ":pango_shared",
+        ":pangoft2_shared",
+    ],
+    shared_lib_name = "libpangocairo-1.0.so.0",
+    target_compatible_with = LINUX_ONLY,
+    user_link_flags = [
+        "-Wl,-soname,libpangocairo-1.0.so.0",
+        # Bazel's _solib runpaths do not cover the three DSOs copied together.
+        "-Wl,-rpath,$ORIGIN",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":pangocairo"],
+)
+
+# Font fixture from the upstream release; runtime tests never scan host fonts.
+exports_files([
+    "tests/fonts/DejaVuSans.ttf",
+    "tests/fonts/emoji-subset.ttf",
+])

--- a/modules/pango/1.56.3/overlay/bazel_test/BUILD.bazel
+++ b/modules/pango/1.56.3/overlay/bazel_test/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_python//python:py_test.bzl", "py_test")
+
+cc_test(
+    name = "cc_smoke",
+    size = "small",
+    srcs = ["smoke.cc"],
+    linkstatic = True,
+    deps = [
+        "@pango",
+        "@pango//:pangocairo",
+        "@pango//:pangoft2",
+    ],
+)
+
+# Each DSO must be independently loadable first in a fresh process, with
+# RTLD_LOCAL and no LD_LIBRARY_PATH or host Pango installation.
+[py_test(
+    name = "dlopen_" + name,
+    size = "small",
+    srcs = ["dlopen_test.py"],
+    args = [
+        str(first),
+        "$(rlocationpath @pango//:pango_shared)",
+        "$(rlocationpath @pango//:pangoft2_shared)",
+        "$(rlocationpath @pango//:pangocairo_shared)",
+        "$(rlocationpath @pango//:tests/fonts/DejaVuSans.ttf)",
+        "$(rlocationpath @pango//:tests/fonts/emoji-subset.ttf)",
+    ] + (["--relocate"] if relocate else []) + ([
+        "--dictionary",
+        "$(rlocationpath @libthai//:dictionary)",
+    ] if dictionary else []),
+    data = [
+        "@pango//:pango_shared",
+        "@pango//:pangocairo_shared",
+        "@pango//:pangoft2_shared",
+        "@pango//:tests/fonts/DejaVuSans.ttf",
+        "@pango//:tests/fonts/emoji-subset.ttf",
+    ] + (["@libthai//:dictionary"] if dictionary else []),
+    env = {
+        "FONTCONFIG_FILE": "/nonexistent/fonts.conf",
+        "FONTCONFIG_PATH": "/nonexistent",
+        "G_DEBUG": "fatal-warnings",
+        "LD_LIBRARY_PATH": "",
+    },
+    main = "dlopen_test.py",
+    deps = ["@rules_python//python/runfiles"],
+) for name, first, relocate, dictionary in [
+    ("pango", 0, False, False),
+    ("pangoft2", 1, False, False),
+    ("pangocairo", 2, False, False),
+    ("relocated_pangocairo", 2, True, False),
+    ("dictionary_override", 2, False, True),
+]]

--- a/modules/pango/1.56.3/overlay/bazel_test/MODULE.bazel
+++ b/modules/pango/1.56.3/overlay/bazel_test/MODULE.bazel
@@ -1,0 +1,12 @@
+module(name = "pango_smoke_test")
+
+bazel_dep(name = "pango", version = "1.56.3")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "rules_python", version = "1.7.0")
+
+local_path_override(
+    module_name = "pango",
+    path = "..",
+)
+
+bazel_dep(name = "libthai", version = "0.1.29")

--- a/modules/pango/1.56.3/overlay/bazel_test/dlopen_test.py
+++ b/modules/pango/1.56.3/overlay/bazel_test/dlopen_test.py
@@ -1,0 +1,174 @@
+"""Exercise Bazel-built Pango through explicit runfiles paths, without linking it."""
+
+import argparse
+import ctypes as C
+import os
+from pathlib import Path
+import shutil
+import tempfile
+
+from python.runfiles import runfiles
+
+
+def function(lib, name, result, *args):
+    fn = getattr(lib, name)
+    fn.restype = result
+    fn.argtypes = list(args)
+    return fn
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("first", type=int, choices=range(3))
+    parser.add_argument("paths", nargs=5)
+    parser.add_argument("--relocate", action="store_true")
+    parser.add_argument("--dictionary")
+    args = parser.parse_args()
+    rf = runfiles.Create()
+    paths = [Path(rf.Rlocation(arg)).resolve(strict=True) for arg in args.paths]
+    first = args.first
+    if args.relocate:
+        relocated = tempfile.TemporaryDirectory()
+        paths[:3] = [Path(shutil.copy2(path, relocated.name)) for path in paths[:3]]
+        assert {path.name for path in Path(relocated.name).iterdir()} == {
+            "libpango-1.0.so.0",
+            "libpangoft2-1.0.so.0",
+            "libpangocairo-1.0.so.0",
+        }
+    # The default must work without a dictionary file or an inherited override.
+    os.environ.pop("LIBTHAI_DICTDIR", None)
+    if args.dictionary:
+        dictionary = Path(rf.Rlocation(args.dictionary)).resolve(strict=True)
+        os.environ["LIBTHAI_DICTDIR"] = str(dictionary.parent)
+    # RTLD_NOW rejects missing symbols even for code not called by this test.
+    handles = [None] * 3
+    for index in [first] + [i for i in range(3) if i != first]:
+        handles[index] = C.CDLL(str(paths[index]), mode=os.RTLD_NOW | os.RTLD_LOCAL)
+    pango, ft2, cairo = handles
+    ptr, integer, string = C.c_void_p, C.c_int, C.c_char_p
+    assert function(pango, "pango_version", integer)() == 15603
+    assert function(pango, "pango_version_string", string)() == b"1.56.3"
+
+    # All three handles must resolve the same core/GObject implementation.
+    for name in ["pango_font_map_get_type", "g_object_unref", "g_type_from_name"]:
+        addresses = [C.cast(getattr(h, name), ptr).value for h in handles]
+        assert len(set(addresses)) == 1, (name, addresses)
+    assert (
+        function(ft2, "pango_fc_font_map_get_type", C.c_size_t)()
+        == function(cairo, "pango_fc_font_map_get_type", C.c_size_t)()
+    )
+
+    # Dictionary-backed Thai breaks: the same sentence used by libthai tests.
+    thai = "สวัสดีครับ กอ.รมน. นี่เป็นการทดสอบตัวเอง"
+    attrs = (C.c_uint * (len(thai) + 1))()
+    language = function(pango, "pango_language_from_string", ptr, string)(b"th")
+    function(pango, "pango_get_log_attrs", None, string, integer, integer, ptr, ptr, integer)(
+        thai.encode(), len(thai.encode()), 0, language, attrs, len(attrs)
+    )
+    for boundary in [6, 11, 19, 22, 26, 29, 34]:
+        assert attrs[boundary] & 1, ("Missing Thai line break", boundary)
+
+    # Supply an empty fontconfig and exactly two fonts from Bazel runfiles.
+    config = function(pango, "FcConfigCreate", ptr)()
+    assert config
+    # Pango requests the generic emoji family. Bind it explicitly to our
+    # fixture, as a normal fontconfig installation does with its emoji rules.
+    emoji_rule = b"""<fontconfig><match>
+      <test name="family"><string>emoji</string></test>
+      <edit name="family" mode="prepend" binding="strong"><string>Noto Color Emoji</string></edit>
+      <edit name="lang" mode="prepend"><string>und-zsye</string></edit>
+    </match></fontconfig>"""
+    assert function(pango, "FcConfigParseAndLoadFromMemory", integer, ptr, string, integer)(config, emoji_rule, 1)
+    assert function(pango, "FcConfigSetCurrent", integer, ptr)(config)
+    assert function(pango, "FcConfigAppFontAddFile", integer, ptr, string)(config, os.fsencode(paths[3]))
+    assert function(pango, "FcConfigAppFontAddFile", integer, ptr, string)(config, os.fsencode(paths[4]))
+    set_config = function(ft2, "pango_fc_font_map_set_config", None, ptr, ptr)
+    unref = function(pango, "g_object_unref", None, ptr)
+    make_context = function(pango, "pango_font_map_create_context", ptr, ptr)
+    make_layout = function(pango, "pango_layout_new", ptr, ptr)
+    set_text = function(pango, "pango_layout_set_text", None, ptr, string, integer)
+    measure = function(pango, "pango_layout_get_pixel_size", None, ptr, C.POINTER(integer), C.POINTER(integer))
+    maps = [function(ft2, "pango_ft2_font_map_new", ptr)(), function(cairo, "pango_cairo_font_map_new", ptr)()]
+    for index, font_map in enumerate(maps):
+        assert font_map
+        set_config(font_map, config)
+        context = make_context(font_map)
+        layout = make_layout(context)
+        assert context and layout
+        text = "Bazel Pango — العربية".encode()
+        set_text(layout, text, len(text))
+        width, height = integer(), integer()
+        measure(layout, C.byref(width), C.byref(height))
+        assert width.value > 0 and height.value > 0
+        assert function(pango, "pango_layout_get_unknown_glyphs_count", integer, ptr)(layout) == 0
+        if index == 1:
+            surface = function(cairo, "cairo_image_surface_create", ptr, integer, integer, integer)(0, 512, 128)
+            cr = function(cairo, "cairo_create", ptr, ptr)(surface)
+            function(cairo, "pango_cairo_update_layout", None, ptr, ptr)(cr, layout)
+            function(cairo, "pango_cairo_show_layout", None, ptr, ptr)(cr, layout)
+            assert function(cairo, "cairo_status", integer, ptr)(cr) == 0
+            function(cairo, "cairo_surface_flush", None, ptr)(surface)
+            pixels = function(cairo, "cairo_image_surface_get_data", ptr, ptr)(surface)
+            assert any(C.string_at(pixels, 512 * 128 * 4)), "No glyphs rendered"
+            function(cairo, "cairo_destroy", None, ptr)(cr)
+            function(cairo, "cairo_surface_destroy", None, ptr)(surface)
+            # A font can resolve successfully yet render blank without PNG support.
+            description = function(pango, "pango_font_description_from_string", ptr, string)(b"Noto Color Emoji 16")
+            function(pango, "pango_layout_set_font_description", None, ptr, ptr)(layout, description)
+            function(pango, "pango_font_description_free", None, ptr)(description)
+            set_text(layout, "😀".encode(), -1)
+            assert function(pango, "pango_layout_get_unknown_glyphs_count", integer, ptr)(layout) == 0
+            surface = function(cairo, "cairo_image_surface_create", ptr, integer, integer, integer)(0, 512, 256)
+            cr = function(cairo, "cairo_create", ptr, ptr)(surface)
+            function(cairo, "pango_cairo_update_layout", None, ptr, ptr)(cr, layout)
+            function(cairo, "pango_cairo_show_layout", None, ptr, ptr)(cr, layout)
+            assert function(cairo, "cairo_status", integer, ptr)(cr) == 0
+            function(cairo, "cairo_surface_flush", None, ptr)(surface)
+            pixels = function(cairo, "cairo_image_surface_get_data", ptr, ptr)(surface)
+            words = C.cast(pixels, C.POINTER(C.c_uint32))
+            assert any(
+                (word >> 24) and ((word & 255) != ((word >> 8) & 255) or (word & 255) != ((word >> 16) & 255))
+                for word in words[: 512 * 256]
+            ), "Color emoji produced no colored pixels"
+            function(cairo, "cairo_destroy", None, ptr)(cr)
+            function(cairo, "cairo_surface_destroy", None, ptr)(surface)
+        unref(layout)
+        unref(context)
+        unref(font_map)
+    function(pango, "FcConfigDestroy", None, ptr)(config)
+
+    # Runtime proof that no host copy of this native stack was loaded.
+    native_prefixes = (
+        "libpango",
+        "libcairo",
+        "libglib",
+        "libgobject",
+        "libgio-",
+        "libharfbuzz",
+        "libfontconfig",
+        "libfreetype",
+        "libfribidi",
+        "libpixman",
+        "libpng",
+        "libz.so",
+        "libffi",
+        "libpcre",
+        "libexpat",
+        "libthai",
+        "libdatrie",
+    )
+    seen = set()
+    for line in Path("/proc/self/maps").read_text().splitlines():
+        path = line.split()[-1]
+        if path.startswith("/") and Path(path).name.startswith(native_prefixes):
+            loaded = Path(path).resolve()
+            # Materialized runfiles may preserve aliases as hardlinks.
+            matches = [expected for expected in paths[:3] if loaded.samefile(expected)]
+            assert matches, f"Unexpected native library: {loaded}"
+            seen.update(matches)
+    assert seen == set(paths[:3]), seen
+    print(f"Pango 1.56.3: dlopen order {first}, FT2 layout, Thai breaks and color emoji passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/pango/1.56.3/overlay/bazel_test/smoke.cc
+++ b/modules/pango/1.56.3/overlay/bazel_test/smoke.cc
@@ -1,0 +1,14 @@
+#include <pango/pango.h>
+#include <pango/pangocairo.h>
+#include <pango/pangoft2.h>
+#include <cstring>
+
+int main() {
+  if (pango_version() != PANGO_VERSION_ENCODE(1, 56, 3) ||
+      std::strcmp(pango_version_string(), "1.56.3") != 0) return 1;
+  PangoFontDescription *desc = pango_font_description_from_string("Sans 12");
+  if (!desc || pango_font_description_get_size(desc) != 12 * PANGO_SCALE) return 2;
+  pango_font_description_free(desc);
+  if (!pango_cairo_font_map_get_type() || !pango_ft2_font_map_get_type()) return 3;
+  return 0;
+}

--- a/modules/pango/1.56.3/overlay/config.h
+++ b/modules/pango/1.56.3/overlay/config.h
@@ -1,0 +1,17 @@
+/* Linux configuration for the pinned BCR dependencies. No host probes. */
+#pragma once
+#define PANGO_BINARY_AGE 5603
+#define PANGO_INTERFACE_AGE 3
+#define PANGO_VERSION_MAJOR 1
+#define PANGO_VERSION_MINOR 56
+#define PANGO_VERSION_MICRO 3
+#define HAVE_FREETYPE 1
+#define HAVE_FCWEIGHTFROMOPENTYPEDOUBLE 1
+#define HAVE_CAIRO 1
+#define HAVE_CAIRO_FREETYPE 1
+#define HAVE_CAIRO_PNG 1
+#define HAVE_CAIRO_PS 1
+#define HAVE_CAIRO_PDF 1
+#define HAVE_LIBTHAI 1
+#define HAVE_TH_BRK_FIND_BREAKS 1
+#undef HAVE_SYSPROF

--- a/modules/pango/1.56.3/presubmit.yml
+++ b/modules/pango/1.56.3/presubmit.yml
@@ -1,0 +1,23 @@
+matrix:
+  platform: [debian13, ubuntu2404]
+  bazel: [7.x, 8.x, 9.x]
+tasks:
+  verify_targets:
+    name: Build Pango libraries
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    # HarfBuzz depends on ICU, which requires C++17 or newer.
+    build_flags: ["--cxxopt=-std=c++17"]
+    build_targets: ["@pango//:all"]
+bcr_test_module:
+  module_path: bazel_test
+  matrix:
+    platform: [debian13, ubuntu2404]
+    bazel: [7.x, 8.x, 9.x]
+  tasks:
+    run_tests:
+      name: Test C++ consumers and runfiles dlopen
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_flags: ["--cxxopt=-std=c++17"]
+      test_targets: ["//:all"]

--- a/modules/pango/1.56.3/source.json
+++ b/modules/pango/1.56.3/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://download.gnome.org/sources/pango/1.56/pango-1.56.3.tar.xz",
+    "integrity": "sha256-JgYlK8Jc2NJOG39+ksOicrN6zWc0NHtztHpIKDS6JJE=",
+    "strip_prefix": "pango-1.56.3",
+    "overlay": {
+        "BUILD.bazel": "sha256-NNa9XtPzLSKxC7MKcBeUrAkjgNY1GAsjt5Z3HamMWV8=",
+        "bazel_test/BUILD.bazel": "sha256-PLQP+oa2i+kgmendbfRC81EWoCGYn4EndAVdQwvk3iM=",
+        "bazel_test/MODULE.bazel": "sha256-7gYHA4oYqn4M0PJKcmhn0KyQXx4RBhqNgJVUQnkpTWg=",
+        "bazel_test/dlopen_test.py": "sha256-vqQijO6JZ9FePdebODmFv1W7/HCmddDYYf+0omXs2Tk=",
+        "bazel_test/smoke.cc": "sha256-R27ya0AC2kTwnh7m97VSa1ioV07K5lY5AfTuehQpDP0=",
+        "config.h": "sha256-9xw3Y5v078p2nff1wMTeVp3OTmvI6F50qL2EtBII3lQ="
+    }
+}

--- a/modules/pango/metadata.json
+++ b/modules/pango/metadata.json
@@ -11,7 +11,8 @@
         "https://download.gnome.org/sources/pango"
     ],
     "versions": [
-        "1.52.1"
+        "1.52.1",
+        "1.56.3"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Update the existing native Bazel overlay to Pango 1.56.3, including version constants and GNU C11 compilation.

Split from #10410 into a PR containing only `modules/pango`. Module files are unchanged from that submission.

Validation: BCR source-archive, patch, overlay, MODULE.bazel, and metadata checks passed locally. The module files match #10410 byte for byte; its build/test results are documented there. Module builds were not rerun for this split.

Prepared with Codex.

-zbarskybot
