### PR TITLE
rules_latex_host@0.3.1

### DIFF
--- a/modules/rules_latex_host/0.3.1/MODULE.bazel
+++ b/modules/rules_latex_host/0.3.1/MODULE.bazel
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+module(
+    name = "rules_latex_host",
+    version = "0.3.1",
+    compatibility_level = 1,
+)
+
+# For the `install_tools` sh_binary convenience target (sh_* rules are no longer
+# built into Bazel 9).
+bazel_dep(name = "rules_shell", version = "0.4.1")
+
+# For the exec constraints of the hermetic toolchain (@platforms//os:linux, ...).
+bazel_dep(name = "platforms", version = "0.0.11")
+
+# For //tests:toolchain_builds, the test that the release workflow runs at the
+# tag. A dev dependency: consumers do not get it, so nothing under //latex may
+# load it.
+bazel_dep(name = "bazel_skylib", version = "1.9.2", dev_dependency = True)
+
+# Auto-register the system (host-tools) LaTeX toolchain for consumers. A
+# consumer that does `bazel_dep(name = "rules_latex_host", ...)` gets this
+# toolchain for free. To go hermetic, use the `hermetic_latex` extension in
+# //latex:extensions.bzl and `register_toolchains` it in the root module: root
+# registrations are tried first, and the hermetic toolchain declares exec
+# constraints, so this one still serves platforms it does not cover.
+register_toolchains("//latex:system_latex_toolchain")

--- a/modules/rules_latex_host/0.3.1/attestations.json
+++ b/modules/rules_latex_host/0.3.1/attestations.json
@@ -1,0 +1,17 @@
+{
+    "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/filmil/bazel_rules_latex_host/releases/download/v0.3.1/source.json.intoto.jsonl",
+            "integrity": "sha256-mTGK4XdvEjGoVj1PCNFqkwDlBmav4afHo4cDdBnT8I0="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/filmil/bazel_rules_latex_host/releases/download/v0.3.1/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-YkyqtoOljrtGRIsnfd7pgVgbdJSaU+XjXuBHlmmKw2U="
+        },
+        "bazel_rules_latex_host-v0.3.1.zip": {
+            "url": "https://github.com/filmil/bazel_rules_latex_host/releases/download/v0.3.1/bazel_rules_latex_host-v0.3.1.zip.intoto.jsonl",
+            "integrity": "sha256-PUaOdvVreOycxDXtfCMFMZBosGp66KEZZotZjQFHrSY="
+        }
+    }
+}

--- a/modules/rules_latex_host/0.3.1/patches/module_dot_bazel_version.patch
+++ b/modules/rules_latex_host/0.3.1/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,8 +1,8 @@
+ # SPDX-License-Identifier: Apache-2.0
+ module(
+     name = "rules_latex_host",
+-    version = "0.0.0",
++    version = "0.3.1",
+     compatibility_level = 1,
+ )
+ 
+ # For the `install_tools` sh_binary convenience target (sh_* rules are no longer

--- a/modules/rules_latex_host/0.3.1/presubmit.yml
+++ b/modules/rules_latex_host/0.3.1/presubmit.yml
@@ -1,0 +1,15 @@
+# The `system` toolchain is non-hermetic (it shells out to host TeX tools), so
+# the presubmit only builds the module's own targets (toolchain + wrappers +
+# helper) which do NOT require TeX to be installed. Actually compiling a
+# document is exercised by the integration modules in the source repo's CI,
+# where the host tools are installed first, or the hermetic TeX is fetched.
+matrix:
+  platform: [debian13, ubuntu2404]
+  bazel: [8.x, 9.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@rules_latex_host//latex/...'

--- a/modules/rules_latex_host/0.3.1/source.json
+++ b/modules/rules_latex_host/0.3.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-v7jCipsymieDCjSZggjOHZfVj/nSOgOaDalHOcPDLwc=",
+    "strip_prefix": "",
+    "url": "https://github.com/filmil/bazel_rules_latex_host/releases/download/v0.3.1/bazel_rules_latex_host-v0.3.1.zip",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-dRkCSqcwHwsHfv09eF0MkCSvSN1jrb+2G50rIENFJ6c="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_latex_host/metadata.json
+++ b/modules/rules_latex_host/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/filmil/bazel_rules_latex_host",
+    "maintainers": [
+        {
+            "name": "Filip Filmar",
+            "email": "246576+filmil@users.noreply.github.com",
+            "github": "filmil",
+            "github_user_id": 246576
+        }
+    ],
+    "repository": [
+        "github:filmil/bazel_rules_latex_host"
+    ],
+    "versions": [
+        "0.3.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/filmil/bazel_rules_latex_host/releases/tag/v0.3.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_