### PR TITLE
Exclude modules/ contents in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,4 @@ repos:
   rev: v0.5.0
   hooks:
   - id: ruff-format
+    exclude: ^modules/


### PR DESCRIPTION
We want to lint the infrastructure files, not module contents.