### PR TITLE
mboworks_mbo@0.15.0

### DIFF
--- a/modules/mboworks_mbo/0.15.0/MODULE.bazel
+++ b/modules/mboworks_mbo/0.15.0/MODULE.bazel
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) M. Boerger, the MBO Works authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module mboworks_mbo"""
+
+module(
+    name = "mboworks_mbo",
+    version = "0.15.0",
+    bazel_compatibility = [">=8.0.0"],
+)
+
+# For local development we include LLVM and Hedron-Compile-Commands.
+# For bazelmod usage these have to be provided by the main module - if necessary.
+# include("//bazelmod:dev.MODULE.bazel")
+# include("//bazelmod:llvm.MODULE.bazel")
+
+bazel_dep(name = "bazel_skylib", version = "1.9.2")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "rules_fuzzing", version = "0.8.0")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+
+# These releases still declare compatibility-level-1 Abseil versions. Patch
+# their module metadata until upstream releases select compatibility level 0.
+single_version_override(
+    module_name = "rules_fuzzing",
+    version = "0.8.0",
+    patches = ["//bazelmod:rules_fuzzing-0.8.0-abseil.patch"],
+    patch_strip = 1,
+)
+
+# RE2's BCR MODULE differs from the release archive, so a source patch cannot
+# apply through single_version_override. Preserve the BCR source and integrity.
+archive_override(
+    module_name = "re2",
+    urls = ["https://github.com/google/re2/releases/download/2025-11-05/re2-2025-11-05.zip"],
+    integrity = "sha256-x7Gnp8aNLXz400PcVmVcG1qMiq3twBfbRT1MHYkTuEQ=",
+    strip_prefix = "re2-2025-11-05",
+    patches = ["//bazelmod:re2-2025-11-05-abseil.patch"],
+    patch_strip = 1,
+)
+
+single_version_override(
+    module_name = "protobuf",
+    version = "36.0.bcr.1",
+    patches = ["//bazelmod:protobuf-36.0-abseil.patch"],
+    patch_strip = 1,
+)
+
+single_version_override(
+    module_name = "rules_java",
+    version = "8.16.1",
+    patches = ["//bazelmod:rules_java-8.16.1-abseil.patch"],
+    patch_strip = 1,
+)
+
+# Abseil 20260817.0 still selects gloop 20260708.rc1, whose dependency on
+# compatibility-level-1 Abseil conflicts with the current level-0 release.
+# Newer gloop releases add a gRPC dependency chain that Bazel 8 cannot parse, so
+# patch only the stale dependency declaration until Abseil updates its metadata.
+single_version_override(
+    module_name = "gloop",
+    version = "20260708.rc1",
+    patches = ["//bazelmod:gloop-20260708.rc1-abseil.patch"],
+    patch_strip = 1,
+)
+
+# The gloop release above selects an older tcmalloc whose Abseil dependency has
+# the same compatibility-level mismatch. The current tcmalloc release uses the
+# level-0 Abseil line and remains compatible with Bazel 8.
+single_version_override(
+    module_name = "tcmalloc",
+    version = "0.0.0-20260818-15db23d",
+)
+
+bazel_dep(name = "abseil-cpp", version = "20260817.0")
+bazel_dep(name = "re2", version = "2025-11-05.bcr.1")
+bazel_dep(name = "googletest", version = "1.18.0.bcr.1")
+bazel_dep(name = "google_benchmark", version = "1.9.5", repo_name = "com_github_google_benchmark")
+bazel_dep(name = "mboworks_bashtest", version = "0.6.1")

--- a/modules/mboworks_mbo/0.15.0/presubmit.yml
+++ b/modules/mboworks_mbo/0.15.0/presubmit.yml
@@ -1,0 +1,21 @@
+matrix:
+  bazel:
+    - 8.x
+    - 9.x
+  platform:
+    - ubuntu2404
+    - macos_arm64
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--cxxopt=-std=c++20"
+    build_targets:
+      - "@mboworks_mbo//mbo/container:limited_set_benchmark"
+      - "@mboworks_mbo//mbo/diff:diff"
+      - "@mboworks_mbo//mbo/digest:digest"
+      - "@mboworks_mbo//mbo/file:glob"
+      - "@mboworks_mbo//mbo/hash:hash_tool"
+      - "@mboworks_mbo//mbo/mope:mope"

--- a/modules/mboworks_mbo/0.15.0/presubmit.yml
+++ b/modules/mboworks_mbo/0.15.0/presubmit.yml
@@ -11,7 +11,7 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_flags:
-      - "--cxxopt=-std=c++20"
+      - "--cxxopt=-std=c++23"
     build_targets:
       - "@mboworks_mbo//mbo/container:limited_set_benchmark"
       - "@mboworks_mbo//mbo/diff:diff"

--- a/modules/mboworks_mbo/0.15.0/source.json
+++ b/modules/mboworks_mbo/0.15.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-vW/ZBWmrKKF+gWGRghQb30T5K5yksfEA7ROfKRf76Xk=",
+    "strip_prefix": "mbo-0.15.0",
+    "url": "https://github.com/mboworks/mbo/releases/download/0.15.0/mbo-0.15.0.tar.gz"
+}

--- a/modules/mboworks_mbo/metadata.json
+++ b/modules/mboworks_mbo/metadata.json
@@ -12,7 +12,8 @@
         "github:mboworks/mbo"
     ],
     "versions": [
-        "0.14.0"
+        "0.14.0",
+        "0.15.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/mboworks/mbo/releases/tag/0.15.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_