### PR TITLE
libigl@2.6.3

### DIFF
--- a/modules/libigl/2.6.3/MODULE.bazel
+++ b/modules/libigl/2.6.3/MODULE.bazel
@@ -1,0 +1,13 @@
+"""
+a header only library for geometry processing
+"""
+
+module(
+    name = "libigl",
+    version = "2.6.3",
+    compatibility_level = 1,
+    bazel_compatibility = [">=8.0.0"],
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.14")
+bazel_dep(name = "eigen", version = "5.0.1")

--- a/modules/libigl/2.6.3/overlay/BUILD.bazel
+++ b/modules/libigl/2.6.3/overlay/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "igl_core",
+    hdrs = glob([
+        "include/igl/*.h",
+        "include/igl/*.hpp",
+        "include/igl/*.cpp",
+        "include/igl/*.c",
+    ]),
+    includes = ["include"],
+    deps = [
+        "@eigen",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/modules/libigl/2.6.3/presubmit.yml
+++ b/modules/libigl/2.6.3/presubmit.yml
@@ -1,0 +1,16 @@
+matrix:
+  platform:
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2204
+    - ubuntu2404
+    - windows
+  bazel: [8.x, rolling]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@libigl//:igl_core"

--- a/modules/libigl/2.6.3/source.json
+++ b/modules/libigl/2.6.3/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/libigl/libigl/archive/refs/tags/v2.6.3.tar.gz",
+    "integrity": "sha256-FFqQcxlCay7xhsAdTz0as7tC9DypzBDVshDIl1TXzOo=",
+    "strip_prefix": "libigl-2.6.3",
+    "overlay": {
+        "BUILD.bazel": "sha256-Co4dA6PcbH1+T08Z48JnwHJYayb6ffE+t3uba62vqUc="
+    },
+    "patch_strip": 0
+}

--- a/modules/libigl/metadata.json
+++ b/modules/libigl/metadata.json
@@ -10,7 +10,8 @@
         "github:libigl/libigl"
     ],
     "versions": [
-        "2.6.0"
+        "2.6.0",
+        "2.6.3"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Adds libigl 2.6.3, released upstream on 2026-08-31 (https://github.com/libigl/libigl/releases/tag/v2.6.3).

Module layout is unchanged from 2.6.0: a single header-only `igl_core` target defined in an overlay `BUILD.bazel`, exposing the top-level `include/igl` headers. `presubmit.yml` is identical to 2.6.0.

Differences from the 2.6.0 module files:

- `bazel_dep(name = "eigen")` raised from `3.4.1` to `5.0.1`. Upstream ported libigl to Eigen 5.0.1 in this release (libigl/libigl#2538) and the release's cmake recipe pins Eigen 5.0.1.
- Removed `copts = ["std=c++17"]` from the overlay. It is not a valid compiler flag (missing `-`) and has no effect on a header-only `cc_library`; upstream now requires C++17 from the consumer's own compile flags.

Verification:

- `tools/bcr_validation.py --check libigl@2.6.3` passes every check except `url_stability`. libigl publishes no release archives (0 assets on the v2.6.3 release), so this needs the same `skip_check unstable_url` as 2.6.0 (#6873).
- Integrity of the archive was computed from a fresh download of the tag tarball; `strip_prefix` verified against the archive.
- Consumed from a local registry by a downstream project on Bazel 9.2.0 (Linux, clang), building several `cc_library` targets that include `igl/AABB.h`, `igl/bbw.h`, `igl/fast_winding_number.h`, `igl/massmatrix.h`, `igl/point_mesh_squared_distance.h`, `igl/readMESH.h`, `igl/readMSH.h`, `igl/readOBJ.h`, `igl/read_triangle_mesh.h`, and running their unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
