### PR TITLE
Add MPICH 4.2.0

### DIFF
--- a/modules/mpich/4.2.0/MODULE.bazel
+++ b/modules/mpich/4.2.0/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "mpich",
+    version = "4.2.0",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_foreign_cc", version = "0.15.1")

--- a/modules/mpich/4.2.0/README.md
+++ b/modules/mpich/4.2.0/README.md
@@ -1,0 +1,12 @@
+# MPICH
+
+This module builds the MPICH 4.2.0 C runtime from its release archive.
+
+The public @mpich//:mpich target supplies C headers and the shared
+libmpich.so.12 library. @mpich//:runtime exposes the installed runtime
+tree for consumers that load MPICH dynamically rather than linking it.
+
+The build intentionally selects the portable CH3 socket device and omits
+Fortran, C++, and process-manager binaries. This keeps the module's
+runtime dependency surface small while preserving the MPI C ABI used by
+prebuilt consumers such as mpi4py.

--- a/modules/mpich/4.2.0/overlay/BUILD.bazel
+++ b/modules/mpich/4.2.0/overlay/BUILD.bazel
@@ -1,10 +1,5 @@
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 
-LINUX_ONLY = select({
-    "@platforms//os:linux": [],
-    "//conditions:default": ["@platforms//:incompatible"],
-})
-
 filegroup(
     name = "all_srcs",
     srcs = glob(
@@ -33,7 +28,7 @@ configure_make(
     },
     lib_source = ":all_srcs",
     out_shared_libs = ["libmpich.so.12"],
-    target_compatible_with = LINUX_ONLY,
+    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
 )
 
@@ -43,6 +38,6 @@ filegroup(
     name = "runtime",
     srcs = [":mpich"],
     output_group = "gen_dir",
-    target_compatible_with = LINUX_ONLY,
+    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
 )

--- a/modules/mpich/4.2.0/overlay/BUILD.bazel
+++ b/modules/mpich/4.2.0/overlay/BUILD.bazel
@@ -1,0 +1,48 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+LINUX_ONLY = select({
+    "@platforms//os:linux": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(
+        ["**"],
+        exclude = ["*.bazel"],
+    ),
+)
+
+# MPICH's release tarball includes generated configure and make inputs.
+# rules_foreign_cc supplies its declared GNU make toolchain, so this does not
+# depend on an ambient host make.
+configure_make(
+    name = "mpich",
+    args = ["-j4"],
+    configure_in_place = True,
+    configure_options = [
+        "--disable-cxx",
+        "--disable-fortran",
+        "--with-device=ch3:sock",
+        "--with-pm=no",
+        "--with-wrapper-dl-type=none",
+    ],
+    env = {
+        # Debian-compatible spelling required by prebuilt mpi4py wheels.
+        "MPILIBNAME": "mpich",
+    },
+    lib_source = ":all_srcs",
+    out_shared_libs = ["libmpich.so.12"],
+    target_compatible_with = LINUX_ONLY,
+    visibility = ["//visibility:public"],
+)
+
+# A single tree-artifact label lets dynamic consumers set a narrow loader path
+# to $(rootpath @mpich//:runtime)/lib without depending on output internals.
+filegroup(
+    name = "runtime",
+    srcs = [":mpich"],
+    output_group = "gen_dir",
+    target_compatible_with = LINUX_ONLY,
+    visibility = ["//visibility:public"],
+)

--- a/modules/mpich/4.2.0/overlay/bazel_test/BUILD.bazel
+++ b/modules/mpich/4.2.0/overlay/bazel_test/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_test(
+    name = "mpi_smoke",
+    srcs = ["mpi_smoke.c"],
+    deps = ["@mpich"],
+)
+
+cc_test(
+    name = "runtime_dlopen_smoke",
+    srcs = ["runtime_dlopen_smoke.c"],
+    args = ["$(rootpath @mpich//:runtime)/lib/libmpich.so.12"],
+    data = ["@mpich//:runtime"],
+    linkopts = ["-ldl"],
+)

--- a/modules/mpich/4.2.0/overlay/bazel_test/MODULE.bazel
+++ b/modules/mpich/4.2.0/overlay/bazel_test/MODULE.bazel
@@ -1,0 +1,9 @@
+module(name = "mpich_test")
+
+bazel_dep(name = "mpich", version = "4.2.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+
+local_path_override(
+    module_name = "mpich",
+    path = "..",
+)

--- a/modules/mpich/4.2.0/overlay/bazel_test/mpi_smoke.c
+++ b/modules/mpich/4.2.0/overlay/bazel_test/mpi_smoke.c
@@ -1,0 +1,18 @@
+#include <mpi.h>
+#include <stddef.h>
+
+int main(void) {
+    int initialized = 0;
+    int rank = -1;
+
+    if (MPI_Init(NULL, NULL) != MPI_SUCCESS) {
+        return 1;
+    }
+    if (MPI_Initialized(&initialized) != MPI_SUCCESS || !initialized) {
+        return 2;
+    }
+    if (MPI_Comm_rank(MPI_COMM_WORLD, &rank) != MPI_SUCCESS || rank != 0) {
+        return 3;
+    }
+    return MPI_Finalize() == MPI_SUCCESS ? 0 : 4;
+}

--- a/modules/mpich/4.2.0/overlay/bazel_test/runtime_dlopen_smoke.c
+++ b/modules/mpich/4.2.0/overlay/bazel_test/runtime_dlopen_smoke.c
@@ -1,0 +1,21 @@
+#include <dlfcn.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    void *handle;
+
+    if (argc != 2) {
+        return 1;
+    }
+    handle = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+    if (handle == NULL) {
+        fprintf(stderr, "%s\n", dlerror());
+        return 2;
+    }
+    if (dlsym(handle, "MPI_Init") == NULL ||
+        dlsym(handle, "MPI_Finalize") == NULL ||
+        dlsym(handle, "MPI_File_open") == NULL) {
+        return 3;
+    }
+    return dlclose(handle) == 0 ? 0 : 4;
+}

--- a/modules/mpich/4.2.0/presubmit.yml
+++ b/modules/mpich/4.2.0/presubmit.yml
@@ -1,0 +1,20 @@
+matrix:
+  platform: [debian13, ubuntu2404, ubuntu2404_arm64]
+  bazel: [7.x, 8.x, 9.x]
+tasks:
+  verify_targets:
+    name: Build MPICH runtime
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets: ["@mpich//:all"]
+bcr_test_module:
+  module_path: bazel_test
+  matrix:
+    platform: [debian13, ubuntu2404, ubuntu2404_arm64]
+    bazel: [7.x, 8.x, 9.x]
+  tasks:
+    run_tests:
+      name: Test MPI C runtime
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets: ["//:all"]

--- a/modules/mpich/4.2.0/source.json
+++ b/modules/mpich/4.2.0/source.json
@@ -1,0 +1,12 @@
+{
+    "url": "https://github.com/pmodels/mpich/releases/download/v4.2.0/mpich-4.2.0.tar.gz",
+    "integrity": "sha256-pkpmeBueUxKtBS0yaJ4jJS90WyfuiBisKsDIIJvAuQ4=",
+    "strip_prefix": "mpich-4.2.0",
+    "overlay": {
+        "BUILD.bazel": "sha256-0ujP1yuc3B3HR6CILe0rhFgB2vJrjYP5jZfIOpNydXo=",
+        "bazel_test/BUILD.bazel": "sha256-wvhWLqaaqSaxfG5+nmEFrGsUUXQzixF8Hp9Z/cX52JY=",
+        "bazel_test/MODULE.bazel": "sha256-pAS5lvcgKx7t4mmld3jEyQySYv1Fn+RokTiQLl6ZVuk=",
+        "bazel_test/mpi_smoke.c": "sha256-yQy9gXPSXznJrRHQW+oCI+y5D0sAJ389yy7mg4mKW+4=",
+        "bazel_test/runtime_dlopen_smoke.c": "sha256-zyDFxdvrI/IHrmhCf/FNJqznZL+G3NoZRAkMQhekBc0="
+    }
+}

--- a/modules/mpich/4.2.0/source.json
+++ b/modules/mpich/4.2.0/source.json
@@ -3,7 +3,7 @@
     "integrity": "sha256-pkpmeBueUxKtBS0yaJ4jJS90WyfuiBisKsDIIJvAuQ4=",
     "strip_prefix": "mpich-4.2.0",
     "overlay": {
-        "BUILD.bazel": "sha256-0ujP1yuc3B3HR6CILe0rhFgB2vJrjYP5jZfIOpNydXo=",
+        "BUILD.bazel": "sha256-GN5gHKzp4BhQd0lyre8rzNA7YYUlq9g7qjNwsa5hh9E=",
         "bazel_test/BUILD.bazel": "sha256-wvhWLqaaqSaxfG5+nmEFrGsUUXQzixF8Hp9Z/cX52JY=",
         "bazel_test/MODULE.bazel": "sha256-pAS5lvcgKx7t4mmld3jEyQySYv1Fn+RokTiQLl6ZVuk=",
         "bazel_test/mpi_smoke.c": "sha256-yQy9gXPSXznJrRHQW+oCI+y5D0sAJ389yy7mg4mKW+4=",

--- a/modules/mpich/metadata.json
+++ b/modules/mpich/metadata.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://www.mpich.org/",
+    "maintainers": [
+        {
+            "github": "oliviernotteghem",
+            "github_user_id": 52428902,
+            "name": "Olivier Notteghem"
+        }
+    ],
+    "repository": [
+        "github:pmodels/mpich"
+    ],
+    "versions": [
+        "4.2.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
## Summary

Add MPICH 4.2.0 as a Linux BCR module built from the official release archive.

- Exposes `@mpich//:mpich` with C headers and `libmpich.so.12`.
- Exposes `@mpich//:runtime` as a single installed tree artifact for unlinked dynamic consumers.
- Uses the portable CH3 socket device and omits C++, Fortran, and process-manager binaries.
- Sets `MPILIBNAME=mpich` so the produced filename and ELF SONAME match Debian-compatible prebuilt consumers such as mpi4py.
- Uses `rules_foreign_cc` 0.15.1; its declared toolchain bootstraps GNU make, so the build does not consume ambient host `make`.

## Runtime contract

The test module verifies both:

1. A normal C consumer links the module, calls `MPI_Init`, checks rank 0, and calls `MPI_Finalize`.
2. An unlinked consumer receives `@mpich//:runtime` as runfiles, directly `dlopen`s `runtime/lib/libmpich.so.12`, and resolves `MPI_Init`, `MPI_Finalize`, and `MPI_File_open`.

Local ELF inspection confirms `SONAME = libmpich.so.12` and only libc, libm, and the platform loader as direct runtime dependencies.

## Patches

No source patches are required. The release tarball already contains generated configure/make inputs. Configuration-only choices are documented in the overlay.

## Validation

Exact commit: `7d78c6f1df626ebb71c56cf34c526b99791b0214`

- `bazel run -- //tools:update_integrity mpich --version 4.2.0`
- `bazel run -- //tools:bcr_validation --check=mpich@4.2.0` (all checks GOOD; expected exit 42 only because a new module requires BCR maintainer review)
- Clean generated BCR test consumer, Bazel 7.7.1: `bazel --nosystem_rc --nohome_rc test -- //:all` — 2/2 passed
- Clean generated BCR test consumer, Bazel 8.8.0: same command — 2/2 passed
- Clean generated BCR test consumer, Bazel 9.2.0: same command — 2/2 passed
- Registry-only anonymous consumer, Bazel 9.2.0: `bazel --nosystem_rc --nohome_rc build -- @mpich//:all` — passed

Presubmit covers Debian 13, Ubuntu 24.04 x86_64, and Ubuntu 24.04 ARM64 on Bazel 7.x, 8.x, and 9.x.

Downstream monorepo rollout is intentionally separate.