### PR TITLE
graphene@1.10.8

### DIFF
--- a/modules/graphene/1.10.8/MODULE.bazel
+++ b/modules/graphene/1.10.8/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "graphene",
+    version = "1.10.8",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "glib", version = "2.82.2.bcr.11")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/graphene/1.10.8/README.md
+++ b/modules/graphene/1.10.8/README.md
@@ -1,0 +1,11 @@
+# Graphene 1.10.8
+
+Link `@graphene` for the native Linux library, including GObject types.
+`@graphene//:graphene` requires `@platforms//os:linux`; Windows and clang-cl
+are not supported. The generated `src/config.h` assumes pthreads, POSIX
+allocation, `sincosf`, and GNU visibility attributes.
+
+The overlay follows upstream `src/meson.build` and generates the version and
+platform headers from the release templates. SIMD headers select SSE or NEON
+according to the target compiler's architecture macros.
+The consumer test exercises vector length and matrix identity operations.

--- a/modules/graphene/1.10.8/overlay/BUILD.bazel
+++ b/modules/graphene/1.10.8/overlay/BUILD.bazel
@@ -1,0 +1,72 @@
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+expand_template(
+    name = "graphene_config",
+    out = "include/graphene-config.h",
+    substitutions = {
+        "#mesondefine GRAPHENE_HAS_SSE": "#define GRAPHENE_HAS_SSE 1",
+        "#mesondefine GRAPHENE_HAS_ARM_NEON": "#define GRAPHENE_HAS_ARM_NEON 1",
+        "#mesondefine GRAPHENE_HAS_GCC": "#define GRAPHENE_HAS_GCC 1",
+    },
+    template = "include/graphene-config.h.meson",
+)
+
+expand_template(
+    name = "graphene_version",
+    out = "include/graphene-version.h",
+    substitutions = {
+        "@GRAPHENE_VERSION@": "1.10.8",
+        "@GRAPHENE_MAJOR_VERSION@": "1",
+        "@GRAPHENE_MINOR_VERSION@": "10",
+        "@GRAPHENE_MICRO_VERSION@": "8",
+    },
+    template = "include/graphene-version.h.meson",
+)
+
+write_file(
+    name = "config",
+    out = "src/config.h",
+    content = [
+        "#define HAVE_PTHREAD_H 1",
+        "#define HAVE_POSIX_MEMALIGN 1",
+        "#define HAVE_ISINF 1",
+        "#define HAVE_ISNAN 1",
+        "#define HAVE_SINCOSF 1",
+        "#define HAVE_IEEE_754_FLOAT_DIVISION 1",
+        "#define _GRAPHENE_PUBLIC __attribute__((visibility(\"default\"))) extern",
+    ],
+)
+
+cc_library(
+    name = "graphene",
+    srcs = glob(["src/*.c"]),
+    hdrs = glob([
+        "include/*.h",
+        "src/*.h",
+    ]) + [
+        ":config",
+        ":graphene_config",
+        ":graphene_version",
+    ],
+    includes = [
+        "include",
+        "src",
+    ],
+    linkopts = select({
+        "@platforms//os:linux": [
+            "-lm",
+            "-pthread",
+        ],
+        "//conditions:default": [],
+    }),
+    linkstatic = True,
+    local_defines = [
+        "GRAPHENE_COMPILATION",
+        "_GNU_SOURCE",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = ["@glib//gobject"],
+)

--- a/modules/graphene/1.10.8/overlay/bazel_test/BUILD.bazel
+++ b/modules/graphene/1.10.8/overlay/bazel_test/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "smoke",
+    srcs = ["smoke.c"],
+    linkstatic = True,
+    deps = ["@graphene"],
+)

--- a/modules/graphene/1.10.8/overlay/bazel_test/MODULE.bazel
+++ b/modules/graphene/1.10.8/overlay/bazel_test/MODULE.bazel
@@ -1,0 +1,2 @@
+bazel_dep(name = "graphene", version = "1.10.8")
+bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/graphene/1.10.8/overlay/bazel_test/smoke.c
+++ b/modules/graphene/1.10.8/overlay/bazel_test/smoke.c
@@ -1,0 +1,10 @@
+#include <graphene.h>
+#include <math.h>
+int main(void) {
+  graphene_vec3_t v;
+  graphene_vec3_init(&v, 3.f, 4.f, 0.f);
+  if (fabsf(graphene_vec3_length(&v) - 5.f) > 0.0001f) return 1;
+  graphene_matrix_t matrix;
+  graphene_matrix_init_identity(&matrix);
+  return !graphene_matrix_is_identity(&matrix);
+}

--- a/modules/graphene/1.10.8/presubmit.yml
+++ b/modules/graphene/1.10.8/presubmit.yml
@@ -1,0 +1,22 @@
+matrix:
+  platform: [debian13, ubuntu2404]
+  bazel: [7.x, 8.x, 9.x]
+tasks:
+  verify_targets:
+    name: Build public library
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags: ["--cxxopt=-std=c++17"]
+    build_targets: ["@graphene//:graphene"]
+bcr_test_module:
+  module_path: bazel_test
+  matrix:
+    platform: [debian13, ubuntu2404]
+    bazel: [7.x, 8.x, 9.x]
+  tasks:
+    run_tests:
+      name: Test external consumer
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_flags: ["--cxxopt=-std=c++17"]
+      test_targets: ["//:all"]

--- a/modules/graphene/1.10.8/source.json
+++ b/modules/graphene/1.10.8/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://download.gnome.org/sources/graphene/1.10/graphene-1.10.8.tar.xz",
+    "strip_prefix": "graphene-1.10.8",
+    "integrity": "sha256-o3uw54pBncvqqccCe8/1L17CNnwl7IWdox394pKPJ5o=",
+    "overlay": {
+        "BUILD.bazel": "sha256-IF3POKS/QPVhGMc22W/wReFMiJibGCRxCSwDRrfnBKs=",
+        "bazel_test/BUILD.bazel": "sha256-zzydzFLCeS6TRJEYdyE1MmsTzwFLMyqXk+YdDgnLq5s=",
+        "bazel_test/MODULE.bazel": "sha256-rX7ATOh7KnoNR0TYmBwet/5k2NPAEEmaHcjhTkKwEDE=",
+        "bazel_test/smoke.c": "sha256-PHggmPYDJsPMkgnRPzt/o9EqTTk5AjeqOqtCSuFTcVM="
+    }
+}

--- a/modules/graphene/metadata.json
+++ b/modules/graphene/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/ebassi/graphene",
+    "maintainers": [
+        {
+            "github": "dzbarsky",
+            "github_user_id": 1565842,
+            "name": "David Zbarsky"
+        }
+    ],
+    "repository": [
+        "https://download.gnome.org/sources/graphene"
+    ],
+    "versions": [
+        "1.10.8"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Add a native Linux Bazel build of Graphene 1.10.8, including GObject types, generated platform/version headers, and an external-consumer smoke test. Select `-lm` and `-pthread` only for Linux and retain `target_compatible_with = ["@platforms//os:linux"]`. The README documents the Linux configuration and Windows/clang-cl limitation. David Zbarsky (`dzbarsky`) is the module maintainer.

Split from #10410. Rebased onto `main` after the GLib prerequisite #10411 merged.

Validation: buildifier and BCR source-archive, patch, overlay, MODULE.bazel, and metadata checks passed locally. The BCR validator returned 42 for new-module presubmit review.

Prepared with Codex.

-zbarskybot
