### PR TITLE
fix: fix mujoco include path

### DIFF
--- a/modules/mujoco/3.10.0.bcr.1/MODULE.bazel
+++ b/modules/mujoco/3.10.0.bcr.1/MODULE.bazel
@@ -1,0 +1,17 @@
+module(
+    name = "mujoco",
+    version = "3.10.0.bcr.1",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "ccd", version = "2.1.0.bcr.2")
+bazel_dep(name = "glfw", version = "3.4.0.bcr.3")
+bazel_dep(name = "lodepng", version = "0.0.0-20250506-17d08dd")
+bazel_dep(name = "marchingcubecpp", version = "0.0.0-20230911-f03a1b3")
+bazel_dep(name = "miniz", version = "3.1.1")
+bazel_dep(name = "package_metadata", version = "0.0.13")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "qhull", version = "8.0.2.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "tinyobjloader", version = "2.0.0-rc1.bcr.2")
+bazel_dep(name = "tinyxml2", version = "11.0.0")

--- a/modules/mujoco/3.10.0.bcr.1/overlay/BUILD.bazel
+++ b/modules/mujoco/3.10.0.bcr.1/overlay/BUILD.bazel
@@ -1,0 +1,351 @@
+load("@package_metadata//licenses/rules:license.bzl", "license")
+load("@package_metadata//purl:purl.bzl", "purl")
+load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
+
+package(default_package_metadata = [":package_metadata"])
+
+exports_files(
+    ["LICENSE"],
+    visibility = ["//visibility:private"],
+)
+
+package_metadata(
+    name = "package_metadata",
+    attributes = [":license"],
+    purl = purl.bazel(
+        module_name(),
+        module_version(),
+    ),
+    visibility = ["//visibility:public"],
+)
+
+license(
+    name = "license",
+    kind = "@package_metadata//licenses/spdx:Apache-2.0",
+    text = "LICENSE",
+    visibility = ["//visibility:public"],
+)
+
+# This intentionally uses MuJoCo's headless renderer. It keeps the physics and
+# model compiler hermetic and avoids host OpenGL/X11 packages. Applications that
+# need the mjr rendering API should provide a rendering backend separately.
+cc_library(
+    name = "mujoco",
+    srcs = [
+        "plugin/obj_decoder/obj_decoder.cc",
+        "plugin/stl_decoder/stl_decoder.cc",
+        "src/engine/engine_callback.c",
+        "src/engine/engine_collision_box.c",
+        "src/engine/engine_collision_convex.c",
+        "src/engine/engine_collision_driver.c",
+        "src/engine/engine_collision_gjk.c",
+        "src/engine/engine_collision_primitive.c",
+        "src/engine/engine_collision_sdf.c",
+        "src/engine/engine_core_constraint.c",
+        "src/engine/engine_core_smooth.c",
+        "src/engine/engine_core_util.c",
+        "src/engine/engine_crossplatform.cc",
+        "src/engine/engine_derivative.c",
+        "src/engine/engine_derivative_fd.c",
+        "src/engine/engine_forward.c",
+        "src/engine/engine_init.c",
+        "src/engine/engine_inverse.c",
+        "src/engine/engine_io.c",
+        "src/engine/engine_island.c",
+        "src/engine/engine_memory.c",
+        "src/engine/engine_name.c",
+        "src/engine/engine_passive.c",
+        "src/engine/engine_plugin.cc",
+        "src/engine/engine_print.c",
+        "src/engine/engine_ray.c",
+        "src/engine/engine_sensor.c",
+        "src/engine/engine_setconst.c",
+        "src/engine/engine_sleep.c",
+        "src/engine/engine_solver.c",
+        "src/engine/engine_support.c",
+        "src/engine/engine_thread.cc",
+        "src/engine/engine_util_blas.c",
+        "src/engine/engine_util_errmem.c",
+        "src/engine/engine_util_misc.c",
+        "src/engine/engine_util_solve.c",
+        "src/engine/engine_util_sparse.c",
+        "src/engine/engine_util_spatial.c",
+        "src/engine/engine_vis_init.c",
+        "src/engine/engine_vis_interact.c",
+        "src/engine/engine_vis_visualize.c",
+        "src/user/user_api.cc",
+        "src/user/user_cache.cc",
+        "src/user/user_composite.cc",
+        "src/user/user_flexcomp.cc",
+        "src/user/user_init.c",
+        "src/user/user_mesh.cc",
+        "src/user/user_model.cc",
+        "src/user/user_objects.cc",
+        "src/user/user_resolver.cc",
+        "src/user/user_resource.cc",
+        "src/user/user_threadpool.cc",
+        "src/user/user_util.cc",
+        "src/user/user_vfs.cc",
+        "src/xml/mjz/mjz_decoder.cc",
+        "src/xml/mjz/mjz_encoder.cc",
+        "src/xml/xml.cc",
+        "src/xml/xml_api.cc",
+        "src/xml/xml_base.cc",
+        "src/xml/xml_global.cc",
+        "src/xml/xml_native_reader.cc",
+        "src/xml/xml_native_writer.cc",
+        "src/xml/xml_numeric_format.cc",
+        "src/xml/xml_urdf.cc",
+        "src/xml/xml_util.cc",
+    ],
+    hdrs = glob(["include/mujoco/*.h"]),
+    conlyopts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-std=c11"],
+    }),
+    copts = select({
+        "@platforms//os:windows": ["/wd4005"],
+        "//conditions:default": [
+            "-Wno-unknown-pragmas",
+        ],
+    }),
+    cxxopts = select({
+        "@platforms//os:windows": [
+            "/std:c++20",
+            "/EHsc",
+        ],
+        "//conditions:default": [
+            "-std=c++20",
+            "-fexceptions",
+        ],
+    }),
+    includes = [
+        "include",
+        "src",
+    ],
+    linkopts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "-lm",
+            "-pthread",
+        ],
+    }),
+    local_defines = [
+        "CCD_STATIC_DEFINE",
+        "MC_IMPLEM_ENABLE",
+        "MUJOCO_DLL_EXPORTS",
+        "TINYOBJLOADER_IMPLEMENTATION",
+        "_GNU_SOURCE",
+    ],
+    textual_hdrs = glob([
+        "src/cc/*.h",
+        "src/engine/*.h",
+        "src/user/*.h",
+        "src/xml/*.h",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ccd",
+        "@lodepng",
+        "@marchingcubecpp",
+        "@miniz",
+        "@qhull//:qhull_r",
+        "@tinyobjloader",
+        "@tinyxml2",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "mujoco_noop_renderer",
+    srcs = ["src/render/noop/render_noop.c"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [":mujoco"],
+)
+
+cc_library(
+    name = "mujoco_renderer",
+    srcs = [
+        "src/render/classic/glad/glad.c",
+        "src/render/classic/glad/loader.cc",
+        "src/render/classic/render_context.c",
+        "src/render/classic/render_gl2.c",
+        "src/render/classic/render_gl3.c",
+        "src/render/classic/render_util.c",
+        "src/ui/ui_main.c",
+    ],
+    conlyopts = ["-std=c11"],
+    cxxopts = [
+        "-std=c++20",
+        "-fexceptions",
+    ],
+    includes = ["src"],
+    linkopts = select({
+        "@platforms//os:linux": ["-ldl"],
+        "//conditions:default": [],
+    }),
+    local_defines = ["_GNU_SOURCE"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    textual_hdrs = glob([
+        "src/render/classic/*.h",
+        "src/render/classic/font/*.inc",
+        "src/render/classic/glad/*.h",
+        "src/ui/*.h",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [":mujoco"],
+    alwayslink = True,
+)
+
+objc_library(
+    name = "simulate_macos",
+    srcs = [
+        "simulate/glfw_corevideo.mm",
+        "simulate/macos_gui.mm",
+    ],
+    copts = [
+        "-std=c++20",
+        "-fexceptions",
+        "-fno-objc-arc",
+        "-Wno-deprecated-declarations",
+    ],
+    includes = ["simulate"],
+    linkopts = [
+        "-framework Cocoa",
+        "-framework CoreVideo",
+    ],
+    target_compatible_with = ["@platforms//os:macos"],
+    textual_hdrs = [
+        "simulate/glfw_adapter.h",
+        "simulate/glfw_corevideo.h",
+        "simulate/glfw_dispatch.h",
+        "simulate/platform_ui_adapter.h",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":mujoco",
+        "@glfw",
+    ],
+)
+
+cc_library(
+    name = "simulate_lib",
+    srcs = [
+        "simulate/glfw_adapter.cc",
+        "simulate/glfw_dispatch.cc",
+        "simulate/platform_ui_adapter.cc",
+        "simulate/simulate.cc",
+    ],
+    hdrs = [
+        "simulate/glfw_adapter.h",
+        "simulate/glfw_dispatch.h",
+        "simulate/platform_ui_adapter.h",
+        "simulate/simulate.h",
+    ],
+    cxxopts = [
+        "-std=c++20",
+        "-fexceptions",
+    ],
+    includes = ["simulate"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    textual_hdrs = [
+        "simulate/array_safety.h",
+        "simulate/glfw_corevideo.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":mujoco",
+        ":mujoco_renderer",
+        "@glfw",
+        "@lodepng",
+    ] + select({
+        "@platforms//os:macos": [":simulate_macos"],
+        "//conditions:default": [],
+    }),
+)
+
+cc_binary(
+    name = "simulate",
+    srcs = ["simulate/main.cc"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [":simulate_lib"],
+)
+
+# Support for running the upstream unit tests in //test. The first-party
+# engine plugins are linked statically into the test binaries (registration
+# happens via mjPLUGIN_LIB_INIT static constructors) instead of being loaded
+# dynamically through MUJOCO_PLUGIN_DIR as in the upstream CMake build.
+filegroup(
+    name = "models",
+    testonly = True,
+    srcs = glob(["model/**"]),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "elasticity_plugin",
+    testonly = True,
+    srcs = glob([
+        "plugin/elasticity/*.cc",
+        "plugin/elasticity/*.h",
+    ]),
+    cxxopts = ["-std=c++20"],
+    visibility = ["//visibility:public"],
+    deps = [":mujoco"],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "actuator_plugin",
+    testonly = True,
+    srcs = glob([
+        "plugin/actuator/*.cc",
+        "plugin/actuator/*.h",
+    ]),
+    cxxopts = ["-std=c++20"],
+    visibility = ["//visibility:public"],
+    deps = [":mujoco"],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "sdf_plugin",
+    testonly = True,
+    srcs = glob([
+        "plugin/sdf/*.cc",
+        "plugin/sdf/*.h",
+    ]),
+    cxxopts = ["-std=c++20"],
+    visibility = ["//visibility:public"],
+    deps = [":mujoco"],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "sensor_plugin",
+    testonly = True,
+    srcs = glob([
+        "plugin/sensor/*.cc",
+        "plugin/sensor/*.h",
+    ]),
+    cxxopts = ["-std=c++20"],
+    visibility = ["//visibility:public"],
+    deps = [":mujoco"],
+    alwayslink = True,
+)

--- a/modules/mujoco/3.10.0.bcr.1/overlay/test/BUILD.bazel
+++ b/modules/mujoco/3.10.0.bcr.1/overlay/test/BUILD.bazel
@@ -1,0 +1,1357 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_testonly = True)
+
+# Upstream MuJoCo unit tests, adapted to run under Bazel. Tests that require
+# dependencies not available in the BCR (google-benchmark, OpenUSD) or the
+# sample binaries are not included.
+
+filegroup(
+    name = "testdata",
+    srcs = glob(
+        ["**/testdata/**"],
+        allow_empty = True,
+    ),
+)
+
+cc_library(
+    name = "fixture",
+    srcs = ["fixture.cc"],
+    hdrs = ["fixture.h"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    include_prefix = "test",
+    deps = [
+        "@abseil-cpp//absl/base:core_headers",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/synchronization",
+        "@googletest//:gtest",
+        "@mujoco",
+        "@rules_cc//cc/runfiles",
+    ],
+)
+
+cc_library(
+    name = "compare_model",
+    srcs = ["compare_model.cc"],
+    hdrs = ["compare_model.h"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    include_prefix = "test",
+    deps = ["@mujoco"],
+)
+
+cc_test(
+    name = "engine_cg_convergence_test",
+    size = "large",
+    srcs = ["engine/engine_cg_convergence_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_collision_box_test",
+    size = "small",
+    srcs = ["engine/engine_collision_box_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_collision_convex_test",
+    size = "small",
+    srcs = ["engine/engine_collision_convex_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_collision_driver_test",
+    size = "medium",
+    srcs = ["engine/engine_collision_driver_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_collision_gjk_test",
+    size = "small",
+    srcs = ["engine/engine_collision_gjk_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@ccd",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_collision_sdf_test",
+    size = "medium",
+    srcs = ["engine/engine_collision_sdf_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@mujoco//:elasticity_plugin",
+        "@mujoco//:sdf_plugin",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_core_constraint_test",
+    size = "medium",
+    srcs = ["engine/engine_core_constraint_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_core_smooth_test",
+    size = "medium",
+    srcs = ["engine/engine_core_smooth_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@abseil-cpp//absl/types:span",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_core_util_test",
+    size = "small",
+    srcs = ["engine/engine_core_util_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_derivative_test",
+    size = "small",
+    srcs = ["engine/engine_derivative_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_forward_test",
+    size = "medium",
+    srcs = ["engine/engine_forward_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_inverse_test",
+    size = "small",
+    srcs = ["engine/engine_inverse_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_io_test",
+    size = "small",
+    srcs = ["engine/engine_io_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@abseil-cpp//absl/strings:str_format",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_island_test",
+    size = "small",
+    srcs = ["engine/engine_island_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_passive_test",
+    size = "small",
+    srcs = ["engine/engine_passive_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_plugin_test",
+    size = "small",
+    srcs = ["engine/engine_plugin_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@mujoco//:actuator_plugin",
+        "@mujoco//:elasticity_plugin",
+        "@mujoco//:sdf_plugin",
+        "@mujoco//:sensor_plugin",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_print_test",
+    size = "small",
+    srcs = ["engine/engine_print_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_ray_test",
+    size = "medium",
+    srcs = ["engine/engine_ray_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@mujoco//:sdf_plugin",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_sensor_test",
+    size = "small",
+    srcs = ["engine/engine_sensor_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_setconst_test",
+    size = "small",
+    srcs = ["engine/engine_setconst_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_sleep_test",
+    size = "small",
+    srcs = ["engine/engine_sleep_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_solver_test",
+    size = "small",
+    srcs = ["engine/engine_solver_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_sort_test",
+    size = "small",
+    srcs = ["engine/engine_sort_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_support_test",
+    size = "small",
+    srcs = ["engine/engine_support_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_thread_test",
+    size = "small",
+    srcs = ["engine/engine_thread_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_util_blas_test",
+    size = "small",
+    srcs = ["engine/engine_util_blas_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+
+cc_test(
+    name = "engine_util_errmem_test",
+    size = "small",
+    srcs = ["engine/engine_util_errmem_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_util_misc_test",
+    size = "small",
+    srcs = ["engine/engine_util_misc_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_util_solve_test",
+    size = "small",
+    srcs = ["engine/engine_util_solve_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_util_sparse_test",
+    size = "small",
+    srcs = ["engine/engine_util_sparse_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_util_spatial_test",
+    size = "small",
+    srcs = ["engine/engine_util_spatial_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "engine_vis_visualize_test",
+    size = "small",
+    srcs = ["engine/engine_vis_visualize_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "fixture_test",
+    size = "small",
+    srcs = ["fixture_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "header_test",
+    size = "small",
+    srcs = ["header_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "mjspecmacro_test",
+    size = "small",
+    srcs = ["mjspecmacro_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "pipeline_test",
+    size = "small",
+    srcs = ["pipeline_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "pid_test",
+    size = "small",
+    srcs = ["plugin/actuator/pid_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@mujoco//:actuator_plugin",
+        "@abseil-cpp//absl/cleanup",
+        "@abseil-cpp//absl/strings",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "decoder_test",
+    size = "small",
+    srcs = ["plugin/decoder/decoder_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "elasticity_test",
+    size = "small",
+    srcs = ["plugin/elasticity/elasticity_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@mujoco//:elasticity_plugin",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "encoder_test",
+    size = "small",
+    srcs = ["plugin/encoder/encoder_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "sensor_test",
+    size = "small",
+    srcs = ["plugin/sensor/sensor_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@mujoco//:sensor_plugin",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_api_test",
+    size = "medium",
+    srcs = ["user/user_api_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@mujoco//:actuator_plugin",
+        "@mujoco//:elasticity_plugin",
+        "@mujoco//:sdf_plugin",
+        "@mujoco//:sensor_plugin",
+        ":compare_model",
+        "@abseil-cpp//absl/strings:str_format",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_cache_test",
+    size = "small",
+    srcs = ["user/user_cache_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_composite_test",
+    size = "small",
+    srcs = ["user/user_composite_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@abseil-cpp//absl/strings:str_format",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_flex_test",
+    size = "medium",
+    srcs = ["user/user_flex_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_mesh_test",
+    size = "medium",
+    srcs = ["user/user_mesh_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_model_test",
+    size = "small",
+    srcs = ["user/user_model_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        ":compare_model",
+        "@abseil-cpp//absl/strings:str_format",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_objects_test",
+    size = "small",
+    srcs = ["user/user_objects_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_recompile_test",
+    size = "large",
+    shard_count = 8,
+    srcs = ["user/user_recompile_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@mujoco//:elasticity_plugin",
+        ":compare_model",
+        "@abseil-cpp//absl/strings",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_resolver_test",
+    size = "small",
+    srcs = ["user/user_resolver_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_resource_test",
+    size = "small",
+    srcs = ["user/user_resource_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@abseil-cpp//absl/strings:str_format",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_threadpool_test",
+    size = "small",
+    srcs = ["user/user_threadpool_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_util_test",
+    size = "small",
+    srcs = ["user/user_util_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "user_vfs_test",
+    size = "small",
+    srcs = ["user/user_vfs_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "mjz_decoder_test",
+    size = "large",
+    srcs = ["xml/mjz/mjz_decoder_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "mjz_encoder_test",
+    size = "large",
+    srcs = ["xml/mjz/mjz_encoder_test.cc"],
+    shard_count = 8,
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@mujoco//:actuator_plugin",
+        "@mujoco//:elasticity_plugin",
+        "@mujoco//:sdf_plugin",
+        "@mujoco//:sensor_plugin",
+        ":compare_model",
+        "@abseil-cpp//absl/strings",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "xml_api_test",
+    size = "small",
+    srcs = ["xml/xml_api_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "xml_native_reader_test",
+    size = "large",
+    shard_count = 4,
+    srcs = ["xml/xml_native_reader_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        ":compare_model",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "xml_native_writer_test",
+    size = "small",
+    srcs = ["xml/xml_native_writer_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@mujoco//:elasticity_plugin",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "xml_schema_test",
+    size = "small",
+    srcs = ["xml/xml_schema_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@abseil-cpp//absl/strings:str_format",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "xml_urdf_test",
+    size = "small",
+    srcs = ["xml/xml_urdf_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "xml_utils_test",
+    size = "small",
+    srcs = ["xml/xml_utils_test.cc"],
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)
+
+cc_test(
+    name = "xml_write_read_test",
+    size = "large",
+    srcs = ["xml/xml_write_read_test.cc"],
+    shard_count = 8,
+    cxxopts = [
+        "-std=c++20",
+        "-isystemexternal/abseil-cpp+",
+    ],
+    data = [
+        ":testdata",
+        "@mujoco//:models",
+    ],
+    deps = [
+        ":fixture",
+        "@mujoco//:elasticity_plugin",
+        ":compare_model",
+        "@abseil-cpp//absl/strings",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@mujoco",
+    ],
+)

--- a/modules/mujoco/3.10.0.bcr.1/overlay/test/MODULE.bazel
+++ b/modules/mujoco/3.10.0.bcr.1/overlay/test/MODULE.bazel
@@ -1,0 +1,12 @@
+module(name = "mujoco_test")
+
+bazel_dep(name = "abseil-cpp", version = "20260107.1")
+bazel_dep(name = "ccd", version = "2.1.0.bcr.2")
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+bazel_dep(name = "mujoco", version = "3.10.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+
+local_path_override(
+    module_name = "mujoco",
+    path = "..",
+)

--- a/modules/mujoco/3.10.0.bcr.1/patches/fix_mc_header_include.patch
+++ b/modules/mujoco/3.10.0.bcr.1/patches/fix_mc_header_include.patch
@@ -1,0 +1,7 @@
+--- a/src/user/user_mesh.cc
++++ b/src/user/user_mesh.cc
+@@ -50,3 +50,3 @@
+ #endif
+-#include <MC.h>
++#include "MC.h"
+ #if defined(__clang__)

--- a/modules/mujoco/3.10.0.bcr.1/patches/support_upstream_tests.patch
+++ b/modules/mujoco/3.10.0.bcr.1/patches/support_upstream_tests.patch
@@ -1,0 +1,83 @@
+diff --git a/test/fixture.cc b/test/fixture.cc
+--- a/test/fixture.cc
++++ b/test/fixture.cc
+@@ -38,6 +38,7 @@
+ #include <absl/synchronization/mutex.h>
+ #include <mujoco/mjmodel.h>
+ #include <mujoco/mujoco.h>
++#include "rules_cc/cc/runfiles/runfiles.h"
+ #include "src/xml/xml_global.h"
+ 
+ namespace mujoco {
+@@ -154,7 +155,22 @@
+ }
+ 
+ const std::string GetModelPath(std::string_view path) {  // NOLINT
+-  return absl::StrCat("../model/", path);
++  // Under Bazel, the model directory is in the runfiles of the mujoco
++  // repository, resolved through the runfiles library. The directory itself
++  // has no runfiles manifest entry, so locate it from a well-known file.
++  static const std::string model_dir = [] {
++    std::string error;
++    std::unique_ptr<rules_cc::cc::runfiles::Runfiles> runfiles(
++        rules_cc::cc::runfiles::Runfiles::CreateForTest(&error));
++    if (runfiles == nullptr) {
++      mju_error("Failed to create runfiles: %s", error.c_str());
++    }
++    constexpr std::string_view kSentinel = "/humanoid/humanoid.xml";
++    std::string sentinel =
++        runfiles->Rlocation(absl::StrCat("mujoco/model", kSentinel));
++    return sentinel.substr(0, sentinel.size() - kSentinel.size());
++  }();
++  return absl::StrCat(model_dir, "/", path);
+ }
+ 
+ MjModelPtr LoadModelFromString(std::string_view xml, char* error,
+diff --git a/test/xml/mjz/mjz_encoder_test.cc b/test/xml/mjz/mjz_encoder_test.cc
+--- a/test/xml/mjz/mjz_encoder_test.cc
++++ b/test/xml/mjz/mjz_encoder_test.cc
+@@ -146,7 +146,7 @@
+   ASSERT_THAT(model, testing::NotNull());
+ 
+   const std::string tmp_path =
+-      testing::TempDir() + "/mjz_encoder_roundtrip.mjz";
++      testing::TempDir() + "mjz_encoder_roundtrip.mjz";
+ 
+   char error[1024] = {0};
+   int nbytes = mj_encode(spec, model, tmp_path.c_str(), nullptr, nullptr, error,
+@@ -193,7 +193,7 @@
+   mjModel* model = mj_compile(spec, nullptr);
+   ASSERT_THAT(model, testing::NotNull());
+ 
+-  const std::string tmp_path = testing::TempDir() + "/xml_string.mjz";
++  const std::string tmp_path = testing::TempDir() + "xml_string.mjz";
+   int nbytes = mj_encode(spec, model, tmp_path.c_str(), nullptr, nullptr, error,
+                          sizeof(error));
+   ASSERT_GT(nbytes, 0) << error;
+@@ -242,7 +242,7 @@
+   mjModel* model = mj_compile(spec, nullptr);
+   ASSERT_THAT(model, testing::NotNull());
+ 
+-  const std::string tmp_path = testing::TempDir() + "/counts.mjz";
++  const std::string tmp_path = testing::TempDir() + "counts.mjz";
+   int nbytes = mj_encode(spec, model, tmp_path.c_str(), nullptr, nullptr, error,
+                          sizeof(error));
+   ASSERT_GT(nbytes, 0) << error;
+@@ -300,7 +300,7 @@
+   mjModel* model = mj_compile(spec, &vfs);
+   ASSERT_THAT(model, testing::NotNull()) << mjs_getError(spec);
+ 
+-  const std::string tmp_path = testing::TempDir() + "/vfs_mesh.mjz";
++  const std::string tmp_path = testing::TempDir() + "vfs_mesh.mjz";
+   int nbytes = mj_encode(spec, model, tmp_path.c_str(), nullptr, &vfs, error,
+                          sizeof(error));
+   ASSERT_GT(nbytes, 0) << error;
+@@ -874,7 +874,7 @@
+   mjModel* m = mj_compile(s, nullptr);
+   ASSERT_THAT(m, NotNull()) << mjs_getError(s);
+ 
+-  const std::string tmp_path = testing::TempDir() + "/mjz_roundtrip.mjz";
++  const std::string tmp_path = testing::TempDir() + "mjz_roundtrip.mjz";
+   int nbytes = mj_encode(s, m, tmp_path.c_str(), nullptr, nullptr, error.data(),
+                          error.size());
+   ASSERT_GT(nbytes, 0) << error.data();

--- a/modules/mujoco/3.10.0.bcr.1/patches/use_bzlmod_dependency_includes.patch
+++ b/modules/mujoco/3.10.0.bcr.1/patches/use_bzlmod_dependency_includes.patch
@@ -1,0 +1,24 @@
+diff --git a/plugin/obj_decoder/obj_decoder.cc b/plugin/obj_decoder/obj_decoder.cc
+--- a/plugin/obj_decoder/obj_decoder.cc
++++ b/plugin/obj_decoder/obj_decoder.cc
+@@ -23 +23 @@
+-#include <tiny_obj_loader.h>
++#include "tiny_obj_loader.h"
+diff --git a/src/user/user_mesh.cc b/src/user/user_mesh.cc
+--- a/src/user/user_mesh.cc
++++ b/src/user/user_mesh.cc
+@@ -71 +71 @@ extern "C" {
+-#include "qhull_ra.h"
++#include "libqhull_r/qhull_ra.h"
+diff --git a/src/xml/mjz/mjz_decoder.cc b/src/xml/mjz/mjz_decoder.cc
+--- a/src/xml/mjz/mjz_decoder.cc
++++ b/src/xml/mjz/mjz_decoder.cc
+@@ -34 +34 @@
+-#include <miniz.h>
++#include "miniz.h"
+diff --git a/src/xml/mjz/mjz_encoder.cc b/src/xml/mjz/mjz_encoder.cc
+--- a/src/xml/mjz/mjz_encoder.cc
++++ b/src/xml/mjz/mjz_encoder.cc
+@@ -33 +33 @@
+-#include <miniz.h>
++#include "miniz.h"

--- a/modules/mujoco/3.10.0.bcr.1/presubmit.yml
+++ b/modules/mujoco/3.10.0.bcr.1/presubmit.yml
@@ -1,0 +1,58 @@
+matrix:
+  unix_platform:
+  - ubuntu2404
+  - ubuntu2404_arm64
+  - macos
+  - macos_arm64
+  linux_platform:
+  - ubuntu2404
+  - ubuntu2404_arm64
+  macos_platform:
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 9.x
+  - rolling
+tasks:
+  verify_targets:
+    name: Verify headless MuJoCo library
+    platform: ${{ unix_platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@mujoco//:mujoco'
+  verify_linux_gui_targets:
+    name: Verify MuJoCo GUI targets on Linux
+    platform: ${{ linux_platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@mujoco//:mujoco_renderer'
+    - '@mujoco//:simulate'
+  verify_macos_gui_targets:
+    name: Verify MuJoCo GUI targets on macOS
+    platform: ${{ macos_platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@mujoco//:mujoco_renderer'
+    - '@mujoco//:simulate'
+    build_flags:
+    - '--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1'
+bcr_test_module:
+  module_path: test
+  matrix:
+    unix_platform:
+    - ubuntu2404
+    - ubuntu2404_arm64
+    - macos
+    - macos_arm64
+    bazel:
+    - 8.x
+    - 9.x
+    - rolling
+  tasks:
+    run_upstream_tests:
+      name: Run upstream unit tests
+      platform: ${{ unix_platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+      - '//...'

--- a/modules/mujoco/3.10.0.bcr.1/source.json
+++ b/modules/mujoco/3.10.0.bcr.1/source.json
@@ -1,0 +1,16 @@
+{
+    "url": "https://github.com/google-deepmind/mujoco/archive/refs/tags/3.10.0.tar.gz",
+    "integrity": "sha256-pHv7dsHA8eDkREEr07ntJI+nomfgFCqyxlhYSG8YPb4=",
+    "strip_prefix": "mujoco-3.10.0",
+    "patch_strip": 1,
+    "patches": {
+        "fix_mc_header_include.patch": "sha256-bWc+by44cM7Izv5RPhpCq5xdm0VUi+hz1XF5Eg4XD6g=",
+        "use_bzlmod_dependency_includes.patch": "sha256-mYuc8PBQPMdCfGxfH7FrAc8kXfqs87nPVQAFQDOYpGk=",
+        "support_upstream_tests.patch": "sha256-Yzg2Yq5AIcCwNJpZ9/Xye7+MxSCE0p9x3cHbLXzNA6c="
+    },
+    "overlay": {
+        "BUILD.bazel": "sha256-9B7PJyw1f18v49F2UXQibfHtd+2NwNvKbUJj2xljmaY=",
+        "test/BUILD.bazel": "sha256-mOTpTjliSySNEc3NXUhU8AyJx9T5AfBWHI0Wf4DLKxw=",
+        "test/MODULE.bazel": "sha256-mkJXc+Xn0R9bydBf2dlIDGkVCD3DMK4hruXXIbK/erI="
+    }
+}

--- a/modules/mujoco/metadata.json
+++ b/modules/mujoco/metadata.json
@@ -6,13 +6,20 @@
             "github": "wep21",
             "github_user_id": 42202095,
             "name": "Daisuke Nishimatsu"
+        },
+        {
+            "email": "daohu527@gmail.com",
+            "github": "daohu527",
+            "name": "daohu527",
+            "github_user_id": 10419854
         }
     ],
     "repository": [
         "github:google-deepmind/mujoco"
     ],
     "versions": [
-        "3.10.0"
+        "3.10.0",
+        "3.10.0.bcr.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Add `modules/mujoco/3.10.0.bcr.1/patches/fix_mc_header_include.patch`

The BCR revision carries the `MC.h` include compatibility fix required by the Bazel packaging of marchingcubecpp. No MuJoCo runtime or vehicle dynamics behavior is changed.