### PR TITLE
upspin@45.1.0

### DIFF
--- a/modules/upspin/45.1.0/MODULE.bazel
+++ b/modules/upspin/45.1.0/MODULE.bazel
@@ -1,0 +1,45 @@
+module(
+    name = "upspin",
+    version = "45.1.0",
+)
+
+bazel_dep(name = "rules_go", version = "0.61.1")
+bazel_dep(name = "gazelle", version = "0.51.3")
+bazel_dep(name = "protobuf", version = "35.1")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_android", version = "0.7.3")
+bazel_dep(name = "rules_oci", version = "2.3.0")
+bazel_dep(name = "rules_pkg", version = "1.2.0")
+
+oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+oci.pull(
+    name = "distroless_static",
+    digest = "sha256:47b2d72ff90843eb8a768b5c2f89b40741843b639d065b9b937b07cd59b479c6",
+    image = "gcr.io/distroless/static",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64/v8",
+    ],
+)
+use_repo(oci, "distroless_static", "distroless_static_linux_amd64", "distroless_static_linux_arm64_v8")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.26.6")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+
+# Use this to generate the go_deps.bzl file
+use_repo(
+    go_deps,
+    "com_github_golang_protobuf",
+    "com_github_microcosm_cc_bluemonday",
+    "com_github_nytimes_gziphandler",
+    "com_github_presotto_fuse",
+    "com_github_russross_blackfriday",
+    "in_gopkg_yaml_v2",
+    "org_golang_google_protobuf",
+    "org_golang_x_crypto",
+    "org_golang_x_net",
+    "org_golang_x_text",
+)

--- a/modules/upspin/45.1.0/attestations.json
+++ b/modules/upspin/45.1.0/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/filmil/upspin/releases/download/v45.1.0/source.json.intoto.jsonl",
+            "integrity": "sha256-nt9Qf4WDlNAbXmRANk2nUCGCpF3VV4RyjnQtwoX5kuU="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/filmil/upspin/releases/download/v45.1.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-fVYglyqfDqaEN4q2pq9IkqYWXgKdOzhqtQbhI4aI0Mg="
+        },
+        "v45.1.0.tar.gz": {
+            "url": "https://github.com/filmil/upspin/releases/download/v45.1.0/v45.1.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-bKcIjzEEwrc0a8Oy/NSC2G1Ext5ZuM14YiwJktE63VA="
+        }
+    }
+}

--- a/modules/upspin/45.1.0/patches/module_dot_bazel_version.patch
+++ b/modules/upspin/45.1.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "upspin",
+-    version = "42.1.6",
++    version = "45.1.0",
+ )
+ 
+ bazel_dep(name = "rules_go", version = "0.61.1")
+ bazel_dep(name = "gazelle", version = "0.51.3")

--- a/modules/upspin/45.1.0/presubmit.yml
+++ b/modules/upspin/45.1.0/presubmit.yml
@@ -1,0 +1,10 @@
+matrix:
+  platform: ["ubuntu2204"]
+  bazel: [9.x]
+tasks:
+  run_tests:
+    name: "Run tests"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "//..."

--- a/modules/upspin/45.1.0/source.json
+++ b/modules/upspin/45.1.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-aQ5ulZKw1pc5qvZiaSt2yVHbWNIZdeWMQMfOI2EwvZs=",
+    "strip_prefix": "upspin-45.1.0",
+    "url": "https://github.com/filmil/upspin/releases/download/v45.1.0/v45.1.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-oN7++KRDSoHRD8HGOdGAlU/5bc3ZzOVaU3TQqHH+Bb8="
+    },
+    "patch_strip": 1
+}

--- a/modules/upspin/metadata.json
+++ b/modules/upspin/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/filmil/upspin",
+    "maintainers": [
+        {
+            "name": "Filip Filmar",
+            "email": "246576+filmil@users.noreply.github.com",
+            "github": "filmil",
+            "github_user_id": 246576
+        }
+    ],
+    "repository": [
+        "github:filmil/upspin"
+    ],
+    "versions": [
+        "45.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/filmil/upspin/releases/tag/v45.1.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_