### PR TITLE
libepoxy@1.5.10

### DIFF
--- a/modules/libepoxy/1.5.10/MODULE.bazel
+++ b/modules/libepoxy/1.5.10/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "libepoxy",
+    version = "1.5.10",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "egl-registry", version = "0.0.0-20250527")
+bazel_dep(name = "libx11", version = "1.8.12.bcr.5")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "rules_python", version = "1.5.0")

--- a/modules/libepoxy/1.5.10/README.md
+++ b/modules/libepoxy/1.5.10/README.md
@@ -1,0 +1,8 @@
+# libepoxy 1.5.10
+
+Link `@libepoxy` (or `@libepoxy//:epoxy`) for the native Linux GL, GLX, and EGL
+dispatch library. Upstream `gen_dispatch.py` generates dispatch sources from
+the release's Khronos XML files on the execution platform. No installed GL
+headers or libraries are needed at build time. GPU drivers are loaded with
+`dlopen` at runtime; linking this library statically does not embed a driver.
+The smoke test links all three public dispatch APIs without opening a display.

--- a/modules/libepoxy/1.5.10/overlay/BUILD.bazel
+++ b/modules/libepoxy/1.5.10/overlay/BUILD.bazel
@@ -1,0 +1,93 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_python//python:defs.bzl", "py_binary")
+
+py_binary(
+    name = "gen_dispatch",
+    srcs = ["src/gen_dispatch.py"],
+    main = "src/gen_dispatch.py",
+)
+
+[
+    genrule(
+        name = api + "_dispatch",
+        srcs = ["registry/" + api + ".xml"],
+        outs = ["src/" + api + "_generated_dispatch.c"],
+        cmd = "$(location :gen_dispatch) --source --no-header --outputdir=$(@D) $(SRCS)",
+        tools = [":gen_dispatch"],
+    )
+    for api in [
+        "gl",
+        "glx",
+        "egl",
+    ]
+]
+
+[
+    genrule(
+        name = api + "_header",
+        srcs = ["registry/" + api + ".xml"],
+        outs = ["include/epoxy/" + api + "_generated.h"],
+        cmd = "$(location :gen_dispatch) --header --no-source --outputdir=$(@D) $(SRCS)",
+        tools = [":gen_dispatch"],
+    )
+    for api in [
+        "gl",
+        "glx",
+        "egl",
+    ]
+]
+
+write_file(
+    name = "config",
+    out = "src/config.h",
+    content = [
+        "#define ENABLE_GLX 1",
+        "#define ENABLE_EGL 1",
+        "#define HAVE_KHRPLATFORM_H 1",
+        "#define ENABLE_X11 1",
+        "#define EPOXY_PUBLIC __attribute__((visibility(\"default\"))) extern",
+    ],
+)
+
+cc_library(
+    name = "epoxy",
+    srcs = [
+        "src/dispatch_common.c",
+        "src/dispatch_egl.c",
+        "src/dispatch_glx.c",
+        ":egl_dispatch",
+        ":gl_dispatch",
+        ":glx_dispatch",
+    ],
+    hdrs = [
+        "include/epoxy/common.h",
+        "include/epoxy/egl.h",
+        "include/epoxy/gl.h",
+        "include/epoxy/glx.h",
+        "src/dispatch_common.h",
+        ":config",
+        ":egl_header",
+        ":gl_header",
+        ":glx_header",
+    ],
+    includes = [
+        "include",
+        "src",
+    ],
+    linkopts = ["-ldl"],
+    linkstatic = True,
+    local_defines = ["_GNU_SOURCE"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@egl-registry//:EGL_headers",
+        "@libx11",
+    ],
+)
+
+alias(
+    name = "libepoxy",
+    actual = ":epoxy",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libepoxy/1.5.10/overlay/bazel_test/BUILD.bazel
+++ b/modules/libepoxy/1.5.10/overlay/bazel_test/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "smoke",
+    srcs = ["smoke.c"],
+    linkstatic = True,
+    deps = ["@libepoxy"],
+)

--- a/modules/libepoxy/1.5.10/overlay/bazel_test/MODULE.bazel
+++ b/modules/libepoxy/1.5.10/overlay/bazel_test/MODULE.bazel
@@ -1,0 +1,2 @@
+bazel_dep(name = "libepoxy", version = "1.5.10")
+bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/libepoxy/1.5.10/overlay/bazel_test/smoke.c
+++ b/modules/libepoxy/1.5.10/overlay/bazel_test/smoke.c
@@ -1,0 +1,6 @@
+#include <epoxy/gl.h>
+#include <epoxy/egl.h>
+#include <epoxy/glx.h>
+int main(void) {
+  return epoxy_glXQueryVersion == 0 || epoxy_eglInitialize == 0 || epoxy_glGetString == 0;
+}

--- a/modules/libepoxy/1.5.10/presubmit.yml
+++ b/modules/libepoxy/1.5.10/presubmit.yml
@@ -1,0 +1,22 @@
+matrix:
+  platform: [debian13, ubuntu2404]
+  bazel: [7.x, 8.x, 9.x]
+tasks:
+  verify_targets:
+    name: Build public library
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags: ["--cxxopt=-std=c++17"]
+    build_targets: ["@libepoxy//:libepoxy"]
+bcr_test_module:
+  module_path: bazel_test
+  matrix:
+    platform: [debian13, ubuntu2404]
+    bazel: [7.x, 8.x, 9.x]
+  tasks:
+    run_tests:
+      name: Test external consumer
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_flags: ["--cxxopt=-std=c++17"]
+      test_targets: ["//:all"]

--- a/modules/libepoxy/1.5.10/source.json
+++ b/modules/libepoxy/1.5.10/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://download.gnome.org/sources/libepoxy/1.5/libepoxy-1.5.10.tar.xz",
+    "strip_prefix": "libepoxy-1.5.10",
+    "integrity": "sha256-ByzaS1ndCYu6jCNjpiRymdsfqJQR3CIci4G47oGS5iM=",
+    "overlay": {
+        "BUILD.bazel": "sha256-lXHAoA1ztBba/hcog7TwzhFtCYLrK32nAck0ULVceL0=",
+        "bazel_test/BUILD.bazel": "sha256-xis9MPAyfbFpV7K2qQ9Q5/9wjWQU8CJ7V9n4silXUWI=",
+        "bazel_test/MODULE.bazel": "sha256-QNbAjU6RmuVoSEF+uWtrj2+r6VPzgAOIprya5TnM5Fk=",
+        "bazel_test/smoke.c": "sha256-mL5QGfSGfN8PG4XEVZ8CCkVKewNZK7K3PLH+NOOjArw="
+    }
+}

--- a/modules/libepoxy/metadata.json
+++ b/modules/libepoxy/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/anholt/libepoxy",
+    "maintainers": [
+        {
+            "github": "dzbarsky",
+            "github_user_id": 1565842,
+            "name": "David Zbarsky"
+        }
+    ],
+    "repository": [
+        "https://download.gnome.org/sources/libepoxy"
+    ],
+    "versions": [
+        "1.5.10"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add native Bazel targets for GL, GLX, and EGL dispatch, using the upstream generators.

Split from #10410 into a PR containing only `modules/libepoxy`. Module files are unchanged from that submission. David Zbarsky (`dzbarsky`) is the module maintainer.

Validation: BCR source-archive, patch, overlay, MODULE.bazel, and metadata checks passed locally. The validator returned 42 because the presubmit requires BCR maintainer review. The module files match #10410 byte for byte; its build/test results are documented there. Module builds were not rerun for this split.

Prepared with Codex.

-zbarskybot
