### PR TITLE
Publish versor@0.1.0.bcr.1

### DIFF
--- a/modules/versor/0.1.0.bcr.1/MODULE.bazel
+++ b/modules/versor/0.1.0.bcr.1/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "versor",
+    version = "0.1.0.bcr.1",
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_license", version = "0.0.8")

--- a/modules/versor/0.1.0.bcr.1/patches/add_build_file.patch
+++ b/modules/versor/0.1.0.bcr.1/patches/add_build_file.patch
@@ -1,0 +1,44 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 0000000..23d04a9
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,38 @@
++load("@rules_cc//cc:defs.bzl", "cc_library")
++load("@rules_license//rules:license.bzl", "license")
++
++package(
++    default_applicable_licenses = [":license"],
++    default_visibility = ["//visibility:public"],
++)
++
++license(
++    name = "license",
++    package_name = "versor",
++    license_kinds = [
++      "@rules_license//licenses/spdx:BSD-2-Clause-FreeBSD",
++    ],
++    license_text = "copyrights/COPYRIGHT",
++)
++
++exports_files(["copyrights/COPYRIGHT"])
++
++cc_library(
++    name = "vsr",
++    srcs = glob(["src/space/*.cpp"]),
++    hdrs = glob([
++        "include/vsr/**/*.h",
++    ]),
++    copts = [
++        "-Wno-reorder",
++        "-Wno-unused-variable",
++    ],
++    features = [
++        "-parse_headers",
++    ],
++    includes = [
++        "include",
++        "include/vsr",
++        "include/vsr/detail",
++    ],
++)

--- a/modules/versor/0.1.0.bcr.1/patches/clang_template_keyword.patch
+++ b/modules/versor/0.1.0.bcr.1/patches/clang_template_keyword.patch
@@ -1,0 +1,49 @@
+diff --git a/include/vsr/detail/vsr_algebra.h b/include/vsr/detail/vsr_algebra.h
+index 324a32c..c4c7047 100644
+--- a/include/vsr/detail/vsr_algebra.h
++++ b/include/vsr/detail/vsr_algebra.h
+@@ -195,7 +195,7 @@ namespace vsr {
+            typedef gp_basis_t<typename B::basis, typename A::basis > tmp_basis;      
+            //............................................lh...........rh.................return type 
+            using x = typename impl::template rot_arrow_t<tmp_basis, typename B::basis, typename A::basis>;                 
+-           return x::Arrow::template Make<A>( gp(b, a), Reverse<typename B::basis>::Type::template Make(b) );
++           return x::Arrow::template Make<A>( gp(b, a), Reverse<typename B::basis>::Type::Make(b) );
+          }
+     
+          /// Reflect a by b, return type a
+@@ -203,7 +203,7 @@ namespace vsr {
+          static constexpr A reflect(const A& a, const B& b) {
+           typedef gp_basis_t<typename B::basis, typename A::basis > tmp_basis;
+           using x = typename impl::template rot_arrow_t<tmp_basis, typename B::basis, typename A::basis>;
+-          return x::Arrow::template Make<A>( gp(b, a.involution() ), Reverse<typename B::basis>::Type::template Make(b) );
++          return x::Arrow::template Make<A>( gp(b, a.involution() ), Reverse<typename B::basis>::Type::Make(b) );
+          } 
+  
+           /// make a type from sum of basis B1 and B2
+diff --git a/include/vsr/detail/vsr_multivector.h b/include/vsr/detail/vsr_multivector.h
+index 33355d8..d629743 100644
+--- a/include/vsr/detail/vsr_multivector.h
++++ b/include/vsr/detail/vsr_multivector.h
+@@ -185,7 +185,7 @@ namespace vsr{
+ 
+       /// Reversion \\(\\tilde{A}\\) 
+       Multivector operator ~() const {
+-        return Reverse< basis >::Type::template Make(*this) ;
++        return Reverse< basis >::Type::Make(*this) ;
+       }
+       
+       /// Inversion \\(\\tilde{A}/A\\tilde{A}\\) 
+@@ -430,11 +430,11 @@ Multivector<Algebra,B> Multivector<Algebra,B>::yz = Multivector<Algebra,B>().tem
+  *-----------------------------------------------------------------------------*/
+ template<typename Algebra, typename B> 
+ Multivector<Algebra,B> Multivector<Algebra,B>::conjugation() const{
+-	return Conjugate<B>::Type::template Make(*this);
++	return Conjugate<B>::Type::Make(*this);
+ }
+ template<typename Algebra, typename B> 
+ Multivector<Algebra,B> Multivector<Algebra,B>::involution() const{
+-	return Involute<B>::Type::template Make(*this);
++	return Involute<B>::Type::Make(*this);
+ } 
+ 
+ 

--- a/modules/versor/0.1.0.bcr.1/patches/module_dot_bazel.patch
+++ b/modules/versor/0.1.0.bcr.1/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- a/MODULE.bazel
++++ a/MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "versor",
++    version = "0.1.0.bcr.1",
++)
++
++bazel_dep(name = "rules_cc", version = "0.0.17")
++bazel_dep(name = "rules_license", version = "0.0.8")

--- a/modules/versor/0.1.0.bcr.1/presubmit.yml
+++ b/modules/versor/0.1.0.bcr.1/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian10
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 7.x
+  - 8.x
+  - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@versor//:*'

--- a/modules/versor/0.1.0.bcr.1/source.json
+++ b/modules/versor/0.1.0.bcr.1/source.json
@@ -1,0 +1,11 @@
+{
+    "url": "https://github.com/wolftype/versor/archive/refs/tags/v0.1.0.tar.gz",
+    "integrity": "sha256-0JPnJb4SI5P71Xf7RB6bdYbDEyVoEf2JidbQXuQ0fKM=",
+    "strip_prefix": "versor-0.1.0",
+    "patches": {
+        "add_build_file.patch": "sha256-ogYaOCyZYT6jxUQcJWN08cgVtm3uB0ho1qkBAFbF3uo=",
+        "module_dot_bazel.patch": "sha256-q+TIL/aBSA2fmsvNef5EbRDXYK0Pn2bXZCFBPfkNx78=",
+        "clang_template_keyword.patch": "sha256-3sfSoxiFR/ehH++SdOqVh39g012yF48j7TcL67s6v+E="
+    },
+    "patch_strip": 1
+}

--- a/modules/versor/metadata.json
+++ b/modules/versor/metadata.json
@@ -4,8 +4,8 @@
         {
             "email": "udayaprakash2899@gmail.com",
             "github": "udaya2899",
-            "name": "Udaya Prakash Nageswaran",
-            "github_user_id": 35005125
+            "github_user_id": 35005125,
+            "name": "Udaya Prakash Nageswaran"
         }
     ],
     "repository": [
@@ -13,7 +13,8 @@
     ],
     "versions": [
         "0.0.1",
-        "0.1.0"
+        "0.1.0",
+        "0.1.0.bcr.1"
     ],
     "yanked_versions": {
         "0.0.1": "wrong include paths, unusable library, upgrade to 0.1.0"


### PR DESCRIPTION
Pulls in https://github.com/wolftype/versor/pull/33 which is needed when using more modern toolchains/Bazel versions.

Since no new release has been published in the upstream repo since 2018, it seemed reasonable to not try to get a new one but rather patch in BCR.