### PR TITLE
graphviz 14.0.0.bcr.2

### DIFF
--- a/modules/graphviz/14.0.0.bcr.2/MODULE.bazel
+++ b/modules/graphviz/14.0.0.bcr.2/MODULE.bazel
@@ -1,0 +1,12 @@
+"""https://graphviz.org/"""
+
+module(
+    name = "graphviz",
+    version = "14.0.0.bcr.2",
+    bazel_compatibility = [">=8.0.0"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+bazel_dep(name = "zlib", version = "1.3.2")

--- a/modules/graphviz/14.0.0.bcr.2/overlay/.bazelignore
+++ b/modules/graphviz/14.0.0.bcr.2/overlay/.bazelignore
@@ -1,0 +1,1 @@
+test_module

--- a/modules/graphviz/14.0.0.bcr.2/overlay/BUILD.bazel
+++ b/modules/graphviz/14.0.0.bcr.2/overlay/BUILD.bazel
@@ -1,0 +1,861 @@
+"""Graphviz, built with Bazel.
+
+This file is the Bazel Central Registry overlay for graphviz: it sits at the
+root of the upstream source archive, next to lib/, plugin/ and cmd/, and
+describes how to build them. Upstream ships no Bazel files, so every target
+here is ours. https://gitlab.com/graphviz/graphviz
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+# ---------------------------------------------------------------------------
+# Upstream's headers and source lists.
+# ---------------------------------------------------------------------------
+# Headers from every lib/ subdir, on the include path as `lib/`. Source
+# files use the `<subdir/header.h>` form to reach into peer libraries.
+cc_library(
+    name = "lib_headers",
+    hdrs = glob([
+        "lib/**/*.h",
+    ]),
+    includes = ["lib"],
+)
+
+# Extra include paths for libraries whose own translation units use
+# unprefixed bracketed includes (e.g. cgraph/grammar.c does
+# `#include <cghdr.h>` for a same-directory header). Headers
+# themselves are already exposed via `lib_headers`; these wrappers
+# add the additional `-I` path so the compiler can locate them.
+cc_library(
+    name = "cdt_inc",
+    includes = ["lib/cdt"],
+)
+
+cc_library(
+    name = "cgraph_inc",
+    includes = ["lib/cgraph"],
+)
+
+cc_library(
+    name = "pathplan_inc",
+    includes = ["lib/pathplan"],
+)
+
+cc_library(
+    name = "common_inc",
+    includes = ["lib/common"],
+)
+
+cc_library(
+    name = "gvc_inc",
+    includes = ["lib/gvc"],
+)
+
+cc_library(
+    name = "pack_inc",
+    includes = ["lib/pack"],
+)
+
+cc_library(
+    name = "gvpr_inc",
+    includes = ["lib/gvpr"],
+)
+
+# Pre-baked version headers at the tarball root.
+cc_library(
+    name = "version_hdrs",
+    hdrs = [
+        "builddate.h",
+        "graphviz_version.h",
+    ],
+    includes = ["."],
+)
+
+exports_files([
+    "lib/cgraph/grammar.c",
+    "lib/cgraph/grammar.h",
+    "lib/cgraph/scan.c",
+    "lib/common/htmlparse.c",
+    "lib/common/htmlparse.h",
+    "lib/common/colortbl.h",
+    "lib/common/entities.h",
+    "builddate.h",
+    "graphviz_version.h",
+])
+
+# Per-library source filegroups.
+filegroup(
+    name = "cdt_srcs",
+    srcs = glob(["lib/cdt/*.c"]),
+)
+
+filegroup(
+    name = "util_srcs",
+    srcs = glob(["lib/util/*.c"]),
+)
+
+filegroup(
+    name = "cgraph_srcs",
+    srcs = glob(
+        ["lib/cgraph/*.c"],
+        exclude = [
+            "lib/cgraph/grammar.c",
+            "lib/cgraph/scan.c",
+        ],
+    ),
+)
+
+filegroup(
+    name = "pathplan_srcs",
+    srcs = glob(["lib/pathplan/*.c"]),
+)
+
+filegroup(
+    name = "xdot_srcs",
+    srcs = glob(["lib/xdot/*.c"]),
+)
+
+filegroup(
+    name = "label_srcs",
+    srcs = glob(["lib/label/*.c"]),
+)
+
+filegroup(
+    name = "pack_srcs",
+    srcs = glob(["lib/pack/*.c"]),
+)
+
+filegroup(
+    name = "common_srcs",
+    srcs = glob(
+        ["lib/common/*.c"],
+        exclude = ["lib/common/htmlparse.c"],
+    ),
+)
+
+filegroup(
+    name = "gvc_srcs",
+    srcs = glob(["lib/gvc/*.c"]),
+)
+
+filegroup(
+    name = "dotgen_srcs",
+    srcs = glob(["lib/dotgen/*.c"]),
+)
+
+filegroup(
+    name = "plugin_core_srcs",
+    srcs = glob(["plugin/core/*.c"]) + glob(["plugin/core/*.h"]),
+)
+
+# Layout engines beyond `dot`. The neato_layout plugin provides neato, fdp,
+# sfdp, circo, twopi, osage and patchwork, so these libraries come as a set.
+
+# neatogen and sfdpgen include each other (lib/neatogen -> <sfdpgen/...> and
+# lib/sfdpgen -> <neatogen/...>), which Bazel cannot express as two targets, so
+# they are compiled as one.
+filegroup(
+    name = "neatogen_srcs",
+    srcs = glob([
+        "lib/neatogen/*.c",
+        "lib/sfdpgen/*.c",
+    ]),
+)
+
+filegroup(
+    name = "sparse_srcs",
+    srcs = glob(["lib/sparse/*.c"]),
+)
+
+# test_red_black_tree.c is upstream's standalone driver and defines main().
+filegroup(
+    name = "rbtree_srcs",
+    srcs = glob(
+        ["lib/rbtree/*.c"],
+        exclude = ["lib/rbtree/test_red_black_tree.c"],
+    ),
+)
+
+filegroup(
+    name = "ortho_srcs",
+    srcs = glob(["lib/ortho/*.c"]),
+)
+
+# The only C++ library in this set.
+filegroup(
+    name = "vpsc_srcs",
+    srcs = glob(["lib/vpsc/*.cpp"]),
+)
+
+filegroup(
+    name = "fdpgen_srcs",
+    srcs = glob(["lib/fdpgen/*.c"]),
+)
+
+filegroup(
+    name = "circogen_srcs",
+    srcs = glob(["lib/circogen/*.c"]),
+)
+
+filegroup(
+    name = "twopigen_srcs",
+    srcs = glob(["lib/twopigen/*.c"]),
+)
+
+filegroup(
+    name = "osage_srcs",
+    srcs = glob(["lib/osage/*.c"]),
+)
+
+filegroup(
+    name = "patchwork_srcs",
+    srcs = glob(["lib/patchwork/*.c"]),
+)
+
+filegroup(
+    name = "plugin_neato_layout_srcs",
+    srcs = glob(["plugin/neato_layout/*.c"]) + glob(
+        ["plugin/neato_layout/*.h"],
+        allow_empty = True,
+    ),
+)
+
+filegroup(
+    name = "plugin_dot_layout_srcs",
+    srcs = glob(["plugin/dot_layout/*.c"]) + glob(
+        ["plugin/dot_layout/*.h"],
+        allow_empty = True,
+    ),
+)
+
+filegroup(
+    name = "cmd_dot_srcs",
+    srcs = ["cmd/dot/dot.c"],
+)
+
+# ---------------------------------------------------------------------------
+# The libraries, plugins and the dot binary.
+# ---------------------------------------------------------------------------
+# Macros that the autotools `config.h` would set, supplied as -D
+# flags. Propagated to dependents via `defines`.
+_CONFIG_DEFINES = [
+    "DEFAULT_DPI=96",
+    "GVPLUGIN_CONFIG_FILE=\\\"config8\\\"",
+    "GVPLUGIN_VERSION=8",
+    "HAVE_ARGZ_ADD=1",
+    "HAVE_ARGZ_APPEND=1",
+    "HAVE_ARGZ_COUNT=1",
+    "HAVE_ARGZ_CREATE_SEP=1",
+    "HAVE_ARGZ_H=1",
+    "HAVE_ARGZ_INSERT=1",
+    "HAVE_ARGZ_NEXT=1",
+    "HAVE_ARGZ_STRINGIFY=1",
+    "HAVE_CLOSEDIR=1",
+    "HAVE_CXX17=1",
+    "HAVE_DIRENT_H=1",
+    "HAVE_DLFCN_H=1",
+    "HAVE_DRAND48=1",
+    "HAVE_ERROR_T=1",
+    "HAVE_INTTYPES_H=1",
+    "HAVE_LIBZ=1",
+    "HAVE_MEMRCHR=1",
+    "HAVE_OPENDIR=1",
+    "HAVE_READDIR=1",
+    "HAVE_SELECT=1",
+    "HAVE_SETENV=1",
+    "HAVE_SRAND48=1",
+    "HAVE_STDINT_H=1",
+    "HAVE_STDIO_H=1",
+    "HAVE_STDLIB_H=1",
+    "HAVE_STRCASESTR=1",
+    "HAVE_STRINGS_H=1",
+    "HAVE_STRING_H=1",
+    "HAVE_SYS_IOCTL_H=1",
+    "HAVE_SYS_MMAN_H=1",
+    "HAVE_SYS_SELECT_H=1",
+    "HAVE_SYS_STAT_H=1",
+    "HAVE_SYS_TIME_H=1",
+    "HAVE_SYS_TYPES_H=1",
+    "HAVE_UNISTD_H=1",
+    "HAVE_WORKING_ARGZ=1",
+    "STDC_HEADERS=1",
+    "WITH_CGRAPH=1",
+    # Upstream marks util's helper functions with hidden visibility so
+    # they don't get exported when statically linked. Bazel builds each
+    # cc_library as an intermediate `.so`, which breaks the hidden-vs-
+    # cross-shared-object contract. Override to default visibility.
+    "UTIL_API=",
+    "PACKAGE_NAME=\\\"graphviz\\\"",
+    "PACKAGE_TARNAME=\\\"graphviz\\\"",
+    "PACKAGE_VERSION=\\\"14.0.0\\\"",
+    "PACKAGE_BUGREPORT=\\\"https://gitlab.com/graphviz/graphviz/-/issues\\\"",
+    "PACKAGE_URL=\\\"\\\"",
+]
+
+# Stub config.h. All real macros come from `_CONFIG_DEFINES`. Many
+# source files include "config.h" unconditionally.
+cc_library(
+    name = "config_h",
+    hdrs = ["include/config.h"],
+    defines = _CONFIG_DEFINES,
+    includes = ["include"],
+)
+
+# Every library below is alwayslink. Graphviz's static libraries call back
+# into each other: lib/common/emit.c calls gvevent_key_binding in lib/gvc,
+# and lib/common/postproc.c calls placeLabels in lib/label, while gvc and
+# label both build on common. No topological order of archives satisfies
+# all of that, so GNU ld drops the members it has not seen a use for yet
+# and the link of dot ends in "undefined reference to gvevent_key_binding".
+# lld happens to resolve it, which is why a build with a zig toolchain
+# hides the problem and the Bazel Central Registry's presubmit, which uses
+# the platform's gcc, does not. See //hosttest, which builds the way the
+# registry's presubmit does.
+cc_library(
+    name = "cdt",
+    srcs = [":cdt_srcs"],
+    deps = [
+        ":cdt_inc",
+        ":config_h",
+        ":lib_headers",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "util",
+    srcs = [":util_srcs"],
+    deps = [
+        ":config_h",
+        ":lib_headers",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "cgraph",
+    srcs = [":cgraph_srcs"] + [
+        ":lib/cgraph/grammar.c",
+        ":lib/cgraph/scan.c",
+    ],
+    deps = [
+        ":cdt",
+        ":cdt_inc",
+        ":cgraph_inc",
+        ":config_h",
+        ":lib_headers",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "pathplan",
+    srcs = [":pathplan_srcs"],
+    deps = [
+        ":config_h",
+        ":lib_headers",
+        ":pathplan_inc",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "xdot",
+    srcs = [":xdot_srcs"],
+    deps = [
+        ":config_h",
+        ":lib_headers",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "label",
+    srcs = [":label_srcs"],
+    deps = [
+        ":cdt",
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common_inc",
+        ":config_h",
+        ":lib_headers",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "pack",
+    srcs = [":pack_srcs"],
+    deps = [
+        ":cdt",
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common_inc",
+        ":config_h",
+        ":gvc_inc",
+        ":lib_headers",
+        ":pathplan",
+        ":pathplan_inc",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "common",
+    srcs = [":common_srcs"] + [":lib/common/htmlparse.c"],
+    deps = [
+        ":cdt",
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common_inc",
+        ":config_h",
+        ":gvc_inc",
+        ":lib_headers",
+        ":pack_inc",
+        ":pathplan",
+        ":pathplan_inc",
+        ":util",
+        ":xdot",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "dotgen",
+    srcs = [":dotgen_srcs"],
+    deps = [
+        ":cdt",
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":gvc_inc",
+        ":lib_headers",
+        ":pack",
+        ":pack_inc",
+        ":pathplan",
+        ":pathplan_inc",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "gvc",
+    srcs = [":gvc_srcs"],
+    deps = [
+        ":cdt",
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":label",
+        ":lib_headers",
+        ":pack",
+        ":pathplan",
+        ":pathplan_inc",
+        ":util",
+        ":version_hdrs",
+        ":xdot",
+        "@zlib",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "plugin_core",
+    srcs = [":plugin_core_srcs"],
+    deps = [
+        ":cdt",
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":gvc",
+        ":gvc_inc",
+        ":gvpr_inc",
+        ":lib_headers",
+        ":pathplan_inc",
+        ":util",
+        ":xdot",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "plugin_dot_layout",
+    srcs = [":plugin_dot_layout_srcs"],
+    deps = [
+        ":cdt",
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":dotgen",
+        ":gvc",
+        ":gvc_inc",
+        ":lib_headers",
+        ":pathplan",
+        ":pathplan_inc",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+# --- Layout engines beyond `dot` -------------------------------------------
+#
+# The neato_layout plugin supplies every remaining layout engine: neato, fdp,
+# sfdp, circo, twopi, osage and patchwork. Dependency edges below were taken
+# from the `#include <subdir/...>` graph of the upstream sources.
+
+cc_library(
+    name = "rbtree",
+    srcs = [":rbtree_srcs"],
+    # graphviz hides its symbols, so these cannot be linked as separate
+    # shared libraries; they are static components of :graphviz.
+    linkstatic = True,
+    deps = [
+        ":config_h",
+        ":lib_headers",
+    ],
+    alwayslink = True,
+)
+
+# Self-contained C++ solver used by neatogen.
+cc_library(
+    name = "vpsc",
+    srcs = [":vpsc_srcs"],
+    # graphviz hides its symbols, so these cannot be linked as separate
+    # shared libraries; they are static components of :graphviz.
+    linkstatic = True,
+    deps = [
+        ":config_h",
+        ":lib_headers",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "sparse",
+    srcs = [":sparse_srcs"],
+    # graphviz hides its symbols, so these cannot be linked as separate
+    # shared libraries; they are static components of :graphviz.
+    linkstatic = True,
+    deps = [
+        ":cdt_inc",
+        ":cgraph_inc",
+        ":common_inc",
+        ":config_h",
+        ":gvc_inc",
+        ":lib_headers",
+        ":pathplan_inc",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "ortho",
+    srcs = [":ortho_srcs"],
+    # graphviz hides its symbols, so these cannot be linked as separate
+    # shared libraries; they are static components of :graphviz.
+    linkstatic = True,
+    deps = [
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":gvc_inc",
+        ":lib_headers",
+        ":pathplan",
+        ":pathplan_inc",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "neatogen",
+    srcs = [":neatogen_srcs"],
+    # graphviz hides its symbols, so these cannot be linked as separate
+    # shared libraries; they are static components of :graphviz.
+    linkstatic = True,
+    deps = [
+        ":cdt",
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":gvc_inc",
+        ":label",
+        ":lib_headers",
+        ":ortho",
+        ":pack",
+        ":pathplan",
+        ":pathplan_inc",
+        ":rbtree",
+        ":sparse",
+        ":util",
+        ":vpsc",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "fdpgen",
+    srcs = [":fdpgen_srcs"],
+    # graphviz hides its symbols, so these cannot be linked as separate
+    # shared libraries; they are static components of :graphviz.
+    linkstatic = True,
+    deps = [
+        ":cdt",
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":gvc_inc",
+        ":lib_headers",
+        ":neatogen",
+        ":pack",
+        ":pathplan",
+        ":pathplan_inc",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "circogen",
+    srcs = [":circogen_srcs"],
+    # graphviz hides its symbols, so these cannot be linked as separate
+    # shared libraries; they are static components of :graphviz.
+    linkstatic = True,
+    deps = [
+        ":cdt",
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":gvc_inc",
+        ":lib_headers",
+        ":neatogen",
+        ":pack",
+        ":pathplan_inc",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "twopigen",
+    srcs = [":twopigen_srcs"],
+    # graphviz hides its symbols, so these cannot be linked as separate
+    # shared libraries; they are static components of :graphviz.
+    linkstatic = True,
+    deps = [
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":gvc_inc",
+        ":lib_headers",
+        ":neatogen",
+        ":pack",
+        ":pathplan_inc",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+# Named *_lib because the layout binary below owns the plain name.
+cc_library(
+    name = "osage_lib",
+    srcs = [":osage_srcs"],
+    # graphviz hides its symbols, so these cannot be linked as separate
+    # shared libraries; they are static components of :graphviz.
+    linkstatic = True,
+    deps = [
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":gvc_inc",
+        ":lib_headers",
+        ":neatogen",
+        ":pack",
+        ":pathplan_inc",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+# Named *_lib because the layout binary below owns the plain name.
+cc_library(
+    name = "patchwork_lib",
+    srcs = [":patchwork_srcs"],
+    # graphviz hides its symbols, so these cannot be linked as separate
+    # shared libraries; they are static components of :graphviz.
+    linkstatic = True,
+    deps = [
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":fdpgen",
+        ":gvc_inc",
+        ":lib_headers",
+        ":neatogen",
+        ":pack",
+        ":pathplan_inc",
+        ":sparse",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "plugin_neato_layout",
+    srcs = [":plugin_neato_layout_srcs"],
+    # gvlayout_neato_layout.c guards the sfdp engine behind #ifdef SFDP. The
+    # sfdpgen sources are compiled as part of :neatogen, so enable it.
+    local_defines = ["SFDP"],
+    deps = [
+        ":cdt_inc",
+        ":cgraph",
+        ":cgraph_inc",
+        ":circogen",
+        ":common",
+        ":common_inc",
+        ":config_h",
+        ":fdpgen",
+        ":gvc",
+        ":gvc_inc",
+        ":lib_headers",
+        ":neatogen",
+        ":osage_lib",
+        ":patchwork_lib",
+        ":pathplan_inc",
+        ":twopigen",
+        ":util",
+    ],
+    alwayslink = True,
+)
+
+# Top-level graphviz library: gvc + statically registered plugins.
+cc_library(
+    name = "graphviz",
+    srcs = ["dot_builtins.cpp"],
+    linkstatic = True,
+    deps = [
+        ":cdt",
+        ":cgraph",
+        ":common",
+        ":config_h",
+        ":dotgen",
+        ":gvc",
+        ":label",
+        ":lib_headers",
+        ":pack",
+        ":pathplan",
+        ":plugin_core",
+        ":plugin_dot_layout",
+        ":plugin_neato_layout",
+        ":util",
+        ":xdot",
+        "@zlib",
+    ],
+    alwayslink = True,
+)
+
+alias(
+    name = "lib",
+    actual = ":graphviz",
+)
+
+# `dot`: layout + render driver. The graphviz library already pulls
+# in the static plugin registration table (dot_builtins.cpp).
+cc_binary(
+    name = "dot",
+    srcs = [":cmd_dot_srcs"],
+    local_defines = ["DEMAND_LOADING=0"],
+    deps = [":graphviz"],
+)
+
+filegroup(
+    name = "dot_bin",
+    srcs = [":dot"],
+)
+
+# The layout engines as separately named binaries.
+#
+# In graphviz these are all the same executable: `dot` selects its layout from
+# argv[0], falling back to `-K<engine>`. Rather than rely on argv[0] surviving
+# Bazel's runfiles handling, each name is a thin wrapper that passes -K
+# explicitly, which is the documented and more predictable route.
+LAYOUT_ENGINES = [
+    "circo",
+    "fdp",
+    "neato",
+    "osage",
+    "patchwork",
+    "sfdp",
+    "twopi",
+]
+
+[
+    genrule(
+        name = "{}_sh".format(engine),
+        outs = ["{}.sh".format(engine)],
+        cmd = ("echo '#!/bin/sh' > $@ && " +
+               "echo 'exec \"$$(dirname \"$$0\")/dot\" -K{} \"$$@\"' >> $@").format(engine),
+    )
+    for engine in LAYOUT_ENGINES
+]
+
+[
+    sh_binary(
+        name = engine,
+        srcs = ["{}.sh".format(engine)],
+        data = [":dot"],
+    )
+    for engine in LAYOUT_ENGINES
+]
+
+# Every graphviz layout binary this module provides, `dot` included.
+filegroup(
+    name = "all_layout_bins",
+    srcs = [":dot"] + [":{}".format(e) for e in LAYOUT_ENGINES],
+)

--- a/modules/graphviz/14.0.0.bcr.2/overlay/MODULE.bazel
+++ b/modules/graphviz/14.0.0.bcr.2/overlay/MODULE.bazel
@@ -1,0 +1,12 @@
+"""https://graphviz.org/"""
+
+module(
+    name = "graphviz",
+    version = "14.0.0.bcr.2",
+    bazel_compatibility = [">=8.0.0"],
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+bazel_dep(name = "zlib", version = "1.3.2")

--- a/modules/graphviz/14.0.0.bcr.2/overlay/dot_builtins.cpp
+++ b/modules/graphviz/14.0.0.bcr.2/overlay/dot_builtins.cpp
@@ -1,0 +1,26 @@
+// Builtin plugin registration for the bazel-native graphviz build.
+//
+// Upstream's cmd/dot/dot_builtins.cpp references plugins that are not
+// part of this build (kitty, vt, pango/gd/quartz/webp -- renderers that
+// need external libraries). Statically register only the plugins we
+// actually compile.
+//
+// neato_layout supplies every layout engine other than dot: neato, fdp,
+// sfdp, circo, twopi, osage and patchwork.
+
+#include <gvc/gvplugin.h>
+
+extern "C" {
+
+extern gvplugin_library_t gvplugin_dot_layout_LTX_library;
+extern gvplugin_library_t gvplugin_neato_layout_LTX_library;
+extern gvplugin_library_t gvplugin_core_LTX_library;
+
+lt_symlist_t lt_preloaded_symbols[] = {
+    {"gvplugin_dot_layout_LTX_library", &gvplugin_dot_layout_LTX_library},
+    {"gvplugin_neato_layout_LTX_library", &gvplugin_neato_layout_LTX_library},
+    {"gvplugin_core_LTX_library", &gvplugin_core_LTX_library},
+    {0, 0},
+};
+
+}

--- a/modules/graphviz/14.0.0.bcr.2/overlay/include/config.h
+++ b/modules/graphviz/14.0.0.bcr.2/overlay/include/config.h
@@ -1,0 +1,9 @@
+/* Stub config.h for the bazel-native build.
+ *
+ * All preprocessor macros that the autotools `config.h` would carry are
+ * supplied via `-D` flags on the cc_library/cc_binary `defines` and
+ * `copts` attributes in BUILD.bazel. This file exists only because many
+ * source files include `"config.h"` unconditionally.
+ */
+
+#pragma once

--- a/modules/graphviz/14.0.0.bcr.2/overlay/test_module/BUILD.bazel
+++ b/modules/graphviz/14.0.0.bcr.2/overlay/test_module/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+# Builds against the graphviz library and exercises a minimum slice of the
+# public API (cgraph + gvc).
+cc_test(
+    name = "test",
+    srcs = ["test.cc"],
+    linkstatic = True,
+    deps = ["@graphviz"],
+)
+
+# Confirms the dot binary is runnable and produces output.
+sh_test(
+    name = "dot_runs",
+    srcs = ["run_dot.sh"],
+    args = ["$(location @graphviz//:dot)"],
+    data = ["@graphviz//:dot"],
+)

--- a/modules/graphviz/14.0.0.bcr.2/overlay/test_module/MODULE.bazel
+++ b/modules/graphviz/14.0.0.bcr.2/overlay/test_module/MODULE.bazel
@@ -1,0 +1,13 @@
+module(
+    name = "graphviz_test_module",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "graphviz", version = "14.0.0.bcr.2")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+
+local_path_override(
+    module_name = "graphviz",
+    path = "..",
+)

--- a/modules/graphviz/14.0.0.bcr.2/overlay/test_module/run_dot.sh
+++ b/modules/graphviz/14.0.0.bcr.2/overlay/test_module/run_dot.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+dot_bin="${1:?missing dot binary path}"
+
+if [[ ! -x "${dot_bin}" ]]; then
+  echo "not executable: ${dot_bin}" >&2
+  exit 1
+fi
+
+out=$(echo 'digraph G { a -> b }' | "${dot_bin}" -Tdot)
+if ! grep -q 'a -> b' <<<"${out}"; then
+  echo "dot output missing expected edge:" >&2
+  echo "${out}" >&2
+  exit 1
+fi

--- a/modules/graphviz/14.0.0.bcr.2/overlay/test_module/test.cc
+++ b/modules/graphviz/14.0.0.bcr.2/overlay/test_module/test.cc
@@ -1,0 +1,54 @@
+// Smoke-test the bazel-native graphviz library from a downstream
+// module: build a tiny graph in memory, run dot layout, and render
+// to the dot output format. Failure to compile or link this file
+// would indicate a regression in the public API surface exposed by
+// `@graphviz//:graphviz`.
+
+#include <cgraph/cgraph.h>
+#include <gvc/gvc.h>
+#include <gvc/gvcext.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+int main() {
+    // The bazel-native build statically registers plugins via
+    // `lt_preloaded_symbols`. Pass them in explicitly; calling
+    // `gvContext()` would leave the context with no builtins
+    // because that overload passes NULL.
+    GVC_t *gvc = gvContextPlugins(lt_preloaded_symbols, 0);
+    if (gvc == nullptr) {
+        std::fprintf(stderr, "gvContext() returned null\n");
+        return 1;
+    }
+
+    Agraph_t *g = agopen(const_cast<char *>("g"), Agdirected, nullptr);
+    Agnode_t *a = agnode(g, const_cast<char *>("a"), 1);
+    Agnode_t *b = agnode(g, const_cast<char *>("b"), 1);
+    agedge(g, a, b, nullptr, 1);
+
+    if (gvLayout(gvc, g, "dot") != 0) {
+        std::fprintf(stderr, "gvLayout failed\n");
+        return 1;
+    }
+
+    char *out = nullptr;
+    std::size_t len = 0;
+    if (gvRenderData(gvc, g, "dot", &out, &len) != 0 || out == nullptr) {
+        std::fprintf(stderr, "gvRenderData failed\n");
+        return 1;
+    }
+
+    int ok = std::strstr(out, "a -> b") != nullptr;
+    gvFreeRenderData(out);
+    gvFreeLayout(gvc, g);
+    agclose(g);
+    gvFreeContext(gvc);
+
+    if (!ok) {
+        std::fprintf(stderr, "rendered output did not contain 'a -> b'\n");
+        return 1;
+    }
+    return 0;
+}

--- a/modules/graphviz/14.0.0.bcr.2/presubmit.yml
+++ b/modules/graphviz/14.0.0.bcr.2/presubmit.yml
@@ -1,0 +1,32 @@
+matrix:
+  platform:
+    - debian13
+    - ubuntu2404
+  bazel:
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@graphviz//:graphviz"
+      - "@graphviz//:dot"
+      - "@graphviz//:all_layout_bins"
+bcr_test_module:
+  module_path: "overlay/test_module"
+  matrix:
+    platform:
+      - debian13
+      - ubuntu2404
+    bazel:
+      - 8.x
+      - 9.x
+  tasks:
+    run_tests:
+      name: Run the test module
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/graphviz/14.0.0.bcr.2/source.json
+++ b/modules/graphviz/14.0.0.bcr.2/source.json
@@ -1,0 +1,16 @@
+{
+    "integrity": "sha256-rT9lTV1OHR5b5khvrTEG3FTo0yD7eIn3XZ05JT0uPYc=",
+    "overlay": {
+        ".bazelignore": "sha256-tqmIyjy2h0kXazydPXeAK07a/vp8NLabWHBWDDNHTi4=",
+        "BUILD.bazel": "sha256-Wgxd6gsBSHxHI0PoCgHXYrhYlcSeNJAYFXw3EMVGqsg=",
+        "MODULE.bazel": "sha256-PtUw8a/ltUaEn++xBMedehcBDGhUmAsVyWOZ1PcEs8k=",
+        "dot_builtins.cpp": "sha256-RJDAbR16vmp6c2Pr92mBZpWiOMZ3IVhuZdSPP/l1zAk=",
+        "include/config.h": "sha256-ErAkHWJWTTiSJfeb/0Znfu7wuzWX1WIz2dzol6qe86I=",
+        "test_module/BUILD.bazel": "sha256-ghxOwyV9C7V8N13zfAaj+qbVZhGPt2V09LtD63domV0=",
+        "test_module/MODULE.bazel": "sha256-Ixg+Zt5BtVt3ul+SnY1FNBOH8NYXd1J1UxJt1zU999g=",
+        "test_module/run_dot.sh": "sha256-s1AU6teVrLT45hnRotNRaZrpoIhBvCgpk5RdZGVjEX0=",
+        "test_module/test.cc": "sha256-vIVaNEXp0a2LBA0cvdF1leVV+QuIQELHoH3nMgfLsaw="
+    },
+    "strip_prefix": "graphviz-14.0.0",
+    "url": "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/14.0.0/graphviz-14.0.0.tar.gz"
+}

--- a/modules/graphviz/metadata.json
+++ b/modules/graphviz/metadata.json
@@ -1,0 +1,20 @@
+{
+    "homepage": "https://graphviz.org/",
+    "maintainers": [
+        {
+            "name": "Filip Filmar",
+            "email": "246576+filmil@users.noreply.github.com",
+            "github": "filmil",
+            "github_user_id": 246576
+        }
+    ],
+    "repository": [
+        "https://gitlab.com/graphviz/graphviz",
+        "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/"
+    ],
+    "versions": [
+        "14.0.0.bcr.1",
+        "14.0.0.bcr.2"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Overlay module for graphviz: upstream's own release archive from gitlab.com/graphviz/graphviz, built with rules_cc alone (no rules_foreign_cc). Provides the library, the dot binary, and one binary per layout engine.

Maintained at https://github.com/filmil/bazel_graphviz, where the entry is generated and validated with tools/bcr_validation.py before it is published.

Fixes: https://github.com/bazelbuild/bazel-central-registry/issues/4599