### PR TITLE
best_cpp@1.0.0

### DIFF
--- a/modules/best_cpp/1.0.0/MODULE.bazel
+++ b/modules/best_cpp/1.0.0/MODULE.bazel
@@ -1,0 +1,2 @@
+module(name = "best_cpp", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")

--- a/modules/best_cpp/1.0.0/presubmit.yml
+++ b/modules/best_cpp/1.0.0/presubmit.yml
@@ -1,0 +1,11 @@
+matrix:
+  platform: [ubuntu2404, macos_arm64]
+  bazel: ["9.*"]
+tasks:
+  verify_targets:
+    name: Verify library and regression tests
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags: ["--cxxopt=-std=c++17"]
+    build_targets: ["@best_cpp//:best_cpp"]
+    test_targets: ["@best_cpp//:regression"]

--- a/modules/best_cpp/1.0.0/source.json
+++ b/modules/best_cpp/1.0.0/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/jhurliman/best-cpp/releases/download/v1.0.0/best-cpp-1.0.0.tar.gz",
+  "integrity": "sha256-jXWteVCGRNp2BJe8n7RnutYwEF2kkMZ/hpIq+BmaMpw=",
+  "strip_prefix": "best-cpp-1.0.0"
+}

--- a/modules/best_cpp/metadata.json
+++ b/modules/best_cpp/metadata.json
@@ -1,0 +1,16 @@
+{
+  "homepage": "https://github.com/jhurliman/best-cpp",
+  "maintainers": [
+    {
+      "github": "jhurliman",
+      "github_user_id": 195374
+    }
+  ],
+  "repository": [
+    "github:jhurliman/best-cpp"
+  ],
+  "versions": [
+    "1.0.0"
+  ],
+  "yanked_versions": {}
+}


### PR DESCRIPTION
Add best_cpp 1.0.0, maintained by the upstream owner. Uses the stable source asset attached to https://github.com/jhurliman/best-cpp/releases/tag/v1.0.0.

Validation: BCR validation passes source URL, integrity, module consistency, metadata identity, and presubmit schema checks. It returns NEED_BCR_MAINTAINER_REVIEW because this is a new module. An independent Bazel 9.2 consumer downloaded the public archive through the candidate registry and compiled and ran successfully, including a renamed repository dependency.

The presubmit covers Ubuntu and macOS ARM64 with C++17.
