### PR TITLE
libxdamage@1.1.6

### DIFF
--- a/modules/libxdamage/1.1.6/MODULE.bazel
+++ b/modules/libxdamage/1.1.6/MODULE.bazel
@@ -1,0 +1,12 @@
+module(
+    name = "libxdamage",
+    version = "1.1.6",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "libx11", version = "1.8.12.bcr.5")
+bazel_dep(name = "libxfixes", version = "6.0.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "xorgproto", version = "2024.1.bcr.1")

--- a/modules/libxdamage/1.1.6/README.md
+++ b/modules/libxdamage/1.1.6/README.md
@@ -1,0 +1,6 @@
+# libXdamage 1.1.6
+
+Link `@libxdamage` (or `@libxdamage//:xdamage`) for the native X Damage extension
+client library. The overlay follows `src/Makefile.am` and uses BCR's X11,
+Xfixes, and protocol headers. The smoke test links the extension-query and
+damage-creation APIs without requiring a running X server.

--- a/modules/libxdamage/1.1.6/overlay/BUILD.bazel
+++ b/modules/libxdamage/1.1.6/overlay/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "xdamage",
+    srcs = ["src/Xdamage.c"],
+    hdrs = [
+        "include/X11/extensions/Xdamage.h",
+        "src/xdamageint.h",
+    ],
+    includes = [
+        "include",
+        "include/X11/extensions",
+    ],
+    linkstatic = True,
+    visibility = ["//visibility:public"],
+    deps = [
+        "@libx11",
+        "@libxfixes",
+        "@xorgproto",
+    ],
+)
+
+alias(
+    name = "libxdamage",
+    actual = ":xdamage",
+    visibility = ["//visibility:public"],
+)

--- a/modules/libxdamage/1.1.6/overlay/bazel_test/BUILD.bazel
+++ b/modules/libxdamage/1.1.6/overlay/bazel_test/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "smoke",
+    srcs = ["smoke.c"],
+    linkstatic = True,
+    deps = ["@libxdamage"],
+)

--- a/modules/libxdamage/1.1.6/overlay/bazel_test/MODULE.bazel
+++ b/modules/libxdamage/1.1.6/overlay/bazel_test/MODULE.bazel
@@ -1,0 +1,2 @@
+bazel_dep(name = "libxdamage", version = "1.1.6")
+bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/libxdamage/1.1.6/overlay/bazel_test/smoke.c
+++ b/modules/libxdamage/1.1.6/overlay/bazel_test/smoke.c
@@ -1,0 +1,7 @@
+#include <X11/extensions/Xdamage.h>
+int main(void) {
+  /* No running display is required to verify that the public API links. */
+  Bool (*volatile query)(Display *, int *, int *) = XDamageQueryExtension;
+  Damage (*volatile create)(Display *, Drawable, int) = XDamageCreate;
+  return query == 0 || create == 0;
+}

--- a/modules/libxdamage/1.1.6/presubmit.yml
+++ b/modules/libxdamage/1.1.6/presubmit.yml
@@ -1,0 +1,22 @@
+matrix:
+  platform: [debian13, ubuntu2404]
+  bazel: [7.x, 8.x, 9.x]
+tasks:
+  verify_targets:
+    name: Build public library
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags: ["--cxxopt=-std=c++17"]
+    build_targets: ["@libxdamage//:libxdamage"]
+bcr_test_module:
+  module_path: bazel_test
+  matrix:
+    platform: [debian13, ubuntu2404]
+    bazel: [7.x, 8.x, 9.x]
+  tasks:
+    run_tests:
+      name: Test external consumer
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_flags: ["--cxxopt=-std=c++17"]
+      test_targets: ["//:all"]

--- a/modules/libxdamage/1.1.6/source.json
+++ b/modules/libxdamage/1.1.6/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://www.x.org/releases/individual/lib/libXdamage-1.1.6.tar.xz",
+    "strip_prefix": "libXdamage-1.1.6",
+    "integrity": "sha256-UnM8H1Ji/KNfZOfVBgxvzYGogLqOHmXJYhzwcnr7XRE=",
+    "overlay": {
+        "BUILD.bazel": "sha256-0tYrGmzIX5FQ5rF9cBTN517PyNHQWIh5NEpbZY/FRGI=",
+        "bazel_test/BUILD.bazel": "sha256-lLKZBprAsNdIYH9tcYzzxYKonptsu2uocJjWZcqOlaw=",
+        "bazel_test/MODULE.bazel": "sha256-7RMmmJCFgSD9cwpIIiQqmkVEYIutrFfVh8Gce/yYdBo=",
+        "bazel_test/smoke.c": "sha256-GXkraE8m5+ONR33rsrrDS8w+jREUTp9FhDcy9teoPmU="
+    }
+}

--- a/modules/libxdamage/metadata.json
+++ b/modules/libxdamage/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://www.x.org/",
+    "maintainers": [
+        {
+            "github": "dzbarsky",
+            "github_user_id": 1565842,
+            "name": "David Zbarsky"
+        }
+    ],
+    "repository": [
+        "https://www.x.org/releases/individual/lib"
+    ],
+    "versions": [
+        "1.1.6"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add a native Bazel build of the X Damage client library and an external-consumer smoke test.

Split from #10410 into a PR containing only `modules/libxdamage`. Module files are unchanged from that submission. David Zbarsky (`dzbarsky`) is the module maintainer.

Validation: BCR source-archive, patch, overlay, MODULE.bazel, and metadata checks passed locally. The validator returned 42 because the presubmit requires BCR maintainer review. The module files match #10410 byte for byte; its build/test results are documented there. Module builds were not rerun for this split.

Prepared with Codex.

-zbarskybot
