### PR TITLE
kdtreepp@2.0.0

### DIFF
--- a/modules/kdtreepp/2.0.0/MODULE.bazel
+++ b/modules/kdtreepp/2.0.0/MODULE.bazel
@@ -1,0 +1,3 @@
+module(name = "kdtreepp", version = "2.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "eigen", version = "3.4.1.bcr.1")

--- a/modules/kdtreepp/2.0.0/presubmit.yml
+++ b/modules/kdtreepp/2.0.0/presubmit.yml
@@ -1,0 +1,11 @@
+matrix:
+  platform: [ubuntu2404, macos_arm64]
+  bazel: ["9.*"]
+tasks:
+  verify_targets:
+    name: Verify library and regression tests
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags: ["--cxxopt=-std=c++17"]
+    build_targets: ["@kdtreepp//:kdtreepp"]
+    test_targets: ["@kdtreepp//:regression_test"]

--- a/modules/kdtreepp/2.0.0/source.json
+++ b/modules/kdtreepp/2.0.0/source.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/jhurliman/kdtreepp/releases/download/v2.0.0/kdtreepp-2.0.0.tar.gz",
+  "integrity": "sha256-4ryT4CoP61Eb5JsmvAz8KQ6kmnpTvTRHjTb1L1NzC3o=",
+  "strip_prefix": "kdtreepp-2.0.0"
+}

--- a/modules/kdtreepp/metadata.json
+++ b/modules/kdtreepp/metadata.json
@@ -1,0 +1,16 @@
+{
+  "homepage": "https://github.com/jhurliman/kdtreepp",
+  "maintainers": [
+    {
+      "github": "jhurliman",
+      "github_user_id": 195374
+    }
+  ],
+  "repository": [
+    "github:jhurliman/kdtreepp"
+  ],
+  "versions": [
+    "2.0.0"
+  ],
+  "yanked_versions": {}
+}


### PR DESCRIPTION
Add kdtreepp 2.0.0, maintained by the upstream owner. Uses the stable source asset attached to https://github.com/jhurliman/kdtreepp/releases/tag/v2.0.0.

Validation: BCR validation passes source URL, integrity, module consistency, metadata identity, and presubmit schema checks. It returns NEED_BCR_MAINTAINER_REVIEW because this is a new module. An independent Bazel 9.2 consumer downloaded the public archive through the candidate registry and compiled and ran successfully, including a renamed repository dependency.

The presubmit covers Ubuntu and macOS ARM64 with C++17.
